### PR TITLE
Amend: Port from 4000 -> 3000

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To run locally
 - Install node modules: `$ npm install`.
 - Copy development environment variables from `.env-dev` into `.env` by running command: `$ node transfer-env-dev`.
 - Create Neo4j database called `theatrebase` and run on port `localhost:7474` (using [Neo4j Community Edition](https://neo4j.com/download/community-edition)).
-- Run server using: `$ npm start` and visit homepage: `localhost:4000`.
+- Run server using: `$ npm start` and visit homepage: `localhost:3000`.
 
 To test
 -------

--- a/server/app.js
+++ b/server/app.js
@@ -114,7 +114,7 @@ const onError = err => {
 
 };
 
-const port = normalizePort(process.env.PORT || '4000');
+const port = normalizePort(process.env.PORT || '3000');
 
 app.set('port', port);
 


### PR DESCRIPTION
Using port `4000` was somehow allowing requests to continue after this line in `server/lib/render-json.js`:
```
return res.send(JSON.stringify(instance));
```
and so caused the below `server/app.js` code to run.
```
// Catch 404 and forward to error handler
app.use((req, res, next) => {

	const err = new Error('Not Found');

	err.status = 404;

	next(err);

});
```
Whilst it did not prevent the JSON response from being displayed, the server logs were misleadingly displaying `Error: Not Found`.

It works fine on port `3000`.

Corresponding `theatrebase-frontend` PR: https://github.com/andygout/theatrebase-frontend/pull/6