### PR TITLE
Allow: Content-Type header in response

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -22,6 +22,7 @@ app.use(logger('dev'));
 app.use((req, res, next) => {
 
 	res.header('Access-Control-Allow-Origin', '*');
+	res.header('Access-Control-Allow-Headers', 'Content-Type');
 
 	next();
 


### PR DESCRIPTION
Required to make API calls via Redux from `theatrebase-cms` app.

MDN web docs:
> The server also sends Access-Control-Allow-Headers with a value of "X-PINGOTHER, Content-Type", confirming that these are permitted headers to be used with the actual request. Like Access-Control-Allow-Methods, Access-Control-Allow-Headers is a comma separated list of acceptable headers.

#### References:
- [github/fetch: Issues - Empty POST body](https://github.com/github/fetch/issues/323) (see: `Piepongwong commented on 22 Sep 2017`).
- [MDN web docs: Cross-Origin Resource Sharing (CORS) - Examples of access control scenarios](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Examples_of_access_control_scenarios).