### PR TITLE
Lowercase: content-type response header

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -22,7 +22,7 @@ app.use(logger('dev'));
 app.use((req, res, next) => {
 
 	res.header('Access-Control-Allow-Origin', '*');
-	res.header('Access-Control-Allow-Headers', 'Content-Type');
+	res.header('Access-Control-Allow-Headers', 'content-type');
 
 	next();
 

--- a/server/lib/render-json.js
+++ b/server/lib/render-json.js
@@ -1,6 +1,6 @@
 export default (res, instance) => {
 
-	res.setHeader('Content-Type', 'application/json');
+	res.setHeader('content-type', 'application/json');
 
 	return res.send(JSON.stringify(instance));
 

--- a/spec/server/lib/render-json.spec.js
+++ b/spec/server/lib/render-json.spec.js
@@ -10,7 +10,7 @@ describe('Render JSON module', () => {
 		const res = httpMocks.createResponse();
 		subject(res, { instanceProperty: 'instanceValue' });
 		expect(res.statusCode).to.eq(200);
-		expect(res._getHeaders()).to.deep.eq({ 'Content-Type': 'application/json' });
+		expect(res._getHeaders()).to.deep.eq({ 'content-type': 'application/json' });
 		expect(res._getData()).to.eq('{"instanceProperty":"instanceValue"}');
 
 	});


### PR DESCRIPTION
See: https://circleci.com/gh/andygout/theatrebase-api/171.

```
  143 passing (3s)
  1 failing

  1) Render JSON module will render form page with requisite data:

      AssertionError: expected { 'content-type': 'application/json' } to deeply equal { 'Content-Type': 'application/json' }
      + expected - actual

       {
      -  "content-type": "application/json"
      +  "Content-Type": "application/json"
       }
```