### PR TITLE
Use: Pre-transpiled code at runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/built/
 /node_modules/
 /.env
 /npm-debug.log

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "lintspaces": "git ls-files | xargs lintspaces -e .editorconfig",
     "unit-test": "find spec -name '*.spec.js' | xargs mocha --require @babel/register spec",
     "test": "npm run lint && npm run lintspaces && npm run unit-test",
-    "start": "nodemon server/app.js --exec babel-node"
+    "build": "babel server --out-dir built",
+    "watch": "babel server --watch --out-dir built",
+    "start": "npm run watch & nodemon built/app.js"
   },
   "pre-commit": [
     "test"
@@ -26,8 +28,8 @@
     "uuid": "^3.0.1"
   },
   "devDependencies": {
+    "@babel/cli": "^7.4.4",
     "@babel/core": "^7.4.5",
-    "@babel/node": "^7.4.5",
     "@babel/preset-env": "^7.4.5",
     "@babel/register": "^7.4.4",
     "babel-plugin-add-module-exports": "^1.0.2",


### PR DESCRIPTION
https://babeljs.io/docs/en/babel-node
> **Not meant for production use**
> You should not be using `babel-node` in production. It is unnecessarily heavy, with high memory usage due to the cache being stored in memory. You will also always experience a startup performance penalty as the entire app needs to be compiled on the fly.
> Check out the [example Node.js server with Babel](https://github.com/babel/example-node-server) for an idea of how to use Babel in a production deployment.

Changed in this PR: Instead of transpiling code at runtime, a `/built` directory containing all the transpiled files will be created when the server starts, to which the server will refer.

The @babel/cli `--watch` flag will re-transpile a file when a change is detected in the source file, and in turn `nodemon` will react to a change in the transpiled file by re-starting the server.

#### References:
- [Babel: @babel/node](https://babeljs.io/docs/en/babel-node).
- [GitHub: babel/example-node-server](https://github.com/babel/example-node-server).
- [Babel: @babel/cli](https://babeljs.io/docs/en/babel-cli).

#### New dependencies:
- [npm: @babel/cli](https://www.npmjs.com/package/@babel/cli).

#### Removed dependencies:
- [npm: @babel/node](https://www.npmjs.com/package/@babel/node).