### PR TITLE
Use: async/await

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,6 +3,13 @@
 		"add-module-exports"
 	],
 	"presets": [
-		"@babel/preset-env"
+		[
+			"@babel/preset-env",
+			{
+				"targets": {
+					"node": "10"
+				}
+			}
+		]
 	]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,8 @@
   },
   "extends": ["eslint:recommended"],
   "parserOptions": {
-      "sourceType": "module"
+      "sourceType": "module",
+      "ecmaVersion": 2017
   },
   "rules": {
     "eqeqeq": 2,

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@babel/register": "^7.4.4",
     "babel-plugin-add-module-exports": "^1.0.2",
     "chai": "^3.5.0",
+    "core-js": "^3.1.4",
     "eslint": "^4.11.0",
     "lintspaces-cli": "^0.6.0",
     "mocha": "^3.2.0",
@@ -41,6 +42,7 @@
     "nodemon": "^1.11.0",
     "pre-commit": "^1.2.2",
     "proxyquire": "^1.7.10",
+    "regenerator-runtime": "^0.13.2",
     "sinon": "^2.3.2"
   },
   "engines": {

--- a/server/app.js
+++ b/server/app.js
@@ -3,6 +3,9 @@
 	no-unused-vars: ["error", { "argsIgnorePattern": "next" }]
 */
 
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
+
 import './dotenv';
 import bodyParser from 'body-parser';
 import express from 'express';
@@ -121,10 +124,12 @@ app.set('port', port);
 
 const server = http.createServer(app);
 
-createConstraints().then(() => {
+(async () => {
+
+	await createConstraints();
 
 	server.listen(port, () => console.log(`Listening on port ${port}`));
 
 	server.on('error', onError);
 
-});
+})();

--- a/server/lib/call-class-methods.js
+++ b/server/lib/call-class-methods.js
@@ -1,24 +1,36 @@
 import renderJson from './render-json';
 
-const callInstanceMethod = (res, next, instance, method) => {
+const callInstanceMethod = async (res, next, instance, method) => {
 
-	return instance[method]()
-		.then(instance => renderJson(res, instance))
-		.catch(err => {
+	try {
 
-			if (err.message === 'Not Found') return res.status(404).send(err.message);
+		const response = await instance[method]();
 
-			return next(err);
+		return renderJson(res, response)
 
-		});
+	} catch (err) {
+
+		if (err.message === 'Not Found') return res.status(404).send(err.message);
+
+		return next(err);
+
+	}
 
 };
 
-const callStaticListMethod = (res, next, Class, model) => {
+const callStaticListMethod = async (res, next, Class, model) => {
 
-	return Class.list(model)
-		.then(instances => renderJson(res, instances))
-		.catch(err => next(err));
+	try {
+
+		const instances = await Class.list(model);
+
+		return renderJson(res, instances);
+
+	} catch (err) {
+
+		return next(err);
+
+	}
 
 };
 

--- a/server/models/base.js
+++ b/server/models/base.js
@@ -39,35 +39,29 @@ export default class Base {
 
 	}
 
-	validateInDb () {
+	async validateInDb () {
 
-		return dbQuery({ query: getValidateQuery(this.model, this.uuid), params: this })
-			.then(({ instanceCount }) => {
+		const { instanceCount } = await dbQuery({ query: getValidateQuery(this.model, this.uuid), params: this });
 
-				if (instanceCount > 0) this.errors.name = ['Name already exists'];
-
-			});
+		if (instanceCount > 0) this.errors.name = ['Name already exists'];
 
 	}
 
-	createUpdate (getCreateUpdateQuery) {
+	async createUpdate (getCreateUpdateQuery) {
 
 		this.validate({ required: true });
 
 		this.hasError = verifyErrorPresence(this);
 
-		if (this.hasError) return Promise.resolve(this);
+		if (this.hasError) return this;
 
-		return this.validateInDb()
-			.then(() => {
+		await this.validateInDb();
 
-				this.hasError = verifyErrorPresence(this);
+		this.hasError = verifyErrorPresence(this);
 
-				if (this.hasError) return Promise.resolve(this);
+		if (this.hasError) return this;
 
-				return dbQuery({ query: getCreateUpdateQuery(this.model), params: prepareAsParams(this) });
-
-			});
+		return dbQuery({ query: getCreateUpdateQuery(this.model), params: prepareAsParams(this) });
 
 	}
 

--- a/server/models/playtext.js
+++ b/server/models/playtext.js
@@ -33,20 +33,17 @@ export default class Playtext extends Base {
 
 	}
 
-	createUpdate (getCreateUpdateQuery) {
+	async createUpdate (getCreateUpdateQuery) {
 
-		if (this.setErrorStatus()) return Promise.resolve(this);
+		if (this.setErrorStatus()) return this;
 
-		return this.validateInDb()
-			.then(() => {
+		await this.validateInDb();
 
-				this.hasError = verifyErrorPresence(this);
+		this.hasError = verifyErrorPresence(this);
 
-				if (this.hasError) return Promise.resolve(this);
+		if (this.hasError) return this;
 
-				return dbQuery({ query: getCreateUpdateQuery(), params: prepareAsParams(this) });
-
-			});
+		return dbQuery({ query: getCreateUpdateQuery(), params: prepareAsParams(this) });
 
 	}
 

--- a/server/models/production.js
+++ b/server/models/production.js
@@ -48,7 +48,7 @@ export default class Production extends Base {
 
 	createUpdate (getCreateUpdateQuery) {
 
-		if (this.setErrorStatus()) return Promise.resolve(this);
+		if (this.setErrorStatus()) return this;
 
 		return dbQuery({ query: getCreateUpdateQuery(), params: prepareAsParams(this) });
 

--- a/server/models/theatre.js
+++ b/server/models/theatre.js
@@ -18,29 +18,23 @@ export default class Theatre extends Base {
 
 	}
 
-	validateDeleteInDb () {
+	async validateDeleteInDb () {
 
-		return dbQuery({ query: getValidateDeleteQuery(), params: this })
-			.then(({ relationshipCount }) => {
+		const { relationshipCount } = await dbQuery({ query: getValidateDeleteQuery(), params: this });
 
-				if (relationshipCount > 0) this.errors.associations = ['productions'];
-
-			});
+		if (relationshipCount > 0) this.errors.associations = ['productions'];
 
 	}
 
-	delete () {
+	async delete () {
 
-		return this.validateDeleteInDb()
-			.then(() => {
+		await this.validateDeleteInDb();
 
-				this.hasError = verifyErrorPresence(this);
+		this.hasError = verifyErrorPresence(this);
 
-				if (this.hasError) return Promise.resolve({ theatre: this });
+		if (this.hasError) return { theatre: this };
 
-				return dbQuery({ query: getDeleteQuery(this.model), params: this });
-
-			});
+		return dbQuery({ query: getDeleteQuery(this.model), params: this });
 
 	}
 

--- a/spec/server/controllers/characters.spec.js
+++ b/spec/server/controllers/characters.spec.js
@@ -63,17 +63,15 @@ describe('Characters controller', () => {
 
 	describe('create method', () => {
 
-		it('will call callInstanceMethod module', done => {
+		it('will call callInstanceMethod module', async () => {
 
 			method = 'create';
-			createInstance(method).then(result => {
-				expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
-				expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
-					stubs.res, stubs.next, stubs.Character(), method
-				)).to.be.true;
-				expect(result).to.eq('callInstanceMethod response');
-				done();
-			});
+			const result = await createInstance(method);
+			expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
+				stubs.res, stubs.next, stubs.Character(), method
+			)).to.be.true;
+			expect(result).to.eq('callInstanceMethod response');
 
 		});
 
@@ -81,17 +79,15 @@ describe('Characters controller', () => {
 
 	describe('edit method', () => {
 
-		it('will call callInstanceMethod module', done => {
+		it('will call callInstanceMethod module', async () => {
 
 			method = 'edit';
-			createInstance(method).then(result => {
-				expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
-				expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
-					stubs.res, stubs.next, stubs.Character(), method
-				)).to.be.true;
-				expect(result).to.eq('callInstanceMethod response');
-				done();
-			});
+			const result = await createInstance(method);
+			expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
+				stubs.res, stubs.next, stubs.Character(), method
+			)).to.be.true;
+			expect(result).to.eq('callInstanceMethod response');
 
 		});
 
@@ -99,17 +95,15 @@ describe('Characters controller', () => {
 
 	describe('update method', () => {
 
-		it('will call callInstanceMethod module', done => {
+		it('will call callInstanceMethod module', async () => {
 
 			method = 'update';
-			createInstance(method).then(result => {
-				expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
-				expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
-					stubs.res, stubs.next, stubs.Character(), method
-				)).to.be.true;
-				expect(result).to.eq('callInstanceMethod response');
-				done();
-			});
+			const result = await createInstance(method);
+			expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
+				stubs.res, stubs.next, stubs.Character(), method
+			)).to.be.true;
+			expect(result).to.eq('callInstanceMethod response');
 
 		});
 
@@ -117,17 +111,15 @@ describe('Characters controller', () => {
 
 	describe('delete method', () => {
 
-		it('will call callInstanceMethod module', done => {
+		it('will call callInstanceMethod module', async () => {
 
 			method = 'delete';
-			createInstance(method).then(result => {
-				expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
-				expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
-					stubs.res, stubs.next, stubs.Character(), method
-				)).to.be.true;
-				expect(result).to.eq('callInstanceMethod response');
-				done();
-			});
+			const result = await createInstance(method);
+			expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
+				stubs.res, stubs.next, stubs.Character(), method
+			)).to.be.true;
+			expect(result).to.eq('callInstanceMethod response');
 
 		});
 
@@ -135,17 +127,15 @@ describe('Characters controller', () => {
 
 	describe('show method', () => {
 
-		it('will call callInstanceMethod module', done => {
+		it('will call callInstanceMethod module', async () => {
 
 			method = 'show';
-			createInstance(method).then(result => {
-				expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
-				expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
-					stubs.res, stubs.next, stubs.Character(), method
-				)).to.be.true;
-				expect(result).to.eq('callInstanceMethod response');
-				done();
-			});
+			const result = await createInstance(method);
+			expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
+				stubs.res, stubs.next, stubs.Character(), method
+			)).to.be.true;
+			expect(result).to.eq('callInstanceMethod response');
 
 		});
 
@@ -153,17 +143,15 @@ describe('Characters controller', () => {
 
 	describe('list method', () => {
 
-		it('will call callStaticListMethod module', done => {
+		it('will call callStaticListMethod module', async () => {
 
 			method = 'list';
-			createInstance(method).then(result => {
-				expect(stubs.callClassMethods.callStaticListMethod.calledOnce).to.be.true;
-				expect(stubs.callClassMethods.callStaticListMethod.calledWithExactly(
-					stubs.res, stubs.next, stubs.Character, 'character'
-				)).to.be.true;
-				expect(result).to.eq('callStaticListMethod response');
-				done();
-			});
+			const result = await createInstance(method);
+			expect(stubs.callClassMethods.callStaticListMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethods.callStaticListMethod.calledWithExactly(
+				stubs.res, stubs.next, stubs.Character, 'character'
+			)).to.be.true;
+			expect(result).to.eq('callStaticListMethod response');
 
 		});
 

--- a/spec/server/controllers/people.spec.js
+++ b/spec/server/controllers/people.spec.js
@@ -63,17 +63,15 @@ describe('People controller', () => {
 
 	describe('create method', () => {
 
-		it('will call callInstanceMethod module', done => {
+		it('will call callInstanceMethod module', async () => {
 
 			method = 'create';
-			createInstance(method).then(result => {
-				expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
-				expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
-					stubs.res, stubs.next, stubs.Person(), method
-				)).to.be.true;
-				expect(result).to.eq('callInstanceMethod response');
-				done();
-			});
+			const result = await createInstance(method);
+			expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
+				stubs.res, stubs.next, stubs.Person(), method
+			)).to.be.true;
+			expect(result).to.eq('callInstanceMethod response');
 
 		});
 
@@ -81,17 +79,15 @@ describe('People controller', () => {
 
 	describe('edit method', () => {
 
-		it('will call callInstanceMethod module', done => {
+		it('will call callInstanceMethod module', async () => {
 
 			method = 'edit';
-			createInstance(method).then(result => {
-				expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
-				expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
-					stubs.res, stubs.next, stubs.Person(), method
-				)).to.be.true;
-				expect(result).to.eq('callInstanceMethod response');
-				done();
-			});
+			const result = await createInstance(method);
+			expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
+				stubs.res, stubs.next, stubs.Person(), method
+			)).to.be.true;
+			expect(result).to.eq('callInstanceMethod response');
 
 		});
 
@@ -99,17 +95,15 @@ describe('People controller', () => {
 
 	describe('update method', () => {
 
-		it('will call callInstanceMethod module', done => {
+		it('will call callInstanceMethod module', async () => {
 
 			method = 'update';
-			createInstance(method).then(result => {
-				expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
-				expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
-					stubs.res, stubs.next, stubs.Person(), method
-				)).to.be.true;
-				expect(result).to.eq('callInstanceMethod response');
-				done();
-			});
+			const result = await createInstance(method);
+			expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
+				stubs.res, stubs.next, stubs.Person(), method
+			)).to.be.true;
+			expect(result).to.eq('callInstanceMethod response');
 
 		});
 
@@ -117,17 +111,15 @@ describe('People controller', () => {
 
 	describe('delete method', () => {
 
-		it('will call callInstanceMethod module', done => {
+		it('will call callInstanceMethod module', async () => {
 
 			method = 'delete';
-			createInstance(method).then(result => {
-				expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
-				expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
-					stubs.res, stubs.next, stubs.Person(), method
-				)).to.be.true;
-				expect(result).to.eq('callInstanceMethod response');
-				done();
-			});
+			const result = await createInstance(method);
+			expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
+				stubs.res, stubs.next, stubs.Person(), method
+			)).to.be.true;
+			expect(result).to.eq('callInstanceMethod response');
 
 		});
 
@@ -135,17 +127,15 @@ describe('People controller', () => {
 
 	describe('show method', () => {
 
-		it('will call callInstanceMethod module', done => {
+		it('will call callInstanceMethod module', async () => {
 
 			method = 'show';
-			createInstance(method).then(result => {
-				expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
-				expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
-					stubs.res, stubs.next, stubs.Person(), method
-				)).to.be.true;
-				expect(result).to.eq('callInstanceMethod response');
-				done();
-			});
+			const result = await createInstance(method);
+			expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
+				stubs.res, stubs.next, stubs.Person(), method
+			)).to.be.true;
+			expect(result).to.eq('callInstanceMethod response');
 
 		});
 
@@ -153,17 +143,15 @@ describe('People controller', () => {
 
 	describe('list method', () => {
 
-		it('will call callStaticListMethod module', done => {
+		it('will call callStaticListMethod module', async () => {
 
 			method = 'list';
-			createInstance(method).then(result => {
-				expect(stubs.callClassMethods.callStaticListMethod.calledOnce).to.be.true;
-				expect(stubs.callClassMethods.callStaticListMethod.calledWithExactly(
-					stubs.res, stubs.next, stubs.Person, 'person'
-				)).to.be.true;
-				expect(result).to.eq('callStaticListMethod response');
-				done();
-			});
+			const result = await createInstance(method);
+			expect(stubs.callClassMethods.callStaticListMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethods.callStaticListMethod.calledWithExactly(
+				stubs.res, stubs.next, stubs.Person, 'person'
+			)).to.be.true;
+			expect(result).to.eq('callStaticListMethod response');
 
 		});
 

--- a/spec/server/controllers/playtexts.spec.js
+++ b/spec/server/controllers/playtexts.spec.js
@@ -63,17 +63,15 @@ describe('Playtexts controller', () => {
 
 	describe('create method', () => {
 
-		it('will call callInstanceMethod module', done => {
+		it('will call callInstanceMethod module', async () => {
 
 			method = 'create';
-			createInstance(method).then(result => {
-				expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
-				expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
-					stubs.res, stubs.next, stubs.Playtext(), method
-				)).to.be.true;
-				expect(result).to.eq('callInstanceMethod response');
-				done();
-			});
+			const result = await createInstance(method);
+			expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
+				stubs.res, stubs.next, stubs.Playtext(), method
+			)).to.be.true;
+			expect(result).to.eq('callInstanceMethod response');
 
 		});
 
@@ -81,17 +79,15 @@ describe('Playtexts controller', () => {
 
 	describe('edit method', () => {
 
-		it('will call callInstanceMethod module', done => {
+		it('will call callInstanceMethod module', async () => {
 
 			method = 'edit';
-			createInstance(method).then(result => {
-				expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
-				expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
-					stubs.res, stubs.next, stubs.Playtext(), method
-				)).to.be.true;
-				expect(result).to.eq('callInstanceMethod response');
-				done();
-			});
+			const result = await createInstance(method);
+			expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
+				stubs.res, stubs.next, stubs.Playtext(), method
+			)).to.be.true;
+			expect(result).to.eq('callInstanceMethod response');
 
 		});
 
@@ -99,17 +95,15 @@ describe('Playtexts controller', () => {
 
 	describe('update method', () => {
 
-		it('will call callInstanceMethod module', done => {
+		it('will call callInstanceMethod module', async () => {
 
 			method = 'update';
-			createInstance(method).then(result => {
-				expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
-				expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
-					stubs.res, stubs.next, stubs.Playtext(), method
-				)).to.be.true;
-				expect(result).to.eq('callInstanceMethod response');
-				done();
-			});
+			const result = await createInstance(method);
+			expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
+				stubs.res, stubs.next, stubs.Playtext(), method
+			)).to.be.true;
+			expect(result).to.eq('callInstanceMethod response');
 
 		});
 
@@ -117,17 +111,15 @@ describe('Playtexts controller', () => {
 
 	describe('delete method', () => {
 
-		it('will call callInstanceMethod module', done => {
+		it('will call callInstanceMethod module', async () => {
 
 			method = 'delete';
-			createInstance(method).then(result => {
-				expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
-				expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
-					stubs.res, stubs.next, stubs.Playtext(), method
-				)).to.be.true;
-				expect(result).to.eq('callInstanceMethod response');
-				done();
-			});
+			const result = await createInstance(method);
+			expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
+				stubs.res, stubs.next, stubs.Playtext(), method
+			)).to.be.true;
+			expect(result).to.eq('callInstanceMethod response');
 
 		});
 
@@ -135,17 +127,15 @@ describe('Playtexts controller', () => {
 
 	describe('show method', () => {
 
-		it('will call callInstanceMethod module', done => {
+		it('will call callInstanceMethod module', async () => {
 
 			method = 'show';
-			createInstance(method).then(result => {
-				expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
-				expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
-					stubs.res, stubs.next, stubs.Playtext(), method
-				)).to.be.true;
-				expect(result).to.eq('callInstanceMethod response');
-				done();
-			});
+			const result = await createInstance(method);
+			expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
+				stubs.res, stubs.next, stubs.Playtext(), method
+			)).to.be.true;
+			expect(result).to.eq('callInstanceMethod response');
 
 		});
 
@@ -153,17 +143,15 @@ describe('Playtexts controller', () => {
 
 	describe('list method', () => {
 
-		it('will call callStaticListMethod module', done => {
+		it('will call callStaticListMethod module', async () => {
 
 			method = 'list';
-			createInstance(method).then(result => {
-				expect(stubs.callClassMethods.callStaticListMethod.calledOnce).to.be.true;
-				expect(stubs.callClassMethods.callStaticListMethod.calledWithExactly(
-					stubs.res, stubs.next, stubs.Playtext, 'playtext'
-				)).to.be.true;
-				expect(result).to.eq('callStaticListMethod response');
-				done();
-			});
+			const result = await createInstance(method);
+			expect(stubs.callClassMethods.callStaticListMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethods.callStaticListMethod.calledWithExactly(
+				stubs.res, stubs.next, stubs.Playtext, 'playtext'
+			)).to.be.true;
+			expect(result).to.eq('callStaticListMethod response');
 
 		});
 

--- a/spec/server/controllers/productions.spec.js
+++ b/spec/server/controllers/productions.spec.js
@@ -63,17 +63,15 @@ describe('Productions controller', () => {
 
 	describe('create method', () => {
 
-		it('will call callInstanceMethod module', done => {
+		it('will call callInstanceMethod module', async () => {
 
 			method = 'create';
-			createInstance(method).then(result => {
-				expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
-				expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
-					stubs.res, stubs.next, stubs.Production(), method
-				)).to.be.true;
-				expect(result).to.eq('callInstanceMethod response');
-				done();
-			});
+			const result = await createInstance(method);
+			expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
+				stubs.res, stubs.next, stubs.Production(), method
+			)).to.be.true;
+			expect(result).to.eq('callInstanceMethod response');
 
 		});
 
@@ -81,17 +79,15 @@ describe('Productions controller', () => {
 
 	describe('edit method', () => {
 
-		it('will call callInstanceMethod module', done => {
+		it('will call callInstanceMethod module', async () => {
 
 			method = 'edit';
-			createInstance(method).then(result => {
-				expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
-				expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
-					stubs.res, stubs.next, stubs.Production(), method
-				)).to.be.true;
-				expect(result).to.eq('callInstanceMethod response');
-				done();
-			});
+			const result = await createInstance(method);
+			expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
+				stubs.res, stubs.next, stubs.Production(), method
+			)).to.be.true;
+			expect(result).to.eq('callInstanceMethod response');
 
 		});
 
@@ -99,17 +95,15 @@ describe('Productions controller', () => {
 
 	describe('update method', () => {
 
-		it('will call callInstanceMethod module', done => {
+		it('will call callInstanceMethod module', async () => {
 
 			method = 'update';
-			createInstance(method).then(result => {
-				expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
-				expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
-					stubs.res, stubs.next, stubs.Production(), method
-				)).to.be.true;
-				expect(result).to.eq('callInstanceMethod response');
-				done();
-			});
+			const result = await createInstance(method);
+			expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
+				stubs.res, stubs.next, stubs.Production(), method
+			)).to.be.true;
+			expect(result).to.eq('callInstanceMethod response');
 
 		});
 
@@ -117,17 +111,15 @@ describe('Productions controller', () => {
 
 	describe('delete method', () => {
 
-		it('will call callInstanceMethod module', done => {
+		it('will call callInstanceMethod module', async () => {
 
 			method = 'delete';
-			createInstance(method).then(result => {
-				expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
-				expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
-					stubs.res, stubs.next, stubs.Production(), method
-				)).to.be.true;
-				expect(result).to.eq('callInstanceMethod response');
-				done();
-			});
+			const result = await createInstance(method);
+			expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
+				stubs.res, stubs.next, stubs.Production(), method
+			)).to.be.true;
+			expect(result).to.eq('callInstanceMethod response');
 
 		});
 
@@ -135,17 +127,15 @@ describe('Productions controller', () => {
 
 	describe('show method', () => {
 
-		it('will call callInstanceMethod module', done => {
+		it('will call callInstanceMethod module', async () => {
 
 			method = 'show';
-			createInstance(method).then(result => {
-				expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
-				expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
-					stubs.res, stubs.next, stubs.Production(), method
-				)).to.be.true;
-				expect(result).to.eq('callInstanceMethod response');
-				done();
-			});
+			const result = await createInstance(method);
+			expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
+				stubs.res, stubs.next, stubs.Production(), method
+			)).to.be.true;
+			expect(result).to.eq('callInstanceMethod response');
 
 		});
 
@@ -153,17 +143,15 @@ describe('Productions controller', () => {
 
 	describe('list method', () => {
 
-		it('will call callStaticListMethod module', done => {
+		it('will call callStaticListMethod module', async () => {
 
 			method = 'list';
-			createInstance(method).then(result => {
-				expect(stubs.callClassMethods.callStaticListMethod.calledOnce).to.be.true;
-				expect(stubs.callClassMethods.callStaticListMethod.calledWithExactly(
-					stubs.res, stubs.next, stubs.Production, 'production'
-				)).to.be.true;
-				expect(result).to.eq('callStaticListMethod response');
-				done();
-			});
+			const result = await createInstance(method);
+			expect(stubs.callClassMethods.callStaticListMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethods.callStaticListMethod.calledWithExactly(
+				stubs.res, stubs.next, stubs.Production, 'production'
+			)).to.be.true;
+			expect(result).to.eq('callStaticListMethod response');
 
 		});
 

--- a/spec/server/controllers/theatres.spec.js
+++ b/spec/server/controllers/theatres.spec.js
@@ -63,17 +63,15 @@ describe('Theatres controller', () => {
 
 	describe('create method', () => {
 
-		it('will call callInstanceMethod module', done => {
+		it('will call callInstanceMethod module', async () => {
 
 			method = 'create';
-			createInstance(method).then(result => {
-				expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
-				expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
-					stubs.res, stubs.next, stubs.Theatre(), method
-				)).to.be.true;
-				expect(result).to.eq('callInstanceMethod response');
-				done();
-			});
+			const result = await createInstance(method);
+			expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
+				stubs.res, stubs.next, stubs.Theatre(), method
+			)).to.be.true;
+			expect(result).to.eq('callInstanceMethod response');
 
 		});
 
@@ -81,17 +79,15 @@ describe('Theatres controller', () => {
 
 	describe('edit method', () => {
 
-		it('will call callInstanceMethod module', done => {
+		it('will call callInstanceMethod module', async () => {
 
 			method = 'edit';
-			createInstance(method).then(result => {
-				expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
-				expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
-					stubs.res, stubs.next, stubs.Theatre(), method
-				)).to.be.true;
-				expect(result).to.eq('callInstanceMethod response');
-				done();
-			});
+			const result = await createInstance(method);
+			expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
+				stubs.res, stubs.next, stubs.Theatre(), method
+			)).to.be.true;
+			expect(result).to.eq('callInstanceMethod response');
 
 		});
 
@@ -99,17 +95,15 @@ describe('Theatres controller', () => {
 
 	describe('update method', () => {
 
-		it('will call callInstanceMethod module', done => {
+		it('will call callInstanceMethod module', async () => {
 
 			method = 'update';
-			createInstance(method).then(result => {
-				expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
-				expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
-					stubs.res, stubs.next, stubs.Theatre(), method
-				)).to.be.true;
-				expect(result).to.eq('callInstanceMethod response');
-				done();
-			});
+			const result = await createInstance(method);
+			expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
+				stubs.res, stubs.next, stubs.Theatre(), method
+			)).to.be.true;
+			expect(result).to.eq('callInstanceMethod response');
 
 		});
 
@@ -117,17 +111,15 @@ describe('Theatres controller', () => {
 
 	describe('delete method', () => {
 
-		it('will call callInstanceMethod module', done => {
+		it('will call callInstanceMethod module', async () => {
 
 			method = 'delete';
-			createInstance(method).then(result => {
-				expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
-				expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
-					stubs.res, stubs.next, stubs.Theatre(), method
-				)).to.be.true;
-				expect(result).to.eq('callInstanceMethod response');
-				done();
-			});
+			const result = await createInstance(method);
+			expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
+				stubs.res, stubs.next, stubs.Theatre(), method
+			)).to.be.true;
+			expect(result).to.eq('callInstanceMethod response');
 
 		});
 
@@ -135,17 +127,15 @@ describe('Theatres controller', () => {
 
 	describe('show method', () => {
 
-		it('will call callInstanceMethod module', done => {
+		it('will call callInstanceMethod module', async () => {
 
 			method = 'show';
-			createInstance(method).then(result => {
-				expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
-				expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
-					stubs.res, stubs.next, stubs.Theatre(), method
-				)).to.be.true;
-				expect(result).to.eq('callInstanceMethod response');
-				done();
-			});
+			const result = await createInstance(method);
+			expect(stubs.callClassMethods.callInstanceMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethods.callInstanceMethod.calledWithExactly(
+				stubs.res, stubs.next, stubs.Theatre(), method
+			)).to.be.true;
+			expect(result).to.eq('callInstanceMethod response');
 
 		});
 
@@ -153,17 +143,15 @@ describe('Theatres controller', () => {
 
 	describe('list method', () => {
 
-		it('will call callStaticListMethod module', done => {
+		it('will call callStaticListMethod module', async () => {
 
 			method = 'list';
-			createInstance(method).then(result => {
-				expect(stubs.callClassMethods.callStaticListMethod.calledOnce).to.be.true;
-				expect(stubs.callClassMethods.callStaticListMethod.calledWithExactly(
-					stubs.res, stubs.next, stubs.Theatre, 'theatre'
-				)).to.be.true;
-				expect(result).to.eq('callStaticListMethod response');
-				done();
-			});
+			const result = await createInstance(method);
+			expect(stubs.callClassMethods.callStaticListMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethods.callStaticListMethod.calledWithExactly(
+				stubs.res, stubs.next, stubs.Theatre, 'theatre'
+			)).to.be.true;
+			expect(result).to.eq('callStaticListMethod response');
 
 		});
 

--- a/spec/server/lib/call-class-methods.spec.js
+++ b/spec/server/lib/call-class-methods.spec.js
@@ -40,18 +40,16 @@ describe('Call Class Methods module', () => {
 
 		context('resolves with data', () => {
 
-			it('will call renderPage module', done => {
+			it('will call renderPage module', async () => {
 
 				const subject = createSubject();
 				const instanceMethodResponse = { property: 'value' };
 				sinon.stub(character, method).callsFake(() => { return Promise.resolve(instanceMethodResponse) });
-				subject.callInstanceMethod(stubs.res, stubs.next, character, method).then(result => {
-					expect(stubs.renderJson.calledOnce).to.be.true;
-					expect(stubs.renderJson.calledWithExactly(stubs.res, instanceMethodResponse)).to.be.true;
-					expect(stubs.next.notCalled).to.be.true;
-					expect(result).to.eq('renderJson response');
-					done();
-				});
+				const result = await subject.callInstanceMethod(stubs.res, stubs.next, character, method);
+				expect(stubs.renderJson.calledOnce).to.be.true;
+				expect(stubs.renderJson.calledWithExactly(stubs.res, instanceMethodResponse)).to.be.true;
+				expect(stubs.next.notCalled).to.be.true;
+				expect(result).to.eq('renderJson response');
 
 			});
 
@@ -59,16 +57,14 @@ describe('Call Class Methods module', () => {
 
 		context('resolves with error', () => {
 
-			it('will call next() with error', done => {
+			it('will call next() with error', async () => {
 
 				const subject = createSubject();
 				sinon.stub(character, method).callsFake(() => { return Promise.reject(err) });
-				subject.callInstanceMethod(stubs.res, stubs.next, character, method).then(() => {
-					expect(stubs.next.calledOnce).to.be.true;
-					expect(stubs.next.calledWithExactly(err)).to.be.true;
-					expect(stubs.renderJson.notCalled).to.be.true;
-					done();
-				});
+				await subject.callInstanceMethod(stubs.res, stubs.next, character, method);
+				expect(stubs.next.calledOnce).to.be.true;
+				expect(stubs.next.calledWithExactly(err)).to.be.true;
+				expect(stubs.renderJson.notCalled).to.be.true;
 
 			});
 
@@ -76,17 +72,15 @@ describe('Call Class Methods module', () => {
 
 		context('resolves with \'Not Found\' error', () => {
 
-			it('will respond with 404 status and send error message', done => {
+			it('will respond with 404 status and send error message', async () => {
 
 				const subject = createSubject();
 				sinon.stub(character, method).callsFake(() => { return Promise.reject(notFoundErr) });
-				subject.callInstanceMethod(stubs.res, stubs.next, character, method).then(() => {
-					expect(stubs.res.statusCode).to.eq(404);
-					expect(stubs.res._getData()).to.eq('Not Found');
-					expect(stubs.renderJson.notCalled).to.be.true;
-					expect(stubs.next.called).to.be.false;
-					done();
-				});
+				await subject.callInstanceMethod(stubs.res, stubs.next, character, method);
+				expect(stubs.res.statusCode).to.eq(404);
+				expect(stubs.res._getData()).to.eq('Not Found');
+				expect(stubs.renderJson.notCalled).to.be.true;
+				expect(stubs.next.called).to.be.false;
 
 			});
 
@@ -110,20 +104,18 @@ describe('Call Class Methods module', () => {
 
 		context('resolves with data', () => {
 
-			it('will call renderPage module', done => {
+			it('will call renderPage module', async () => {
 
 				const subject = createSubject();
 				const staticListMethodResponse = [{ property: 'value' }];
 				sinon.stub(Character, method).callsFake(() => { return Promise.resolve(staticListMethodResponse) });
-				subject.callStaticListMethod(stubs.res, stubs.next, Character, 'character').then(result => {
-					expect(stubs.renderJson.calledOnce).to.be.true;
-					expect(stubs.renderJson.calledWithExactly(
-						stubs.res, staticListMethodResponse
-					)).to.be.true;
-					expect(stubs.next.notCalled).to.be.true;
-					expect(result).to.eq('renderJson response');
-					done();
-				});
+				const result = await subject.callStaticListMethod(stubs.res, stubs.next, Character, 'character');
+				expect(stubs.renderJson.calledOnce).to.be.true;
+				expect(stubs.renderJson.calledWithExactly(
+					stubs.res, staticListMethodResponse
+				)).to.be.true;
+				expect(stubs.next.notCalled).to.be.true;
+				expect(result).to.eq('renderJson response');
 
 			});
 
@@ -131,16 +123,14 @@ describe('Call Class Methods module', () => {
 
 		context('resolves with error', () => {
 
-			it('will call next() with error', done => {
+			it('will call next() with error', async () => {
 
 				const subject = createSubject();
 				sinon.stub(Character, method).callsFake(() => { return Promise.reject(err) });
-				subject.callStaticListMethod(stubs.res, stubs.next, Character, 'character').then(() => {
-					expect(stubs.next.calledOnce).to.be.true;
-					expect(stubs.next.calledWithExactly(err)).to.be.true;
-					expect(stubs.renderJson.notCalled).to.be.true;
-					done();
-				});
+				await subject.callStaticListMethod(stubs.res, stubs.next, Character, 'character');
+				expect(stubs.next.calledOnce).to.be.true;
+				expect(stubs.next.calledWithExactly(err)).to.be.true;
+				expect(stubs.renderJson.notCalled).to.be.true;
 
 			});
 

--- a/spec/server/models/base.spec.js
+++ b/spec/server/models/base.spec.js
@@ -113,32 +113,28 @@ describe('Base model', () => {
 
 	describe('validateInDb method', () => {
 
-		it('will validate update in database', done => {
+		it('will validate update in database', async () => {
 
-			instance.validateInDb().then(() => {
-				expect(stubs.cypherQueriesShared.getValidateQuery.calledOnce).to.be.true;
-				expect(stubs.cypherQueriesShared.getValidateQuery.calledWithExactly(
-					instance.model, instance.uuid
-				)).to.be.true;
-				expect(stubs.dbQuery.calledOnce).to.be.true;
-				expect(stubs.dbQuery.calledWithExactly(
-					{ query: 'getValidateQuery response', params: instance }
-				)).to.be.true;
-				done();
-			});
+			await instance.validateInDb();
+			expect(stubs.cypherQueriesShared.getValidateQuery.calledOnce).to.be.true;
+			expect(stubs.cypherQueriesShared.getValidateQuery.calledWithExactly(
+				instance.model, instance.uuid
+			)).to.be.true;
+			expect(stubs.dbQuery.calledOnce).to.be.true;
+			expect(stubs.dbQuery.calledWithExactly(
+				{ query: 'getValidateQuery response', params: instance }
+			)).to.be.true;
 
 		});
 
 		context('valid data (results returned that indicate name does not already exist)', () => {
 
-			it('will not add properties to errors property', done => {
+			it('will not add properties to errors property', async () => {
 
 				instance = createInstance({ dbQuery: sinon.stub().resolves({ instanceCount: 0 }) });
-				instance.validateInDb().then(() => {
-					expect(instance.errors).not.to.have.property('name');
-					expect(instance.errors).to.deep.eq({});
-					done();
-				});
+				await instance.validateInDb();
+				expect(instance.errors).not.to.have.property('name');
+				expect(instance.errors).to.deep.eq({});
 
 			});
 
@@ -146,16 +142,14 @@ describe('Base model', () => {
 
 		context('invalid data (results returned that indicate name already exists)', () => {
 
-			it('will add properties that are arrays to errors property', done => {
+			it('will add properties that are arrays to errors property', async () => {
 
 				instance = createInstance({ dbQuery: sinon.stub().resolves({ instanceCount: 1 }) });
-				instance.validateInDb().then(() => {
-					expect(instance.errors)
-						.to.have.property('name')
-						.that.is.an('array')
-						.that.deep.eq(['Name already exists']);
-					done();
-				});
+				await instance.validateInDb();
+				expect(instance.errors)
+					.to.have.property('name')
+					.that.is.an('array')
+					.that.deep.eq(['Name already exists']);
 
 			});
 
@@ -167,65 +161,61 @@ describe('Base model', () => {
 
 		context('valid data', () => {
 
-			it('will create', done => {
+			it('will create', async () => {
 
 				sinon.spy(instance, 'validate');
 				sinon.spy(instance, 'validateInDb');
-				instance.createUpdate(stubs.cypherQueriesShared.getCreateQuery).then(result => {
-					sinon.assert.callOrder(
-						instance.validate.withArgs({ required: true }),
-						stubs.verifyErrorPresence.withArgs(instance),
-						instance.validateInDb.withArgs(),
-						stubs.cypherQueriesShared.getValidateQuery.withArgs(instance.model),
-						stubs.dbQuery.withArgs({ query: 'getValidateQuery response', params: instance }),
-						stubs.verifyErrorPresence.withArgs(instance),
-						stubs.cypherQueriesShared.getCreateQuery.withArgs(instance.model),
-						stubs.prepareAsParams.withArgs(instance),
-						stubs.dbQuery.withArgs(
-							{ query: 'getCreateQuery response', params: 'prepareAsParams response' }
-						)
-					);
-					expect(instance.validate.calledOnce).to.be.true;
-					expect(stubs.verifyErrorPresence.calledTwice).to.be.true;
-					expect(instance.validateInDb.calledOnce).to.be.true;
-					expect(stubs.cypherQueriesShared.getValidateQuery.calledOnce).to.be.true;
-					expect(stubs.dbQuery.calledTwice).to.be.true;
-					expect(stubs.cypherQueriesShared.getCreateQuery.calledOnce).to.be.true;
-					expect(stubs.prepareAsParams.calledOnce).to.be.true;
-					expect(result).to.deep.eq(dbQueryFixture);
-					done();
-				});
+				const result = await instance.createUpdate(stubs.cypherQueriesShared.getCreateQuery)
+				sinon.assert.callOrder(
+					instance.validate.withArgs({ required: true }),
+					stubs.verifyErrorPresence.withArgs(instance),
+					instance.validateInDb.withArgs(),
+					stubs.cypherQueriesShared.getValidateQuery.withArgs(instance.model),
+					stubs.dbQuery.withArgs({ query: 'getValidateQuery response', params: instance }),
+					stubs.verifyErrorPresence.withArgs(instance),
+					stubs.cypherQueriesShared.getCreateQuery.withArgs(instance.model),
+					stubs.prepareAsParams.withArgs(instance),
+					stubs.dbQuery.withArgs(
+						{ query: 'getCreateQuery response', params: 'prepareAsParams response' }
+					)
+				);
+				expect(instance.validate.calledOnce).to.be.true;
+				expect(stubs.verifyErrorPresence.calledTwice).to.be.true;
+				expect(instance.validateInDb.calledOnce).to.be.true;
+				expect(stubs.cypherQueriesShared.getValidateQuery.calledOnce).to.be.true;
+				expect(stubs.dbQuery.calledTwice).to.be.true;
+				expect(stubs.cypherQueriesShared.getCreateQuery.calledOnce).to.be.true;
+				expect(stubs.prepareAsParams.calledOnce).to.be.true;
+				expect(result).to.deep.eq(dbQueryFixture);
 
 			});
 
-			it('will update', done => {
+			it('will update', async () => {
 
 				sinon.spy(instance, 'validate');
 				sinon.spy(instance, 'validateInDb');
-				instance.createUpdate(stubs.cypherQueriesShared.getUpdateQuery).then(result => {
-					sinon.assert.callOrder(
-						instance.validate.withArgs({ required: true }),
-						stubs.verifyErrorPresence.withArgs(instance),
-						instance.validateInDb.withArgs(),
-						stubs.cypherQueriesShared.getValidateQuery.withArgs(instance.model),
-						stubs.dbQuery.withArgs({ query: 'getValidateQuery response', params: instance }),
-						stubs.verifyErrorPresence.withArgs(instance),
-						stubs.cypherQueriesShared.getUpdateQuery.withArgs(instance.model),
-						stubs.prepareAsParams.withArgs(instance),
-						stubs.dbQuery.withArgs(
-							{ query: 'getUpdateQuery response', params: 'prepareAsParams response' }
-						)
-					);
-					expect(instance.validate.calledOnce).to.be.true;
-					expect(stubs.verifyErrorPresence.calledTwice).to.be.true;
-					expect(instance.validateInDb.calledOnce).to.be.true;
-					expect(stubs.cypherQueriesShared.getValidateQuery.calledOnce).to.be.true;
-					expect(stubs.dbQuery.calledTwice).to.be.true;
-					expect(stubs.cypherQueriesShared.getUpdateQuery.calledOnce).to.be.true;
-					expect(stubs.prepareAsParams.calledOnce).to.be.true;
-					expect(result).to.deep.eq(dbQueryFixture);
-					done();
-				});
+				const result = await instance.createUpdate(stubs.cypherQueriesShared.getUpdateQuery);
+				sinon.assert.callOrder(
+					instance.validate.withArgs({ required: true }),
+					stubs.verifyErrorPresence.withArgs(instance),
+					instance.validateInDb.withArgs(),
+					stubs.cypherQueriesShared.getValidateQuery.withArgs(instance.model),
+					stubs.dbQuery.withArgs({ query: 'getValidateQuery response', params: instance }),
+					stubs.verifyErrorPresence.withArgs(instance),
+					stubs.cypherQueriesShared.getUpdateQuery.withArgs(instance.model),
+					stubs.prepareAsParams.withArgs(instance),
+					stubs.dbQuery.withArgs(
+						{ query: 'getUpdateQuery response', params: 'prepareAsParams response' }
+					)
+				);
+				expect(instance.validate.calledOnce).to.be.true;
+				expect(stubs.verifyErrorPresence.calledTwice).to.be.true;
+				expect(instance.validateInDb.calledOnce).to.be.true;
+				expect(stubs.cypherQueriesShared.getValidateQuery.calledOnce).to.be.true;
+				expect(stubs.dbQuery.calledTwice).to.be.true;
+				expect(stubs.cypherQueriesShared.getUpdateQuery.calledOnce).to.be.true;
+				expect(stubs.prepareAsParams.calledOnce).to.be.true;
+				expect(result).to.deep.eq(dbQueryFixture);
 
 			});
 
@@ -235,7 +225,7 @@ describe('Base model', () => {
 
 			context('initial validation errors caused by submitted values', () => {
 
-				it('will return instance without creating/updating', done => {
+				it('will return instance without creating/updating', async () => {
 
 					const verifyErrorPresenceStub = sinon.stub().returns(true);
 					const getCreateUpdateQueryStub = sinon.stub();
@@ -243,20 +233,18 @@ describe('Base model', () => {
 					instance.model = 'theatre';
 					sinon.spy(instance, 'validate');
 					sinon.spy(instance, 'validateInDb');
-					instance.createUpdate(getCreateUpdateQueryStub).then(result => {
-						expect(instance.validate.calledBefore(verifyErrorPresenceStub)).to.be.true;
-						expect(instance.validate.calledOnce).to.be.true;
-						expect(instance.validate.calledWithExactly({ required: true })).to.be.true;
-						expect(verifyErrorPresenceStub.calledOnce).to.be.true;
-						expect(verifyErrorPresenceStub.calledWithExactly(instance)).to.be.true;
-						expect(instance.validateInDb.notCalled).to.be.true;
-						expect(stubs.cypherQueriesShared.getValidateQuery.notCalled).to.be.true;
-						expect(stubs.dbQuery.notCalled).to.be.true;
-						expect(getCreateUpdateQueryStub.notCalled).to.be.true;
-						expect(stubs.prepareAsParams.notCalled).to.be.true;
-						expect(result).to.deep.eq(instance);
-						done();
-					});
+					const result = await instance.createUpdate(getCreateUpdateQueryStub);
+					expect(instance.validate.calledBefore(verifyErrorPresenceStub)).to.be.true;
+					expect(instance.validate.calledOnce).to.be.true;
+					expect(instance.validate.calledWithExactly({ required: true })).to.be.true;
+					expect(verifyErrorPresenceStub.calledOnce).to.be.true;
+					expect(verifyErrorPresenceStub.calledWithExactly(instance)).to.be.true;
+					expect(instance.validateInDb.notCalled).to.be.true;
+					expect(stubs.cypherQueriesShared.getValidateQuery.notCalled).to.be.true;
+					expect(stubs.dbQuery.notCalled).to.be.true;
+					expect(getCreateUpdateQueryStub.notCalled).to.be.true;
+					expect(stubs.prepareAsParams.notCalled).to.be.true;
+					expect(result).to.deep.eq(instance);
 
 				});
 
@@ -264,7 +252,7 @@ describe('Base model', () => {
 
 			context('secondary validation errors caused by database checks', () => {
 
-				it('will return instance without creating/updating', done => {
+				it('will return instance without creating/updating', async () => {
 
 					const verifyErrorPresenceStub = sinon.stub();
 					verifyErrorPresenceStub.onFirstCall().returns(false).onSecondCall().returns(true);
@@ -273,25 +261,23 @@ describe('Base model', () => {
 					instance.model = 'theatre';
 					sinon.spy(instance, 'validate');
 					sinon.spy(instance, 'validateInDb');
-					instance.createUpdate(getCreateUpdateQueryStub).then(result => {
-						sinon.assert.callOrder(
-							instance.validate.withArgs({ required: true }),
-							verifyErrorPresenceStub.withArgs(instance),
-							instance.validateInDb.withArgs(),
-							stubs.cypherQueriesShared.getValidateQuery.withArgs(instance.model),
-							stubs.dbQuery.withArgs({ query: 'getValidateQuery response', params: instance }),
-							verifyErrorPresenceStub.withArgs(instance)
-						);
-						expect(instance.validate.calledOnce).to.be.true;
-						expect(verifyErrorPresenceStub.calledTwice).to.be.true;
-						expect(instance.validateInDb.calledOnce).to.be.true;
-						expect(stubs.cypherQueriesShared.getValidateQuery.calledOnce).to.be.true;
-						expect(stubs.dbQuery.calledOnce).to.be.true;
-						expect(getCreateUpdateQueryStub.notCalled).to.be.true;
-						expect(stubs.prepareAsParams.notCalled).to.be.true;
-						expect(result).to.deep.eq(instance);
-						done();
-					});
+					const result = await instance.createUpdate(getCreateUpdateQueryStub);
+					sinon.assert.callOrder(
+						instance.validate.withArgs({ required: true }),
+						verifyErrorPresenceStub.withArgs(instance),
+						instance.validateInDb.withArgs(),
+						stubs.cypherQueriesShared.getValidateQuery.withArgs(instance.model),
+						stubs.dbQuery.withArgs({ query: 'getValidateQuery response', params: instance }),
+						verifyErrorPresenceStub.withArgs(instance)
+					);
+					expect(instance.validate.calledOnce).to.be.true;
+					expect(verifyErrorPresenceStub.calledTwice).to.be.true;
+					expect(instance.validateInDb.calledOnce).to.be.true;
+					expect(stubs.cypherQueriesShared.getValidateQuery.calledOnce).to.be.true;
+					expect(stubs.dbQuery.calledOnce).to.be.true;
+					expect(getCreateUpdateQueryStub.notCalled).to.be.true;
+					expect(stubs.prepareAsParams.notCalled).to.be.true;
+					expect(result).to.deep.eq(instance);
 
 				});
 
@@ -305,17 +291,15 @@ describe('Base model', () => {
 
 		context('instance requires a model-specific query', () => {
 
-			it('will call createUpdate method with function to get model-specific create query as argument', done => {
+			it('will call createUpdate method with function to get model-specific create query as argument', async () => {
 
 				instance.model = 'production';
 				sinon.spy(instance, 'createUpdate');
-				instance.create().then(() => {
-					expect(instance.createUpdate.calledOnce).to.be.true;
-					expect(instance.createUpdate.calledWithExactly(
-						stubs.cypherQueriesModelSpecific.getCreateQueries[instance.model]
-					)).to.be.true;
-					done();
-				});
+				await instance.create();
+				expect(instance.createUpdate.calledOnce).to.be.true;
+				expect(instance.createUpdate.calledWithExactly(
+					stubs.cypherQueriesModelSpecific.getCreateQueries[instance.model]
+				)).to.be.true;
 
 			});
 
@@ -323,14 +307,12 @@ describe('Base model', () => {
 
 		context('instance can use shared query', () => {
 
-			it('will call createUpdate method with function to get shared create query as argument', done => {
+			it('will call createUpdate method with function to get shared create query as argument', async () => {
 
 				sinon.spy(instance, 'createUpdate');
-				instance.create().then(() => {
-					expect(instance.createUpdate.calledOnce).to.be.true;
-					expect(instance.createUpdate.calledWithExactly(stubs.cypherQueriesShared.getCreateQuery)).to.be.true;
-					done();
-				});
+				await instance.create();
+				expect(instance.createUpdate.calledOnce).to.be.true;
+				expect(instance.createUpdate.calledWithExactly(stubs.cypherQueriesShared.getCreateQuery)).to.be.true;
 
 			});
 
@@ -342,20 +324,18 @@ describe('Base model', () => {
 
 		context('instance requires a model-specific query', () => {
 
-			it('will get edit data using model-specific query', done => {
+			it('will get edit data using model-specific query', async () => {
 
 				instance.model = 'production';
-				instance.edit().then(result => {
-					expect(stubs.cypherQueriesModelSpecific.getEditQueries[instance.model].calledOnce).to.be.true;
-					expect(stubs.cypherQueriesModelSpecific.getEditQueries[instance.model].calledWithExactly()).to.be.true;
-					expect(stubs.cypherQueriesShared.getEditQuery.notCalled).to.be.true;
-					expect(stubs.dbQuery.calledOnce).to.be.true;
-					expect(stubs.dbQuery.calledWithExactly(
-						{ query: 'getEditProductionQuery response', params: instance }
-					)).to.be.true;
-					expect(result).to.deep.eq(dbQueryFixture);
-					done();
-				});
+				const result = await instance.edit();
+				expect(stubs.cypherQueriesModelSpecific.getEditQueries[instance.model].calledOnce).to.be.true;
+				expect(stubs.cypherQueriesModelSpecific.getEditQueries[instance.model].calledWithExactly()).to.be.true;
+				expect(stubs.cypherQueriesShared.getEditQuery.notCalled).to.be.true;
+				expect(stubs.dbQuery.calledOnce).to.be.true;
+				expect(stubs.dbQuery.calledWithExactly(
+					{ query: 'getEditProductionQuery response', params: instance }
+				)).to.be.true;
+				expect(result).to.deep.eq(dbQueryFixture);
 
 			});
 
@@ -363,19 +343,17 @@ describe('Base model', () => {
 
 		context('instance can use shared query', () => {
 
-			it('will get edit data using shared query', done => {
+			it('will get edit data using shared query', async () => {
 
-				instance.edit().then(result => {
-					expect(stubs.cypherQueriesShared.getEditQuery.calledOnce).to.be.true;
-					expect(stubs.cypherQueriesShared.getEditQuery.calledWithExactly(instance.model)).to.be.true;
-					expect(stubs.cypherQueriesModelSpecific.getEditQueries.production.notCalled).to.be.true;
-					expect(stubs.dbQuery.calledOnce).to.be.true;
-					expect(stubs.dbQuery.calledWithExactly(
-						{ query: 'getEditQuery response', params: instance }
-					)).to.be.true;
-					expect(result).to.deep.eq(dbQueryFixture);
-					done();
-				});
+				const result = await instance.edit();
+				expect(stubs.cypherQueriesShared.getEditQuery.calledOnce).to.be.true;
+				expect(stubs.cypherQueriesShared.getEditQuery.calledWithExactly(instance.model)).to.be.true;
+				expect(stubs.cypherQueriesModelSpecific.getEditQueries.production.notCalled).to.be.true;
+				expect(stubs.dbQuery.calledOnce).to.be.true;
+				expect(stubs.dbQuery.calledWithExactly(
+					{ query: 'getEditQuery response', params: instance }
+				)).to.be.true;
+				expect(result).to.deep.eq(dbQueryFixture);
 
 			});
 
@@ -387,17 +365,15 @@ describe('Base model', () => {
 
 		context('instance requires a model-specific query', () => {
 
-			it('will call createUpdate method with function to get model-specific update query as argument', done => {
+			it('will call createUpdate method with function to get model-specific update query as argument', async () => {
 
 				instance.model = 'production';
 				sinon.spy(instance, 'createUpdate');
-				instance.update().then(() => {
-					expect(instance.createUpdate.calledOnce).to.be.true;
-					expect(instance.createUpdate.calledWithExactly(
-						stubs.cypherQueriesModelSpecific.getUpdateQueries[instance.model]
-					)).to.be.true;
-					done();
-				});
+				await instance.update();
+				expect(instance.createUpdate.calledOnce).to.be.true;
+				expect(instance.createUpdate.calledWithExactly(
+					stubs.cypherQueriesModelSpecific.getUpdateQueries[instance.model]
+				)).to.be.true;
 
 			});
 
@@ -405,14 +381,12 @@ describe('Base model', () => {
 
 		context('instance can use shared query', () => {
 
-			it('will call createUpdate method with function to get shared update query as argument', done => {
+			it('will call createUpdate method with function to get shared update query as argument', async () => {
 
 				sinon.spy(instance, 'createUpdate');
-				instance.update().then(() => {
-					expect(instance.createUpdate.calledOnce).to.be.true;
-					expect(instance.createUpdate.calledWithExactly(stubs.cypherQueriesShared.getUpdateQuery)).to.be.true;
-					done();
-				});
+				await instance.update();
+				expect(instance.createUpdate.calledOnce).to.be.true;
+				expect(instance.createUpdate.calledWithExactly(stubs.cypherQueriesShared.getUpdateQuery)).to.be.true;
 
 			});
 
@@ -424,20 +398,18 @@ describe('Base model', () => {
 
 		context('instance requires a model-specific query', () => {
 
-			it('will delete using model-specific query', done => {
+			it('will delete using model-specific query', async () => {
 
 				instance.model = 'production';
-				instance.delete().then(result => {
-					expect(stubs.cypherQueriesModelSpecific.getDeleteQueries[instance.model].calledOnce).to.be.true;
-					expect(stubs.cypherQueriesModelSpecific.getDeleteQueries[instance.model].calledWithExactly()).to.be.true;
-					expect(stubs.cypherQueriesShared.getDeleteQuery.notCalled).to.be.true;
-					expect(stubs.dbQuery.calledOnce).to.be.true;
-					expect(stubs.dbQuery.calledWithExactly(
-						{ query: 'getDeleteProductionQuery response', params: instance }
-					)).to.be.true;
-					expect(result).to.deep.eq(dbQueryFixture);
-					done();
-				});
+				const result = await instance.delete();
+				expect(stubs.cypherQueriesModelSpecific.getDeleteQueries[instance.model].calledOnce).to.be.true;
+				expect(stubs.cypherQueriesModelSpecific.getDeleteQueries[instance.model].calledWithExactly()).to.be.true;
+				expect(stubs.cypherQueriesShared.getDeleteQuery.notCalled).to.be.true;
+				expect(stubs.dbQuery.calledOnce).to.be.true;
+				expect(stubs.dbQuery.calledWithExactly(
+					{ query: 'getDeleteProductionQuery response', params: instance }
+				)).to.be.true;
+				expect(result).to.deep.eq(dbQueryFixture);
 
 			});
 
@@ -445,19 +417,17 @@ describe('Base model', () => {
 
 		context('instance can use shared query', () => {
 
-			it('will delete using shared query', done => {
+			it('will delete using shared query', async () => {
 
-				instance.delete().then(result => {
-					expect(stubs.cypherQueriesShared.getDeleteQuery.calledOnce).to.be.true;
-					expect(stubs.cypherQueriesShared.getDeleteQuery.calledWithExactly(instance.model)).to.be.true;
-					expect(stubs.cypherQueriesModelSpecific.getDeleteQueries.production.notCalled).to.be.true;
-					expect(stubs.dbQuery.calledOnce).to.be.true;
-					expect(stubs.dbQuery.calledWithExactly(
-						{ query: 'getDeleteQuery response', params: instance }
-					)).to.be.true;
-					expect(result).to.deep.eq(dbQueryFixture);
-					done();
-				});
+				const result = await instance.delete();
+				expect(stubs.cypherQueriesShared.getDeleteQuery.calledOnce).to.be.true;
+				expect(stubs.cypherQueriesShared.getDeleteQuery.calledWithExactly(instance.model)).to.be.true;
+				expect(stubs.cypherQueriesModelSpecific.getDeleteQueries.production.notCalled).to.be.true;
+				expect(stubs.dbQuery.calledOnce).to.be.true;
+				expect(stubs.dbQuery.calledWithExactly(
+					{ query: 'getDeleteQuery response', params: instance }
+				)).to.be.true;
+				expect(result).to.deep.eq(dbQueryFixture);
 
 			});
 
@@ -467,18 +437,16 @@ describe('Base model', () => {
 
 	describe('show method', () => {
 
-		it('will get show data', done => {
+		it('will get show data', async () => {
 
-			instance.show().then(result => {
-				expect(stubs.cypherQueriesModelSpecific.getShowQueries.theatre.calledOnce).to.be.true;
-				expect(stubs.cypherQueriesModelSpecific.getShowQueries.theatre.calledWithExactly()).to.be.true;
-				expect(stubs.dbQuery.calledOnce).to.be.true;
-				expect(stubs.dbQuery.calledWithExactly(
-					{ query: 'getShowTheatreQuery response', params: instance }
-				)).to.be.true;
-				expect(result).to.deep.eq(dbQueryFixture);
-				done();
-			});
+			const result = await instance.show();
+			expect(stubs.cypherQueriesModelSpecific.getShowQueries.theatre.calledOnce).to.be.true;
+			expect(stubs.cypherQueriesModelSpecific.getShowQueries.theatre.calledWithExactly()).to.be.true;
+			expect(stubs.dbQuery.calledOnce).to.be.true;
+			expect(stubs.dbQuery.calledWithExactly(
+				{ query: 'getShowTheatreQuery response', params: instance }
+			)).to.be.true;
+			expect(result).to.deep.eq(dbQueryFixture);
 
 		});
 
@@ -486,19 +454,17 @@ describe('Base model', () => {
 
 	describe('list method', () => {
 
-		it('will get list data', done => {
+		it('will get list data', async () => {
 
 			const subject = createSubject();
-			subject.list('model').then(result => {
-				expect(stubs.cypherQueriesShared.getListQuery.calledOnce).to.be.true;
-				expect(stubs.cypherQueriesShared.getListQuery.calledWithExactly('model')).to.be.true;
-				expect(stubs.dbQuery.calledOnce).to.be.true;
-				expect(stubs.dbQuery.calledWithExactly(
-					{ query: 'getListQuery response' }, { isReqdResult: false, returnArray: true }
-				)).to.be.true;
-				expect(result).to.deep.eq(dbQueryFixture);
-				done();
-			});
+			const result = await subject.list('model');
+			expect(stubs.cypherQueriesShared.getListQuery.calledOnce).to.be.true;
+			expect(stubs.cypherQueriesShared.getListQuery.calledWithExactly('model')).to.be.true;
+			expect(stubs.dbQuery.calledOnce).to.be.true;
+			expect(stubs.dbQuery.calledWithExactly(
+				{ query: 'getListQuery response' }, { isReqdResult: false, returnArray: true }
+			)).to.be.true;
+			expect(result).to.deep.eq(dbQueryFixture);
 
 		});
 

--- a/spec/server/models/playtext.spec.js
+++ b/spec/server/models/playtext.spec.js
@@ -132,55 +132,51 @@ describe('Playtext model', () => {
 
 		context('valid data', () => {
 
-			it('will create using provided function to get appropriate query', done => {
+			it('will create using provided function to get appropriate query', async () => {
 
 				const getCreateQueryStub = sinon.stub().returns('getCreateQuery response');
 				sinon.spy(instance, 'setErrorStatus');
 				sinon.spy(instance, 'validateInDb');
-				instance.createUpdate(getCreateQueryStub).then(result => {
-					sinon.assert.callOrder(
-						instance.setErrorStatus.withArgs(),
-						instance.validateInDb.withArgs(),
-						stubs.verifyErrorPresence.withArgs(instance),
-						getCreateQueryStub.withArgs(),
-						stubs.prepareAsParams.withArgs(instance),
-						stubs.dbQuery.withArgs({ query: 'getCreateQuery response', params: 'prepareAsParams response' })
-					);
-					expect(instance.setErrorStatus.calledOnce).to.be.true;
-					expect(instance.validateInDb.calledOnce).to.be.true;
-					expect(stubs.verifyErrorPresence.calledTwice).to.be.true;
-					expect(getCreateQueryStub.calledOnce).to.be.true;
-					expect(stubs.prepareAsParams.calledOnce).to.be.true;
-					expect(stubs.dbQuery.calledOnce).to.be.true;
-					expect(result).to.deep.eq(dbQueryFixture);
-					done();
-				});
+				const result = await instance.createUpdate(getCreateQueryStub);
+				sinon.assert.callOrder(
+					instance.setErrorStatus.withArgs(),
+					instance.validateInDb.withArgs(),
+					stubs.verifyErrorPresence.withArgs(instance),
+					getCreateQueryStub.withArgs(),
+					stubs.prepareAsParams.withArgs(instance),
+					stubs.dbQuery.withArgs({ query: 'getCreateQuery response', params: 'prepareAsParams response' })
+				);
+				expect(instance.setErrorStatus.calledOnce).to.be.true;
+				expect(instance.validateInDb.calledOnce).to.be.true;
+				expect(stubs.verifyErrorPresence.calledTwice).to.be.true;
+				expect(getCreateQueryStub.calledOnce).to.be.true;
+				expect(stubs.prepareAsParams.calledOnce).to.be.true;
+				expect(stubs.dbQuery.calledOnce).to.be.true;
+				expect(result).to.deep.eq(dbQueryFixture);
 
 			});
 
-			it('will update using provided function to get appropriate query', done => {
+			it('will update using provided function to get appropriate query', async () => {
 
 				const getUpdateQueryStub = sinon.stub().returns('getUpdateQuery response');
 				sinon.spy(instance, 'setErrorStatus');
 				sinon.spy(instance, 'validateInDb');
-				instance.createUpdate(getUpdateQueryStub).then(result => {
-					sinon.assert.callOrder(
-						instance.setErrorStatus.withArgs(),
-						instance.validateInDb.withArgs(),
-						stubs.verifyErrorPresence.withArgs(instance),
-						getUpdateQueryStub.withArgs(),
-						stubs.prepareAsParams.withArgs(instance),
-						stubs.dbQuery.withArgs({ query: 'getUpdateQuery response', params: 'prepareAsParams response' })
-					);
-					expect(instance.setErrorStatus.calledOnce).to.be.true;
-					expect(instance.validateInDb.calledOnce).to.be.true;
-					expect(stubs.verifyErrorPresence.calledTwice).to.be.true;
-					expect(getUpdateQueryStub.calledOnce).to.be.true;
-					expect(stubs.prepareAsParams.calledOnce).to.be.true;
-					expect(stubs.dbQuery.calledOnce).to.be.true;
-					expect(result).to.deep.eq(dbQueryFixture);
-					done();
-				});
+				const result = await instance.createUpdate(getUpdateQueryStub);
+				sinon.assert.callOrder(
+					instance.setErrorStatus.withArgs(),
+					instance.validateInDb.withArgs(),
+					stubs.verifyErrorPresence.withArgs(instance),
+					getUpdateQueryStub.withArgs(),
+					stubs.prepareAsParams.withArgs(instance),
+					stubs.dbQuery.withArgs({ query: 'getUpdateQuery response', params: 'prepareAsParams response' })
+				);
+				expect(instance.setErrorStatus.calledOnce).to.be.true;
+				expect(instance.validateInDb.calledOnce).to.be.true;
+				expect(stubs.verifyErrorPresence.calledTwice).to.be.true;
+				expect(getUpdateQueryStub.calledOnce).to.be.true;
+				expect(stubs.prepareAsParams.calledOnce).to.be.true;
+				expect(stubs.dbQuery.calledOnce).to.be.true;
+				expect(result).to.deep.eq(dbQueryFixture);
 
 			});
 
@@ -190,23 +186,21 @@ describe('Playtext model', () => {
 
 			context('initial validation errors caused by submitted values', () => {
 
-				it('will return instance without creating', done => {
+				it('will return instance without creating', async () => {
 
 					const verifyErrorPresenceStub = sinon.stub().returns(true);
 					const getCreateUpdateQueryStub = sinon.stub();
 					instance = createInstance({ verifyErrorPresence: verifyErrorPresenceStub });
 					sinon.spy(instance, 'setErrorStatus');
 					sinon.spy(instance, 'validateInDb');
-					instance.createUpdate(getCreateUpdateQueryStub).then(result => {
-						expect(instance.setErrorStatus.calledOnce).to.be.true;
-						expect(verifyErrorPresenceStub.calledOnce).to.be.true;
-						expect(instance.validateInDb.notCalled).to.be.true;
-						expect(getCreateUpdateQueryStub.notCalled).to.be.true;
-						expect(stubs.prepareAsParams.notCalled).to.be.true;
-						expect(stubs.dbQuery.notCalled).to.be.true;
-						expect(result).to.deep.eq(instance);
-						done();
-					});
+					const result = await instance.createUpdate(getCreateUpdateQueryStub);
+					expect(instance.setErrorStatus.calledOnce).to.be.true;
+					expect(verifyErrorPresenceStub.calledOnce).to.be.true;
+					expect(instance.validateInDb.notCalled).to.be.true;
+					expect(getCreateUpdateQueryStub.notCalled).to.be.true;
+					expect(stubs.prepareAsParams.notCalled).to.be.true;
+					expect(stubs.dbQuery.notCalled).to.be.true;
+					expect(result).to.deep.eq(instance);
 
 				});
 
@@ -214,7 +208,7 @@ describe('Playtext model', () => {
 
 			context('secondary validation errors caused by database checks', () => {
 
-				it('will return instance without creating', done => {
+				it('will return instance without creating', async () => {
 
 					const verifyErrorPresenceStub = sinon.stub();
 					verifyErrorPresenceStub.onFirstCall().returns(false).onSecondCall().returns(true);
@@ -222,21 +216,19 @@ describe('Playtext model', () => {
 					instance = createInstance({ verifyErrorPresence: verifyErrorPresenceStub });
 					sinon.spy(instance, 'setErrorStatus');
 					sinon.spy(instance, 'validateInDb');
-					instance.createUpdate(getCreateUpdateQueryStub).then(result => {
-						sinon.assert.callOrder(
-							instance.setErrorStatus.withArgs(),
-							instance.validateInDb.withArgs(),
-							verifyErrorPresenceStub.withArgs(instance)
-						);
-						expect(instance.setErrorStatus.calledOnce).to.be.true;
-						expect(instance.validateInDb.calledOnce).to.be.true;
-						expect(verifyErrorPresenceStub.calledTwice).to.be.true;
-						expect(getCreateUpdateQueryStub.notCalled).to.be.true;
-						expect(stubs.prepareAsParams.notCalled).to.be.true;
-						expect(stubs.dbQuery.notCalled).to.be.true;
-						expect(result).to.deep.eq(instance);
-						done();
-					});
+					const result = await instance.createUpdate(getCreateUpdateQueryStub);
+					sinon.assert.callOrder(
+						instance.setErrorStatus.withArgs(),
+						instance.validateInDb.withArgs(),
+						verifyErrorPresenceStub.withArgs(instance)
+					);
+					expect(instance.setErrorStatus.calledOnce).to.be.true;
+					expect(instance.validateInDb.calledOnce).to.be.true;
+					expect(verifyErrorPresenceStub.calledTwice).to.be.true;
+					expect(getCreateUpdateQueryStub.notCalled).to.be.true;
+					expect(stubs.prepareAsParams.notCalled).to.be.true;
+					expect(stubs.dbQuery.notCalled).to.be.true;
+					expect(result).to.deep.eq(instance);
 
 				});
 

--- a/spec/server/models/production.spec.js
+++ b/spec/server/models/production.spec.js
@@ -155,45 +155,41 @@ describe('Production model', () => {
 
 		context('valid data', () => {
 
-			it('will create using provided function to get appropriate query', done => {
+			it('will create using provided function to get appropriate query', async () => {
 
 				const getCreateQueryStub = sinon.stub().returns('getCreateQuery response');
 				sinon.spy(instance, 'setErrorStatus');
-				instance.createUpdate(getCreateQueryStub).then(result => {
-					sinon.assert.callOrder(
-						instance.setErrorStatus.withArgs(),
-						getCreateQueryStub.withArgs(),
-						stubs.prepareAsParams.withArgs(instance),
-						stubs.dbQuery.withArgs({ query: 'getCreateQuery response', params: 'prepareAsParams response' })
-					);
-					expect(instance.setErrorStatus.calledOnce).to.be.true;
-					expect(getCreateQueryStub.calledOnce).to.be.true;
-					expect(stubs.prepareAsParams.calledOnce).to.be.true;
-					expect(stubs.dbQuery.calledOnce).to.be.true;
-					expect(result).to.deep.eq(dbQueryFixture);
-					done();
-				});
+				const result = await instance.createUpdate(getCreateQueryStub);
+				sinon.assert.callOrder(
+					instance.setErrorStatus.withArgs(),
+					getCreateQueryStub.withArgs(),
+					stubs.prepareAsParams.withArgs(instance),
+					stubs.dbQuery.withArgs({ query: 'getCreateQuery response', params: 'prepareAsParams response' })
+				);
+				expect(instance.setErrorStatus.calledOnce).to.be.true;
+				expect(getCreateQueryStub.calledOnce).to.be.true;
+				expect(stubs.prepareAsParams.calledOnce).to.be.true;
+				expect(stubs.dbQuery.calledOnce).to.be.true;
+				expect(result).to.deep.eq(dbQueryFixture);
 
 			});
 
-			it('will update using provided function to get appropriate query', done => {
+			it('will update using provided function to get appropriate query', async () => {
 
 				const getUpdateQueryStub = sinon.stub().returns('getUpdateQuery response');
 				sinon.spy(instance, 'setErrorStatus');
-				instance.createUpdate(getUpdateQueryStub).then(result => {
-					sinon.assert.callOrder(
-						instance.setErrorStatus.withArgs(),
-						getUpdateQueryStub.withArgs(),
-						stubs.prepareAsParams.withArgs(instance),
-						stubs.dbQuery.withArgs({ query: 'getUpdateQuery response', params: 'prepareAsParams response' })
-					);
-					expect(instance.setErrorStatus.calledOnce).to.be.true;
-					expect(getUpdateQueryStub.calledOnce).to.be.true;
-					expect(stubs.prepareAsParams.calledOnce).to.be.true;
-					expect(stubs.dbQuery.calledOnce).to.be.true;
-					expect(result).to.deep.eq(dbQueryFixture);
-					done();
-				});
+				const result = await instance.createUpdate(getUpdateQueryStub);
+				sinon.assert.callOrder(
+					instance.setErrorStatus.withArgs(),
+					getUpdateQueryStub.withArgs(),
+					stubs.prepareAsParams.withArgs(instance),
+					stubs.dbQuery.withArgs({ query: 'getUpdateQuery response', params: 'prepareAsParams response' })
+				);
+				expect(instance.setErrorStatus.calledOnce).to.be.true;
+				expect(getUpdateQueryStub.calledOnce).to.be.true;
+				expect(stubs.prepareAsParams.calledOnce).to.be.true;
+				expect(stubs.dbQuery.calledOnce).to.be.true;
+				expect(result).to.deep.eq(dbQueryFixture);
 
 			});
 
@@ -201,20 +197,18 @@ describe('Production model', () => {
 
 		context('invalid data', () => {
 
-			it('will return instance without creating', done => {
+			it('will return instance without creating', async () => {
 
 				const getCreateUpdateQueryStub = sinon.stub();
 				instance = createInstance({ verifyErrorPresence: sinon.stub().returns(true) });
 				sinon.spy(instance, 'setErrorStatus');
-				instance.createUpdate(getCreateUpdateQueryStub).then(result => {
-					expect(instance.setErrorStatus.calledOnce).to.be.true;
-					expect(instance.setErrorStatus.calledWithExactly()).to.be.true;
-					expect(getCreateUpdateQueryStub.notCalled).to.be.true;
-					expect(stubs.prepareAsParams.notCalled).to.be.true;
-					expect(stubs.dbQuery.notCalled).to.be.true;
-					expect(result).to.deep.eq(instance);
-					done();
-				});
+				const result = await instance.createUpdate(getCreateUpdateQueryStub);
+				expect(instance.setErrorStatus.calledOnce).to.be.true;
+				expect(instance.setErrorStatus.calledWithExactly()).to.be.true;
+				expect(getCreateUpdateQueryStub.notCalled).to.be.true;
+				expect(stubs.prepareAsParams.notCalled).to.be.true;
+				expect(stubs.dbQuery.notCalled).to.be.true;
+				expect(result).to.deep.eq(instance);
 
 			});
 

--- a/spec/server/models/theatre.spec.js
+++ b/spec/server/models/theatre.spec.js
@@ -44,30 +44,26 @@ describe('Theatre model', () => {
 
 	describe('validateDeleteInDb method', () => {
 
-		it('will validate delete in database', done => {
+		it('will validate delete in database', async () => {
 
-			instance.validateDeleteInDb().then(() => {
-				expect(stubs.cypherQueriesTheatre.getValidateDeleteQuery.calledOnce).to.be.true;
-				expect(stubs.cypherQueriesTheatre.getValidateDeleteQuery.calledWithExactly()).to.be.true;
-				expect(stubs.dbQuery.calledOnce).to.be.true;
-				expect(stubs.dbQuery.calledWithExactly(
-					{ query: 'getValidateDeleteQuery response', params: instance }
-				)).to.be.true;
-				done();
-			});
+			await instance.validateDeleteInDb();
+			expect(stubs.cypherQueriesTheatre.getValidateDeleteQuery.calledOnce).to.be.true;
+			expect(stubs.cypherQueriesTheatre.getValidateDeleteQuery.calledWithExactly()).to.be.true;
+			expect(stubs.dbQuery.calledOnce).to.be.true;
+			expect(stubs.dbQuery.calledWithExactly(
+				{ query: 'getValidateDeleteQuery response', params: instance }
+			)).to.be.true;
 
 		});
 
 		context('valid data (results returned that indicate no dependent associations exist)', () => {
 
-			it('will not add properties to errors property', done => {
+			it('will not add properties to errors property', async () => {
 
 				instance = createInstance({ dbQuery: sinon.stub().resolves({ relationshipCount: 0 }) });
-				instance.validateDeleteInDb().then(() => {
-					expect(instance.errors).not.to.have.property('associations');
-					expect(instance.errors).to.deep.eq({});
-					done();
-				});
+				await instance.validateDeleteInDb();
+				expect(instance.errors).not.to.have.property('associations');
+				expect(instance.errors).to.deep.eq({});
 
 			});
 
@@ -75,16 +71,14 @@ describe('Theatre model', () => {
 
 		context('invalid data (results returned that indicate dependent associations exist)', () => {
 
-			it('will add properties that are arrays to errors property', done => {
+			it('will add properties that are arrays to errors property', async () => {
 
 				instance = createInstance({ dbQuery: sinon.stub().resolves({ relationshipCount: 1 }) });
-				instance.validateDeleteInDb().then(() => {
-					expect(instance.errors)
-						.to.have.property('associations')
-						.that.is.an('array')
-						.that.deep.eq(['productions']);
-					done();
-				});
+				await instance.validateDeleteInDb();
+				expect(instance.errors)
+					.to.have.property('associations')
+					.that.is.an('array')
+					.that.deep.eq(['productions']);
 
 			});
 
@@ -96,26 +90,24 @@ describe('Theatre model', () => {
 
 		context('no dependent associations', () => {
 
-			it('will delete', done => {
+			it('will delete', async () => {
 
 				sinon.spy(instance, 'validateDeleteInDb');
-				instance.delete().then(result => {
-					sinon.assert.callOrder(
-						instance.validateDeleteInDb.withArgs(),
-						stubs.cypherQueriesTheatre.getValidateDeleteQuery.withArgs(),
-						stubs.dbQuery.withArgs({ query: 'getValidateDeleteQuery response', params: instance }),
-						stubs.verifyErrorPresence.withArgs(instance),
-						stubs.cypherQueriesShared.getDeleteQuery.withArgs(instance.model),
-						stubs.dbQuery.withArgs({ query: 'getDeleteQuery response', params: instance })
-					);
-					expect(instance.validateDeleteInDb.calledOnce).to.be.true;
-					expect(stubs.cypherQueriesTheatre.getValidateDeleteQuery.calledOnce).to.be.true;
-					expect(stubs.dbQuery.calledTwice).to.be.true;
-					expect(stubs.verifyErrorPresence.calledOnce).to.be.true;
-					expect(stubs.cypherQueriesShared.getDeleteQuery.calledOnce).to.be.true;
-					expect(result).to.deep.eq(dbQueryFixture);
-					done();
-				});
+				const result = await instance.delete();
+				sinon.assert.callOrder(
+					instance.validateDeleteInDb.withArgs(),
+					stubs.cypherQueriesTheatre.getValidateDeleteQuery.withArgs(),
+					stubs.dbQuery.withArgs({ query: 'getValidateDeleteQuery response', params: instance }),
+					stubs.verifyErrorPresence.withArgs(instance),
+					stubs.cypherQueriesShared.getDeleteQuery.withArgs(instance.model),
+					stubs.dbQuery.withArgs({ query: 'getDeleteQuery response', params: instance })
+				);
+				expect(instance.validateDeleteInDb.calledOnce).to.be.true;
+				expect(stubs.cypherQueriesTheatre.getValidateDeleteQuery.calledOnce).to.be.true;
+				expect(stubs.dbQuery.calledTwice).to.be.true;
+				expect(stubs.verifyErrorPresence.calledOnce).to.be.true;
+				expect(stubs.cypherQueriesShared.getDeleteQuery.calledOnce).to.be.true;
+				expect(result).to.deep.eq(dbQueryFixture);
 
 			});
 
@@ -123,26 +115,24 @@ describe('Theatre model', () => {
 
 		context('dependent associations', () => {
 
-			it('will return instance without deleting', done => {
+			it('will return instance without deleting', async () => {
 
 				const verifyErrorPresenceStub = sinon.stub().returns(true);
 				instance = createInstance({ verifyErrorPresence: verifyErrorPresenceStub });
 				sinon.spy(instance, 'validateDeleteInDb');
-				instance.delete().then(result => {
-					sinon.assert.callOrder(
-						instance.validateDeleteInDb.withArgs(),
-						stubs.cypherQueriesTheatre.getValidateDeleteQuery.withArgs(),
-						stubs.dbQuery.withArgs({ query: 'getValidateDeleteQuery response', params: instance }),
-						verifyErrorPresenceStub.withArgs(instance)
-					);
-					expect(instance.validateDeleteInDb.calledOnce).to.be.true;
-					expect(stubs.cypherQueriesTheatre.getValidateDeleteQuery.calledOnce).to.be.true;
-					expect(stubs.dbQuery.calledOnce).to.be.true;
-					expect(verifyErrorPresenceStub.calledOnce).to.be.true;
-					expect(stubs.cypherQueriesShared.getDeleteQuery.notCalled).to.be.true;
-					expect(result).to.deep.eq({ theatre: instance });
-					done();
-				});
+				const result = await instance.delete();
+				sinon.assert.callOrder(
+					instance.validateDeleteInDb.withArgs(),
+					stubs.cypherQueriesTheatre.getValidateDeleteQuery.withArgs(),
+					stubs.dbQuery.withArgs({ query: 'getValidateDeleteQuery response', params: instance }),
+					verifyErrorPresenceStub.withArgs(instance)
+				);
+				expect(instance.validateDeleteInDb.calledOnce).to.be.true;
+				expect(stubs.cypherQueriesTheatre.getValidateDeleteQuery.calledOnce).to.be.true;
+				expect(stubs.dbQuery.calledOnce).to.be.true;
+				expect(verifyErrorPresenceStub.calledOnce).to.be.true;
+				expect(stubs.cypherQueriesShared.getDeleteQuery.notCalled).to.be.true;
+				expect(result).to.deep.eq({ theatre: instance });
 
 			});
 


### PR DESCRIPTION
Applies ES2017 (ES8) `async/await` syntax for promise handling.

#### References:
- [Stack Overflow: Babel 6 regeneratorRuntime is not defined](https://stackoverflow.com/questions/33527653/babel-6-regeneratorruntime-is-not-defined#answer-33527883): "`babel-polyfill` is required".
- [Babel: @babel/polyfill](https://babeljs.io/docs/en/babel-polyfill): "As of Babel 7.4.0, this package has been deprecated in favor of directly including `core-js/stable` (to polyfill ECMAScript features) and `regenerator-runtime/runtime` (needed to use transpiled generator functions)".
- [GitHub: esline/eslint: Issues: Error with async: "Parsing error: Unexpected token =>"](https://github.com/eslint/eslint/issues/8126#issuecomment-281559970): "you should use `ecmaVersion: 8` or `ecmaVersion: 2017` in your config".
- [Medium: Enabling Async/Await and Generator Functions in Babel and Node JS by Binyamin](https://medium.com/@binyamin/enabling-async-await-and-generator-functions-in-babel-node-and-express-71e941b183e2): `.babelrc` changes required to prevent `Uncaught ReferenceError: regeneratorRuntime is not defined`.

#### New dependencies:
- [npm: core-js](https://www.npmjs.com/package/core-js).
- [npm: regenerator-runtime](https://www.npmjs.com/package/regenerator-runtime).