### PR TITLE
Import Sinon methods individually

### DIFF
--- a/spec/server/lib/call-class-methods.spec.js
+++ b/spec/server/lib/call-class-methods.spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import httpMocks from 'node-mocks-http';
-import sinon from 'sinon';
+import { createSandbox } from 'sinon';
 
 import * as callClassMethods from '../../../server/lib/call-class-methods';
 import * as renderJsonModule from '../../../server/lib/render-json';
@@ -13,7 +13,7 @@ describe('Call Class Methods module', () => {
 	const err = new Error('errorText');
 	const notFoundErr = new Error('Not Found');
 
-	const sandbox = sinon.createSandbox();
+	const sandbox = createSandbox();
 
 	beforeEach(() => {
 

--- a/spec/server/lib/prepare-as-params.spec.js
+++ b/spec/server/lib/prepare-as-params.spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import sinon from 'sinon';
+import { assert, createSandbox } from 'sinon';
 import { v4 as uuid } from 'uuid';
 
 import * as isObjectModule from '../../../server/lib/is-object';
@@ -9,7 +9,7 @@ describe('Prepare As Params module', () => {
 
 	let stubs;
 
-	const sandbox = sinon.createSandbox();
+	const sandbox = createSandbox();
 
 	beforeEach(() => {
 
@@ -101,7 +101,7 @@ describe('Prepare As Params module', () => {
 			const instance = { theatre: { uuid: '' } };
 			const result = prepareAsParams(instance);
 			expect(stubs.isObject.calledTwice).to.be.true;
-			sinon.assert.calledWithExactly(stubs.isObject.secondCall, '');
+			assert.calledWithExactly(stubs.isObject.secondCall, '');
 			expect(stubs.uuid.calledOnce).to.be.true;
 			expect(result.theatre.uuid).to.eq('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
 
@@ -113,7 +113,7 @@ describe('Prepare As Params module', () => {
 			const instance = { theatre: { uuid: undefined } };
 			const result = prepareAsParams(instance);
 			expect(stubs.isObject.calledTwice).to.be.true;
-			sinon.assert.calledWithExactly(stubs.isObject.secondCall, undefined);
+			assert.calledWithExactly(stubs.isObject.secondCall, undefined);
 			expect(stubs.uuid.calledOnce).to.be.true;
 			expect(result.theatre.uuid).to.eq('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
 
@@ -125,7 +125,7 @@ describe('Prepare As Params module', () => {
 			const instance = { theatre: { uuid: 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy' } };
 			const result = prepareAsParams(instance);
 			expect(stubs.isObject.calledTwice).to.be.true;
-			sinon.assert.calledWithExactly(stubs.isObject.secondCall, 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy');
+			assert.calledWithExactly(stubs.isObject.secondCall, 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy');
 			expect(stubs.uuid.called).to.be.false;
 			expect(result.theatre.uuid).to.eq('yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy');
 
@@ -137,7 +137,7 @@ describe('Prepare As Params module', () => {
 			const instance = { theatre: { foo: '' } };
 			const result = prepareAsParams(instance);
 			expect(stubs.isObject.calledTwice).to.be.true;
-			sinon.assert.calledWithExactly(stubs.isObject.secondCall, '');
+			assert.calledWithExactly(stubs.isObject.secondCall, '');
 			expect(stubs.uuid.called).to.be.false;
 			expect(result.theatre.foo).to.eq('');
 
@@ -168,7 +168,7 @@ describe('Prepare As Params module', () => {
 			const instance = { cast: [{ uuid: '' }] };
 			const result = prepareAsParams(instance);
 			expect(stubs.isObject.callCount).to.eq(4);
-			sinon.assert.calledWithExactly(stubs.isObject.thirdCall, '');
+			assert.calledWithExactly(stubs.isObject.thirdCall, '');
 			expect(stubs.uuid.calledOnce).to.be.true;
 			expect(result.cast[0].uuid).to.eq('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
 
@@ -184,7 +184,7 @@ describe('Prepare As Params module', () => {
 			const instance = { cast: [{ uuid: undefined }] };
 			const result = prepareAsParams(instance);
 			expect(stubs.isObject.callCount).to.eq(4);
-			sinon.assert.calledWithExactly(stubs.isObject.thirdCall, undefined);
+			assert.calledWithExactly(stubs.isObject.thirdCall, undefined);
 			expect(stubs.uuid.calledOnce).to.be.true;
 			expect(result.cast[0].uuid).to.eq('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
 
@@ -200,7 +200,7 @@ describe('Prepare As Params module', () => {
 			const instance = { cast: [{ uuid: 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy' }] };
 			const result = prepareAsParams(instance);
 			expect(stubs.isObject.callCount).to.eq(4);
-			sinon.assert.calledWithExactly(stubs.isObject.thirdCall, 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy');
+			assert.calledWithExactly(stubs.isObject.thirdCall, 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy');
 			expect(stubs.uuid.called).to.be.false;
 			expect(result.cast[0].uuid).to.eq('yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy');
 
@@ -216,7 +216,7 @@ describe('Prepare As Params module', () => {
 			const instance = { cast: [{ foo: '' }] }
 			const result = prepareAsParams(instance);
 			expect(stubs.isObject.callCount).to.eq(4);
-			sinon.assert.calledWithExactly(stubs.isObject.thirdCall, '');
+			assert.calledWithExactly(stubs.isObject.thirdCall, '');
 			expect(stubs.uuid.called).to.be.false;
 			expect(result.cast[0].foo).to.eq('');
 
@@ -232,7 +232,7 @@ describe('Prepare As Params module', () => {
 			const instance = { cast: [{ uuid: '' }] };
 			const result = prepareAsParams(instance);
 			expect(stubs.isObject.callCount).to.eq(4);
-			sinon.assert.calledWithExactly(stubs.isObject.lastCall, 0);
+			assert.calledWithExactly(stubs.isObject.lastCall, 0);
 			expect(stubs.uuid.calledOnce).to.be.true;
 			expect(result.cast[0].position).to.eq(0);
 
@@ -253,7 +253,7 @@ describe('Prepare As Params module', () => {
 			const instance = { playtext: { roles: [{ uuid: '' }] } };
 			const result = prepareAsParams(instance);
 			expect(stubs.isObject.callCount).to.eq(5);
-			sinon.assert.calledWithExactly(stubs.isObject.getCall(3), '');
+			assert.calledWithExactly(stubs.isObject.getCall(3), '');
 			expect(stubs.uuid.calledOnce).to.be.true;
 			expect(result.playtext.roles[0].uuid).to.eq('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
 
@@ -270,7 +270,7 @@ describe('Prepare As Params module', () => {
 			const instance = { playtext: { roles: [{ uuid: undefined }] } };
 			const result = prepareAsParams(instance);
 			expect(stubs.isObject.callCount).to.eq(5);
-			sinon.assert.calledWithExactly(stubs.isObject.getCall(3), undefined);
+			assert.calledWithExactly(stubs.isObject.getCall(3), undefined);
 			expect(stubs.uuid.calledOnce).to.be.true;
 			expect(result.playtext.roles[0].uuid).to.eq('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
 
@@ -287,7 +287,7 @@ describe('Prepare As Params module', () => {
 			const instance = { playtext: { roles: [{ uuid: 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy' }] } };
 			const result = prepareAsParams(instance);
 			expect(stubs.isObject.callCount).to.eq(5);
-			sinon.assert.calledWithExactly(stubs.isObject.getCall(3), 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy');
+			assert.calledWithExactly(stubs.isObject.getCall(3), 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy');
 			expect(stubs.uuid.called).to.be.false;
 			expect(result.playtext.roles[0].uuid).to.eq('yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy');
 
@@ -304,7 +304,7 @@ describe('Prepare As Params module', () => {
 			const instance = { playtext: { roles: [{ foo: '' }] } };
 			const result = prepareAsParams(instance);
 			expect(stubs.isObject.callCount).to.eq(5);
-			sinon.assert.calledWithExactly(stubs.isObject.getCall(3), '');
+			assert.calledWithExactly(stubs.isObject.getCall(3), '');
 			expect(stubs.uuid.called).to.be.false;
 			expect(result.playtext.roles[0].foo).to.eq('');
 
@@ -321,7 +321,7 @@ describe('Prepare As Params module', () => {
 			const instance = { playtext: { roles: [{ uuid: '' }] } };
 			const result = prepareAsParams(instance);
 			expect(stubs.isObject.callCount).to.eq(5);
-			sinon.assert.calledWithExactly(stubs.isObject.lastCall, 0);
+			assert.calledWithExactly(stubs.isObject.lastCall, 0);
 			expect(stubs.uuid.calledOnce).to.be.true;
 			expect(result.playtext.roles[0].position).to.eq(0);
 
@@ -344,7 +344,7 @@ describe('Prepare As Params module', () => {
 			const instance = { cast: [{ roles: [{ uuid: '' }] }] };
 			const result = prepareAsParams(instance);
 			expect(stubs.isObject.callCount).to.eq(7);
-			sinon.assert.calledWithExactly(stubs.isObject.getCall(4), '');
+			assert.calledWithExactly(stubs.isObject.getCall(4), '');
 			expect(stubs.uuid.calledOnce).to.be.true;
 			expect(result.cast[0].roles[0].uuid).to.eq('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
 
@@ -363,7 +363,7 @@ describe('Prepare As Params module', () => {
 			const instance = { cast: [{ roles: [{ uuid: undefined }] }] };
 			const result = prepareAsParams(instance);
 			expect(stubs.isObject.callCount).to.eq(7);
-			sinon.assert.calledWithExactly(stubs.isObject.getCall(4), undefined);
+			assert.calledWithExactly(stubs.isObject.getCall(4), undefined);
 			expect(stubs.uuid.calledOnce).to.be.true;
 			expect(result.cast[0].roles[0].uuid).to.eq('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
 
@@ -382,7 +382,7 @@ describe('Prepare As Params module', () => {
 			const instance = { cast: [{ roles: [{ uuid: 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy' }] }] };
 			const result = prepareAsParams(instance);
 			expect(stubs.isObject.callCount).to.eq(7);
-			sinon.assert.calledWithExactly(stubs.isObject.getCall(4), 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy');
+			assert.calledWithExactly(stubs.isObject.getCall(4), 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy');
 			expect(stubs.uuid.called).to.be.false;
 			expect(result.cast[0].roles[0].uuid).to.eq('yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy');
 
@@ -401,7 +401,7 @@ describe('Prepare As Params module', () => {
 			const instance = { cast: [{ roles: [{ foo: '' }] }] };
 			const result = prepareAsParams(instance);
 			expect(stubs.isObject.callCount).to.eq(7);
-			sinon.assert.calledWithExactly(stubs.isObject.getCall(4), '');
+			assert.calledWithExactly(stubs.isObject.getCall(4), '');
 			expect(stubs.uuid.called).to.be.false;
 			expect(result.cast[0].roles[0].foo).to.eq('');
 
@@ -420,8 +420,8 @@ describe('Prepare As Params module', () => {
 			const instance = { cast: [{ roles: [{ uuid: '' }] }] };
 			const result = prepareAsParams(instance);
 			expect(stubs.isObject.callCount).to.eq(7);
-			sinon.assert.calledWithExactly(stubs.isObject.getCall(5), 0);
-			sinon.assert.calledWithExactly(stubs.isObject.lastCall, 0);
+			assert.calledWithExactly(stubs.isObject.getCall(5), 0);
+			assert.calledWithExactly(stubs.isObject.lastCall, 0);
 			expect(stubs.uuid.calledOnce).to.be.true;
 			expect(result.cast[0].position).to.eq(0);
 			expect(result.cast[0].roles[0].position).to.eq(0);

--- a/spec/server/lib/verify-error-presence.spec.js
+++ b/spec/server/lib/verify-error-presence.spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import sinon from 'sinon';
+import { assert, createSandbox } from 'sinon';
 
 import * as isObjectModule from '../../../server/lib/is-object';
 import { verifyErrorPresence } from '../../../server/lib/verify-error-presence';
@@ -8,7 +8,7 @@ describe('Verify Error Presence module', () => {
 
 	let stubs;
 
-	const sandbox = sinon.createSandbox();
+	const sandbox = createSandbox();
 
 	beforeEach(() => {
 
@@ -37,11 +37,11 @@ describe('Verify Error Presence module', () => {
 			const instance = { errors: {}, theatre: { errors: {} } };
 			const result = verifyErrorPresence(instance);
 			expect(stubs.isObject.callCount).to.eq(5);
-			sinon.assert.calledWithExactly(stubs.isObject.firstCall, {});
-			sinon.assert.calledWithExactly(stubs.isObject.secondCall, {});
-			sinon.assert.calledWithExactly(stubs.isObject.thirdCall, { errors: {} });
-			sinon.assert.calledWithExactly(stubs.isObject.getCall(3), {});
-			sinon.assert.calledWithExactly(stubs.isObject.getCall(4), {});
+			assert.calledWithExactly(stubs.isObject.firstCall, {});
+			assert.calledWithExactly(stubs.isObject.secondCall, {});
+			assert.calledWithExactly(stubs.isObject.thirdCall, { errors: {} });
+			assert.calledWithExactly(stubs.isObject.getCall(3), {});
+			assert.calledWithExactly(stubs.isObject.getCall(4), {});
 			expect(result).to.be.false;
 
 		});
@@ -61,8 +61,8 @@ describe('Verify Error Presence module', () => {
 			const instance = { errors: null };
 			const result = verifyErrorPresence(instance);
 			expect(stubs.isObject.calledTwice).to.be.true;
-			sinon.assert.calledWithExactly(stubs.isObject.firstCall, null);
-			sinon.assert.calledWithExactly(stubs.isObject.secondCall, null);
+			assert.calledWithExactly(stubs.isObject.firstCall, null);
+			assert.calledWithExactly(stubs.isObject.secondCall, null);
 			expect(result).to.be.false;
 
 		});
@@ -72,9 +72,9 @@ describe('Verify Error Presence module', () => {
 			const instance = { errors: ['Name is too short'] };
 			const result = verifyErrorPresence(instance);
 			expect(stubs.isObject.calledThrice).to.be.true;
-			sinon.assert.calledWithExactly(stubs.isObject.firstCall, ['Name is too short']);
-			sinon.assert.calledWithExactly(stubs.isObject.secondCall, ['Name is too short']);
-			sinon.assert.calledWithExactly(stubs.isObject.thirdCall, 'Name is too short');
+			assert.calledWithExactly(stubs.isObject.firstCall, ['Name is too short']);
+			assert.calledWithExactly(stubs.isObject.secondCall, ['Name is too short']);
+			assert.calledWithExactly(stubs.isObject.thirdCall, 'Name is too short');
 			expect(result).to.be.false;
 
 		});
@@ -106,8 +106,8 @@ describe('Verify Error Presence module', () => {
 			const instance = { theatre: { errors: { name: ['Name is too short'] } } };
 			const result = verifyErrorPresence(instance);
 			expect(stubs.isObject.calledTwice).to.be.true;
-			sinon.assert.calledWithExactly(stubs.isObject.firstCall, { errors: { name: ['Name is too short'] } });
-			sinon.assert.calledWithExactly(stubs.isObject.secondCall, { name: ['Name is too short'] });
+			assert.calledWithExactly(stubs.isObject.firstCall, { errors: { name: ['Name is too short'] } });
+			assert.calledWithExactly(stubs.isObject.secondCall, { name: ['Name is too short'] });
 			expect(result).to.be.true;
 
 		});
@@ -125,9 +125,9 @@ describe('Verify Error Presence module', () => {
 			const instance = { cast: [{ errors: { name: ['Name is too short'] } }] };
 			const result = verifyErrorPresence(instance);
 			expect(stubs.isObject.calledThrice).to.be.true;
-			sinon.assert.calledWithExactly(stubs.isObject.firstCall, [{ errors: { name: ['Name is too short'] } }]);
-			sinon.assert.calledWithExactly(stubs.isObject.secondCall, { errors: { name: ['Name is too short'] } });
-			sinon.assert.calledWithExactly(stubs.isObject.thirdCall, { name: ['Name is too short'] });
+			assert.calledWithExactly(stubs.isObject.firstCall, [{ errors: { name: ['Name is too short'] } }]);
+			assert.calledWithExactly(stubs.isObject.secondCall, { errors: { name: ['Name is too short'] } });
+			assert.calledWithExactly(stubs.isObject.thirdCall, { name: ['Name is too short'] });
 			expect(result).to.be.true;
 
 		});

--- a/spec/server/models/base.spec.js
+++ b/spec/server/models/base.spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import sinon from 'sinon';
+import { assert, createSandbox, spy, stub } from 'sinon';
 
 import * as prepareAsParamsModule from '../../../server/lib/prepare-as-params';
 import * as validateStringModule from '../../../server/lib/validate-string';
@@ -15,7 +15,7 @@ describe('Base model', () => {
 	let stubs;
 	let instance;
 
-	const sandbox = sinon.createSandbox();
+	const sandbox = createSandbox();
 
 	beforeEach(() => {
 
@@ -179,10 +179,10 @@ describe('Base model', () => {
 
 			it('creates', async () => {
 
-				sinon.spy(instance, 'validate');
-				sinon.spy(instance, 'validateInDb');
+				spy(instance, 'validate');
+				spy(instance, 'validateInDb');
 				const result = await instance.createUpdate(stubs.getCreateQuery)
-				sinon.assert.callOrder(
+				assert.callOrder(
 					instance.validate.withArgs({ required: true }),
 					stubs.verifyErrorPresence.withArgs(instance),
 					instance.validateInDb.withArgs(),
@@ -208,10 +208,10 @@ describe('Base model', () => {
 
 			it('updates', async () => {
 
-				sinon.spy(instance, 'validate');
-				sinon.spy(instance, 'validateInDb');
+				spy(instance, 'validate');
+				spy(instance, 'validateInDb');
 				const result = await instance.createUpdate(stubs.getUpdateQuery);
-				sinon.assert.callOrder(
+				assert.callOrder(
 					instance.validate.withArgs({ required: true }),
 					stubs.verifyErrorPresence.withArgs(instance),
 					instance.validateInDb.withArgs(),
@@ -244,10 +244,10 @@ describe('Base model', () => {
 				it('returns instance without creating/updating', async () => {
 
 					stubs.verifyErrorPresence.returns(true);
-					const getCreateUpdateQueryStub = sinon.stub();
+					const getCreateUpdateQueryStub = stub();
 					instance.model = 'theatre';
-					sinon.spy(instance, 'validate');
-					sinon.spy(instance, 'validateInDb');
+					spy(instance, 'validate');
+					spy(instance, 'validateInDb');
 					const result = await instance.createUpdate(getCreateUpdateQueryStub);
 					expect(instance.validate.calledBefore(stubs.verifyErrorPresence)).to.be.true;
 					expect(instance.validate.calledOnce).to.be.true;
@@ -270,12 +270,12 @@ describe('Base model', () => {
 				it('returns instance without creating/updating', async () => {
 
 					stubs.verifyErrorPresence.onFirstCall().returns(false).onSecondCall().returns(true);
-					const getCreateUpdateQueryStub = sinon.stub();
+					const getCreateUpdateQueryStub = stub();
 					instance.model = 'theatre';
-					sinon.spy(instance, 'validate');
-					sinon.spy(instance, 'validateInDb');
+					spy(instance, 'validate');
+					spy(instance, 'validateInDb');
 					const result = await instance.createUpdate(getCreateUpdateQueryStub);
-					sinon.assert.callOrder(
+					assert.callOrder(
 						instance.validate.withArgs({ required: true }),
 						stubs.verifyErrorPresence.withArgs(instance),
 						instance.validateInDb.withArgs(),
@@ -307,7 +307,7 @@ describe('Base model', () => {
 			it('calls createUpdate method with function to get model-specific create query as argument', async () => {
 
 				instance.model = 'production';
-				sinon.spy(instance, 'createUpdate');
+				spy(instance, 'createUpdate');
 				await instance.create();
 				expect(instance.createUpdate.calledOnce).to.be.true;
 				expect(instance.createUpdate.calledWithExactly(stubs.getCreateQueries[instance.model])).to.be.true;
@@ -320,7 +320,7 @@ describe('Base model', () => {
 
 			it('calls createUpdate method with function to get shared create query as argument', async () => {
 
-				sinon.spy(instance, 'createUpdate');
+				spy(instance, 'createUpdate');
 				await instance.create();
 				expect(instance.createUpdate.calledOnce).to.be.true;
 				expect(instance.createUpdate.calledWithExactly(stubs.getCreateQuery)).to.be.true;
@@ -379,7 +379,7 @@ describe('Base model', () => {
 			it('calls createUpdate method with function to get model-specific update query as argument', async () => {
 
 				instance.model = 'production';
-				sinon.spy(instance, 'createUpdate');
+				spy(instance, 'createUpdate');
 				await instance.update();
 				expect(instance.createUpdate.calledOnce).to.be.true;
 				expect(instance.createUpdate.calledWithExactly(stubs.getUpdateQueries[instance.model])).to.be.true;
@@ -392,7 +392,7 @@ describe('Base model', () => {
 
 			it('calls createUpdate method with function to get shared update query as argument', async () => {
 
-				sinon.spy(instance, 'createUpdate');
+				spy(instance, 'createUpdate');
 				await instance.update();
 				expect(instance.createUpdate.calledOnce).to.be.true;
 				expect(instance.createUpdate.calledWithExactly(stubs.getUpdateQuery)).to.be.true;

--- a/spec/server/models/role.spec.js
+++ b/spec/server/models/role.spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import sinon from 'sinon';
+import { createSandbox } from 'sinon';
 
 import * as validateStringModule from '../../../server/lib/validate-string';
 import Role from '../../../server/models/role';
@@ -8,7 +8,7 @@ describe('Role model', () => {
 
 	let stubs;
 
-	const sandbox = sinon.createSandbox();
+	const sandbox = createSandbox();
 
 	beforeEach(() => {
 

--- a/spec/server/models/theatre.spec.js
+++ b/spec/server/models/theatre.spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import sinon from 'sinon';
+import { assert, createSandbox, spy } from 'sinon';
 
 import * as verifyErrorPresenceModule from '../../../server/lib/verify-error-presence';
 import Theatre from '../../../server/models/theatre';
@@ -13,7 +13,7 @@ describe('Theatre model', () => {
 	let stubs;
 	let instance;
 
-	const sandbox = sinon.createSandbox();
+	const sandbox = createSandbox();
 
 	beforeEach(() => {
 
@@ -85,9 +85,9 @@ describe('Theatre model', () => {
 
 			it('deletes', async () => {
 
-				sinon.spy(instance, 'validateDeleteInDb');
+				spy(instance, 'validateDeleteInDb');
 				const result = await instance.delete();
-				sinon.assert.callOrder(
+				assert.callOrder(
 					instance.validateDeleteInDb.withArgs(),
 					stubs.getValidateDeleteQuery.withArgs(),
 					stubs.neo4jQuery.withArgs({ query: 'getValidateDeleteQuery response', params: instance }),
@@ -111,9 +111,9 @@ describe('Theatre model', () => {
 			it('returns instance without deleting', async () => {
 
 				stubs.verifyErrorPresence.returns(true);
-				sinon.spy(instance, 'validateDeleteInDb');
+				spy(instance, 'validateDeleteInDb');
 				const result = await instance.delete();
-				sinon.assert.callOrder(
+				assert.callOrder(
 					instance.validateDeleteInDb.withArgs(),
 					stubs.getValidateDeleteQuery.withArgs(),
 					stubs.neo4jQuery.withArgs({ query: 'getValidateDeleteQuery response', params: instance }),

--- a/spec/server/neo4j/cypher-queries/shared.spec.js
+++ b/spec/server/neo4j/cypher-queries/shared.spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import sinon from 'sinon';
+import { createSandbox } from 'sinon';
 
 import * as strings from '../../../../server/lib/strings';
 import * as cypherQueriesShared from '../../../../server/neo4j/cypher-queries/shared';
@@ -9,7 +9,7 @@ describe('Cypher Queries Shared module', () => {
 
 	let stubs;
 
-	const sandbox = sinon.createSandbox();
+	const sandbox = createSandbox();
 
 	beforeEach(() => {
 


### PR DESCRIPTION
In some cases it is unnecessary to import Sinon in its entirety as we can import the methods we require individually, as suggested [here](https://sinonjs.org/releases/latest/sandbox).

However, it is not possible with `createStubInstance` (produces `TypeError: Cannot read property 'stub' of undefined`), and so we continue to import Sinon in its entirety where that is used (we do not want to use a sandbox in those cases, e.g. `sandbox.createStubInstance()`, as the creation of a new subject for each test avoids the point of using a sandbox).

#### References
- [Sinon.JS - Sandboxes](https://sinonjs.org/releases/latest/sandbox).