### PR TITLE
Fix usage of Validate String module

### DIFF
--- a/server/models/base.js
+++ b/server/models/base.js
@@ -28,7 +28,7 @@ export default class Base {
 
 	}
 
-	validate (opts = {}) {
+	validate (opts = { requiresName: false }) {
 
 		const nameErrors = validateString(this.name, opts.requiresName);
 

--- a/server/models/role.js
+++ b/server/models/role.js
@@ -16,13 +16,13 @@ export default class Role {
 
 	}
 
-	validate (opts = {}) {
+	validate (opts = { requiresName: false, requiresCharacterName: false }) {
 
-		const nameErrors = validateString(this.name, opts);
+		const nameErrors = validateString(this.name, opts.requiresName);
 
 		if (nameErrors.length) this.errors.name = nameErrors;
 
-		const characterNameErrors = validateString(this.characterName, opts);
+		const characterNameErrors = validateString(this.characterName, opts.requiresCharacterName);
 
 		if (characterNameErrors.length) this.errors.characterName = characterNameErrors;
 

--- a/spec/server/lib/validate-string.spec.js
+++ b/spec/server/lib/validate-string.spec.js
@@ -16,7 +16,7 @@ describe('Validate String module', () => {
 
 			it('adds error to and returns stringErrors array', () => {
 
-				expect(validateString(emptyString, { required: true })).to.deep.eq(['Name is too short']);
+				expect(validateString(emptyString, true)).to.deep.eq(['Name is too short']);
 
 			});
 
@@ -26,7 +26,7 @@ describe('Validate String module', () => {
 
 			it('returns empty stringErrors array', () => {
 
-				expect(validateString(emptyString)).to.deep.eq([]);
+				expect(validateString(emptyString, false)).to.deep.eq([]);
 
 			});
 
@@ -40,7 +40,7 @@ describe('Validate String module', () => {
 
 			it('returns empty stringErrors array', () => {
 
-				expect(validateString(maxLengthString, { required: true })).to.deep.eq([]);
+				expect(validateString(maxLengthString, true)).to.deep.eq([]);
 
 			});
 
@@ -50,7 +50,7 @@ describe('Validate String module', () => {
 
 			it('returns empty stringErrors array', () => {
 
-				expect(validateString(maxLengthString)).to.deep.eq([]);
+				expect(validateString(maxLengthString, false)).to.deep.eq([]);
 
 			});
 
@@ -64,7 +64,7 @@ describe('Validate String module', () => {
 
 			it('adds error to and returns stringErrors array', () => {
 
-				expect(validateString(aboveMaxLengthString, { required: true })).to.deep.eq(['Name is too long']);
+				expect(validateString(aboveMaxLengthString, true)).to.deep.eq(['Name is too long']);
 
 			});
 
@@ -74,7 +74,7 @@ describe('Validate String module', () => {
 
 			it('adds error to and returns stringErrors array', () => {
 
-				expect(validateString(aboveMaxLengthString)).to.deep.eq(['Name is too long']);
+				expect(validateString(aboveMaxLengthString, false)).to.deep.eq(['Name is too long']);
 
 			});
 
@@ -88,7 +88,7 @@ describe('Validate String module', () => {
 
 			it('adds error to and returns stringErrors array', () => {
 
-				expect(validateString(null, { required: true })).to.deep.eq(['Name is too short']);
+				expect(validateString(null, true)).to.deep.eq(['Name is too short']);
 
 			});
 
@@ -98,7 +98,7 @@ describe('Validate String module', () => {
 
 			it('returns empty stringErrors array', () => {
 
-				expect(validateString(null)).to.deep.eq([]);
+				expect(validateString(null, false)).to.deep.eq([]);
 
 			});
 


### PR DESCRIPTION
Fixes mistake of providing `validateString` function with a second argument of an object instead of a boolean (occurring in the `Role` model's `validate()` method).

Treating this second argument as a boolean would incorrectly evaluate an empty object (`{}`) to **true** when **false** was intended.

The tests in `spec/server/lib/validate-string.spec.js` had been passing by the fluke of all the tests that required an argument of **true** having an object present and all those that required an argument of **false** having no object present.