### PR TITLE
Introduce integration tests (using Docker to serve Neo4j)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,11 @@ jobs:
   build:
     docker:
       - image: circleci/node:10.16.0
+      - image: neo4j:3.5.12
+        environment:
+          NEO4J_AUTH: none
     steps:
       - checkout
       - run: npm install
       - run: npm test
+      - run: npm run test-int

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ Graph database-driven API for site of theatrical productions and playtexts.
 - Ensure `$ npm install` has been run.
 - `$ npm test`.
 
+## To run integration tests
+- Ensure `$ npm install` has been run.
+- Download and run the [Docker desktop app](https://www.docker.com/products/docker-desktop).
+- Stop any Neo4j databases running on the Desktop app.
+- Start the Docker-served resources by running `$ npm run start:test-int:dependencies` and wait until they are ready.
+- In a separate CLI tab run `$ npm run test-int`.
+- The Docker-served Neo4j database can be queried via the Neo4j browser by visiting `http://localhost:7474`.
+
 ## Endpoints
 Using theatre model as an example.
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+    neo4j:
+        image: neo4j:3.5.12
+        environment:
+            - NEO4J_AUTH=none
+        ports:
+            - '7474:7474'
+            - '7687:7687'

--- a/package.json
+++ b/package.json
@@ -6,11 +6,13 @@
   "scripts": {
     "lint": "eslint --ext .js server/ spec/",
     "lintspaces": "git ls-files | xargs lintspaces -e .editorconfig",
+    "start:test-int:dependencies": "docker-compose -f ./docker/docker-compose.yml up",
+    "test-int": "find spec-int -name '*.spec-int.js' | xargs mocha --require @babel/register spec-int",
     "unit-test": "find spec -name '*.spec.js' | xargs mocha --require @babel/register spec",
     "test": "npm run lint && npm run lintspaces && npm run unit-test",
     "build": "babel server --out-dir built",
     "watch": "babel server --watch --out-dir built",
-    "start": "npm run watch & nodemon built/app.js"
+    "start": "node built/setup.js && npm run watch & nodemon built/app.js"
   },
   "pre-commit": [
     "test"
@@ -35,6 +37,7 @@
     "@babel/register": "^7.4.4",
     "babel-plugin-add-module-exports": "^1.0.2",
     "chai": "^3.5.0",
+    "chai-http": "^4.3.0",
     "eslint": "^4.11.0",
     "lintspaces-cli": "^0.6.0",
     "mocha": "^3.2.0",

--- a/server/app.js
+++ b/server/app.js
@@ -12,7 +12,6 @@ import express from 'express';
 import http from 'http';
 import logger from 'morgan';
 
-import createNeo4jConstraints from './neo4j/create-constraints';
 import router from './routes';
 
 const app = express();
@@ -124,12 +123,9 @@ app.set('port', port);
 
 const server = http.createServer(app);
 
-(async () => {
+server.listen(port, () => console.log(`Listening on port ${port}`));
 
-	await createNeo4jConstraints();
+server.on('error', onError);
 
-	server.listen(port, () => console.log(`Listening on port ${port}`));
-
-	server.on('error', onError);
-
-})();
+// Export for integration tests.
+export default app;

--- a/server/setup.js
+++ b/server/setup.js
@@ -1,0 +1,9 @@
+import './dotenv';
+
+import createNeo4jConstraints from './neo4j/create-constraints';
+
+(async () => {
+
+	await createNeo4jConstraints();
+
+})();

--- a/spec-int/mocha.env.js
+++ b/spec-int/mocha.env.js
@@ -1,0 +1,6 @@
+// Docker-served Neo4j logs display: `Bolt enabled on 0.0.0.0:7687`.
+process.env.DATABASE_URL = 'bolt://0.0.0.0:7687';
+// Docker-served Neo4j is configured in `docker/docker-compose.yml` to require no authorisation: `NEO4J_AUTH=none`.
+process.env.DATABASE_USERNAME = null;
+// Docker-served Neo4j is configured in `docker/docker-compose.yml` to require no authorisation: `NEO4J_AUTH=none`.
+process.env.DATABASE_PASSWORD = null;

--- a/spec-int/setup.spec-int.js
+++ b/spec-int/setup.spec-int.js
@@ -1,0 +1,21 @@
+import createNeo4jConstraints from '../server/neo4j/create-constraints';
+import { neo4jQuery } from '../server/neo4j/query';
+
+async function purgeNeo4jDatabase () {
+
+	const purgeDatabaseQuery = `
+		MATCH (n)
+		DETACH DELETE n
+	`;
+
+	await neo4jQuery({ query: purgeDatabaseQuery, params: {} }, { isReqdResult: false });
+
+}
+
+before(async () => {
+
+	await purgeNeo4jDatabase();
+
+	await createNeo4jConstraints();
+
+});

--- a/spec-int/theatre-create.spec-int.js
+++ b/spec-int/theatre-create.spec-int.js
@@ -1,0 +1,25 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+
+import app from '../server/app';
+
+chai.use(chaiHttp);
+
+const expect = chai.expect;
+
+describe('Create Theatre API endpoint', () => {
+
+	it('creates theatre', async () => {
+
+		const response = await chai.request(app)
+			.post('/theatres')
+			.send({ name: 'National Theatre' })
+
+		expect(response).to.have.status(200);
+		expect(response.body).to.have.property('model').that.equals('theatre');
+		expect(response.body).to.have.property('name').that.equals('National Theatre');
+		expect(response.body).to.have.property('uuid');
+
+	});
+
+});


### PR DESCRIPTION
Lays groundwork for integration tests (including a single basic test, with more to follow).

Uses the official Neo4j image (v3.5.12 - the latest version at time of writing).

When the integration tests run, it uses the env vars dictated by `spec-int/mocha.env.js` when accessing the Docker-served Neo4j database rather than using the development env vars which are for accessing the development Neo4j database.

For the tests to have integrity the Docker-served Neo4j database should be as similar to that which is used in development/production, making running the `createNeo4jConstraints` process before any tests a necessity. Some re-organisation of when `createNeo4jConstraints` is called by the app and integration tests respectively was required to ensure that this process is called on the respective Neo4j databases (i.e. development DB for development, Docker-served DB for integration tests).

`spec-int/setup.spec-int.js` uses Mocha's root-level hooks: because the `before()` function is not within any `describe` block (i.e. at the outermost level), it will run before any other tests or the `before()` functions of any other test files (which will be inside a `describe` block).

The root-level hook's `before()` function includes a function to purge the Docker-served Neo4j database to provide a clean slate on which to run tests. It makes sense to perform this as part of the `before()` rather than the `after()`, because if the test suite threw an error half-way through then the `after()` would not get called.

`chai-http` allows the app to be tested by calling the API endpoints it serves and examining the response ([npm: supertest](https://www.npmjs.com/package/supertest) looks like it could also have done this job). When addressing the asynchronous behaviour of test assertions, the package's documentation demonstrates the usage of `done()`, but to keep consistent with other tests in this repo I have used `async`/`await`.

#### References
- [Docker Hub: neo4j (official image)](https://hub.docker.com/_/neo4j).
- [Mocha: Root-Level Hooks](https://mochajs.org/#root-level-hooks).

#### New dependencies
- [npm: chai-http](https://www.npmjs.com/package/chai-http).