### PR TITLE
Add integration tests for APIs for minimum + full range of attributes

### DIFF
--- a/spec-int/characters-api.spec-int.js
+++ b/spec-int/characters-api.spec-int.js
@@ -13,150 +13,158 @@ const expect = chai.expect;
 
 describe('Characters API', () => {
 
-	const CHARACTER_UUID = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+	describe('GET new endpoint', () => {
 
-	const sandbox = createSandbox();
+		it('responds with data required to prepare new character', async () => {
 
-	before(async () => {
+			const response = await chai.request(app)
+				.get('/characters/new');
 
-		let uuidCallCount = 0;
+			const expectedResponseBody = {
+				name: '',
+				productions: [],
+				errors: {}
+			};
 
-		sandbox.stub(uuid, 'v4').returns(CHARACTER_UUID);
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
 
-		await purgeDatabase();
-
-	});
-
-	after(() => {
-
-		sandbox.restore();
-
-	});
-
-	it('gets data required to prepare new character', async () => {
-
-		const response = await chai.request(app)
-			.get('/characters/new');
-
-		const expectedResponseBody = {
-			name: '',
-			productions: [],
-			errors: {}
-		};
-
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
+		});
 
 	});
 
-	it('creates character', async () => {
+	describe('CRUD', () => {
 
-		expect(await countNodesWithLabel('Character')).to.equal(0);
+		const CHARACTER_UUID = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
 
-		const response = await chai.request(app)
-			.post('/characters')
-			.send({ name: 'Romeo' });
+		const sandbox = createSandbox();
 
-		const expectedResponseBody = {
-			model: 'character',
-			uuid: CHARACTER_UUID,
-			name: 'Romeo'
-		};
+		before(async () => {
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
-		expect(await countNodesWithLabel('Character')).to.equal(1);
+			let uuidCallCount = 0;
 
-	});
+			sandbox.stub(uuid, 'v4').returns(CHARACTER_UUID);
 
-	it('gets data required to edit specific character', async () => {
+			await purgeDatabase();
 
-		const response = await chai.request(app)
-			.get(`/characters/${CHARACTER_UUID}/edit`);
+		});
 
-		const expectedResponseBody = {
-			model: 'character',
-			uuid: CHARACTER_UUID,
-			name: 'Romeo'
-		};
+		after(() => {
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
+			sandbox.restore();
 
-	});
+		});
 
-	it('updates character', async () => {
+		it('creates character', async () => {
 
-		expect(await countNodesWithLabel('Character')).to.equal(1);
+			expect(await countNodesWithLabel('Character')).to.equal(0);
 
-		const response = await chai.request(app)
-			.post(`/characters/${CHARACTER_UUID}`)
-			.send({ name: 'Juliet' })
+			const response = await chai.request(app)
+				.post('/characters')
+				.send({ name: 'Romeo' });
 
-		const expectedResponseBody = {
-			model: 'character',
-			uuid: CHARACTER_UUID,
-			name: 'Juliet'
-		};
+			const expectedResponseBody = {
+				model: 'character',
+				uuid: CHARACTER_UUID,
+				name: 'Romeo'
+			};
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
-		expect(await countNodesWithLabel('Character')).to.equal(1);
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Character')).to.equal(1);
 
-	});
+		});
 
-	it('shows character', async () => {
+		it('gets data required to edit specific character', async () => {
 
-		const response = await chai.request(app)
-			.get(`/characters/${CHARACTER_UUID}`);
+			const response = await chai.request(app)
+				.get(`/characters/${CHARACTER_UUID}/edit`);
 
-		const expectedResponseBody = {
-			model: 'character',
-			uuid: CHARACTER_UUID,
-			name: 'Juliet',
-			playtexts: [],
-			productions: [],
-			variantNames: []
-		};
+			const expectedResponseBody = {
+				model: 'character',
+				uuid: CHARACTER_UUID,
+				name: 'Romeo'
+			};
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
 
-	});
+		});
 
-	it('lists all characters', async () => {
+		it('updates character', async () => {
 
-		const response = await chai.request(app)
-			.get('/characters');
+			expect(await countNodesWithLabel('Character')).to.equal(1);
 
-		const expectedResponseBody = [
-			{
+			const response = await chai.request(app)
+				.post(`/characters/${CHARACTER_UUID}`)
+				.send({ name: 'Juliet' });
+
+			const expectedResponseBody = {
 				model: 'character',
 				uuid: CHARACTER_UUID,
 				name: 'Juliet'
-			}
-		];
+			};
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Character')).to.equal(1);
 
-	});
+		});
 
-	it('deletes character', async () => {
+		it('shows character', async () => {
 
-		expect(await countNodesWithLabel('Character')).to.equal(1);
+			const response = await chai.request(app)
+				.get(`/characters/${CHARACTER_UUID}`);
 
-		const response = await chai.request(app)
-			.delete(`/characters/${CHARACTER_UUID}`);
+			const expectedResponseBody = {
+				model: 'character',
+				uuid: CHARACTER_UUID,
+				name: 'Juliet',
+				playtexts: [],
+				productions: [],
+				variantNames: []
+			};
 
-		const expectedResponseBody = {
-			model: 'character',
-			name: 'Juliet'
-		};
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
-		expect(await countNodesWithLabel('Character')).to.equal(0);
+		});
+
+		it('lists all characters', async () => {
+
+			const response = await chai.request(app)
+				.get('/characters');
+
+			const expectedResponseBody = [
+				{
+					model: 'character',
+					uuid: CHARACTER_UUID,
+					name: 'Juliet'
+				}
+			];
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+
+		});
+
+		it('deletes character', async () => {
+
+			expect(await countNodesWithLabel('Character')).to.equal(1);
+
+			const response = await chai.request(app)
+				.delete(`/characters/${CHARACTER_UUID}`);
+
+			const expectedResponseBody = {
+				model: 'character',
+				name: 'Juliet'
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Character')).to.equal(0);
+
+		});
 
 	});
 

--- a/spec-int/people-api.spec-int.js
+++ b/spec-int/people-api.spec-int.js
@@ -13,149 +13,157 @@ const expect = chai.expect;
 
 describe('People API', () => {
 
-	const PERSON_UUID = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+	describe('GET new endpoint', () => {
 
-	const sandbox = createSandbox();
+		it('responds with data required to prepare new person', async () => {
 
-	before(async () => {
+			const response = await chai.request(app)
+				.get('/people/new');
 
-		let uuidCallCount = 0;
+			const expectedResponseBody = {
+				name: '',
+				productions: [],
+				roles: [],
+				errors: {}
+			};
 
-		sandbox.stub(uuid, 'v4').returns(PERSON_UUID)
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
 
-		await purgeDatabase();
-
-	});
-
-	after(() => {
-
-		sandbox.restore();
-
-	});
-
-	it('gets data required to prepare new person', async () => {
-
-		const response = await chai.request(app)
-			.get('/people/new');
-
-		const expectedResponseBody = {
-			name: '',
-			productions: [],
-			roles: [],
-			errors: {}
-		};
-
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
+		});
 
 	});
 
-	it('creates person', async () => {
+	describe('CRUD', () => {
 
-		expect(await countNodesWithLabel('Person')).to.equal(0);
+		const PERSON_UUID = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
 
-		const response = await chai.request(app)
-			.post('/people')
-			.send({ name: 'Ian McKellen' });
+		const sandbox = createSandbox();
 
-		const expectedResponseBody = {
-			model: 'person',
-			uuid: PERSON_UUID,
-			name: 'Ian McKellen'
-		};
+		before(async () => {
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
-		expect(await countNodesWithLabel('Person')).to.equal(1);
+			let uuidCallCount = 0;
 
-	});
+			sandbox.stub(uuid, 'v4').returns(PERSON_UUID)
 
-	it('gets data required to edit specific person', async () => {
+			await purgeDatabase();
 
-		const response = await chai.request(app)
-			.get(`/people/${PERSON_UUID}/edit`);
+		});
 
-		const expectedResponseBody = {
-			model: 'person',
-			uuid: PERSON_UUID,
-			name: 'Ian McKellen'
-		};
+		after(() => {
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
+			sandbox.restore();
 
-	});
+		});
 
-	it('updates person', async () => {
+		it('creates person', async () => {
 
-		expect(await countNodesWithLabel('Person')).to.equal(1);
+			expect(await countNodesWithLabel('Person')).to.equal(0);
 
-		const response = await chai.request(app)
-			.post(`/people/${PERSON_UUID}`)
-			.send({ name: 'Patrick Stewart' })
+			const response = await chai.request(app)
+				.post('/people')
+				.send({ name: 'Ian McKellen' });
 
-		const expectedResponseBody = {
-			model: 'person',
-			uuid: PERSON_UUID,
-			name: 'Patrick Stewart'
-		};
+			const expectedResponseBody = {
+				model: 'person',
+				uuid: PERSON_UUID,
+				name: 'Ian McKellen'
+			};
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
-		expect(await countNodesWithLabel('Person')).to.equal(1);
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Person')).to.equal(1);
 
-	});
+		});
 
-	it('shows person', async () => {
+		it('gets data required to edit specific person', async () => {
 
-		const response = await chai.request(app)
-			.get(`/people/${PERSON_UUID}`);
+			const response = await chai.request(app)
+				.get(`/people/${PERSON_UUID}/edit`);
 
-		const expectedResponseBody = {
-			model: 'person',
-			uuid: PERSON_UUID,
-			name: 'Patrick Stewart',
-			productions: []
-		};
+			const expectedResponseBody = {
+				model: 'person',
+				uuid: PERSON_UUID,
+				name: 'Ian McKellen'
+			};
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
 
-	});
+		});
 
-	it('lists all people', async () => {
+		it('updates person', async () => {
 
-		const response = await chai.request(app)
-			.get('/people');
+			expect(await countNodesWithLabel('Person')).to.equal(1);
 
-		const expectedResponseBody = [
-			{
+			const response = await chai.request(app)
+				.post(`/people/${PERSON_UUID}`)
+				.send({ name: 'Patrick Stewart' });
+
+			const expectedResponseBody = {
 				model: 'person',
 				uuid: PERSON_UUID,
 				name: 'Patrick Stewart'
-			}
-		];
+			};
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Person')).to.equal(1);
 
-	});
+		});
 
-	it('deletes person', async () => {
+		it('shows person', async () => {
 
-		expect(await countNodesWithLabel('Person')).to.equal(1);
+			const response = await chai.request(app)
+				.get(`/people/${PERSON_UUID}`);
 
-		const response = await chai.request(app)
-			.delete(`/people/${PERSON_UUID}`);
+			const expectedResponseBody = {
+				model: 'person',
+				uuid: PERSON_UUID,
+				name: 'Patrick Stewart',
+				productions: []
+			};
 
-		const expectedResponseBody = {
-			model: 'person',
-			name: 'Patrick Stewart'
-		};
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
-		expect(await countNodesWithLabel('Person')).to.equal(0);
+		});
+
+		it('lists all people', async () => {
+
+			const response = await chai.request(app)
+				.get('/people');
+
+			const expectedResponseBody = [
+				{
+					model: 'person',
+					uuid: PERSON_UUID,
+					name: 'Patrick Stewart'
+				}
+			];
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+
+		});
+
+		it('deletes person', async () => {
+
+			expect(await countNodesWithLabel('Person')).to.equal(1);
+
+			const response = await chai.request(app)
+				.delete(`/people/${PERSON_UUID}`);
+
+			const expectedResponseBody = {
+				model: 'person',
+				name: 'Patrick Stewart'
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Person')).to.equal(0);
+
+		});
 
 	});
 

--- a/spec-int/playtexts-api.spec-int.js
+++ b/spec-int/playtexts-api.spec-int.js
@@ -13,155 +13,393 @@ const expect = chai.expect;
 
 describe('Playtexts API', () => {
 
-	const PLAYTEXT_UUID = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+	describe('GET new endpoint', () => {
 
-	const sandbox = createSandbox();
+		it('responds with data required to prepare new playtext', async () => {
 
-	before(async () => {
+			const response = await chai.request(app)
+				.get('/playtexts/new');
 
-		let uuidCallCount = 0;
+			const expectedResponseBody = {
+				name: '',
+				characters: [],
+				productions: [],
+				errors: {}
+			};
 
-		sandbox.stub(uuid, 'v4').returns(PLAYTEXT_UUID);
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
 
-		await purgeDatabase();
-
-	});
-
-	after(() => {
-
-		sandbox.restore();
-
-	});
-
-	it('gets data required to prepare new playtext', async () => {
-
-		const response = await chai.request(app)
-			.get('/playtexts/new');
-
-		const expectedResponseBody = {
-			name: '',
-			characters: [],
-			productions: [],
-			errors: {}
-		};
-
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
+		});
 
 	});
 
-	it('creates playtext', async () => {
+	describe('CRUD with minimum range of attributes assigned values', () => {
 
-		expect(await countNodesWithLabel('Playtext')).to.equal(0);
+		const PLAYTEXT_UUID = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
 
-		const response = await chai.request(app)
-			.post('/playtexts')
-			.send({ name: 'The Seagull' });
+		const sandbox = createSandbox();
 
-		const expectedResponseBody = {
-			model: 'playtext',
-			uuid: PLAYTEXT_UUID,
-			name: 'The Seagull'
-		};
+		before(async () => {
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
-		expect(await countNodesWithLabel('Playtext')).to.equal(1);
+			let uuidCallCount = 0;
 
-	});
+			sandbox.stub(uuid, 'v4').returns(PLAYTEXT_UUID);
 
-	it('gets data required to edit specific playtext', async () => {
+			await purgeDatabase();
 
-		const response = await chai.request(app)
-			.get(`/playtexts/${PLAYTEXT_UUID}/edit`);
+		});
 
-		const expectedResponseBody = {
-			model: 'playtext',
-			uuid: PLAYTEXT_UUID,
-			name: 'The Seagull',
-			characters: [
+		after(() => {
+
+			sandbox.restore();
+
+		});
+
+		it('creates playtext', async () => {
+
+			expect(await countNodesWithLabel('Playtext')).to.equal(0);
+
+			const response = await chai.request(app)
+				.post('/playtexts')
+				.send({ name: 'Uncle Vanya' });
+
+			const expectedResponseBody = {
+				model: 'playtext',
+				uuid: PLAYTEXT_UUID,
+				name: 'Uncle Vanya'
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Playtext')).to.equal(1);
+
+		});
+
+		it('gets data required to edit specific playtext', async () => {
+
+			const response = await chai.request(app)
+				.get(`/playtexts/${PLAYTEXT_UUID}/edit`);
+
+			const expectedResponseBody = {
+				model: 'playtext',
+				uuid: PLAYTEXT_UUID,
+				name: 'Uncle Vanya',
+				characters: [
+					{
+						name: ''
+					}
+				]
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+
+		});
+
+		it('updates playtext', async () => {
+
+			expect(await countNodesWithLabel('Playtext')).to.equal(1);
+
+			const response = await chai.request(app)
+				.post(`/playtexts/${PLAYTEXT_UUID}`)
+				.send({ name: 'The Cherry Orchard' });
+
+			const expectedResponseBody = {
+				model: 'playtext',
+				uuid: PLAYTEXT_UUID,
+				name: 'The Cherry Orchard'
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Playtext')).to.equal(1);
+
+		});
+
+		it('shows playtext', async () => {
+
+			const response = await chai.request(app)
+				.get(`/playtexts/${PLAYTEXT_UUID}`);
+
+			const expectedResponseBody = {
+				model: 'playtext',
+				uuid: PLAYTEXT_UUID,
+				name: 'The Cherry Orchard',
+				characters: [],
+				productions: []
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+
+		});
+
+		it('lists all playtexts', async () => {
+
+			const response = await chai.request(app)
+				.get('/playtexts');
+
+			const expectedResponseBody = [
 				{
-					name: ''
+					model: 'playtext',
+					uuid: PLAYTEXT_UUID,
+					name: 'The Cherry Orchard'
 				}
-			]
-		};
+			];
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
 
-	});
+		});
 
-	it('updates playtext', async () => {
+		it('deletes playtext', async () => {
 
-		expect(await countNodesWithLabel('Playtext')).to.equal(1);
+			expect(await countNodesWithLabel('Playtext')).to.equal(1);
 
-		const response = await chai.request(app)
-			.post(`/playtexts/${PLAYTEXT_UUID}`)
-			.send({ name: 'Three Sisters' })
+			const response = await chai.request(app)
+				.delete(`/playtexts/${PLAYTEXT_UUID}`);
 
-		const expectedResponseBody = {
-			model: 'playtext',
-			uuid: PLAYTEXT_UUID,
-			name: 'Three Sisters'
-		};
+			const expectedResponseBody = {
+				model: 'playtext',
+				name: 'The Cherry Orchard'
+			};
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
-		expect(await countNodesWithLabel('Playtext')).to.equal(1);
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Playtext')).to.equal(0);
 
-	});
-
-	it('shows playtext', async () => {
-
-		const response = await chai.request(app)
-			.get(`/playtexts/${PLAYTEXT_UUID}`);
-
-		const expectedResponseBody = {
-			model: 'playtext',
-			uuid: PLAYTEXT_UUID,
-			name: 'Three Sisters',
-			characters: [],
-			productions: []
-		};
-
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
+		});
 
 	});
 
-	it('lists all playtexts', async () => {
+	describe('CRUD with full range of attributes assigned values', () => {
 
-		const response = await chai.request(app)
-			.get('/playtexts');
+		const PLAYTEXT_UUID = '0';
+		const IRINA_NIKOLAYEVNA_ARKADINA_UUID = '1';
+		const KONSTANTIN_GAVRILOVICH_TREPLYOV_UUID = '2';
+		const BORIS_ALEXEYEVICH_TRIGORIN_UUID = '3';
+		const OLGA_SERGEYEVNA_PROZOROVA_UUID = '4';
+		const MARIA_SERGEYEVNA_KULYGINA_UUID = '5';
+		const IRINA_SERGEYEVNA_PROZOROVA_UUID = '6';
 
-		const expectedResponseBody = [
-			{
+		const sandbox = createSandbox();
+
+		before(async () => {
+
+			let uuidCallCount = 0;
+
+			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+
+			await purgeDatabase();
+
+		});
+
+		after(() => {
+
+			sandbox.restore();
+
+		});
+
+		it('creates playtext', async () => {
+
+			expect(await countNodesWithLabel('Playtext')).to.equal(0);
+
+			const response = await chai.request(app)
+				.post('/playtexts')
+				.send({
+					name: 'The Seagull',
+					characters: [
+						{
+							name: 'Irina Nikolayevna Arkadina'
+						},
+						{
+							name: 'Konstantin Gavrilovich Treplyov'
+						},
+						{
+							name: 'Boris Alexeyevich Trigorin'
+						}
+					]
+				});
+
+			const expectedResponseBody = {
+				model: 'playtext',
+				uuid: PLAYTEXT_UUID,
+				name: 'The Seagull'
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Playtext')).to.equal(1);
+
+		});
+
+		it('shows playtext (post-creation)', async () => {
+
+			const response = await chai.request(app)
+				.get(`/playtexts/${PLAYTEXT_UUID}`);
+
+			const expectedResponseBody = {
+				model: 'playtext',
+				uuid: PLAYTEXT_UUID,
+				name: 'The Seagull',
+				characters: [
+					{
+						model: 'character',
+						uuid: IRINA_NIKOLAYEVNA_ARKADINA_UUID,
+						name: 'Irina Nikolayevna Arkadina'
+					},
+					{
+						model: 'character',
+						uuid: KONSTANTIN_GAVRILOVICH_TREPLYOV_UUID,
+						name: 'Konstantin Gavrilovich Treplyov'
+					},
+					{
+						model: 'character',
+						uuid: BORIS_ALEXEYEVICH_TRIGORIN_UUID,
+						name: 'Boris Alexeyevich Trigorin'
+					}
+				],
+				productions: []
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+
+		});
+
+		it('gets data required to edit specific playtext', async () => {
+
+			const response = await chai.request(app)
+				.get(`/playtexts/${PLAYTEXT_UUID}/edit`);
+
+			const expectedResponseBody = {
+				model: 'playtext',
+				uuid: PLAYTEXT_UUID,
+				name: 'The Seagull',
+				characters: [
+					{
+						name: 'Irina Nikolayevna Arkadina'
+					},
+					{
+						name: 'Konstantin Gavrilovich Treplyov'
+					},
+					{
+						name: 'Boris Alexeyevich Trigorin'
+					},
+					{
+						name: ''
+					}
+				]
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+
+		});
+
+		it('updates playtext', async () => {
+
+			expect(await countNodesWithLabel('Playtext')).to.equal(1);
+
+			const response = await chai.request(app)
+				.post(`/playtexts/${PLAYTEXT_UUID}`)
+				.send({
+					name: 'Three Sisters',
+					characters: [
+						{
+							name: 'Olga Sergeyevna Prozorova'
+						},
+						{
+							name: 'Maria Sergeyevna Kulygina'
+						},
+						{
+							name: 'Irina Sergeyevna Prozorova'
+						}
+					]
+				});
+
+			const expectedResponseBody = {
 				model: 'playtext',
 				uuid: PLAYTEXT_UUID,
 				name: 'Three Sisters'
-			}
-		];
+			};
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Playtext')).to.equal(1);
 
-	});
+		});
 
-	it('deletes playtext', async () => {
+		it('shows playtext (post-update)', async () => {
 
-		expect(await countNodesWithLabel('Playtext')).to.equal(1);
+			const response = await chai.request(app)
+				.get(`/playtexts/${PLAYTEXT_UUID}`);
 
-		const response = await chai.request(app)
-			.delete(`/playtexts/${PLAYTEXT_UUID}`);
+			const expectedResponseBody = {
+				model: 'playtext',
+				uuid: PLAYTEXT_UUID,
+				name: 'Three Sisters',
+				characters: [
+					{
+						model: 'character',
+						uuid: OLGA_SERGEYEVNA_PROZOROVA_UUID,
+						name: 'Olga Sergeyevna Prozorova'
+					},
+					{
+						model: 'character',
+						uuid: MARIA_SERGEYEVNA_KULYGINA_UUID,
+						name: 'Maria Sergeyevna Kulygina'
+					},
+					{
+						model: 'character',
+						uuid: IRINA_SERGEYEVNA_PROZOROVA_UUID,
+						name: 'Irina Sergeyevna Prozorova'
+					}
+				],
+				productions: []
+			};
 
-		const expectedResponseBody = {
-			model: 'playtext',
-			name: 'Three Sisters'
-		};
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
-		expect(await countNodesWithLabel('Playtext')).to.equal(0);
+		});
+
+		it('lists all playtexts', async () => {
+
+			const response = await chai.request(app)
+				.get('/playtexts');
+
+			const expectedResponseBody = [
+				{
+					model: 'playtext',
+					uuid: PLAYTEXT_UUID,
+					name: 'Three Sisters'
+				}
+			];
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+
+		});
+
+		it('deletes playtext', async () => {
+
+			expect(await countNodesWithLabel('Playtext')).to.equal(1);
+
+			const response = await chai.request(app)
+				.delete(`/playtexts/${PLAYTEXT_UUID}`);
+
+			const expectedResponseBody = {
+				model: 'playtext',
+				name: 'Three Sisters'
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Playtext')).to.equal(0);
+
+		});
 
 	});
 

--- a/spec-int/productions-api.spec-int.js
+++ b/spec-int/productions-api.spec-int.js
@@ -13,188 +13,678 @@ const expect = chai.expect;
 
 describe('Productions API', () => {
 
-	const PRODUCTION_UUID = '0';
-	const THEATRE_UUID = '1';
+	describe('GET new endpoint', () => {
 
-	const sandbox = createSandbox();
+		it('responds with data required to prepare new production', async () => {
 
-	before(async () => {
+			const response = await chai.request(app)
+				.get('/productions/new');
 
-		let uuidCallCount = 0;
-
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
-
-		await purgeDatabase();
-
-	});
-
-	after(() => {
-
-		sandbox.restore();
-
-	});
-
-	it('gets data required to prepare new production', async () => {
-
-		const response = await chai.request(app)
-			.get('/productions/new');
-
-		const expectedResponseBody = {
-			name: '',
-			cast: [],
-			playtext: {
+			const expectedResponseBody = {
 				name: '',
-				characters: [],
-				productions: [],
-				errors: {}
-			},
-			theatre: {
-				name: '',
-				productions: [],
-				errors: {}
-			},
-			errors: {}
-		};
-
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
-
-	});
-
-	it('creates production', async () => {
-
-		expect(await countNodesWithLabel('Production')).to.equal(0);
-
-		const response = await chai.request(app)
-			.post('/productions')
-			.send({ name: 'As You Like It', theatre: { name: 'Novello Theatre' } });
-
-		const expectedResponseBody = {
-			model: 'production',
-			uuid: PRODUCTION_UUID,
-			name: 'As You Like It'
-		};
-
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
-		expect(await countNodesWithLabel('Production')).to.equal(1);
-
-	});
-
-	it('gets data required to edit specific production', async () => {
-
-		const response = await chai.request(app)
-			.get(`/productions/${PRODUCTION_UUID}/edit`);
-
-		const expectedResponseBody = {
-			model: 'production',
-			uuid: PRODUCTION_UUID,
-			name: 'As You Like It',
-			cast: [
-				{
+				theatre: {
 					name: '',
-					roles: [
-						{
-							characterName: '',
-							name: ''
-						}
-					]
-				}
-			],
-			playtext: {
-				name: null
-			},
-			theatre: {
-				name: 'Novello Theatre'
-			}
-		};
+					productions: [],
+					errors: {}
+				},
+				playtext: {
+					name: '',
+					characters: [],
+					productions: [],
+					errors: {}
+				},
+				cast: [],
+				errors: {}
+			};
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
 
-	});
-
-	it('updates production', async () => {
-
-		expect(await countNodesWithLabel('Production')).to.equal(1);
-
-		const response = await chai.request(app)
-			.post(`/productions/${PRODUCTION_UUID}`)
-			.send({ name: 'The Tempest', theatre: { name: 'Novello Theatre' } });
-
-		const expectedResponseBody = {
-			model: 'production',
-			uuid: PRODUCTION_UUID,
-			name: 'The Tempest'
-		};
-
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
-		expect(await countNodesWithLabel('Production')).to.equal(1);
+		});
 
 	});
 
-	it('shows production', async () => {
+	describe('CRUD with minimum range of attributes assigned values', () => {
 
-		const response = await chai.request(app)
-			.get(`/productions/${PRODUCTION_UUID}`);
+		const PRODUCTION_UUID = '0';
+		const THEATRE_UUID = '1';
 
-		const expectedResponseBody = {
-			model: 'production',
-			uuid: PRODUCTION_UUID,
-			name: 'The Tempest',
-			cast: [],
-			playtext: null,
-			theatre: {
-				model: 'theatre',
-				name: 'Novello Theatre',
-				uuid: THEATRE_UUID
-			}
-		};
+		const sandbox = createSandbox();
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
+		before(async () => {
 
-	});
+			let uuidCallCount = 0;
 
-	it('lists all productions', async () => {
+			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
 
-		const response = await chai.request(app)
-			.get('/productions');
+			await purgeDatabase();
 
-		const expectedResponseBody = [
-			{
+		});
+
+		after(() => {
+
+			sandbox.restore();
+
+		});
+
+		it('creates production', async () => {
+
+			expect(await countNodesWithLabel('Production')).to.equal(0);
+
+			const response = await chai.request(app)
+				.post('/productions')
+				.send({ name: 'As You Like It', theatre: { name: 'Novello Theatre' } });
+
+			const expectedResponseBody = {
+				model: 'production',
+				uuid: PRODUCTION_UUID,
+				name: 'As You Like It'
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Production')).to.equal(1);
+
+		});
+
+		it('gets data required to edit specific production', async () => {
+
+			const response = await chai.request(app)
+				.get(`/productions/${PRODUCTION_UUID}/edit`);
+
+			const expectedResponseBody = {
+				model: 'production',
+				uuid: PRODUCTION_UUID,
+				name: 'As You Like It',
+				theatre: {
+					name: 'Novello Theatre'
+				},
+				playtext: {
+					name: null
+				},
+				cast: [
+					{
+						name: '',
+						roles: [
+							{
+								characterName: '',
+								name: ''
+							}
+						]
+					}
+				]
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+
+		});
+
+		it('updates production', async () => {
+
+			expect(await countNodesWithLabel('Production')).to.equal(1);
+
+			const response = await chai.request(app)
+				.post(`/productions/${PRODUCTION_UUID}`)
+				.send({ name: 'The Tempest', theatre: { name: 'Novello Theatre' } });
+
+			const expectedResponseBody = {
+				model: 'production',
+				uuid: PRODUCTION_UUID,
+				name: 'The Tempest'
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Production')).to.equal(1);
+
+		});
+
+		it('shows production', async () => {
+
+			const response = await chai.request(app)
+				.get(`/productions/${PRODUCTION_UUID}`);
+
+			const expectedResponseBody = {
 				model: 'production',
 				uuid: PRODUCTION_UUID,
 				name: 'The Tempest',
 				theatre: {
 					model: 'theatre',
-					name: 'Novello Theatre',
-					uuid: THEATRE_UUID
-				}
-			}
-		];
+					uuid: THEATRE_UUID,
+					name: 'Novello Theatre'
+				},
+				playtext: null,
+				cast: []
+			};
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+
+		});
+
+		it('lists all productions', async () => {
+
+			const response = await chai.request(app)
+				.get('/productions');
+
+			const expectedResponseBody = [
+				{
+					model: 'production',
+					uuid: PRODUCTION_UUID,
+					name: 'The Tempest',
+					theatre: {
+						model: 'theatre',
+						uuid: THEATRE_UUID,
+						name: 'Novello Theatre'
+					}
+				}
+			];
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+
+		});
+
+		it('deletes production', async () => {
+
+			expect(await countNodesWithLabel('Production')).to.equal(1);
+
+			const response = await chai.request(app)
+				.delete(`/productions/${PRODUCTION_UUID}`);
+
+			const expectedResponseBody = {
+				model: 'production',
+				name: 'The Tempest'
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Production')).to.equal(0);
+
+		});
 
 	});
 
-	it('deletes production', async () => {
+	describe('CRUD with full range of attributes assigned values', () => {
 
-		expect(await countNodesWithLabel('Production')).to.equal(1);
+		const PRODUCTION_UUID = '0';
+		const NATIONAL_THEATRE_UUID = '1';
+		const THE_TRAGEDY_OF_HAMLET_PRINCE_OF_DENMARK_UUID = '2';
+		const RORY_KINNEAR_UUID = '3';
+		const JAMES_LAURENSON_UUID = '4';
+		const MICHAEL_SHELDON_UUID = '5';
+		const LEO_STAAR_UUID = '6';
+		const ALMEIDA_THEATRE_UUID = '7';
+		const THE_TRAGEDY_OF_KING_RICHARD_III_UUID = '8';
+		const RALPH_FIENNES_UUID = '9';
+		const TOM_CANTON_UUID = '10';
+		const MARK_HADFIELD_UUID = '11';
+		const JOSH_COLLINS_UUID = '12';
 
-		const response = await chai.request(app)
-			.delete(`/productions/${PRODUCTION_UUID}`);
+		const sandbox = createSandbox();
 
-		const expectedResponseBody = {
-			model: 'production',
-			name: 'The Tempest'
-		};
+		before(async () => {
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
-		expect(await countNodesWithLabel('Production')).to.equal(0);
+			let uuidCallCount = 0;
+
+			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+
+			await purgeDatabase();
+
+		});
+
+		after(() => {
+
+			sandbox.restore();
+
+		});
+
+		it('creates production', async () => {
+
+			expect(await countNodesWithLabel('Production')).to.equal(0);
+
+			const response = await chai.request(app)
+				.post('/productions')
+				.send({
+					name: 'Hamlet',
+					theatre: {
+						name: 'National Theatre'
+					},
+					playtext: {
+						name: 'The Tragedy of Hamlet, Prince of Denmark'
+					},
+					cast: [
+						{
+							name: 'Rory Kinnear',
+							roles: [
+								{
+									name: 'Hamlet',
+									characterName: ''
+								}
+							]
+						},
+						{
+							name: 'James Laurenson',
+							roles: [
+								{
+									name: 'Ghost',
+									characterName: 'Ghost of King Hamlet'
+								},
+								{
+									name: 'Player King',
+									characterName: 'First Player'
+								}
+							]
+						},
+						{
+							name: 'Michael Sheldon',
+							roles: [
+								{
+									name: 'Lucianus',
+									characterName: ''
+								},
+								{
+									name: 'English Ambassador',
+									characterName: ''
+								}
+							]
+						},
+						{
+							name: 'Leo Staar',
+							roles: [
+								{
+									name: '',
+									characterName: ''
+								}
+							]
+						}
+					]
+				});
+
+			const expectedResponseBody = {
+				model: 'production',
+				uuid: PRODUCTION_UUID,
+				name: 'Hamlet'
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Production')).to.equal(1);
+
+		});
+
+		it('shows production (post-creation)', async () => {
+
+			const response = await chai.request(app)
+				.get(`/productions/${PRODUCTION_UUID}`);
+
+			const expectedResponseBody = {
+				model: 'production',
+				uuid: PRODUCTION_UUID,
+				name: 'Hamlet',
+				theatre: {
+					model: 'theatre',
+					uuid: NATIONAL_THEATRE_UUID,
+					name: 'National Theatre'
+				},
+				playtext: {
+					model: 'playtext',
+					uuid: THE_TRAGEDY_OF_HAMLET_PRINCE_OF_DENMARK_UUID,
+					name: 'The Tragedy of Hamlet, Prince of Denmark'
+				},
+				cast: [
+					{
+						model: 'person',
+						uuid: RORY_KINNEAR_UUID,
+						name: 'Rory Kinnear',
+						roles: [
+							{
+								model: 'character',
+								uuid: null,
+								name: 'Hamlet'
+							}
+						]
+					},
+					{
+						model: 'person',
+						uuid: JAMES_LAURENSON_UUID,
+						name: 'James Laurenson',
+						roles: [
+							{
+								model: 'character',
+								uuid: null,
+								name: 'Ghost'
+							},
+							{
+								model: 'character',
+								uuid: null,
+								name: 'Player King'
+							}
+						]
+					},
+					{
+						model: 'person',
+						uuid: MICHAEL_SHELDON_UUID,
+						name: 'Michael Sheldon',
+						roles: [
+							{
+								model: 'character',
+								uuid: null,
+								name: 'Lucianus'
+							},
+							{
+								model: 'character',
+								uuid: null,
+								name: 'English Ambassador'
+							}
+						]
+					},
+					{
+						model: 'person',
+						uuid: LEO_STAAR_UUID,
+						name: 'Leo Staar',
+						roles: [
+							{
+								name: 'Performer'
+							}
+						]
+					}
+				]
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+
+		});
+
+		it('gets data required to edit specific production', async () => {
+
+			const response = await chai.request(app)
+				.get(`/productions/${PRODUCTION_UUID}/edit`);
+
+			const expectedResponseBody = {
+				model: 'production',
+				uuid: PRODUCTION_UUID,
+				name: 'Hamlet',
+				theatre: {
+					name: 'National Theatre'
+				},
+				playtext: {
+					name: 'The Tragedy of Hamlet, Prince of Denmark'
+				},
+				cast: [
+					{
+						name: 'Rory Kinnear',
+						roles: [
+							{
+								name: 'Hamlet',
+								characterName: null
+							},
+							{
+								characterName: '',
+								name: ''
+							}
+						]
+					},
+					{
+						name: 'James Laurenson',
+						roles: [
+							{
+								name: 'Ghost',
+								characterName: 'Ghost of King Hamlet'
+							},
+							{
+								name: 'Player King',
+								characterName: 'First Player'
+							},
+							{
+								characterName: '',
+								name: ''
+							}
+						]
+					},
+					{
+						name: 'Michael Sheldon',
+						roles: [
+							{
+								name: 'Lucianus',
+								characterName: null
+							},
+							{
+								name: 'English Ambassador',
+								characterName: null
+							},
+							{
+								characterName: '',
+								name: ''
+							}
+						]
+					},
+					{
+						name: 'Leo Staar',
+						roles: [
+							{
+								name: '',
+								characterName: ''
+							}
+						]
+					},
+					{
+						name: '',
+						roles: [
+							{
+								name: '',
+								characterName: ''
+							}
+						]
+					}
+				]
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+
+		});
+
+		it('updates production', async () => {
+
+			expect(await countNodesWithLabel('Production')).to.equal(1);
+
+			const response = await chai.request(app)
+				.post(`/productions/${PRODUCTION_UUID}`)
+				.send({
+					name: 'Richard III',
+					theatre: {
+						name: 'Almeida Theatre'
+					},
+					playtext: {
+						name: 'The Tragedy of King Richard III'
+					},
+					cast: [
+						{
+							name: 'Ralph Fiennes',
+							roles: [
+								{
+									name: 'Richard, Duke of Gloucester',
+									characterName: ''
+								}
+							]
+						},
+						{
+							name: 'Tom Canton',
+							roles: [
+								{
+									name: 'Brakenbury',
+									characterName: 'Sir Robert Brakenbury'
+								},
+								{
+									name: 'Richmond',
+									characterName: 'Henry, Earl of Richmond'
+								}
+							]
+						},
+						{
+							name: 'Mark Hadfield',
+							roles: [
+								{
+									name: 'Ratcliffe',
+									characterName: ''
+								},
+								{
+									name: 'Lord Mayor',
+									characterName: ''
+								}
+							]
+						},
+						{
+							name: 'Josh Collins',
+							roles: [
+								{
+									name: '',
+									characterName: ''
+								}
+							]
+						}
+					]
+				});
+
+			const expectedResponseBody = {
+				model: 'production',
+				uuid: PRODUCTION_UUID,
+				name: 'Richard III'
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Production')).to.equal(1);
+
+		});
+
+		it('shows production (post-update)', async () => {
+
+			const response = await chai.request(app)
+				.get(`/productions/${PRODUCTION_UUID}`);
+
+			const expectedResponseBody = {
+				model: 'production',
+				uuid: PRODUCTION_UUID,
+				name: 'Richard III',
+				theatre: {
+					model: 'theatre',
+					uuid: ALMEIDA_THEATRE_UUID,
+					name: 'Almeida Theatre'
+				},
+				playtext: {
+					model: 'playtext',
+					uuid: THE_TRAGEDY_OF_KING_RICHARD_III_UUID,
+					name: 'The Tragedy of King Richard III'
+				},
+				cast: [
+					{
+						model: 'person',
+						uuid: RALPH_FIENNES_UUID,
+						name: 'Ralph Fiennes',
+						roles: [
+							{
+								model: 'character',
+								uuid: null,
+								name: 'Richard, Duke of Gloucester'
+							}
+						]
+					},
+					{
+						model: 'person',
+						uuid: TOM_CANTON_UUID,
+						name: 'Tom Canton',
+						roles: [
+							{
+								model: 'character',
+								uuid: null,
+								name: 'Brakenbury'
+							},
+							{
+								model: 'character',
+								uuid: null,
+								name: 'Richmond'
+							}
+						]
+					},
+					{
+						model: 'person',
+						uuid: MARK_HADFIELD_UUID,
+						name: 'Mark Hadfield',
+						roles: [
+							{
+								model: 'character',
+								uuid: null,
+								name: 'Ratcliffe'
+							},
+							{
+								model: 'character',
+								uuid: null,
+								name: 'Lord Mayor'
+							}
+						]
+					},
+					{
+						model: 'person',
+						uuid: JOSH_COLLINS_UUID,
+						name: 'Josh Collins',
+						roles: [
+							{
+								name: 'Performer'
+							}
+						]
+					}
+				]
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+
+		});
+
+		it('lists all productions', async () => {
+
+			const response = await chai.request(app)
+				.get('/productions');
+
+			const expectedResponseBody = [
+				{
+					model: 'production',
+					uuid: PRODUCTION_UUID,
+					name: 'Richard III',
+					theatre: {
+						model: 'theatre',
+						uuid: ALMEIDA_THEATRE_UUID,
+						name: 'Almeida Theatre'
+					}
+				}
+			];
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+
+		});
+
+		it('deletes production', async () => {
+
+			expect(await countNodesWithLabel('Production')).to.equal(1);
+
+			const response = await chai.request(app)
+				.delete(`/productions/${PRODUCTION_UUID}`);
+
+			const expectedResponseBody = {
+				model: 'production',
+				name: 'Richard III'
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Production')).to.equal(0);
+
+		});
 
 	});
 

--- a/spec-int/theatres-api.spec-int.js
+++ b/spec-int/theatres-api.spec-int.js
@@ -13,148 +13,156 @@ const expect = chai.expect;
 
 describe('Theatres API', () => {
 
-	const THEATRE_UUID = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+	describe('GET new endpoint', () => {
 
-	const sandbox = createSandbox();
+		it('responds with data required to prepare new theatre', async () => {
 
-	before(async () => {
+			const response = await chai.request(app)
+				.get('/theatres/new');
 
-		let uuidCallCount = 0;
+			const expectedResponseBody = {
+				name: '',
+				productions: [],
+				errors: {}
+			};
 
-		sandbox.stub(uuid, 'v4').returns(THEATRE_UUID);
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
 
-		await purgeDatabase();
-
-	});
-
-	after(() => {
-
-		sandbox.restore();
-
-	});
-
-	it('gets data required to prepare new theatre', async () => {
-
-		const response = await chai.request(app)
-			.get('/theatres/new');
-
-		const expectedResponseBody = {
-			name: '',
-			productions: [],
-			errors: {}
-		};
-
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
+		});
 
 	});
 
-	it('creates theatre', async () => {
+	describe('CRUD', () => {
 
-		expect(await countNodesWithLabel('Theatre')).to.equal(0);
+		const THEATRE_UUID = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
 
-		const response = await chai.request(app)
-			.post('/theatres')
-			.send({ name: 'National Theatre' });
+		const sandbox = createSandbox();
 
-		const expectedResponseBody = {
-			model: 'theatre',
-			uuid: THEATRE_UUID,
-			name: 'National Theatre'
-		};
+		before(async () => {
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
-		expect(await countNodesWithLabel('Theatre')).to.equal(1);
+			let uuidCallCount = 0;
 
-	});
+			sandbox.stub(uuid, 'v4').returns(THEATRE_UUID);
 
-	it('gets data required to edit specific theatre', async () => {
+			await purgeDatabase();
 
-		const response = await chai.request(app)
-			.get(`/theatres/${THEATRE_UUID}/edit`);
+		});
 
-		const expectedResponseBody = {
-			model: 'theatre',
-			uuid: THEATRE_UUID,
-			name: 'National Theatre'
-		};
+		after(() => {
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
+			sandbox.restore();
 
-	});
+		});
 
-	it('updates theatre', async () => {
+		it('creates theatre', async () => {
 
-		expect(await countNodesWithLabel('Theatre')).to.equal(1);
+			expect(await countNodesWithLabel('Theatre')).to.equal(0);
 
-		const response = await chai.request(app)
-			.post(`/theatres/${THEATRE_UUID}`)
-			.send({ name: 'Almeida Theatre' })
+			const response = await chai.request(app)
+				.post('/theatres')
+				.send({ name: 'National Theatre' });
 
-		const expectedResponseBody = {
-			model: 'theatre',
-			uuid: THEATRE_UUID,
-			name: 'Almeida Theatre'
-		};
+			const expectedResponseBody = {
+				model: 'theatre',
+				uuid: THEATRE_UUID,
+				name: 'National Theatre'
+			};
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
-		expect(await countNodesWithLabel('Theatre')).to.equal(1);
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Theatre')).to.equal(1);
 
-	});
+		});
 
-	it('shows theatre', async () => {
+		it('gets data required to edit specific theatre', async () => {
 
-		const response = await chai.request(app)
-			.get(`/theatres/${THEATRE_UUID}`);
+			const response = await chai.request(app)
+				.get(`/theatres/${THEATRE_UUID}/edit`);
 
-		const expectedResponseBody = {
-			model: 'theatre',
-			uuid: THEATRE_UUID,
-			name: 'Almeida Theatre',
-			productions: []
-		};
+			const expectedResponseBody = {
+				model: 'theatre',
+				uuid: THEATRE_UUID,
+				name: 'National Theatre'
+			};
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
 
-	});
+		});
 
-	it('lists all theatres', async () => {
+		it('updates theatre', async () => {
 
-		const response = await chai.request(app)
-			.get('/theatres');
+			expect(await countNodesWithLabel('Theatre')).to.equal(1);
 
-		const expectedResponseBody = [
-			{
+			const response = await chai.request(app)
+				.post(`/theatres/${THEATRE_UUID}`)
+				.send({ name: 'Almeida Theatre' });
+
+			const expectedResponseBody = {
 				model: 'theatre',
 				uuid: THEATRE_UUID,
 				name: 'Almeida Theatre'
-			}
-		];
+			};
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Theatre')).to.equal(1);
 
-	});
+		});
 
-	it('deletes theatre', async () => {
+		it('shows theatre', async () => {
 
-		expect(await countNodesWithLabel('Theatre')).to.equal(1);
+			const response = await chai.request(app)
+				.get(`/theatres/${THEATRE_UUID}`);
 
-		const response = await chai.request(app)
-			.delete(`/theatres/${THEATRE_UUID}`);
+			const expectedResponseBody = {
+				model: 'theatre',
+				uuid: THEATRE_UUID,
+				name: 'Almeida Theatre',
+				productions: []
+			};
 
-		const expectedResponseBody = {
-			model: 'theatre',
-			name: 'Almeida Theatre'
-		};
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
-		expect(await countNodesWithLabel('Theatre')).to.equal(0);
+		});
+
+		it('lists all theatres', async () => {
+
+			const response = await chai.request(app)
+				.get('/theatres');
+
+			const expectedResponseBody = [
+				{
+					model: 'theatre',
+					uuid: THEATRE_UUID,
+					name: 'Almeida Theatre'
+				}
+			];
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+
+		});
+
+		it('deletes theatre', async () => {
+
+			expect(await countNodesWithLabel('Theatre')).to.equal(1);
+
+			const response = await chai.request(app)
+				.delete(`/theatres/${THEATRE_UUID}`);
+
+			const expectedResponseBody = {
+				model: 'theatre',
+				name: 'Almeida Theatre'
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Theatre')).to.equal(0);
+
+		});
 
 	});
 


### PR DESCRIPTION
Adds more extensive integration tests that check the outcome of CRUD operations for models with associated data (i.e. a production that has a playtext and cast).