### PR TITLE
Revise production edit API response to return empty strings not null values

### DIFF
--- a/server/neo4j/cypher-queries/production.js
+++ b/server/neo4j/cypher-queries/production.js
@@ -71,7 +71,10 @@ const getEditQuery = () => `
 	WITH production, theatre, playtext, castRel, person,
 		COLLECT(CASE WHEN role IS NULL
 			THEN null
-			ELSE { name: role.name, characterName: role.characterName }
+			ELSE {
+				name: role.name,
+				characterName: CASE WHEN role.characterName IS NULL THEN '' ELSE role.characterName END
+			}
 		END) + [{ name: '', characterName: '' }] AS roles
 		ORDER BY castRel.position
 
@@ -80,7 +83,7 @@ const getEditQuery = () => `
 		production.uuid AS uuid,
 		production.name AS name,
 		{ name: theatre.name } AS theatre,
-		{ name: playtext.name } AS playtext,
+		{ name: CASE WHEN playtext.name IS NULL THEN '' ELSE playtext.name END } AS playtext,
 		COLLECT(CASE WHEN person IS NULL
 			THEN null
 			ELSE { name: person.name, roles: roles }

--- a/spec-int/productions-api.spec-int.js
+++ b/spec-int/productions-api.spec-int.js
@@ -100,7 +100,7 @@ describe('Productions API', () => {
 					name: 'Novello Theatre'
 				},
 				playtext: {
-					name: null
+					name: ''
 				},
 				cast: [
 					{
@@ -419,7 +419,7 @@ describe('Productions API', () => {
 						roles: [
 							{
 								name: 'Hamlet',
-								characterName: null
+								characterName: ''
 							},
 							{
 								characterName: '',
@@ -449,11 +449,11 @@ describe('Productions API', () => {
 						roles: [
 							{
 								name: 'Lucianus',
-								characterName: null
+								characterName: ''
 							},
 							{
 								name: 'English Ambassador',
-								characterName: null
+								characterName: ''
 							},
 							{
 								characterName: '',


### PR DESCRIPTION
CMS currently does special handling to convert null values to empty strings, but it should be the responsibility of this API to provide data in a form that is an accurate and understandable representation of how the data can be edited.

#### `/productions/{uuid}/edit`
#### Before
<img width="332" alt="before" src="https://user-images.githubusercontent.com/10484515/71089977-daa23d80-2199-11ea-864a-6ce4ac635cf6.png">

#### After
<img width="329" alt="after" src="https://user-images.githubusercontent.com/10484515/71089981-de35c480-2199-11ea-8330-75d63669b478.png">
