### PR TITLE
Require mocha.env.js for unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint --ext .js server/ test-unit/",
     "lintspaces": "git ls-files | xargs lintspaces -e .editorconfig",
-    "unit-test": "find test-unit -name '*.test.js' | xargs mocha --require @babel/register test-unit",
+    "unit-test": "find test-unit -name '*.test.js' | xargs mocha --require @babel/register --require test-unit/mocha.env.js test-unit",
     "checks": "npm run lint && npm run lintspaces && npm run unit-test",
     "int-test-resources": "docker-compose -f ./docker/docker-compose.yml up",
     "int-test": "find test-int -name '*.test.js' | xargs mocha --require @babel/register --require test-int/mocha.env.js test-int",


### PR DESCRIPTION
Currently the `/test-unit/mocha.env.js` file is getting applied by coincidence, not by design.

This is happening because it located at a position in the directory structure where it will be encountered by Mocha before any test files (i.e. it is top-level while all test files are at a nested level):

<img width="214" alt="Screenshot 2019-12-28 at 17 29 51" src="https://user-images.githubusercontent.com/10484515/71547436-e52db580-2997-11ea-8a60-ddfda6782d57.png">

However, if a test file was added at a position in the structure which came before  `/test-unit/mocha.env.js` (as demonstrated by the `foobar.test.js` file in the below screenshot), then this new test file would not have access to have env vars set by `mocha.env.js`, which it should given those env vars ensure that no requests are made to an actual Neo4j database.

<img width="209" alt="Screenshot 2019-12-28 at 17 30 29" src="https://user-images.githubusercontent.com/10484515/71547458-18704480-2998-11ea-8918-447b526c3d1d.png">

This PR corrects this coincidence and ensures that the unit tests use the `mocha.env.js` file regardless of its position in relation to the unit test files.