### PR TITLE
Use Express body-parser middleware

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -4,7 +4,6 @@
 */
 
 import './dotenv';
-import bodyParser from 'body-parser';
 import express from 'express';
 import http from 'http';
 import logger from 'morgan';
@@ -13,8 +12,7 @@ import router from './routes';
 
 const app = express();
 
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: true }));
+app.use(express.json());
 
 app.use(logger('dev'));
 


### PR DESCRIPTION
As of v4.16, Express includes body-parser middleware by default, meaning the `body-parser` package can be removed.

It also seems this app can do without `.urlencoded({ extended: true }))` as it is not dealing with `urlencoded` bodies.

#### References
- [Medium: Express JS— body-parser and why may not need it by Michael Majdanski](https://medium.com/@mmajdanski/express-body-parser-and-why-may-not-need-it-335803cd048c).
- [Reddit: Express now includes body-parser middleware by default by u/papers_](https://www.reddit.com/r/javascript/comments/78jjna/express_now_includes_bodyparser_middleware_by/).
- [GitHub - expressjs/body-parser: bodyParser.urlencoded([options])](https://github.com/expressjs/body-parser#bodyparserurlencodedoptions).
- [Stack Overflow: What does body-parser do with express?](https://stackoverflow.com/questions/38306569/what-does-body-parser-do-with-express#answer-47486182).