### PR TITLE
Revise NODE_ENV values for tests

### DIFF
--- a/server/neo4j/query.js
+++ b/server/neo4j/query.js
@@ -2,7 +2,7 @@ import neo4j from 'neo4j-driver';
 
 const { DATABASE_URL, DATABASE_USERNAME, DATABASE_PASSWORD, NODE_ENV } = process.env;
 
-const driver = (NODE_ENV !== 'test') ?
+const driver = (NODE_ENV !== 'unit-test') ?
 	neo4j.driver(DATABASE_URL, neo4j.auth.basic(DATABASE_USERNAME, DATABASE_PASSWORD)) :
 	null;
 

--- a/test-int/mocha.env.js
+++ b/test-int/mocha.env.js
@@ -4,3 +4,4 @@ process.env.DATABASE_URL = 'bolt://0.0.0.0:7687';
 process.env.DATABASE_USERNAME = null;
 // Docker-served Neo4j is configured in `docker/docker-compose.yml` to require no authorisation: `NEO4J_AUTH=none`.
 process.env.DATABASE_PASSWORD = null;
+process.env.NODE_ENV = 'int-test';

--- a/test-unit/mocha.env.js
+++ b/test-unit/mocha.env.js
@@ -1,1 +1,1 @@
-process.env.NODE_ENV = 'test';
+process.env.NODE_ENV = 'unit-test';


### PR DESCRIPTION
In `server/neo4j/query.js`, `driver` should only be assigned a value of `null` for unit tests but not integration tests. Therefore it is important to make this distinction between the two and so this PR updates the `NODE_ENV` value for the respective tests accordingly.