### PR TITLE
Exclude Base from models index

### DIFF
--- a/server/models/index.js
+++ b/server/models/index.js
@@ -1,4 +1,3 @@
-import Base from './base';
 import BasicModel from './basic-model';
 import Character from './character';
 import PersonCastMember from './person-cast-member';
@@ -9,7 +8,6 @@ import Role from './role';
 import Theatre from './theatre';
 
 export {
-	Base,
 	BasicModel,
 	Character,
 	PersonCastMember,


### PR DESCRIPTION
Base (model) should only ever be exported from its file rather than via the models index.

This is because it serves as a base class from which consuming classes will extend. As such, when testing the models, Base therefore needs to have its dependencies `proxyquire`d, and so cannot be lumped together with the other classes that a class consumes which just need to be stubbed in a straightforward manner.