### PR TITLE
Apply updates to use Neo4j v4

### DIFF
--- a/.env-dev
+++ b/.env-dev
@@ -1,3 +1,3 @@
 DATABASE_PASSWORD=theatrebase
-DATABASE_URL=bolt://localhost:11001
+DATABASE_URL=bolt://localhost:11006
 DATABASE_USERNAME=neo4j

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
     neo4j:
-        image: neo4j:3.5.12
+        image: neo4j:4.0.3
         environment:
             - NEO4J_AUTH=none
         ports:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "express": "^4.17.1",
     "method-override": "^2.3.6",
     "morgan": "^1.5.1",
-    "neo4j-driver": "^1.5.1",
+    "neo4j-driver": "^4.0.2",
     "uuid": "^3.0.1"
   },
   "devDependencies": {

--- a/server/neo4j/query.js
+++ b/server/neo4j/query.js
@@ -51,8 +51,6 @@ export const neo4jQuery = async (queryData, queryOpts = {}) => {
 
 		session.close();
 
-		driver.close();
-
 		const results = convertRecordsToObjects(response);
 
 		if (!results.length && isRequiredResult) throw new Error('Not Found');


### PR DESCRIPTION
Applies updates required to make app compatible with Neo4j version 4:

- Docker now uses the v4 image for Neo4j.

- `neo4j-driver` package is updated to v4:
> Upcoming version is now named as 4.0.0 instead of 2.0.0 to better align with server versions [of Neo4j].

- `driver.close()` is removed from `server/neo4j/query.js` as it was causing the below error on every call to database except the first (after the server had started).

```
Neo4jError: Pool is closed, it is no more able to serve requests.

    at captureStacktrace (/Users/andy.gout/Documents/theatrebase-api/node_modules/neo4j-driver/lib/result.js:263:15)
    at new Result (/Users/andy.gout/Documents/theatrebase-api/node_modules/neo4j-driver/lib/result.js:68:19)
    at Session._run (/Users/andy.gout/Documents/theatrebase-api/node_modules/neo4j-driver/lib/session.js:174:14)
    at Session.run (/Users/andy.gout/Documents/theatrebase-api/node_modules/neo4j-driver/lib/session.js:135:19)
    at neo4jQuery (/Users/andy.gout/Documents/theatrebase-api/built/neo4j/query.js:48:36)
    at Function.list (/Users/andy.gout/Documents/theatrebase-api/built/models/Base.js:119:34)
    at callStaticListMethod (/Users/andy.gout/Documents/theatrebase-api/built/lib/call-class-methods.js:24:35)
    at listRoute (/Users/andy.gout/Documents/theatrebase-api/built/controllers/playtexts.js:41:91)
    at Layer.handle [as handle_request] (/Users/andy.gout/Documents/theatrebase-api/node_modules/express/lib/router/layer.js:95:5)
    at next (/Users/andy.gout/Documents/theatrebase-api/node_modules/express/lib/router/route.js:137:13) {
  code: 'N/A',
  name: 'Neo4jError'
}
```

Furthermore, the advice on this point seems to be (according to below Neo4j Community link):
> You should definitely **not** close the connection after every query

#### References
- [npm: neo4-driver](https://www.npmjs.com/package/neo4j-driver).
- [Neo4j Community: When should we close the database connection?](https://community.neo4j.com/t/when-should-we-close-the-database-connection/6984).