### PR TITLE
Unnest character performers role name

### DIFF
--- a/server/neo4j/cypher-queries/character.js
+++ b/server/neo4j/cypher-queries/character.js
@@ -47,7 +47,7 @@ const getShowQuery = () => `
 			model: 'person',
 			uuid: person.uuid,
 			name: person.name,
-			role: { name: role.name },
+			roleName: role.name,
 			otherRoles: otherRoles
 		}) AS performers
 		ORDER BY production.name, theatre.name

--- a/test-int/model-interaction/cast-member-diff-roles-of-playtext.test.js
+++ b/test-int/model-interaction/cast-member-diff-roles-of-playtext.test.js
@@ -165,9 +165,7 @@ describe('Cast member performing different roles in different productions of sam
 						model: 'person',
 						uuid: MICHAEL_GAMBON_PERSON_UUID,
 						name: 'Michael Gambon',
-						role: {
-							name: 'King Lear'
-						},
+						roleName: 'King Lear',
 						otherRoles: []
 					}
 				]
@@ -187,9 +185,7 @@ describe('Cast member performing different roles in different productions of sam
 						model: 'person',
 						uuid: ANTONY_SHER_PERSON_UUID,
 						name: 'Antony Sher',
-						role: {
-							name: 'King Lear'
-						},
+						roleName: 'King Lear',
 						otherRoles: []
 					}
 				]
@@ -230,9 +226,7 @@ describe('Cast member performing different roles in different productions of sam
 						model: 'person',
 						uuid: ANTONY_SHER_PERSON_UUID,
 						name: 'Antony Sher',
-						role: {
-							name: 'Fool'
-						},
+						roleName: 'Fool',
 						otherRoles: []
 					}
 				]
@@ -252,9 +246,7 @@ describe('Cast member performing different roles in different productions of sam
 						model: 'person',
 						uuid: GRAHAM_TURNER_PERSON_UUID,
 						name: 'Graham Turner',
-						role: {
-							name: 'Fool'
-						},
+						roleName: 'Fool',
 						otherRoles: []
 					}
 				]

--- a/test-int/model-interaction/cast-member-same-role-of-playtext.test.js
+++ b/test-int/model-interaction/cast-member-same-role-of-playtext.test.js
@@ -129,9 +129,7 @@ describe('Cast member performing same role in different productions of same play
 						model: 'person',
 						uuid: JUDI_DENCH_PERSON_UUID,
 						name: 'Judi Dench',
-						role: {
-							name: 'Titania'
-						},
+						roleName: 'Titania',
 						otherRoles: []
 					}
 				]
@@ -151,9 +149,7 @@ describe('Cast member performing same role in different productions of same play
 						model: 'person',
 						uuid: JUDI_DENCH_PERSON_UUID,
 						name: 'Judi Dench',
-						role: {
-							name: 'Titania, Faerie Queene'
-						},
+						roleName: 'Titania, Faerie Queene',
 						otherRoles: []
 					}
 				]

--- a/test-int/model-interaction/character-in-multiple-playtexts.test.js
+++ b/test-int/model-interaction/character-in-multiple-playtexts.test.js
@@ -222,9 +222,7 @@ describe('Character in multiple playtexts', () => {
 						model: 'person',
 						uuid: MICHAEL_GAMBON_PERSON_UUID,
 						name: 'Michael Gambon',
-						role: {
-							name: 'Sir John Falstaff'
-						},
+						roleName: 'Sir John Falstaff',
 						otherRoles: []
 					}
 				]
@@ -244,9 +242,7 @@ describe('Character in multiple playtexts', () => {
 						model: 'person',
 						uuid: ROGER_ALLAM_PERSON_UUID,
 						name: 'Roger Allam',
-						role: {
-							name: 'Sir John Falstaff'
-						},
+						roleName: 'Sir John Falstaff',
 						otherRoles: []
 					}
 				]
@@ -266,9 +262,7 @@ describe('Character in multiple playtexts', () => {
 						model: 'person',
 						uuid: RICHARD_CORDERY_PERSON_UUID,
 						name: 'Richard Cordery',
-						role: {
-							name: 'Sir John Falstaff'
-						},
+						roleName: 'Sir John Falstaff',
 						otherRoles: []
 					}
 				]

--- a/test-int/model-interaction/character-with-variant-names.test.js
+++ b/test-int/model-interaction/character-with-variant-names.test.js
@@ -231,9 +231,7 @@ describe('Character with variant names', () => {
 						model: 'person',
 						uuid: DAVID_RINTOUL_PERSON_UUID,
 						name: 'David Rintoul',
-						role: {
-							name: 'Ghost'
-						},
+						roleName: 'Ghost',
 						otherRoles: [
 							{
 								model: 'character',
@@ -259,9 +257,7 @@ describe('Character with variant names', () => {
 						model: 'person',
 						uuid: PATRICK_STEWART_PERSON_UUID,
 						name: 'Patrick Stewart',
-						role: {
-							name: 'Ghost of King Hamlet'
-						},
+						roleName: 'Ghost of King Hamlet',
 						otherRoles: [
 							{
 								model: 'character',
@@ -287,9 +283,7 @@ describe('Character with variant names', () => {
 						model: 'person',
 						uuid: PETER_EYRE_PERSON_UUID,
 						name: 'Peter Eyre',
-						role: {
-							name: 'King Hamlet'
-						},
+						roleName: 'King Hamlet',
 						otherRoles: [
 							{
 								model: 'character',

--- a/test-int/model-interaction/roles-with-alternating-cast.test.js
+++ b/test-int/model-interaction/roles-with-alternating-cast.test.js
@@ -186,9 +186,7 @@ describe('Roles with alternating cast', () => {
 						model: 'person',
 						uuid: NIGEL_HARMAN_PERSON_UUID,
 						name: 'Nigel Harman',
-						role: {
-							name: 'Austin'
-						},
+						roleName: 'Austin',
 						otherRoles: [
 							{
 								model: 'character',
@@ -201,9 +199,7 @@ describe('Roles with alternating cast', () => {
 						model: 'person',
 						uuid: JOHN_LIGHT_PERSON_UUID,
 						name: 'John Light',
-						role: {
-							name: 'Austin'
-						},
+						roleName: 'Austin',
 						otherRoles: [
 							{
 								model: 'character',
@@ -229,9 +225,7 @@ describe('Roles with alternating cast', () => {
 						model: 'person',
 						uuid: KIT_HARINGTON_PERSON_UUID,
 						name: 'Kit Harington',
-						role: {
-							name: 'Austin'
-						},
+						roleName: 'Austin',
 						otherRoles: [
 							{
 								model: 'character',
@@ -244,9 +238,7 @@ describe('Roles with alternating cast', () => {
 						model: 'person',
 						uuid: JOHNNY_FLYNN_PERSON_UUID,
 						name: 'Johnny Flynn',
-						role: {
-							name: 'Austin'
-						},
+						roleName: 'Austin',
 						otherRoles: [
 							{
 								model: 'character',
@@ -292,9 +284,7 @@ describe('Roles with alternating cast', () => {
 						model: 'person',
 						uuid: NIGEL_HARMAN_PERSON_UUID,
 						name: 'Nigel Harman',
-						role: {
-							name: 'Lee'
-						},
+						roleName: 'Lee',
 						otherRoles: [
 							{
 								model: 'character',
@@ -307,9 +297,7 @@ describe('Roles with alternating cast', () => {
 						model: 'person',
 						uuid: JOHN_LIGHT_PERSON_UUID,
 						name: 'John Light',
-						role: {
-							name: 'Lee'
-						},
+						roleName: 'Lee',
 						otherRoles: [
 							{
 								model: 'character',
@@ -335,9 +323,7 @@ describe('Roles with alternating cast', () => {
 						model: 'person',
 						uuid: KIT_HARINGTON_PERSON_UUID,
 						name: 'Kit Harington',
-						role: {
-							name: 'Lee'
-						},
+						roleName: 'Lee',
 						otherRoles: [
 							{
 								model: 'character',
@@ -350,9 +336,7 @@ describe('Roles with alternating cast', () => {
 						model: 'person',
 						uuid: JOHNNY_FLYNN_PERSON_UUID,
 						name: 'Johnny Flynn',
-						role: {
-							name: 'Lee'
-						},
+						roleName: 'Lee',
 						otherRoles: [
 							{
 								model: 'character',


### PR DESCRIPTION
Using `role.name` is unnecessary nesting as no other values will ever need to also be nested in this object, so it may as well be unnested to a `roleName` attribute.

#### Before:
<img width="480" alt="before" src="https://user-images.githubusercontent.com/10484515/80909175-37a02980-8d1e-11ea-9f32-010da04a3c10.png">

#### After:
<img width="485" alt="after" src="https://user-images.githubusercontent.com/10484515/80909181-4090fb00-8d1e-11ea-9487-b24f9d0707d4.png">