### PR TITLE
Add Role node data to PERFORMS_IN relationship

### DIFF
--- a/server/neo4j/cypher-queries/person.js
+++ b/server/neo4j/cypher-queries/person.js
@@ -3,18 +3,15 @@ const getShowQuery = () => `
 
 	OPTIONAL MATCH (person)-[castRel:PERFORMS_IN]->(production:Production)-[:PLAYS_AT]->(theatre:Theatre)
 
-	OPTIONAL MATCH (person)-[roleRel:PERFORMS_AS { prodUuid: production.uuid }]->(role:Role)
+	OPTIONAL MATCH (production)-[:PRODUCTION_OF]->(:Playtext)-[:INCLUDES_CHARACTER]->(character:Character)
+		WHERE castRel.roleName = character.name OR castRel.characterName = character.name
 
-	OPTIONAL MATCH (role)<-[roleRel]-(person)-[castRel]->(production)-[:PRODUCTION_OF]->
-		(:Playtext)-[:INCLUDES_CHARACTER]->(character:Character)
-		WHERE role.name = character.name OR role.characterName = character.name
-
-	WITH person, production, theatre, roleRel, role, character
-		ORDER BY roleRel.position
+	WITH person, production, theatre, castRel, character
+		ORDER BY castRel.rolePosition
 
 	WITH person, production, theatre,
-		COLLECT(CASE WHEN role IS NULL THEN { name: 'Performer' } ELSE
-				{ model: 'character', uuid: character.uuid, name: role.name }
+		COLLECT(CASE WHEN castRel.roleName IS NULL THEN { name: 'Performer' } ELSE
+				{ model: 'character', uuid: character.uuid, name: castRel.roleName }
 			END) AS roles
 		ORDER BY production.name, theatre.name
 


### PR DESCRIPTION
The current pattern is to connect a `Role` node to a `Person` node for each role the person performs. The `PERFORMS_AS` relationship between the two nodes needs the context of the production in which the role was performed and so has a `prodUuid` property (i.e. the `uuid` of the `Production` node).

Over time this pattern will produce a very large amount of `Role` nodes.

This PR revises the pattern to put all the data from each `Role` node onto a relationship between the `Person` and the `Production`, removing the need for `Role` nodes altogether.

#### Before:
<img width="1000" alt="before" src="https://user-images.githubusercontent.com/10484515/81475158-52810b00-9202-11ea-8281-04291dda9632.png">

#### After:
<img width="999" alt="after" src="https://user-images.githubusercontent.com/10484515/81475160-53b23800-9202-11ea-8a9f-ad00fd1d5e76.png">
