### PR TITLE
Remove method-override dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "directly": "^2.0.4",
     "dotenv": "^2.0.0",
     "express": "^4.17.1",
-    "method-override": "^2.3.6",
     "morgan": "^1.5.1",
     "neo4j-driver": "^4.0.2",
     "uuid": "^3.0.1"

--- a/server/router.js
+++ b/server/router.js
@@ -1,25 +1,10 @@
-/* eslint no-unused-vars: ["error", { "argsIgnorePattern": "response|next" }] */
+/* eslint no-unused-vars: ["error", { "argsIgnorePattern": "next" }] */
 
 import { Router } from 'express';
-import methodOverride from 'method-override';
 
 import * as controllers from './controllers';
 
 const router = new Router();
-
-router.use(methodOverride((request, response) => {
-
-	if (request.body && typeof request.body === 'object' && '_method' in request.body) {
-
-		const method = request.body._method;
-
-		delete request.body._method;
-
-		return method;
-
-	}
-
-}));
 
 router.get('/characters/new', controllers.characters.newRoute);
 router.post('/characters', controllers.characters.createRoute);


### PR DESCRIPTION
All the requests being made to the API work fine without the presence of this module, so I cannot that it needs to be employed.

### Removed dependencies:
- [npm: method-override](https://www.npmjs.com/package/method-override).