### PR TITLE
Add response header Access-Control-Allow-Methods

### DIFF
--- a/server/middleware/access-control-setter.js
+++ b/server/middleware/access-control-setter.js
@@ -3,6 +3,14 @@ export default function (request, response, next) {
 	response.header('Access-Control-Allow-Origin', '*');
 	response.header('Access-Control-Allow-Headers', 'content-type');
 
+	if (request.method === 'OPTIONS') {
+
+		response.header('Access-Control-Allow-Methods', 'PUT');
+
+		return response.sendStatus(200);
+
+	}
+
 	next();
 
 }


### PR DESCRIPTION
If a PUT request is made from Postman then the request works fine.

If a PUT request is made from the browser (e.g. using `theatrebase-cms`) via fetch using CORS (Cross-Origin Resource Sharing), then the request fails.

The `Access-Control-Allow-Methods` response header to the OPTIONS request (which is made as a preflight request ahead of the CORS request) has to be set and include the requisite methods (in this case: PUT).

PUT requests are the only ones that seem to cause this problem (POST requests caused no problem before they were switched for the more semantically correct PUT method for updates), so that is the only method included in this list, but it can be added to in the future if required.

### References:
- [Stack Overflow: In HTTP logs I am seeing OPTIONS, GET, OPTIONS, POST why?](https://stackoverflow.com/questions/25324424/in-http-logs-i-am-seeing-options-get-options-post-why).
- [Stack Overflow: Can't access body data from fetch PUT to express server](https://stackoverflow.com/questions/51231946/cant-access-body-data-from-fetch-put-to-express-server).