### PR TITLE
Remove this.errors from Role class constructor

### DIFF
--- a/src/models/Role.js
+++ b/src/models/Role.js
@@ -9,7 +9,6 @@ export default class Role extends Base {
 
 		this.model = 'role';
 		this.characterName = props.characterName.trim();
-		this.errors = {};
 
 	}
 


### PR DESCRIPTION
Role class is an extension of Base class, which already includes `this.errors = {};` in its constructor, and so including it in the Role class' constructor is a duplication.

This PR removes the duplication.