### PR TITLE
Close Neo4j driver when required

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -8,6 +8,7 @@ import express from 'express';
 import logger from 'morgan';
 
 import { accessControlSetter, errorHandler } from './middleware';
+import { getDriver as getNeo4jDriver } from './neo4j/get-driver';
 import router from './router';
 
 const app = express();
@@ -20,6 +21,8 @@ app.use(
 	errorHandler
 );
 
+const neo4jDriver = getNeo4jDriver();
+
 const port = '3000';
 
 app.set('port', port);
@@ -27,6 +30,11 @@ app.set('port', port);
 const server = http.createServer(app);
 
 server.listen(port, () => console.log(`Listening on port ${port}`)); // eslint-disable-line no-console
+
+const shutDown = () => server.close(() => neo4jDriver.close().then(() => process.exit(0)));
+
+process.on('SIGTERM', shutDown);
+process.on('SIGINT', shutDown);
 
 // Export for integration tests.
 export default app;

--- a/src/neo4j/get-driver.js
+++ b/src/neo4j/get-driver.js
@@ -1,0 +1,9 @@
+import neo4j from 'neo4j-driver';
+
+const { DATABASE_URL, DATABASE_USERNAME, DATABASE_PASSWORD, NODE_ENV } = process.env;
+
+const driver = (NODE_ENV !== 'unit-test') ?
+	neo4j.driver(DATABASE_URL, neo4j.auth.basic(DATABASE_USERNAME, DATABASE_PASSWORD)) :
+	null;
+
+export const getDriver = () => driver;

--- a/src/neo4j/query.js
+++ b/src/neo4j/query.js
@@ -1,10 +1,8 @@
 import neo4j from 'neo4j-driver';
 
-const { DATABASE_URL, DATABASE_USERNAME, DATABASE_PASSWORD, NODE_ENV } = process.env;
+import { getDriver } from './get-driver';
 
-const driver = (NODE_ENV !== 'unit-test') ?
-	neo4j.driver(DATABASE_URL, neo4j.auth.basic(DATABASE_USERNAME, DATABASE_PASSWORD)) :
-	null;
+const driver = getDriver();
 
 const convertRecordsToObjects = response => {
 

--- a/src/setup.js
+++ b/src/setup.js
@@ -1,9 +1,16 @@
 import './dotenv';
 
 import createNeo4jConstraints from './neo4j/create-constraints';
+import { getDriver as getNeo4jDriver } from './neo4j/get-driver';
+
+const neo4jDriver = getNeo4jDriver();
 
 (async () => {
 
 	await createNeo4jConstraints();
+
+	await neo4jDriver.close();
+
+	return;
 
 })();


### PR DESCRIPTION
As per the `neo4j-driver` driver documentation, the driver instance should be closed when the Node.js application exits.

This PR ensures that a shared instance of the driver is closed when:
- Process is terminated.
- Neo4j database 'create constraints' task has finished.

### References:
- [npm: neo4j-driver](https://www.npmjs.com/package/neo4j-driver).
- [Stack Overflow: How Do I Shut Down My Express Server Gracefully When Its Process Is Killed?](https://stackoverflow.com/questions/43003870/how-do-i-shut-down-my-express-server-gracefully-when-its-process-is-killed/43095094#answer-43095094).