### PR TITLE
Use sinon.createStubInstance() for model tests

### DIFF
--- a/test-unit/src/models/Playtext.test.js
+++ b/test-unit/src/models/Playtext.test.js
@@ -17,7 +17,7 @@ describe('Playtext model', () => {
 
 	const CharacterStub = function () {
 
-		this.validateGroupItem = sinon.stub();
+		return sinon.createStubInstance(Character);
 
 	};
 
@@ -70,7 +70,7 @@ describe('Playtext model', () => {
 				'../neo4j/cypher-queries': stubs.Base.cypherQueries,
 				'../neo4j/query': stubs.Base.neo4jQueryModule
 			}),
-			'.': stubOverrides.models || stubs.models
+			'.': stubs.models
 		}).default;
 
 	const createInstance = (stubOverrides = {}, props = DEFAULT_INSTANCE_PROPS) => {
@@ -95,7 +95,6 @@ describe('Playtext model', () => {
 
 			it('assigns array of characters if included in props, retaining those with empty or whitespace-only string names', () => {
 
-				const CharacterStubOverride = function () { return sinon.createStubInstance(Character); };
 				const props = {
 					name: 'The Tragedy of Hamlet, Prince of Denmark',
 					characters: [
@@ -104,7 +103,7 @@ describe('Playtext model', () => {
 						{ name: ' ' }
 					]
 				};
-				const instance = createInstance({ models: { Character: CharacterStubOverride } }, props);
+				const instance = createInstance({}, props);
 				expect(instance.characters.length).to.eq(3);
 				expect(instance.characters[0].constructor.name).to.eq('Character');
 				expect(instance.characters[1].constructor.name).to.eq('Character');

--- a/test-unit/src/models/Production.test.js
+++ b/test-unit/src/models/Production.test.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import proxyquire from 'proxyquire';
 import sinon from 'sinon';
 
-import { PersonCastMember } from '../../../src/models';
+import { BasicModel, PersonCastMember, Theatre } from '../../../src/models';
 import neo4jQueryFixture from '../../fixtures/neo4j-query';
 
 describe('Production model', () => {
@@ -12,19 +12,19 @@ describe('Production model', () => {
 
 	const BasicModelStub = function () {
 
-		this.validate = sinon.stub();
+		return sinon.createStubInstance(BasicModel);
 
 	};
 
 	const PersonCastMemberStub = function () {
 
-		this.runValidations = sinon.stub();
+		return sinon.createStubInstance(PersonCastMember);
 
 	};
 
 	const TheatreStub = function () {
 
-		this.validate = sinon.stub();
+		return sinon.createStubInstance(Theatre);
 
 	};
 
@@ -75,7 +75,7 @@ describe('Production model', () => {
 				'../lib/validate-string': stubs.Base.validateStringModule,
 				'../neo4j/query': stubs.Base.neo4jQueryModule
 			}),
-			'.': stubOverrides.models || stubs.models
+			'.': stubs.models
 		}).default;
 
 	const createInstance = (stubOverrides = {}, props = { name: 'Hamlet', cast: [{ name: 'Patrick Stewart' }] }) => {
@@ -100,7 +100,6 @@ describe('Production model', () => {
 
 			it('assigns array of cast if included in props, retaining those with empty or whitespace-only string names', () => {
 
-				const PersonCastMemberStubOverride = function () { return sinon.createStubInstance(PersonCastMember); };
 				const props = {
 					name: 'Hamlet',
 					cast: [
@@ -109,16 +108,7 @@ describe('Production model', () => {
 						{ name: ' ' }
 					]
 				};
-				const instance = createInstance(
-					{
-						models: {
-							BasicModel: BasicModelStub,
-							PersonCastMember: PersonCastMemberStubOverride,
-							Theatre: TheatreStub
-						}
-					},
-					props
-				);
+				const instance = createInstance({}, props);
 				expect(instance.cast.length).to.eq(3);
 				expect(instance.cast[0].constructor.name).to.eq('PersonCastMember');
 				expect(instance.cast[1].constructor.name).to.eq('PersonCastMember');


### PR DESCRIPTION
Using `test-unit/src/models/Playtext.test.js` as an example:

#### Before:
```js
const CharacterStub = function () {

	this.validateGroupItem = sinon.stub();

};
```

Following the instance being created via `instance = createInstance();`…

`instance.characters[0]` looks like:

```
CharacterStub {
	validateGroupItem: [Function: functionStub] {
		createStubInstance: [Function],
		callsFake: [Function],
		callsArg: [Function],
		callsArgOn: [Function],
		callsArgWith: [Function],
		callsArgOnWith: [Function],
		usingPromise: [Function],
		yields: [Function],
		yieldsRight: [Function],
		yieldsOn: [Function],
		yieldsTo: [Function],
		yieldsToOn: [Function],
		throws: [Function],
		throwsException: [Function],
		returns: [Function],
		returnsArg: [Function],
		throwsArg: [Function],
		returnsThis: [Function],
		resolves: [Function],
		resolvesArg: [Function],
		rejects: [Function],
		resolvesThis: [Function],
		callThrough: [Function],
		callThroughWithNew: [Function],
		get: [Function],
		set: [Function],
		value: [Function],
		callsArgAsync: [Function],
		callsArgOnAsync: [Function],
		callsArgWithAsync: [Function],
		callsArgOnWithAsync: [Function],
		yieldsAsync: [Function],
		yieldsRightAsync: [Function],
		yieldsOnAsync: [Function],
		yieldsToAsync: [Function],
		yieldsToOnAsync: [Function],
		create: [Function: create],
		resetBehavior: [Function: resetBehavior],
		reset: [Function: reset],
		onCall: [Function: onCall],
		onFirstCall: [Function: onFirstCall],
		onSecondCall: [Function: onSecondCall],
		onThirdCall: [Function: onThirdCall]
	}
}
```

`instance.characters[0].validateGroupItem` looks like:

```
[Function: functionStub] {
	createStubInstance: [Function],
	callsFake: [Function],
	callsArg: [Function],
	callsArgOn: [Function],
	callsArgWith: [Function],
	callsArgOnWith: [Function],
	usingPromise: [Function],
	yields: [Function],
	yieldsRight: [Function],
	yieldsOn: [Function],
	yieldsTo: [Function],
	yieldsToOn: [Function],
	throws: [Function],
	throwsException: [Function],
	returns: [Function],
	returnsArg: [Function],
	throwsArg: [Function],
	returnsThis: [Function],
	resolves: [Function],
	resolvesArg: [Function],
	rejects: [Function],
	resolvesThis: [Function],
	callThrough: [Function],
	callThroughWithNew: [Function],
	get: [Function],
	set: [Function],
	value: [Function],
	callsArgAsync: [Function],
	callsArgOnAsync: [Function],
	callsArgWithAsync: [Function],
	callsArgOnWithAsync: [Function],
	yieldsAsync: [Function],
	yieldsRightAsync: [Function],
	yieldsOnAsync: [Function],
	yieldsToAsync: [Function],
	yieldsToOnAsync: [Function],
	create: [Function: create],
	resetBehavior: [Function: resetBehavior],
	reset: [Function: reset],
	onCall: [Function: onCall],
	onFirstCall: [Function: onFirstCall],
	onSecondCall: [Function: onSecondCall],
	onThirdCall: [Function: onThirdCall]
}
```

#### After:
```js
const CharacterStub = function () {

	return sinon.createStubInstance(Character);

};
```

Following the instance being created via `instance = createInstance();`…

`instance.characters[0]` looks like:

```
Character {}
```

`instance.characters[0].validateGroupItem` looks like:

```
[Function: functionStub] {
	createStubInstance: [Function],
	callsFake: [Function],
	callsArg: [Function],
	callsArgOn: [Function],
	callsArgWith: [Function],
	callsArgOnWith: [Function],
	usingPromise: [Function],
	yields: [Function],
	yieldsRight: [Function],
	yieldsOn: [Function],
	yieldsTo: [Function],
	yieldsToOn: [Function],
	throws: [Function],
	throwsException: [Function],
	returns: [Function],
	returnsArg: [Function],
	throwsArg: [Function],
	returnsThis: [Function],
	resolves: [Function],
	resolvesArg: [Function],
	rejects: [Function],
	resolvesThis: [Function],
	callThrough: [Function],
	callThroughWithNew: [Function],
	get: [Function],
	set: [Function],
	value: [Function],
	callsArgAsync: [Function],
	callsArgOnAsync: [Function],
	callsArgWithAsync: [Function],
	callsArgOnWithAsync: [Function],
	yieldsAsync: [Function],
	yieldsRightAsync: [Function],
	yieldsOnAsync: [Function],
	yieldsToAsync: [Function],
	yieldsToOnAsync: [Function],
	create: [Function: create],
	resetBehavior: [Function: resetBehavior],
	reset: [Function: reset],
	onCall: [Function: onCall],
	onFirstCall: [Function: onFirstCall],
	onSecondCall: [Function: onSecondCall],
	onThirdCall: [Function: onThirdCall],
	wrappedMethod: [Function: validateGroupItem]
}
```

---

I guess the current implementation was applied because it looked like `sinon.createStubInstance()` would create an instance where the methods were not be present and could therefore not be examined, but in fact this is not the case and it behaves just as the documentation describes:
> Creates a new object with the given function as the prototype and stubs all implemented functions.

#### References:
- [Sinon.JS: Utilities - sinon.createStubInstance(constructor);](https://sinonjs.org/releases/latest/utils#sinoncreatestubinstanceconstructor).