### PR TITLE
Use instanceof operator for model unit tests

### DIFF
--- a/test-unit/src/models/Base.test.js
+++ b/test-unit/src/models/Base.test.js
@@ -277,7 +277,7 @@ describe('Base model', () => {
 				expect(stubs.neo4jQuery.calledTwice).to.be.true;
 				expect(stubs.sharedQueries.getCreateQuery.calledOnce).to.be.true;
 				expect(stubs.prepareAsParams.calledOnce).to.be.true;
-				expect(result.constructor.name).to.eq('Base');
+				expect(result instanceof Base).to.be.true;
 
 			});
 
@@ -306,7 +306,7 @@ describe('Base model', () => {
 				expect(stubs.neo4jQuery.calledTwice).to.be.true;
 				expect(stubs.sharedQueries.getUpdateQuery.calledOnce).to.be.true;
 				expect(stubs.prepareAsParams.calledOnce).to.be.true;
-				expect(result.constructor.name).to.eq('Base');
+				expect(result instanceof Base).to.be.true;
 
 			});
 
@@ -421,7 +421,7 @@ describe('Base model', () => {
 				expect(stubs.neo4jQuery.calledWithExactly(
 					{ query: 'getEditProductionQuery response', params: instance }
 				)).to.be.true;
-				expect(result.constructor.name).to.eq('Base');
+				expect(result instanceof Base).to.be.true;
 
 			});
 
@@ -439,7 +439,7 @@ describe('Base model', () => {
 				expect(stubs.neo4jQuery.calledWithExactly(
 					{ query: 'getEditQuery response', params: instance }
 				)).to.be.true;
-				expect(result.constructor.name).to.eq('Base');
+				expect(result instanceof Base).to.be.true;
 
 			});
 

--- a/test-unit/src/models/PersonCastMember.test.js
+++ b/test-unit/src/models/PersonCastMember.test.js
@@ -67,9 +67,9 @@ describe('Person Cast Member model', () => {
 				};
 				instance = createInstance(props);
 				expect(instance.roles.length).to.eq(3);
-				expect(instance.roles[0].constructor.name).to.eq('Role');
-				expect(instance.roles[1].constructor.name).to.eq('Role');
-				expect(instance.roles[2].constructor.name).to.eq('Role');
+				expect(instance.roles[0] instanceof Role).to.be.true;
+				expect(instance.roles[1] instanceof Role).to.be.true;
+				expect(instance.roles[2] instanceof Role).to.be.true;
 
 			});
 

--- a/test-unit/src/models/Playtext.test.js
+++ b/test-unit/src/models/Playtext.test.js
@@ -105,9 +105,9 @@ describe('Playtext model', () => {
 				};
 				const instance = createInstance({}, props);
 				expect(instance.characters.length).to.eq(3);
-				expect(instance.characters[0].constructor.name).to.eq('Character');
-				expect(instance.characters[1].constructor.name).to.eq('Character');
-				expect(instance.characters[2].constructor.name).to.eq('Character');
+				expect(instance.characters[0] instanceof Character).to.be.true;
+				expect(instance.characters[1] instanceof Character).to.be.true;
+				expect(instance.characters[2] instanceof Character).to.be.true;
 
 			});
 

--- a/test-unit/src/models/Production.test.js
+++ b/test-unit/src/models/Production.test.js
@@ -110,9 +110,9 @@ describe('Production model', () => {
 				};
 				const instance = createInstance({}, props);
 				expect(instance.cast.length).to.eq(3);
-				expect(instance.cast[0].constructor.name).to.eq('PersonCastMember');
-				expect(instance.cast[1].constructor.name).to.eq('PersonCastMember');
-				expect(instance.cast[2].constructor.name).to.eq('PersonCastMember');
+				expect(instance.cast[0] instanceof PersonCastMember).to.be.true;
+				expect(instance.cast[1] instanceof PersonCastMember).to.be.true;
+				expect(instance.cast[2] instanceof PersonCastMember).to.be.true;
 
 			});
 


### PR DESCRIPTION
The `instanceof` operator allows the comparison to be made against the actual class rather than the constructor name. It's essentially the same test but this somehow feels a little more tightly aligned with the intention.

In `test-unit/src/models/Playtext.test.js` and `test-unit/src/models/Production.test.js` there are test expectations for a value to be an instance of the Playtext and Production classes respectively, but in those cases they have been created via proxyquire and so are technically not instances of the class meaning we still have to use an expectation based on `constructor.name` for the test.