### PR TITLE
Reorder NODE_ENV ternary

### DIFF
--- a/src/neo4j/get-driver.js
+++ b/src/neo4j/get-driver.js
@@ -2,8 +2,8 @@ import neo4j from 'neo4j-driver';
 
 const { DATABASE_URL, DATABASE_USERNAME, DATABASE_PASSWORD, NODE_ENV } = process.env;
 
-const driver = (NODE_ENV !== 'unit-test') ?
-	neo4j.driver(DATABASE_URL, neo4j.auth.basic(DATABASE_USERNAME, DATABASE_PASSWORD)) :
-	null;
+const driver = (NODE_ENV === 'unit-test') ?
+	null :
+	neo4j.driver(DATABASE_URL, neo4j.auth.basic(DATABASE_USERNAME, DATABASE_PASSWORD));
 
 export const getDriver = () => driver;


### PR DESCRIPTION
Conditionals are generally easier to parse if they start with a positive expression rather than a negation.