### PR TITLE
Rename renderJson module -> sendJsonResponse

### DIFF
--- a/src/controllers/characters.js
+++ b/src/controllers/characters.js
@@ -1,11 +1,11 @@
 /* eslint no-unused-vars: ["error", { "argsIgnorePattern": "next" }] */
 
 import { callInstanceMethod, callStaticListMethod } from '../lib/call-class-methods';
-import { renderJson } from '../lib/render-json';
+import { sendJsonResponse } from '../lib/send-json-response';
 import { Character } from '../models';
 
 const newRoute = (request, response, next) =>
-	renderJson(response, new Character());
+	sendJsonResponse(response, new Character());
 
 const createRoute = (request, response, next) =>
 	callInstanceMethod(response, next, new Character(request.body), 'create');

--- a/src/controllers/people.js
+++ b/src/controllers/people.js
@@ -1,11 +1,11 @@
 /* eslint no-unused-vars: ["error", { "argsIgnorePattern": "next" }] */
 
 import { callInstanceMethod, callStaticListMethod } from '../lib/call-class-methods';
-import { renderJson } from '../lib/render-json';
+import { sendJsonResponse } from '../lib/send-json-response';
 import { Person } from '../models';
 
 const newRoute = (request, response, next) =>
-	renderJson(response, new Person());
+	sendJsonResponse(response, new Person());
 
 const createRoute = (request, response, next) =>
 	callInstanceMethod(response, next, new Person(request.body), 'create');

--- a/src/controllers/playtexts.js
+++ b/src/controllers/playtexts.js
@@ -2,11 +2,11 @@
 
 import { playtext as playtextTemplateProps } from './model-template-props';
 import { callInstanceMethod, callStaticListMethod } from '../lib/call-class-methods';
-import { renderJson } from '../lib/render-json';
+import { sendJsonResponse } from '../lib/send-json-response';
 import { Playtext } from '../models';
 
 const newRoute = (request, response, next) =>
-	renderJson(response, new Playtext(playtextTemplateProps));
+	sendJsonResponse(response, new Playtext(playtextTemplateProps));
 
 const createRoute = (request, response, next) =>
 	callInstanceMethod(response, next, new Playtext(request.body), 'create');

--- a/src/controllers/productions.js
+++ b/src/controllers/productions.js
@@ -2,11 +2,11 @@
 
 import { production as productionTemplateProps } from './model-template-props';
 import { callInstanceMethod, callStaticListMethod } from '../lib/call-class-methods';
-import { renderJson } from '../lib/render-json';
+import { sendJsonResponse } from '../lib/send-json-response';
 import { Production } from '../models';
 
 const newRoute = (request, response, next) =>
-	renderJson(response, new Production(productionTemplateProps));
+	sendJsonResponse(response, new Production(productionTemplateProps));
 
 const createRoute = (request, response, next) =>
 	callInstanceMethod(response, next, new Production(request.body), 'create');

--- a/src/controllers/theatres.js
+++ b/src/controllers/theatres.js
@@ -1,11 +1,11 @@
 /* eslint no-unused-vars: ["error", { "argsIgnorePattern": "next" }] */
 
 import { callInstanceMethod, callStaticListMethod } from '../lib/call-class-methods';
-import { renderJson } from '../lib/render-json';
+import { sendJsonResponse } from '../lib/send-json-response';
 import { Theatre } from '../models';
 
 const newRoute = (request, response, next) =>
-	renderJson(response, new Theatre());
+	sendJsonResponse(response, new Theatre());
 
 const createRoute = (request, response, next) =>
 	callInstanceMethod(response, next, new Theatre(request.body), 'create');

--- a/src/lib/call-class-methods.js
+++ b/src/lib/call-class-methods.js
@@ -1,4 +1,4 @@
-import { renderJson } from './render-json';
+import { sendJsonResponse } from './send-json-response';
 
 const callInstanceMethod = async (response, next, classInstance, method) => {
 
@@ -6,7 +6,7 @@ const callInstanceMethod = async (response, next, classInstance, method) => {
 
 		const instance = await classInstance[method]();
 
-		return renderJson(response, instance)
+		return sendJsonResponse(response, instance)
 
 	} catch (error) {
 
@@ -24,7 +24,7 @@ const callStaticListMethod = async (response, next, Class, model) => {
 
 		const instances = await Class.list(model);
 
-		return renderJson(response, instances);
+		return sendJsonResponse(response, instances);
 
 	} catch (error) {
 

--- a/src/lib/send-json-response.js
+++ b/src/lib/send-json-response.js
@@ -1,4 +1,4 @@
-export const renderJson = (response, instance) => {
+export const sendJsonResponse = (response, instance) => {
 
 	response.setHeader('content-type', 'application/json');
 

--- a/test-unit/src/controllers/characters.test.js
+++ b/test-unit/src/controllers/characters.test.js
@@ -21,8 +21,8 @@ describe('Characters controller', () => {
 				callInstanceMethod: sinon.stub().resolves('callInstanceMethod response'),
 				callStaticListMethod: sinon.stub().resolves('callStaticListMethod response')
 			},
-			renderJsonModule: {
-				renderJson: sinon.stub().returns('renderJson response')
+			sendJsonResponseModule: {
+				sendJsonResponse: sinon.stub().returns('sendJsonResponse response')
 			},
 			models: {
 				Character: CharacterStub
@@ -37,7 +37,7 @@ describe('Characters controller', () => {
 	const createSubject = () =>
 		proxyquire('../../../src/controllers/characters', {
 			'../lib/call-class-methods': stubs.callClassMethodsModule,
-			'../lib/render-json': stubs.renderJsonModule,
+			'../lib/send-json-response': stubs.sendJsonResponseModule,
 			'../models': stubs.models
 		});
 
@@ -51,11 +51,11 @@ describe('Characters controller', () => {
 
 	describe('newRoute function', () => {
 
-		it('calls renderJson module', () => {
+		it('calls sendJsonResponse module', () => {
 
-			expect(callFunction('newRoute')).to.eq('renderJson response');
-			expect(stubs.renderJsonModule.renderJson.calledOnce).to.be.true;
-			expect(stubs.renderJsonModule.renderJson.calledWithExactly(
+			expect(callFunction('newRoute')).to.eq('sendJsonResponse response');
+			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledOnce).to.be.true;
+			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledWithExactly(
 				stubs.response,
 				stubs.models.Character()
 			)).to.be.true;

--- a/test-unit/src/controllers/people.test.js
+++ b/test-unit/src/controllers/people.test.js
@@ -21,8 +21,8 @@ describe('People controller', () => {
 				callInstanceMethod: sinon.stub().resolves('callInstanceMethod response'),
 				callStaticListMethod: sinon.stub().resolves('callStaticListMethod response')
 			},
-			renderJsonModule: {
-				renderJson: sinon.stub().returns('renderJson response')
+			sendJsonResponseModule: {
+				sendJsonResponse: sinon.stub().returns('sendJsonResponse response')
 			},
 			models: {
 				Person: PersonStub
@@ -37,7 +37,7 @@ describe('People controller', () => {
 	const createSubject = () =>
 		proxyquire('../../../src/controllers/people', {
 			'../lib/call-class-methods': stubs.callClassMethodsModule,
-			'../lib/render-json': stubs.renderJsonModule,
+			'../lib/send-json-response': stubs.sendJsonResponseModule,
 			'../models': stubs.models
 		});
 
@@ -51,11 +51,13 @@ describe('People controller', () => {
 
 	describe('newRoute function', () => {
 
-		it('calls renderJson module', () => {
+		it('calls sendJsonResponse module', () => {
 
-			expect(callFunction('newRoute')).to.eq('renderJson response');
-			expect(stubs.renderJsonModule.renderJson.calledOnce).to.be.true;
-			expect(stubs.renderJsonModule.renderJson.calledWithExactly(stubs.response, stubs.models.Person())).to.be.true;
+			expect(callFunction('newRoute')).to.eq('sendJsonResponse response');
+			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledOnce).to.be.true;
+			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledWithExactly(
+				stubs.response, stubs.models.Person()
+			)).to.be.true;
 
 		});
 

--- a/test-unit/src/controllers/playtexts.test.js
+++ b/test-unit/src/controllers/playtexts.test.js
@@ -21,8 +21,8 @@ describe('Playtexts controller', () => {
 				callInstanceMethod: sinon.stub().resolves('callInstanceMethod response'),
 				callStaticListMethod: sinon.stub().resolves('callStaticListMethod response')
 			},
-			renderJsonModule: {
-				renderJson: sinon.stub().returns('renderJson response')
+			sendJsonResponseModule: {
+				sendJsonResponse: sinon.stub().returns('sendJsonResponse response')
 			},
 			models: {
 				Playtext: PlaytextStub
@@ -37,7 +37,7 @@ describe('Playtexts controller', () => {
 	const createSubject = () =>
 		proxyquire('../../../src/controllers/playtexts', {
 			'../lib/call-class-methods': stubs.callClassMethodsModule,
-			'../lib/render-json': stubs.renderJsonModule,
+			'../lib/send-json-response': stubs.sendJsonResponseModule,
 			'../models': stubs.models
 		});
 
@@ -51,11 +51,13 @@ describe('Playtexts controller', () => {
 
 	describe('newRoute function', () => {
 
-		it('calls renderJson module', () => {
+		it('calls sendJsonResponse module', () => {
 
-			expect(callFunction('newRoute')).to.eq('renderJson response');
-			expect(stubs.renderJsonModule.renderJson.calledOnce).to.be.true;
-			expect(stubs.renderJsonModule.renderJson.calledWithExactly(stubs.response, stubs.models.Playtext())).to.be.true;
+			expect(callFunction('newRoute')).to.eq('sendJsonResponse response');
+			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledOnce).to.be.true;
+			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledWithExactly(
+				stubs.response, stubs.models.Playtext()
+			)).to.be.true;
 
 		});
 

--- a/test-unit/src/controllers/productions.test.js
+++ b/test-unit/src/controllers/productions.test.js
@@ -21,8 +21,8 @@ describe('Productions controller', () => {
 				callInstanceMethod: sinon.stub().resolves('callInstanceMethod response'),
 				callStaticListMethod: sinon.stub().resolves('callStaticListMethod response')
 			},
-			renderJsonModule: {
-				renderJson: sinon.stub().returns('renderJson response')
+			sendJsonResponseModule: {
+				sendJsonResponse: sinon.stub().returns('sendJsonResponse response')
 			},
 			models: {
 				Production: ProductionStub
@@ -37,7 +37,7 @@ describe('Productions controller', () => {
 	const createSubject = () =>
 		proxyquire('../../../src/controllers/productions', {
 			'../lib/call-class-methods': stubs.callClassMethodsModule,
-			'../lib/render-json': stubs.renderJsonModule,
+			'../lib/send-json-response': stubs.sendJsonResponseModule,
 			'../models': stubs.models
 		});
 
@@ -51,11 +51,11 @@ describe('Productions controller', () => {
 
 	describe('newRoute function', () => {
 
-		it('calls renderJson module', () => {
+		it('calls sendJsonResponse module', () => {
 
-			expect(callFunction('newRoute')).to.eq('renderJson response');
-			expect(stubs.renderJsonModule.renderJson.calledOnce).to.be.true;
-			expect(stubs.renderJsonModule.renderJson.calledWithExactly(
+			expect(callFunction('newRoute')).to.eq('sendJsonResponse response');
+			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledOnce).to.be.true;
+			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledWithExactly(
 				stubs.response,
 				stubs.models.Production()
 			)).to.be.true;

--- a/test-unit/src/controllers/theatres.test.js
+++ b/test-unit/src/controllers/theatres.test.js
@@ -21,8 +21,8 @@ describe('Theatres controller', () => {
 				callInstanceMethod: sinon.stub().resolves('callInstanceMethod response'),
 				callStaticListMethod: sinon.stub().resolves('callStaticListMethod response')
 			},
-			renderJsonModule: {
-				renderJson: sinon.stub().returns('renderJson response')
+			sendJsonResponseModule: {
+				sendJsonResponse: sinon.stub().returns('sendJsonResponse response')
 			},
 			models: {
 				Theatre: TheatreStub
@@ -37,7 +37,7 @@ describe('Theatres controller', () => {
 	const createSubject = () =>
 		proxyquire('../../../src/controllers/theatres', {
 			'../lib/call-class-methods': stubs.callClassMethodsModule,
-			'../lib/render-json': stubs.renderJsonModule,
+			'../lib/send-json-response': stubs.sendJsonResponseModule,
 			'../models': stubs.models
 		});
 
@@ -51,11 +51,13 @@ describe('Theatres controller', () => {
 
 	describe('newRoute function', () => {
 
-		it('calls renderJson module', () => {
+		it('calls sendJsonResponse module', () => {
 
-			expect(callFunction('newRoute')).to.eq('renderJson response');
-			expect(stubs.renderJsonModule.renderJson.calledOnce).to.be.true;
-			expect(stubs.renderJsonModule.renderJson.calledWithExactly(stubs.response, stubs.models.Theatre())).to.be.true;
+			expect(callFunction('newRoute')).to.eq('sendJsonResponse response');
+			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledOnce).to.be.true;
+			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledWithExactly(
+				stubs.response, stubs.models.Theatre()
+			)).to.be.true;
 
 		});
 

--- a/test-unit/src/lib/call-class-methods.test.js
+++ b/test-unit/src/lib/call-class-methods.test.js
@@ -3,7 +3,7 @@ import httpMocks from 'node-mocks-http';
 import { createSandbox } from 'sinon';
 
 import * as callClassMethods from '../../../src/lib/call-class-methods';
-import * as renderJsonModule from '../../../src/lib/render-json';
+import * as sendJsonResponseModule from '../../../src/lib/send-json-response';
 import { Character } from '../../../src/models';
 
 describe('Call Class Methods module', () => {
@@ -18,7 +18,8 @@ describe('Call Class Methods module', () => {
 	beforeEach(() => {
 
 		stubs = {
-			renderJson: sandbox.stub(renderJsonModule, 'renderJson').returns('renderJson response'),
+			sendJsonResponse:
+				sandbox.stub(sendJsonResponseModule, 'sendJsonResponse').returns('sendJsonResponse response'),
 			response: httpMocks.createResponse(),
 			next: sandbox.stub()
 		};
@@ -49,10 +50,10 @@ describe('Call Class Methods module', () => {
 				const instanceMethodResponse = { property: 'value' };
 				sandbox.stub(character, method).callsFake(() => { return Promise.resolve(instanceMethodResponse) });
 				const result = await callClassMethods.callInstanceMethod(stubs.response, stubs.next, character, method);
-				expect(stubs.renderJson.calledOnce).to.be.true;
-				expect(stubs.renderJson.calledWithExactly(stubs.response, instanceMethodResponse)).to.be.true;
+				expect(stubs.sendJsonResponse.calledOnce).to.be.true;
+				expect(stubs.sendJsonResponse.calledWithExactly(stubs.response, instanceMethodResponse)).to.be.true;
 				expect(stubs.next.notCalled).to.be.true;
-				expect(result).to.eq('renderJson response');
+				expect(result).to.eq('sendJsonResponse response');
 
 			});
 
@@ -66,7 +67,7 @@ describe('Call Class Methods module', () => {
 				await callClassMethods.callInstanceMethod(stubs.response, stubs.next, character, method);
 				expect(stubs.next.calledOnce).to.be.true;
 				expect(stubs.next.calledWithExactly(error)).to.be.true;
-				expect(stubs.renderJson.notCalled).to.be.true;
+				expect(stubs.sendJsonResponse.notCalled).to.be.true;
 
 			});
 
@@ -80,7 +81,7 @@ describe('Call Class Methods module', () => {
 				await callClassMethods.callInstanceMethod(stubs.response, stubs.next, character, method);
 				expect(stubs.response.statusCode).to.eq(404);
 				expect(stubs.response._getData()).to.eq('Not Found');
-				expect(stubs.renderJson.notCalled).to.be.true;
+				expect(stubs.sendJsonResponse.notCalled).to.be.true;
 				expect(stubs.next.called).to.be.false;
 
 			});
@@ -107,12 +108,12 @@ describe('Call Class Methods module', () => {
 				sandbox.stub(Character, method).callsFake(() => { return Promise.resolve(staticListMethodResponse) });
 				const result =
 					await callClassMethods.callStaticListMethod(stubs.response, stubs.next, Character, 'character');
-				expect(stubs.renderJson.calledOnce).to.be.true;
-				expect(stubs.renderJson.calledWithExactly(
+				expect(stubs.sendJsonResponse.calledOnce).to.be.true;
+				expect(stubs.sendJsonResponse.calledWithExactly(
 					stubs.response, staticListMethodResponse
 				)).to.be.true;
 				expect(stubs.next.notCalled).to.be.true;
-				expect(result).to.eq('renderJson response');
+				expect(result).to.eq('sendJsonResponse response');
 
 			});
 
@@ -126,7 +127,7 @@ describe('Call Class Methods module', () => {
 				await callClassMethods.callStaticListMethod(stubs.response, stubs.next, Character, 'character');
 				expect(stubs.next.calledOnce).to.be.true;
 				expect(stubs.next.calledWithExactly(error)).to.be.true;
-				expect(stubs.renderJson.notCalled).to.be.true;
+				expect(stubs.sendJsonResponse.notCalled).to.be.true;
 
 			});
 

--- a/test-unit/src/lib/send-json-response.test.js
+++ b/test-unit/src/lib/send-json-response.test.js
@@ -1,14 +1,14 @@
 import { expect } from 'chai';
 import httpMocks from 'node-mocks-http';
 
-import { renderJson } from '../../../src/lib/render-json';
+import { sendJsonResponse } from '../../../src/lib/send-json-response';
 
-describe('Render JSON module', () => {
+describe('Send JSON Response module', () => {
 
 	it('renders form page with requisite data', () => {
 
 		const response = httpMocks.createResponse();
-		renderJson(response, { instanceProperty: 'instanceValue' });
+		sendJsonResponse(response, { instanceProperty: 'instanceValue' });
 		expect(response.statusCode).to.eq(200);
 		expect(response._getHeaders()).to.deep.eq({ 'content-type': 'application/json' });
 		expect(response._getData()).to.eq('{"instanceProperty":"instanceValue"}');


### PR DESCRIPTION
The new name makes a lot more sense given what the module does, i.e. sends a JSON response (duh).