### PR TITLE
Check instance existence before update validation

### DIFF
--- a/src/models/Base.js
+++ b/src/models/Base.js
@@ -57,6 +57,19 @@ export default class Base {
 
 	}
 
+	async confirmExistenceInDb () {
+
+		const { getExistenceQuery } = sharedQueries;
+
+		const { exists } = await neo4jQuery({
+			query: getExistenceQuery(this.model),
+			params: this
+		});
+
+		if (!exists) throw new Error('Not Found');
+
+	}
+
 	setErrorStatus () {
 
 		this.hasErrors = hasErrors(this);
@@ -107,7 +120,9 @@ export default class Base {
 
 	}
 
-	update () {
+	async update () {
+
+		await this.confirmExistenceInDb();
 
 		const { getUpdateQuery } = sharedQueries;
 

--- a/src/neo4j/cypher-queries/shared.js
+++ b/src/neo4j/cypher-queries/shared.js
@@ -1,5 +1,15 @@
 import { capitalise } from '../../lib/strings';
 
+const getExistenceQuery = model => `
+	MATCH (n:${capitalise(model)} { uuid: $uuid })
+
+	RETURN
+		CASE WHEN SIGN(COUNT(n)) = 1
+			THEN true
+			ELSE false
+		END AS exists
+`;
+
 const getValidateQuery = (model, uuid) => `
 	MATCH (n:${capitalise(model)} { name: $name })
 		${uuid ? 'WHERE n.uuid <> $uuid' : ''}
@@ -65,6 +75,7 @@ const getListQuery = model => {
 };
 
 export {
+	getExistenceQuery,
 	getValidateQuery,
 	getCreateQuery,
 	getEditQuery,


### PR DESCRIPTION
- Non-database validations, e.g. name is too short/long.
- Database validations, e.g. instance does not exist, name already exists on another instance.

The current behaviour will return the instance if there are any non-database validation errors, i.e. will not proceed to the database validations.

If unwittingly trying to update a non-existent instance without the GUI (`theatrebase-cms`), e.g. via Postman, then if there are non-database validation errors (e.g. name property is too short/long) then these errors would need to be corrected before the user receives the feedback that the instance does not even exist, and so adds unnecessary work.

Future work will be to perform both sets of validations before sending response (i.e. those that do not consult the database, and those that do).