### PR TITLE
Revise createUpdate validations

### DIFF
--- a/src/lib/validate-string.js
+++ b/src/lib/validate-string.js
@@ -2,20 +2,20 @@ export const validateString = (stringValue, isRequiredString) => {
 
 	const STRING_MAX_LENGTH = 1000;
 
-	const stringErrors = [];
+	let errorText;
 
 	const isStringWithLength =
 		stringValue !== null &&
 		!!stringValue.length;
 
-	if (isRequiredString && !isStringWithLength) stringErrors.push('Name is too short');
+	if (isRequiredString && !isStringWithLength) errorText = 'Name is too short';
 
 	const isStringExceedingMaxLength =
 		isStringWithLength &&
 		stringValue.length > STRING_MAX_LENGTH;
 
-	if (isStringExceedingMaxLength) stringErrors.push('Name is too long');
+	if (isStringExceedingMaxLength) errorText = 'Name is too long';
 
-	return stringErrors;
+	return errorText;
 
 };

--- a/src/models/Base.js
+++ b/src/models/Base.js
@@ -22,9 +22,9 @@ export default class Base {
 
 	validate (opts = { requiresName: false }) {
 
-		const nameErrors = validateString(this.name, opts.requiresName);
+		const nameErrorText = validateString(this.name, opts.requiresName);
 
-		if (nameErrors.length) this.errors.name = nameErrors;
+		if (nameErrorText) this.addPropertyError('name', nameErrorText);
 
 	}
 
@@ -32,15 +32,7 @@ export default class Base {
 
 		this.validate(opts);
 
-		if (opts.hasDuplicateName) {
-
-			const nameDuplicationErrorText = 'Name has been duplicated in this group';
-
-			this.errors.name
-				? this.errors.name.push(nameDuplicationErrorText)
-				: this.errors.name = [nameDuplicationErrorText];
-
-		}
+		if (opts.hasDuplicateName) this.addPropertyError('name', 'Name has been duplicated in this group');
 
 	}
 
@@ -53,7 +45,15 @@ export default class Base {
 			params: this
 		});
 
-		if (instanceCount > 0) this.errors.name = ['Name already exists'];
+		if (instanceCount > 0) this.addPropertyError('name', 'Name already exists');
+
+	}
+
+	addPropertyError (property, errorText) {
+
+		this.errors[property]
+			? this.errors[property].push(errorText)
+			: this.errors[property] = [errorText];
 
 	}
 
@@ -79,10 +79,6 @@ export default class Base {
 	async createUpdate (getCreateUpdateQuery) {
 
 		this.validate({ requiresName: true });
-
-		this.setErrorStatus();
-
-		if (this.hasErrors) return this;
 
 		await this.validateInDb();
 

--- a/src/models/Playtext.js
+++ b/src/models/Playtext.js
@@ -36,10 +36,6 @@ export default class Playtext extends Base {
 
 		this.runValidations();
 
-		this.setErrorStatus();
-
-		if (this.hasErrors) return this;
-
 		await this.validateInDb();
 
 		this.setErrorStatus();

--- a/src/models/Role.js
+++ b/src/models/Role.js
@@ -14,9 +14,9 @@ export default class Role extends Base {
 
 	validateCharacterName (opts) {
 
-		const characterNameErrors = validateString(this.characterName, opts.requiresCharacterName);
+		const characterNameErrorText = validateString(this.characterName, opts.requiresCharacterName);
 
-		if (characterNameErrors.length) this.errors.characterName = characterNameErrors;
+		if (characterNameErrorText) this.addPropertyError('characterName', characterNameErrorText);
 
 	}
 

--- a/test-unit/src/lib/validate-string.test.js
+++ b/test-unit/src/lib/validate-string.test.js
@@ -15,7 +15,7 @@ describe('Validate String module', () => {
 
 			it('adds error to and returns stringErrors array', () => {
 
-				expect(validateString(EMPTY_STRING, true)).to.deep.eq(['Name is too short']);
+				expect(validateString(EMPTY_STRING, true)).to.eq('Name is too short');
 
 			});
 
@@ -25,7 +25,7 @@ describe('Validate String module', () => {
 
 			it('returns empty stringErrors array', () => {
 
-				expect(validateString(EMPTY_STRING, false)).to.deep.eq([]);
+				expect(validateString(EMPTY_STRING, false)).to.eq(undefined);
 
 			});
 
@@ -39,7 +39,7 @@ describe('Validate String module', () => {
 
 			it('returns empty stringErrors array', () => {
 
-				expect(validateString(MAX_LENGTH_STRING, true)).to.deep.eq([]);
+				expect(validateString(MAX_LENGTH_STRING, true)).to.eq(undefined);
 
 			});
 
@@ -49,7 +49,7 @@ describe('Validate String module', () => {
 
 			it('returns empty stringErrors array', () => {
 
-				expect(validateString(MAX_LENGTH_STRING, false)).to.deep.eq([]);
+				expect(validateString(MAX_LENGTH_STRING, false)).to.eq(undefined);
 
 			});
 
@@ -63,7 +63,7 @@ describe('Validate String module', () => {
 
 			it('adds error to and returns stringErrors array', () => {
 
-				expect(validateString(ABOVE_MAX_LENGTH_STRING, true)).to.deep.eq(['Name is too long']);
+				expect(validateString(ABOVE_MAX_LENGTH_STRING, true)).to.eq('Name is too long');
 
 			});
 
@@ -73,7 +73,7 @@ describe('Validate String module', () => {
 
 			it('adds error to and returns stringErrors array', () => {
 
-				expect(validateString(ABOVE_MAX_LENGTH_STRING, false)).to.deep.eq(['Name is too long']);
+				expect(validateString(ABOVE_MAX_LENGTH_STRING, false)).to.eq('Name is too long');
 
 			});
 
@@ -87,7 +87,7 @@ describe('Validate String module', () => {
 
 			it('adds error to and returns stringErrors array', () => {
 
-				expect(validateString(null, true)).to.deep.eq(['Name is too short']);
+				expect(validateString(null, true)).to.eq('Name is too short');
 
 			});
 
@@ -97,7 +97,7 @@ describe('Validate String module', () => {
 
 			it('returns empty stringErrors array', () => {
 
-				expect(validateString(null, false)).to.deep.eq([]);
+				expect(validateString(null, false)).to.eq(undefined);
 
 			});
 

--- a/test-unit/src/models/Playtext.test.js
+++ b/test-unit/src/models/Playtext.test.js
@@ -142,13 +142,15 @@ describe('Playtext model', () => {
 
 				const getCreateQueryStub = sinon.stub().returns('getCreateQuery response');
 				sinon.spy(instance, 'runValidations');
-				sinon.spy(instance, 'setErrorStatus');
 				sinon.spy(instance, 'validateInDb');
+				sinon.spy(instance, 'setErrorStatus');
 				const result = await instance.createUpdate(getCreateQueryStub);
 				sinon.assert.callOrder(
 					instance.runValidations.withArgs(),
-					instance.setErrorStatus.withArgs(),
 					instance.validateInDb.withArgs(),
+					stubs.Base.cypherQueries.sharedQueries.getValidateQuery.withArgs(instance.model, instance.uuid),
+					stubs.Base.neo4jQueryModule.neo4jQuery.withArgs({ query: 'getValidateQuery response', params: instance }),
+					instance.setErrorStatus.withArgs(),
 					stubs.Base.hasErrorsModule.hasErrors.withArgs(instance),
 					getCreateQueryStub.withArgs(),
 					stubs.prepareAsParamsModule.prepareAsParams.withArgs(instance),
@@ -156,9 +158,11 @@ describe('Playtext model', () => {
 						.withArgs({ query: 'getCreateQuery response', params: 'prepareAsParams response' })
 				);
 				expect(instance.runValidations.calledOnce).to.be.true;
-				expect(instance.setErrorStatus.calledTwice).to.be.true;
-				expect(stubs.Base.hasErrorsModule.hasErrors.calledTwice).to.be.true;
 				expect(instance.validateInDb.calledOnce).to.be.true;
+				expect(stubs.Base.cypherQueries.sharedQueries.getValidateQuery.calledOnce).to.be.true;
+				expect(stubs.Base.neo4jQueryModule.neo4jQuery.calledOnce).to.be.true;
+				expect(instance.setErrorStatus.calledOnce).to.be.true;
+				expect(stubs.Base.hasErrorsModule.hasErrors.calledOnce).to.be.true;
 				expect(getCreateQueryStub.calledOnce).to.be.true;
 				expect(stubs.prepareAsParamsModule.prepareAsParams.calledOnce).to.be.true;
 				expect(stubs.neo4jQueryModule.neo4jQuery.calledOnce).to.be.true;
@@ -170,13 +174,15 @@ describe('Playtext model', () => {
 
 				const getUpdateQueryStub = sinon.stub().returns('getUpdateQuery response');
 				sinon.spy(instance, 'runValidations');
-				sinon.spy(instance, 'setErrorStatus');
 				sinon.spy(instance, 'validateInDb');
+				sinon.spy(instance, 'setErrorStatus');
 				const result = await instance.createUpdate(getUpdateQueryStub);
 				sinon.assert.callOrder(
 					instance.runValidations.withArgs(),
-					instance.setErrorStatus.withArgs(),
 					instance.validateInDb.withArgs(),
+					stubs.Base.cypherQueries.sharedQueries.getValidateQuery.withArgs(instance.model, instance.uuid),
+					stubs.Base.neo4jQueryModule.neo4jQuery.withArgs({ query: 'getValidateQuery response', params: instance }),
+					instance.setErrorStatus.withArgs(),
 					stubs.Base.hasErrorsModule.hasErrors.withArgs(instance),
 					getUpdateQueryStub.withArgs(),
 					stubs.prepareAsParamsModule.prepareAsParams.withArgs(instance),
@@ -185,9 +191,11 @@ describe('Playtext model', () => {
 					)
 				);
 				expect(instance.runValidations.calledOnce).to.be.true;
-				expect(instance.setErrorStatus.calledTwice).to.be.true;
-				expect(stubs.Base.hasErrorsModule.hasErrors.calledTwice).to.be.true;
 				expect(instance.validateInDb.calledOnce).to.be.true;
+				expect(stubs.Base.cypherQueries.sharedQueries.getValidateQuery.calledOnce).to.be.true;
+				expect(stubs.Base.neo4jQueryModule.neo4jQuery.calledOnce).to.be.true;
+				expect(instance.setErrorStatus.calledOnce).to.be.true;
+				expect(stubs.Base.hasErrorsModule.hasErrors.calledOnce).to.be.true;
 				expect(getUpdateQueryStub.calledOnce).to.be.true;
 				expect(stubs.prepareAsParamsModule.prepareAsParams.calledOnce).to.be.true;
 				expect(stubs.neo4jQueryModule.neo4jQuery.calledOnce).to.be.true;
@@ -199,59 +207,33 @@ describe('Playtext model', () => {
 
 		context('invalid data', () => {
 
-			context('initial validation errors caused by submitted values', () => {
+			it('returns instance without creating', async () => {
 
-				it('returns instance without creating', async () => {
-
-					const hasErrorsModuleStub = { hasErrors: sinon.stub().returns(true) };
-					const getCreateUpdateQueryStub = sinon.stub();
-					const instance = createInstance({ hasErrorsModule: hasErrorsModuleStub });
-					sinon.spy(instance, 'runValidations');
-					sinon.spy(instance, 'setErrorStatus');
-					sinon.spy(instance, 'validateInDb');
-					const result = await instance.createUpdate(getCreateUpdateQueryStub);
-					expect(instance.runValidations.calledOnce).to.be.true;
-					expect(instance.setErrorStatus.calledOnce).to.be.true;
-					expect(hasErrorsModuleStub.hasErrors.calledOnce).to.be.true;
-					expect(instance.validateInDb.notCalled).to.be.true;
-					expect(getCreateUpdateQueryStub.notCalled).to.be.true;
-					expect(stubs.prepareAsParamsModule.prepareAsParams.notCalled).to.be.true;
-					expect(stubs.neo4jQueryModule.neo4jQuery.notCalled).to.be.true;
-					expect(result).to.deep.eq(instance);
-
-				});
-
-			});
-
-			context('secondary validation errors caused by database checks', () => {
-
-				it('returns instance without creating', async () => {
-
-					const hasErrorsModuleStub = { hasErrors: sinon.stub() };
-					hasErrorsModuleStub.hasErrors
-						.onFirstCall().returns(false)
-						.onSecondCall().returns(true);
-					const getCreateUpdateQueryStub = sinon.stub();
-					const instance = createInstance({ hasErrorsModule: hasErrorsModuleStub });
-					sinon.spy(instance, 'runValidations');
-					sinon.spy(instance, 'setErrorStatus');
-					sinon.spy(instance, 'validateInDb');
-					const result = await instance.createUpdate(getCreateUpdateQueryStub);
-					sinon.assert.callOrder(
-						instance.setErrorStatus.withArgs(),
-						instance.validateInDb.withArgs(),
-						hasErrorsModuleStub.hasErrors.withArgs(instance)
-					);
-					expect(instance.runValidations.calledOnce).to.be.true;
-					expect(instance.setErrorStatus.calledTwice).to.be.true;
-					expect(hasErrorsModuleStub.hasErrors.calledTwice).to.be.true;
-					expect(instance.validateInDb.calledOnce).to.be.true;
-					expect(getCreateUpdateQueryStub.notCalled).to.be.true;
-					expect(stubs.prepareAsParamsModule.prepareAsParams.notCalled).to.be.true;
-					expect(stubs.neo4jQueryModule.neo4jQuery.notCalled).to.be.true;
-					expect(result).to.deep.eq(instance);
-
-				});
+				const hasErrorsModuleStub = { hasErrors: sinon.stub().returns(true) };
+				const getCreateUpdateQueryStub = sinon.stub();
+				const instance = createInstance({ hasErrorsModule: hasErrorsModuleStub });
+				sinon.spy(instance, 'runValidations');
+				sinon.spy(instance, 'validateInDb');
+				sinon.spy(instance, 'setErrorStatus');
+				const result = await instance.createUpdate(getCreateUpdateQueryStub);
+				sinon.assert.callOrder(
+					instance.runValidations.withArgs(),
+					instance.validateInDb.withArgs(),
+					stubs.Base.cypherQueries.sharedQueries.getValidateQuery.withArgs(instance.model, instance.uuid),
+					stubs.Base.neo4jQueryModule.neo4jQuery.withArgs({ query: 'getValidateQuery response', params: instance }),
+					instance.setErrorStatus.withArgs(),
+					hasErrorsModuleStub.hasErrors.withArgs(instance)
+				);
+				expect(instance.runValidations.calledOnce).to.be.true;
+				expect(instance.validateInDb.calledOnce).to.be.true;
+				expect(stubs.Base.cypherQueries.sharedQueries.getValidateQuery.calledOnce).to.be.true;
+				expect(stubs.Base.neo4jQueryModule.neo4jQuery.calledOnce).to.be.true;
+				expect(instance.setErrorStatus.calledOnce).to.be.true;
+				expect(hasErrorsModuleStub.hasErrors.calledOnce).to.be.true;
+				expect(getCreateUpdateQueryStub.notCalled).to.be.true;
+				expect(stubs.prepareAsParamsModule.prepareAsParams.notCalled).to.be.true;
+				expect(stubs.neo4jQueryModule.neo4jQuery.notCalled).to.be.true;
+				expect(result).to.deep.eq(instance);
 
 			});
 

--- a/test-unit/src/models/Role.test.js
+++ b/test-unit/src/models/Role.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { createSandbox } from 'sinon';
+import { createSandbox, spy } from 'sinon';
 
 import * as validateStringModule from '../../../src/lib/validate-string';
 import Role from '../../../src/models/Role';
@@ -16,10 +16,10 @@ describe('Role model', () => {
 	beforeEach(() => {
 
 		stubs = {
-			validateString: sandbox.stub(validateStringModule, 'validateString').returns([])
+			validateString: sandbox.stub(validateStringModule, 'validateString').returns(undefined)
 		};
 
-		stubs.validateString.withArgs(ABOVE_MAX_LENGTH_STRING, false).returns(['Name is too long']);
+		stubs.validateString.withArgs(ABOVE_MAX_LENGTH_STRING, false).returns('Name is too long');
 
 	});
 
@@ -97,7 +97,11 @@ describe('Role model', () => {
 			it('will not add properties to errors property', () => {
 
 				const instance = new Role({ name: 'Hamlet, Prince of Denmark', characterName: '' });
+				spy(instance, 'addPropertyError');
 				instance.validateCharacterName({ requiresCharacterName: false });
+				expect(stubs.validateString.calledOnce).to.be.true;
+				expect(stubs.validateString.calledWithExactly(instance.characterName, false)).to.be.true;
+				expect(instance.addPropertyError.notCalled).to.be.true;
 				expect(instance.errors).not.to.have.property('name');
 				expect(instance.errors).to.deep.eq({});
 
@@ -110,7 +114,12 @@ describe('Role model', () => {
 			it('adds properties whose values are arrays to errors property', () => {
 
 				const instance = new Role({ name: 'Hamlet, Prince of Denmark', characterName: ABOVE_MAX_LENGTH_STRING });
+				spy(instance, 'addPropertyError');
 				instance.validateCharacterName({ requiresCharacterName: false });
+				expect(stubs.validateString.calledOnce).to.be.true;
+				expect(stubs.validateString.calledWithExactly(instance.characterName, false)).to.be.true;
+				expect(instance.addPropertyError.calledOnce).to.be.true;
+				expect(instance.addPropertyError.calledWithExactly('characterName', 'Name is too long')).to.be.true;
 				expect(instance.errors)
 					.to.have.property('characterName')
 					.that.is.an('array')


### PR DESCRIPTION
This PR does some refactoring of the `createUpdate` method for the Base and Playtext classes, and their associated methods.

Instance validation currently consists of two stages:
- Non-database validation, e.g. a string input is too long.
- Database validation, e.g. a value that must be unique already exists on another instance in the database.

Currently if the first stage fails, the instance will be returned and only detail those errors. Those errors must be resolved before the second stage errors will reveal themselves, which is a time-wasting approach.

This PR merges the two stages of validation so that if there are errors from either stage then the instance returned will detail them regardless of whether the first stage passed or not. If applicable, an instance can be returned detailing errors from both the first and second stages of validation.