### PR TITLE
Switch withArgs() for calledWithExactly()

### DIFF
--- a/test-unit/src/models/Base.test.js
+++ b/test-unit/src/models/Base.test.js
@@ -343,26 +343,38 @@ describe('Base model', () => {
 				spy(instance, 'setErrorStatus');
 				const result = await instance.createUpdate(stubs.sharedQueries.getCreateQuery)
 				assert.callOrder(
-					instance.runInputValidations.withArgs(),
-					instance.runDatabaseValidations.withArgs(),
-					stubs.sharedQueries.getDuplicateNameCountQuery.withArgs(instance.model, instance.uuid),
-					stubs.neo4jQuery.withArgs({ query: 'getDuplicateNameCountQuery response', params: instance }),
-					instance.setErrorStatus.withArgs(),
-					stubs.hasErrors.withArgs(instance),
-					stubs.sharedQueries.getCreateQuery.withArgs(instance.model),
-					stubs.prepareAsParams.withArgs(instance),
-					stubs.neo4jQuery.withArgs(
-						{ query: 'getCreateQuery response', params: 'prepareAsParams response' }
-					)
+					instance.runInputValidations,
+					instance.runDatabaseValidations,
+					stubs.sharedQueries.getDuplicateNameCountQuery,
+					stubs.neo4jQuery,
+					instance.setErrorStatus,
+					stubs.hasErrors,
+					stubs.prepareAsParams,
+					stubs.neo4jQuery
 				);
 				expect(instance.runInputValidations.calledOnce).to.be.true;
+				expect(instance.runInputValidations.calledWithExactly()).to.be.true;
 				expect(instance.runDatabaseValidations.calledOnce).to.be.true;
+				expect(instance.runDatabaseValidations.calledWithExactly()).to.be.true;
 				expect(stubs.sharedQueries.getDuplicateNameCountQuery.calledOnce).to.be.true;
+				expect(stubs.sharedQueries.getDuplicateNameCountQuery.calledWithExactly(
+					instance.model, instance.uuid
+				)).to.be.true;
 				expect(stubs.neo4jQuery.calledTwice).to.be.true;
+				expect(stubs.neo4jQuery.firstCall.calledWithExactly(
+					{ query: 'getDuplicateNameCountQuery response', params: instance }
+				)).to.be.true;
+				expect(stubs.neo4jQuery.secondCall.calledWithExactly(
+					{ query: 'getCreateQuery response', params: 'prepareAsParams response' }
+				)).to.be.true;
 				expect(instance.setErrorStatus.calledOnce).to.be.true;
+				expect(instance.setErrorStatus.calledWithExactly()).to.be.true;
 				expect(stubs.hasErrors.calledOnce).to.be.true;
+				expect(stubs.hasErrors.calledWithExactly(instance)).to.be.true;
 				expect(stubs.sharedQueries.getCreateQuery.calledOnce).to.be.true;
+				expect(stubs.sharedQueries.getCreateQuery.calledWithExactly(instance.model)).to.be.true;
 				expect(stubs.prepareAsParams.calledOnce).to.be.true;
+				expect(stubs.prepareAsParams.calledWithExactly(instance)).to.be.true;
 				expect(result instanceof Base).to.be.true;
 
 			});
@@ -374,26 +386,39 @@ describe('Base model', () => {
 				spy(instance, 'setErrorStatus');
 				const result = await instance.createUpdate(stubs.sharedQueries.getUpdateQuery);
 				assert.callOrder(
-					instance.runInputValidations.withArgs(),
-					instance.runDatabaseValidations.withArgs(),
-					stubs.sharedQueries.getDuplicateNameCountQuery.withArgs(instance.model, instance.uuid),
-					stubs.neo4jQuery.withArgs({ query: 'getDuplicateNameCountQuery response', params: instance }),
-					instance.setErrorStatus.withArgs(),
-					stubs.hasErrors.withArgs(instance),
-					stubs.sharedQueries.getUpdateQuery.withArgs(instance.model),
-					stubs.prepareAsParams.withArgs(instance),
-					stubs.neo4jQuery.withArgs(
-						{ query: 'getUpdateQuery response', params: 'prepareAsParams response' }
-					)
+					instance.runInputValidations,
+					instance.runDatabaseValidations,
+					stubs.sharedQueries.getDuplicateNameCountQuery,
+					stubs.neo4jQuery,
+					instance.setErrorStatus,
+					stubs.hasErrors,
+					stubs.sharedQueries.getUpdateQuery,
+					stubs.prepareAsParams,
+					stubs.neo4jQuery
 				);
 				expect(instance.runInputValidations.calledOnce).to.be.true;
+				expect(instance.runInputValidations.calledWithExactly()).to.be.true;
 				expect(instance.runDatabaseValidations.calledOnce).to.be.true;
+				expect(instance.runDatabaseValidations.calledWithExactly()).to.be.true;
 				expect(stubs.sharedQueries.getDuplicateNameCountQuery.calledOnce).to.be.true;
+				expect(stubs.sharedQueries.getDuplicateNameCountQuery.calledWithExactly(
+					instance.model, instance.uuid
+				)).to.be.true;
 				expect(stubs.neo4jQuery.calledTwice).to.be.true;
+				expect(stubs.neo4jQuery.firstCall.calledWithExactly(
+					{ query: 'getDuplicateNameCountQuery response', params: instance }
+				)).to.be.true;
+				expect(stubs.neo4jQuery.secondCall.calledWithExactly(
+					{ query: 'getUpdateQuery response', params: 'prepareAsParams response' }
+				)).to.be.true;
 				expect(instance.setErrorStatus.calledOnce).to.be.true;
+				expect(instance.setErrorStatus.calledWithExactly()).to.be.true;
 				expect(stubs.hasErrors.calledOnce).to.be.true;
+				expect(stubs.hasErrors.calledWithExactly(instance)).to.be.true;
 				expect(stubs.sharedQueries.getUpdateQuery.calledOnce).to.be.true;
+				expect(stubs.sharedQueries.getUpdateQuery.calledWithExactly(instance.model)).to.be.true;
 				expect(stubs.prepareAsParams.calledOnce).to.be.true;
+				expect(stubs.prepareAsParams.calledWithExactly(instance)).to.be.true;
 				expect(result instanceof Base).to.be.true;
 
 			});
@@ -412,19 +437,29 @@ describe('Base model', () => {
 				spy(instance, 'setErrorStatus');
 				const result = await instance.createUpdate(getCreateUpdateQueryStub);
 				assert.callOrder(
-					instance.runInputValidations.withArgs(),
-					instance.runDatabaseValidations.withArgs(),
-					stubs.sharedQueries.getDuplicateNameCountQuery.withArgs(instance.model, instance.uuid),
-					stubs.neo4jQuery.withArgs({ query: 'getDuplicateNameCountQuery response', params: instance }),
-					instance.setErrorStatus.withArgs(),
-					stubs.hasErrors.withArgs(instance)
+					instance.runInputValidations,
+					instance.runDatabaseValidations,
+					stubs.sharedQueries.getDuplicateNameCountQuery,
+					stubs.neo4jQuery,
+					instance.setErrorStatus,
+					stubs.hasErrors
 				);
 				expect(instance.runInputValidations.calledOnce).to.be.true;
+				expect(instance.runInputValidations.calledWithExactly()).to.be.true;
 				expect(instance.runDatabaseValidations.calledOnce).to.be.true;
+				expect(instance.runDatabaseValidations.calledWithExactly()).to.be.true;
 				expect(stubs.sharedQueries.getDuplicateNameCountQuery.calledOnce).to.be.true;
+				expect(stubs.sharedQueries.getDuplicateNameCountQuery.calledWithExactly(
+					instance.model, instance.uuid
+				)).to.be.true;
 				expect(stubs.neo4jQuery.calledOnce).to.be.true;
+				expect(stubs.neo4jQuery.calledWithExactly(
+					{ query: 'getDuplicateNameCountQuery response', params: instance }
+				)).to.be.true;
 				expect(instance.setErrorStatus.calledOnce).to.be.true;
+				expect(instance.setErrorStatus.calledWithExactly()).to.be.true;
 				expect(stubs.hasErrors.calledOnce).to.be.true;
+				expect(stubs.hasErrors.calledWithExactly(instance)).to.be.true;
 				expect(getCreateUpdateQueryStub.notCalled).to.be.true;
 				expect(stubs.prepareAsParams.notCalled).to.be.true;
 				expect(result).to.deep.eq(instance);

--- a/test-unit/src/models/PersonCastMember.test.js
+++ b/test-unit/src/models/PersonCastMember.test.js
@@ -85,19 +85,31 @@ describe('Person Cast Member model', () => {
 			spy(instance, 'validateNameUniquenessInGroup');
 			instance.runInputValidations({ hasDuplicateName: false });
 			assert.callOrder(
-				instance.validateName.withArgs({ requiresName: false }),
-				instance.validateNameUniquenessInGroup.withArgs({ hasDuplicateName: false }),
-				stubs.getDuplicateNameIndicesModule.getDuplicateNameIndices.withArgs(instance.roles),
-				instance.roles[0].validateName.withArgs({ requiresName: false }),
-				instance.roles[0].validateCharacterName.withArgs({ requiresCharacterName: false }),
-				instance.roles[0].validateNameUniquenessInGroup.withArgs({ hasDuplicateName: false })
+				instance.validateName,
+				instance.validateNameUniquenessInGroup,
+				stubs.getDuplicateNameIndicesModule.getDuplicateNameIndices,
+				instance.roles[0].validateName,
+				instance.roles[0].validateCharacterName,
+				instance.roles[0].validateNameUniquenessInGroup
 			);
 			expect(instance.validateName.calledOnce).to.be.true;
+			expect(instance.validateName.calledWithExactly({ requiresName: false })).to.be.true;
 			expect(instance.validateNameUniquenessInGroup.calledOnce).to.be.true;
+			expect(instance.validateNameUniquenessInGroup.calledWithExactly({ hasDuplicateName: false })).to.be.true;
 			expect(stubs.getDuplicateNameIndicesModule.getDuplicateNameIndices.calledOnce).to.be.true;
+			expect(stubs.getDuplicateNameIndicesModule.getDuplicateNameIndices.calledWithExactly(
+				instance.roles
+			)).to.be.true;
 			expect(instance.roles[0].validateName.calledOnce).to.be.true;
+			expect(instance.roles[0].validateName.calledWithExactly({ requiresName: false })).to.be.true;
 			expect(instance.roles[0].validateCharacterName.calledOnce).to.be.true;
+			expect(instance.roles[0].validateCharacterName.calledWithExactly(
+				{ requiresCharacterName: false }
+			)).to.be.true;
 			expect(instance.roles[0].validateNameUniquenessInGroup.calledOnce).to.be.true;
+			expect(instance.roles[0].validateNameUniquenessInGroup.calledWithExactly(
+				{ hasDuplicateName: false }
+			)).to.be.true;
 
 		});
 

--- a/test-unit/src/models/Playtext.test.js
+++ b/test-unit/src/models/Playtext.test.js
@@ -98,15 +98,23 @@ describe('Playtext model', () => {
 			spy(instance, 'validateName');
 			instance.runInputValidations();
 			assert.callOrder(
-				instance.validateName.withArgs({ requiresName: true }),
-				stubs.getDuplicateNameIndicesModule.getDuplicateNameIndices.withArgs(instance.characters),
-				instance.characters[0].validateName.withArgs({ requiresName: false }),
-				instance.characters[0].validateNameUniquenessInGroup.withArgs({ hasDuplicateName: false })
+				instance.validateName,
+				stubs.getDuplicateNameIndicesModule.getDuplicateNameIndices,
+				instance.characters[0].validateName,
+				instance.characters[0].validateNameUniquenessInGroup
 			);
 			expect(instance.validateName.calledOnce).to.be.true;
+			expect(instance.validateName.calledWithExactly({ requiresName: true })).to.be.true;
 			expect(stubs.getDuplicateNameIndicesModule.getDuplicateNameIndices.calledOnce).to.be.true;
+			expect(stubs.getDuplicateNameIndicesModule.getDuplicateNameIndices.calledWithExactly(
+				instance.characters
+			)).to.be.true;
 			expect(instance.characters[0].validateName.calledOnce).to.be.true;
+			expect(instance.characters[0].validateName.calledWithExactly({ requiresName: false })).to.be.true;
 			expect(instance.characters[0].validateNameUniquenessInGroup.calledOnce).to.be.true;
+			expect(instance.characters[0].validateNameUniquenessInGroup.calledWithExactly(
+				{ hasDuplicateName: false }
+			)).to.be.true;
 
 		});
 

--- a/test-unit/src/models/Production.test.js
+++ b/test-unit/src/models/Production.test.js
@@ -111,17 +111,24 @@ describe('Production model', () => {
 			spy(instance, 'validateName');
 			instance.runInputValidations();
 			assert.callOrder(
-				instance.validateName.withArgs({ requiresName: true }),
-				instance.theatre.validateName.withArgs({ requiresName: true }),
-				instance.playtext.validateName.withArgs({ requiresName: false }),
-				stubs.getDuplicateNameIndicesModule.getDuplicateNameIndices.withArgs(instance.cast),
-				instance.cast[0].runInputValidations.withArgs({ hasDuplicateName: false })
+				instance.validateName,
+				instance.theatre.validateName,
+				instance.playtext.validateName,
+				stubs.getDuplicateNameIndicesModule.getDuplicateNameIndices,
+				instance.cast[0].runInputValidations
 			);
 			expect(instance.validateName.calledOnce).to.be.true;
+			expect(instance.validateName.calledWithExactly({ requiresName: true })).to.be.true;
 			expect(instance.theatre.validateName.calledOnce).to.be.true;
+			expect(instance.theatre.validateName.calledWithExactly({ requiresName: true })).to.be.true;
 			expect(instance.playtext.validateName.calledOnce).to.be.true;
+			expect(instance.playtext.validateName.calledWithExactly({ requiresName: false })).to.be.true;
 			expect(stubs.getDuplicateNameIndicesModule.getDuplicateNameIndices.calledOnce).to.be.true;
+			expect(stubs.getDuplicateNameIndicesModule.getDuplicateNameIndices.calledWithExactly(
+				instance.cast
+			)).to.be.true;
 			expect(instance.cast[0].runInputValidations.calledOnce).to.be.true;
+			expect(instance.cast[0].runInputValidations.calledWithExactly({ hasDuplicateName: false })).to.be.true;
 
 		});
 

--- a/test-unit/src/models/Theatre.test.js
+++ b/test-unit/src/models/Theatre.test.js
@@ -93,18 +93,28 @@ describe('Theatre model', () => {
 				spy(instance, 'validateDeleteRequestInDatabase');
 				const result = await instance.delete();
 				assert.callOrder(
-					instance.validateDeleteRequestInDatabase.withArgs(),
-					stubs.getValidateDeleteQueries.theatre.withArgs(),
-					stubs.neo4jQuery.withArgs({ query: 'getValidateDeleteQuery response', params: instance }),
-					stubs.hasErrors.withArgs(instance),
-					stubs.sharedQueries.getDeleteQuery.withArgs(instance.model),
-					stubs.neo4jQuery.withArgs({ query: 'getDeleteQuery response', params: instance })
+					instance.validateDeleteRequestInDatabase,
+					stubs.getValidateDeleteQueries.theatre,
+					stubs.neo4jQuery,
+					stubs.hasErrors,
+					stubs.sharedQueries.getDeleteQuery,
+					stubs.neo4jQuery
 				);
 				expect(instance.validateDeleteRequestInDatabase.calledOnce).to.be.true;
+				expect(instance.validateDeleteRequestInDatabase.calledWithExactly()).to.be.true;
 				expect(stubs.getValidateDeleteQueries.theatre.calledOnce).to.be.true;
+				expect(stubs.getValidateDeleteQueries.theatre.calledWithExactly()).to.be.true;
 				expect(stubs.neo4jQuery.calledTwice).to.be.true;
+				expect(stubs.neo4jQuery.firstCall.calledWithExactly(
+					{ query: 'getValidateDeleteQuery response', params: instance }
+				)).to.be.true;
+				expect(stubs.neo4jQuery.secondCall.calledWithExactly(
+					{ query: 'getDeleteQuery response', params: instance }
+				)).to.be.true;
 				expect(stubs.hasErrors.calledOnce).to.be.true;
+				expect(stubs.hasErrors.calledWithExactly(instance)).to.be.true;
 				expect(stubs.sharedQueries.getDeleteQuery.calledOnce).to.be.true;
+				expect(stubs.sharedQueries.getDeleteQuery.calledWithExactly(instance.model)).to.be.true;
 				expect(result).to.deep.eq(neo4jQueryFixture);
 
 			});
@@ -119,15 +129,21 @@ describe('Theatre model', () => {
 				spy(instance, 'validateDeleteRequestInDatabase');
 				const result = await instance.delete();
 				assert.callOrder(
-					instance.validateDeleteRequestInDatabase.withArgs(),
-					stubs.getValidateDeleteQueries.theatre.withArgs(),
-					stubs.neo4jQuery.withArgs({ query: 'getValidateDeleteQuery response', params: instance }),
-					stubs.hasErrors.withArgs(instance)
+					instance.validateDeleteRequestInDatabase,
+					stubs.getValidateDeleteQueries.theatre,
+					stubs.neo4jQuery,
+					stubs.hasErrors
 				);
 				expect(instance.validateDeleteRequestInDatabase.calledOnce).to.be.true;
+				expect(instance.validateDeleteRequestInDatabase.calledWithExactly()).to.be.true;
 				expect(stubs.getValidateDeleteQueries.theatre.calledOnce).to.be.true;
+				expect(stubs.getValidateDeleteQueries.theatre.calledWithExactly()).to.be.true;
 				expect(stubs.neo4jQuery.calledOnce).to.be.true;
+				expect(stubs.neo4jQuery.calledWithExactly(
+					{ query: 'getValidateDeleteQuery response', params: instance }
+				)).to.be.true;
 				expect(stubs.hasErrors.calledOnce).to.be.true;
+				expect(stubs.hasErrors.calledWithExactly(instance)).to.be.true;
 				expect(stubs.sharedQueries.getDeleteQuery.notCalled).to.be.true;
 				expect(result).to.deep.eq({ theatre: instance });
 


### PR DESCRIPTION
`stubFunction.withArgs(arg1)` will pass even if `stubFunction()` was actually called with two args (e.g. `stubFunction(arg1, arg2)`).

`.calledWithExactly()` allows the expectation to be more strict because it:
> Passes if `spy` was called with the provided arguments and no others.

This expectation has to be done outside the context of `assert.callOrder()` because a `withExactArgs()` method that does the same thing as `.calledWithExactly()` does not yet exist for this context.

#### References:
- [Sinon.JS - Assertions](https://sinonjs.org/releases/latest/assertions).