### PR TITLE
Revise Theatre model validateDeleteRequestInDatabase method

### DIFF
--- a/src/models/Theatre.js
+++ b/src/models/Theatre.js
@@ -17,7 +17,7 @@ export default class Theatre extends Base {
 
 		const { relationshipCount } = await neo4jQuery({ query: getValidateDeleteQueries[this.model](), params: this });
 
-		if (relationshipCount > 0) this.errors.associations = ['productions'];
+		if (relationshipCount > 0) this.addPropertyError('associations', 'productions');
 
 	}
 

--- a/test-unit/src/models/Theatre.test.js
+++ b/test-unit/src/models/Theatre.test.js
@@ -47,6 +47,7 @@ describe('Theatre model', () => {
 			it('will not add properties to errors property', async () => {
 
 				stubs.neo4jQuery.resolves({ relationshipCount: 0 });
+				spy(instance, 'addPropertyError');
 				await instance.validateDeleteRequestInDatabase();
 				assert.callOrder(
 					stubs.getValidateDeleteQueries.theatre,
@@ -58,6 +59,7 @@ describe('Theatre model', () => {
 				expect(stubs.neo4jQuery.calledWithExactly(
 					{ query: 'getValidateDeleteQuery response', params: instance }
 				)).to.be.true;
+				expect(instance.addPropertyError.notCalled).to.be.true;
 				expect(instance.errors).not.to.have.property('associations');
 				expect(instance.errors).to.deep.eq({});
 
@@ -70,10 +72,12 @@ describe('Theatre model', () => {
 			it('adds properties whose values are arrays to errors property', async () => {
 
 				stubs.neo4jQuery.resolves({ relationshipCount: 1 });
+				spy(instance, 'addPropertyError');
 				await instance.validateDeleteRequestInDatabase();
 				assert.callOrder(
 					stubs.getValidateDeleteQueries.theatre,
-					stubs.neo4jQuery
+					stubs.neo4jQuery,
+					instance.addPropertyError
 				);
 				expect(stubs.getValidateDeleteQueries.theatre.calledOnce).to.be.true;
 				expect(stubs.getValidateDeleteQueries.theatre.calledWithExactly()).to.be.true;
@@ -81,6 +85,8 @@ describe('Theatre model', () => {
 				expect(stubs.neo4jQuery.calledWithExactly(
 					{ query: 'getValidateDeleteQuery response', params: instance }
 				)).to.be.true;
+				expect(instance.addPropertyError.calledOnce).to.be.true;
+				expect(instance.addPropertyError.calledWithExactly('associations', 'productions')).to.be.true;
 				expect(instance.errors)
 					.to.have.property('associations')
 					.that.is.an('array')


### PR DESCRIPTION
The Theatre model's `validateDeleteRequestInDatabase` method should be using the Base class `addPropertyError` method to apply errors to the theatre instance.