### PR TITLE
Rename validateDelete -> validateDeleteRequest

### DIFF
--- a/src/models/Theatre.js
+++ b/src/models/Theatre.js
@@ -1,5 +1,5 @@
 import Base from './Base';
-import { getValidateDeleteQueries, sharedQueries } from '../neo4j/cypher-queries';
+import { getValidateDeleteRequestQueries, sharedQueries } from '../neo4j/cypher-queries';
 import { neo4jQuery } from '../neo4j/query';
 
 export default class Theatre extends Base {
@@ -15,7 +15,10 @@ export default class Theatre extends Base {
 
 	async validateDeleteRequestInDatabase () {
 
-		const { relationshipCount } = await neo4jQuery({ query: getValidateDeleteQueries[this.model](), params: this });
+		const { relationshipCount } = await neo4jQuery({
+			query: getValidateDeleteRequestQueries[this.model](),
+			params: this
+		});
 
 		if (relationshipCount > 0) this.addPropertyError('associations', 'productions');
 

--- a/src/neo4j/cypher-queries/index.js
+++ b/src/neo4j/cypher-queries/index.js
@@ -15,7 +15,7 @@ import {
 } from './production';
 import * as sharedQueries from './shared';
 import {
-	getValidateDeleteQuery as getTheatreValidateDeleteQuery,
+	getValidateDeleteRequestQuery as getTheatreValidateDeleteRequestQuery,
 	getShowQuery as getTheatreShowQuery
 } from './theatre';
 
@@ -46,8 +46,8 @@ const getShowQueries = {
 	theatre: getTheatreShowQuery
 };
 
-const getValidateDeleteQueries = {
-	theatre: getTheatreValidateDeleteQuery
+const getValidateDeleteRequestQueries = {
+	theatre: getTheatreValidateDeleteRequestQuery
 };
 
 export {
@@ -56,6 +56,6 @@ export {
 	getUpdateQueries,
 	getDeleteQueries,
 	getShowQueries,
-	getValidateDeleteQueries,
+	getValidateDeleteRequestQueries,
 	sharedQueries
 };

--- a/src/neo4j/cypher-queries/theatre.js
+++ b/src/neo4j/cypher-queries/theatre.js
@@ -1,4 +1,4 @@
-const getValidateDeleteQuery = () => `
+const getValidateDeleteRequestQuery = () => `
 	MATCH (theatre:Theatre { uuid: $uuid })<-[relationship:PLAYS_AT]-(production:Production)
 
 	RETURN SIGN(COUNT(relationship)) AS relationshipCount
@@ -25,6 +25,6 @@ const getShowQuery = () => `
 `;
 
 export {
-	getValidateDeleteQuery,
+	getValidateDeleteRequestQuery,
 	getShowQuery
 };

--- a/test-unit/src/models/Theatre.test.js
+++ b/test-unit/src/models/Theatre.test.js
@@ -18,10 +18,10 @@ describe('Theatre model', () => {
 
 		stubs = {
 			hasErrors: sandbox.stub(hasErrorsModule, 'hasErrors').returns(false),
-			getValidateDeleteQueries: {
+			getValidateDeleteRequestQueries: {
 				theatre:
-					sandbox.stub(cypherQueries.getValidateDeleteQueries, 'theatre')
-						.returns('getValidateDeleteQuery response')
+					sandbox.stub(cypherQueries.getValidateDeleteRequestQueries, 'theatre')
+						.returns('getValidateDeleteRequestQuery response')
 			},
 			sharedQueries: {
 				getDeleteQuery:
@@ -50,14 +50,14 @@ describe('Theatre model', () => {
 				spy(instance, 'addPropertyError');
 				await instance.validateDeleteRequestInDatabase();
 				assert.callOrder(
-					stubs.getValidateDeleteQueries.theatre,
+					stubs.getValidateDeleteRequestQueries.theatre,
 					stubs.neo4jQuery
 				);
-				expect(stubs.getValidateDeleteQueries.theatre.calledOnce).to.be.true;
-				expect(stubs.getValidateDeleteQueries.theatre.calledWithExactly()).to.be.true;
+				expect(stubs.getValidateDeleteRequestQueries.theatre.calledOnce).to.be.true;
+				expect(stubs.getValidateDeleteRequestQueries.theatre.calledWithExactly()).to.be.true;
 				expect(stubs.neo4jQuery.calledOnce).to.be.true;
 				expect(stubs.neo4jQuery.calledWithExactly(
-					{ query: 'getValidateDeleteQuery response', params: instance }
+					{ query: 'getValidateDeleteRequestQuery response', params: instance }
 				)).to.be.true;
 				expect(instance.addPropertyError.notCalled).to.be.true;
 				expect(instance.errors).not.to.have.property('associations');
@@ -75,15 +75,15 @@ describe('Theatre model', () => {
 				spy(instance, 'addPropertyError');
 				await instance.validateDeleteRequestInDatabase();
 				assert.callOrder(
-					stubs.getValidateDeleteQueries.theatre,
+					stubs.getValidateDeleteRequestQueries.theatre,
 					stubs.neo4jQuery,
 					instance.addPropertyError
 				);
-				expect(stubs.getValidateDeleteQueries.theatre.calledOnce).to.be.true;
-				expect(stubs.getValidateDeleteQueries.theatre.calledWithExactly()).to.be.true;
+				expect(stubs.getValidateDeleteRequestQueries.theatre.calledOnce).to.be.true;
+				expect(stubs.getValidateDeleteRequestQueries.theatre.calledWithExactly()).to.be.true;
 				expect(stubs.neo4jQuery.calledOnce).to.be.true;
 				expect(stubs.neo4jQuery.calledWithExactly(
-					{ query: 'getValidateDeleteQuery response', params: instance }
+					{ query: 'getValidateDeleteRequestQuery response', params: instance }
 				)).to.be.true;
 				expect(instance.addPropertyError.calledOnce).to.be.true;
 				expect(instance.addPropertyError.calledWithExactly('associations', 'productions')).to.be.true;
@@ -121,7 +121,7 @@ describe('Theatre model', () => {
 				expect(stubs.sharedQueries.getDeleteQuery.calledWithExactly(instance.model)).to.be.true;
 				expect(stubs.neo4jQuery.calledTwice).to.be.true;
 				expect(stubs.neo4jQuery.firstCall.calledWithExactly(
-					{ query: 'getValidateDeleteQuery response', params: instance }
+					{ query: 'getValidateDeleteRequestQuery response', params: instance }
 				)).to.be.true;
 				expect(stubs.neo4jQuery.secondCall.calledWithExactly(
 					{ query: 'getDeleteQuery response', params: instance }
@@ -151,7 +151,7 @@ describe('Theatre model', () => {
 				expect(stubs.sharedQueries.getDeleteQuery.notCalled).to.be.true;
 				expect(stubs.neo4jQuery.calledOnce).to.be.true;
 				expect(stubs.neo4jQuery.calledWithExactly(
-					{ query: 'getValidateDeleteQuery response', params: instance }
+					{ query: 'getValidateDeleteRequestQuery response', params: instance }
 				)).to.be.true;
 				expect(result).to.deep.eq({ theatre: instance });
 


### PR DESCRIPTION
'Validate delete' makes it sound like the validation is ensuring whether a deletion has been successfully completed.

'Validate delete request' hopefully clarifies that the validation ensures that the deletion can proceed.