### PR TITLE
Revise theatre instance deletion process

### DIFF
--- a/src/models/Theatre.js
+++ b/src/models/Theatre.js
@@ -1,5 +1,5 @@
 import Base from './Base';
-import { getValidateDeleteRequestQueries, sharedQueries } from '../neo4j/cypher-queries';
+import { getDeleteQueries } from '../neo4j/cypher-queries';
 import { neo4jQuery } from '../neo4j/query';
 
 export default class Theatre extends Base {
@@ -13,26 +13,20 @@ export default class Theatre extends Base {
 
 	}
 
-	async validateDeleteRequestInDatabase () {
+	async delete () {
 
-		const { relationshipCount } = await neo4jQuery({
-			query: getValidateDeleteRequestQueries[this.model](),
+		const { model, name, isDeleted } = await neo4jQuery({
+			query: getDeleteQueries.theatre(),
 			params: this
 		});
 
-		if (relationshipCount > 0) this.addPropertyError('associations', 'productions');
+		if (isDeleted) return { model, name };
 
-	}
-
-	async delete () {
-
-		await this.validateDeleteRequestInDatabase();
+		this.addPropertyError('associations', 'productions');
 
 		this.setErrorStatus();
 
-		if (this.hasErrors) return { theatre: this };
-
-		return neo4jQuery({ query: sharedQueries.getDeleteQuery(this.model), params: this });
+		return { theatre: this };
 
 	}
 

--- a/src/neo4j/cypher-queries/index.js
+++ b/src/neo4j/cypher-queries/index.js
@@ -15,7 +15,7 @@ import {
 } from './production';
 import * as sharedQueries from './shared';
 import {
-	getValidateDeleteRequestQuery as getTheatreValidateDeleteRequestQuery,
+	getDeleteQuery as getTheatreDeleteQuery,
 	getShowQuery as getTheatreShowQuery
 } from './theatre';
 
@@ -35,7 +35,8 @@ const getUpdateQueries = {
 };
 
 const getDeleteQueries = {
-	production: getProductionDeleteQuery
+	production: getProductionDeleteQuery,
+	theatre: getTheatreDeleteQuery
 };
 
 const getShowQueries = {
@@ -46,16 +47,11 @@ const getShowQueries = {
 	theatre: getTheatreShowQuery
 };
 
-const getValidateDeleteRequestQueries = {
-	theatre: getTheatreValidateDeleteRequestQuery
-};
-
 export {
 	getCreateQueries,
 	getEditQueries,
 	getUpdateQueries,
 	getDeleteQueries,
 	getShowQueries,
-	getValidateDeleteRequestQueries,
 	sharedQueries
 };


### PR DESCRIPTION
Consolidates theatre deletion into a single query:
- Check that theatre instance exists (first line of query - `MATCH (:Theatre { uuid: $uuid })` - will return no rows if no match).
- Reporting if the instance has existing associations and cannot be deleted.
- Deleting the instance if it has no existing associations.

The current implementation runs an initial query (`getValidateDeleteRequestQuery`) to ascertain if the theatre instance has any associations before making a subsequent query to perform the actual delete. This is not error-proof as it is possible that between those two queries another query changes the associations of that theatre; it is far better that the entire process is done within a single query.