### PR TITLE
Revise process to confirm instance existence in database

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@babel/preset-env": "^7.4.5",
     "@babel/register": "^7.4.4",
     "chai": "^3.5.0",
-    "chai-as-promised": "^7.1.1",
     "chai-http": "^4.3.0",
     "eslint": "^4.11.0",
     "lintspaces-cli": "^0.6.0",

--- a/src/models/Base.js
+++ b/src/models/Base.js
@@ -77,12 +77,10 @@ export default class Base {
 
 		const { getExistenceQuery } = sharedQueries;
 
-		const { exists } = await neo4jQuery({
+		await neo4jQuery({
 			query: getExistenceQuery(this.model),
 			params: this
 		});
-
-		if (!exists) throw new Error('Not Found');
 
 	}
 

--- a/src/neo4j/cypher-queries/shared.js
+++ b/src/neo4j/cypher-queries/shared.js
@@ -3,11 +3,7 @@ import { capitalise } from '../../lib/strings';
 const getExistenceQuery = model => `
 	MATCH (n:${capitalise(model)} { uuid: $uuid })
 
-	RETURN
-		CASE WHEN SIGN(COUNT(n)) = 1
-			THEN true
-			ELSE false
-		END AS exists
+	RETURN n
 `;
 
 const getDuplicateNameCountQuery = (model, uuid) => `

--- a/test-unit/src/models/Base.test.js
+++ b/test-unit/src/models/Base.test.js
@@ -1,5 +1,4 @@
-import chai from 'chai';
-import chaiAsPromised from 'chai-as-promised';
+import { expect } from 'chai';
 import { assert, createSandbox, spy, stub } from 'sinon';
 
 import * as hasErrorsModule from '../../../src/lib/has-errors';
@@ -11,9 +10,6 @@ import * as neo4jQueryModule from '../../../src/neo4j/query';
 import neo4jQueryFixture from '../../fixtures/neo4j-query';
 
 describe('Base model', () => {
-
-	const expect = chai.expect;
-	chai.use(chaiAsPromised);
 
 	let stubs;
 	let instance;
@@ -338,28 +334,6 @@ describe('Base model', () => {
 
 		});
 
-		context('instance does not exist', () => {
-
-			it('will throw Not Found error', async () => {
-
-				stubs.neo4jQuery.resolves({ exists: false });
-				await expect(instance.confirmExistenceInDatabase()).to.be.rejectedWith(Error, 'Not Found');
-
-			});
-
-		});
-
-		context('instance exists', () => {
-
-			it('will not throw Not Found error', async () => {
-
-				stubs.neo4jQuery.resolves({ exists: true });
-				await expect(instance.confirmExistenceInDatabase()).to.not.be.rejectedWith(Error, 'Not Found');
-
-			});
-
-		});
-
 	});
 
 	describe('createUpdate method', () => {
@@ -548,29 +522,12 @@ describe('Base model', () => {
 
 	describe('update method', () => {
 
-		context('instance does not exist', () => {
-
-			it('will throw Not Found error', async () => {
-
-				stubs.neo4jQuery.resolves({ exists: false });
-				spy(instance, 'confirmExistenceInDatabase');
-				spy(instance, 'createUpdate');
-				await expect(instance.update()).to.be.rejectedWith(Error, 'Not Found');
-				expect(instance.confirmExistenceInDatabase.calledOnce).to.be.true;
-				expect(instance.confirmExistenceInDatabase.calledWithExactly()).to.be.true;
-				expect(instance.createUpdate.called).to.be.false;
-
-			});
-
-		});
-
 		context('instance exists', () => {
 
 			context('instance requires a model-specific query', () => {
 
 				it('calls createUpdate method with function to get model-specific update query as argument', async () => {
 
-					stubs.neo4jQuery.resolves({ exists: true });
 					instance.model = 'production';
 					spy(instance, 'confirmExistenceInDatabase');
 					spy(instance, 'createUpdate');
@@ -588,7 +545,6 @@ describe('Base model', () => {
 
 				it('calls createUpdate method with function to get shared update query as argument', async () => {
 
-					stubs.neo4jQuery.resolves({ exists: true });
 					spy(instance, 'confirmExistenceInDatabase');
 					spy(instance, 'createUpdate');
 					await instance.update();

--- a/test-unit/src/neo4j/cypher-queries/shared.test.js
+++ b/test-unit/src/neo4j/cypher-queries/shared.test.js
@@ -65,11 +65,7 @@ describe('Cypher Queries Shared module', () => {
 				expect(removeWhitespace(result)).to.equal(removeWhitespace(`
 					MATCH (n:Theatre { uuid: $uuid })
 
-					RETURN
-						CASE WHEN SIGN(COUNT(n)) = 1
-							THEN true
-							ELSE false
-						END AS exists
+					RETURN n
 				`));
 
 			});


### PR DESCRIPTION
This PR simplifies the Neo4j Cypher query for ascertaining the existence of an instance in the database.

#### Before:
```
MATCH (n:${capitalise(model)} { uuid: $uuid })

RETURN
	CASE WHEN SIGN(COUNT(n)) = 1
		THEN true
		ELSE false
	END AS exists
```

#### After:
```
MATCH (n:${capitalise(model)} { uuid: $uuid })

RETURN n
```

Instead of specifying an `exists` property to return upon which to base the decision of whether to throw a Not Found error, the shorter query will simply return no results if an instance does not exist, meaning the Neo4j `query` module will handle deciding and throwing the Not Found error.

### Removed dev dependencies:
- [npm: chai-as-promised](https://www.npmjs.com/package/chai-as-promised).
