### PR TITLE
Make CastMember class an extension of Person class

### DIFF
--- a/src/models/CastMember.js
+++ b/src/models/CastMember.js
@@ -1,20 +1,14 @@
 import { getDuplicateNameIndices } from '../lib/get-duplicate-name-indices';
-import Base from './Base';
+import Person from './Person';
 import { Role } from '.';
 
-export default class PersonCastMember extends Base {
+export default class CastMember extends Person {
 
 	constructor (props = {}) {
 
 		super(props);
 
-		const { uuid, roles } = props;
-
-		this.model = 'person';
-		this.uuid = uuid;
-		this.roles = roles
-			? roles.map(role => new Role(role))
-			: [];
+		this.roles = props.roles.map(role => new Role(role));
 
 	}
 

--- a/src/models/Production.js
+++ b/src/models/Production.js
@@ -1,6 +1,6 @@
 import { getDuplicateNameIndices } from '../lib/get-duplicate-name-indices';
 import Base from './Base';
-import { BasicModel, PersonCastMember, Theatre } from '.';
+import { BasicModel, CastMember, Theatre } from '.';
 
 export default class Production extends Base {
 
@@ -15,7 +15,7 @@ export default class Production extends Base {
 		this.theatre = new Theatre(theatre);
 		this.playtext = new BasicModel({ model: 'playtext', ...playtext });
 		this.cast = cast
-			? cast.map(castMember => new PersonCastMember(castMember))
+			? cast.map(castMember => new CastMember(castMember))
 			: [];
 
 	}

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,6 +1,6 @@
 import BasicModel from './BasicModel';
+import CastMember from './CastMember';
 import Character from './Character';
-import PersonCastMember from './PersonCastMember';
 import Person from './Person';
 import Playtext from './Playtext';
 import Production from './Production';
@@ -9,8 +9,8 @@ import Theatre from './Theatre';
 
 export {
 	BasicModel,
+	CastMember,
 	Character,
-	PersonCastMember,
 	Person,
 	Playtext,
 	Production,

--- a/src/neo4j/create-constraints.js
+++ b/src/neo4j/create-constraints.js
@@ -7,7 +7,7 @@ const EXCLUDED_MODELS = [
 	'Base',
 	'BasicModel',
 	'index',
-	'PersonCastMember'
+	'CastMember'
 ];
 
 const models = require('fs')

--- a/test-unit/src/models/CastMember.test.js
+++ b/test-unit/src/models/CastMember.test.js
@@ -4,7 +4,7 @@ import { assert, createStubInstance, spy, stub } from 'sinon';
 
 import { Role } from '../../../src/models';
 
-describe('Person Cast Member model', () => {
+describe('Cast Member model', () => {
 
 	let stubs;
 	let instance;
@@ -31,16 +31,16 @@ describe('Person Cast Member model', () => {
 	});
 
 	const createSubject = () =>
-		proxyquire('../../../src/models/PersonCastMember', {
+		proxyquire('../../../src/models/CastMember', {
 			'../lib/get-duplicate-name-indices': stubs.getDuplicateNameIndicesModule,
 			'.': stubs.models
 		}).default;
 
 	const createInstance = (props = { name: 'Ian McKellen', roles: [{ name: 'King Lear' }] }) => {
 
-		const PersonCastMember = createSubject();
+		const CastMember = createSubject();
 
-		return new PersonCastMember(props);
+		return new CastMember(props);
 
 	};
 
@@ -48,14 +48,7 @@ describe('Person Cast Member model', () => {
 
 		describe('roles property', () => {
 
-			it('assigns empty array if absent from props', () => {
-
-				instance = createInstance({ name: 'Ian McKellen' });
-				expect(instance.roles).to.deep.eq([]);
-
-			});
-
-			it('assigns array of roles if included in props, retaining those with empty or whitespace-only string names', () => {
+			it('assigns array of role instances, retaining those with empty or whitespace-only string names', () => {
 
 				const props = {
 					name: 'Ian McKellen',

--- a/test-unit/src/models/Production.test.js
+++ b/test-unit/src/models/Production.test.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import proxyquire from 'proxyquire';
 import { assert, createStubInstance, spy, stub } from 'sinon';
 
-import { BasicModel, PersonCastMember, Theatre } from '../../../src/models';
+import { BasicModel, CastMember, Theatre } from '../../../src/models';
 
 describe('Production model', () => {
 
@@ -15,9 +15,9 @@ describe('Production model', () => {
 
 	};
 
-	const PersonCastMemberStub = function () {
+	const CastMemberStub = function () {
 
-		return createStubInstance(PersonCastMember);
+		return createStubInstance(CastMember);
 
 	};
 
@@ -43,7 +43,7 @@ describe('Production model', () => {
 			},
 			models: {
 				BasicModel: BasicModelStub,
-				PersonCastMember: PersonCastMemberStub,
+				CastMember: CastMemberStub,
 				Theatre: TheatreStub
 			}
 		};
@@ -94,9 +94,9 @@ describe('Production model', () => {
 				};
 				const instance = createInstance(props);
 				expect(instance.cast.length).to.equal(3);
-				expect(instance.cast[0] instanceof PersonCastMember).to.be.true;
-				expect(instance.cast[1] instanceof PersonCastMember).to.be.true;
-				expect(instance.cast[2] instanceof PersonCastMember).to.be.true;
+				expect(instance.cast[0] instanceof CastMember).to.be.true;
+				expect(instance.cast[1] instanceof CastMember).to.be.true;
+				expect(instance.cast[2] instanceof CastMember).to.be.true;
 
 			});
 


### PR DESCRIPTION
Revises the `CastMember` class to be an extension of the `Person` class (which is itself an extension of the `Base` class).

This improves the semantics of the class structure: a cast member is a specific type of person, or rather a person who fulfils a specific role (performing in a cast).

It also means that the `CastMember` class does not need to assign `model` and `uuid` properties upon instantiation, as it inherits them from the `Person` class.

Now that `CastMember` is an extension of `Person`, there is no need to qualify it by prepending 'Person' to its name (i.e. `PersonCastMember`), and so now it is simply named `CastMember`.