### PR TITLE
Amend Cypher query formatting

### DIFF
--- a/src/neo4j/cypher-queries/playtext.js
+++ b/src/neo4j/cypher-queries/playtext.js
@@ -8,8 +8,10 @@ const getCreateUpdateQuery = action => {
 			OPTIONAL MATCH (playtext)-[relationship:INCLUDES_CHARACTER]->(:Character)
 
 			WITH playtext, COLLECT(relationship) AS relationships
-				FOREACH (relationship IN relationships | DELETE relationship)
-				SET playtext.name = $name
+
+			FOREACH (relationship IN relationships | DELETE relationship)
+
+			SET playtext.name = $name
 		`
 	};
 

--- a/src/neo4j/cypher-queries/production.js
+++ b/src/neo4j/cypher-queries/production.js
@@ -8,8 +8,10 @@ const getCreateUpdateQuery = action => {
 			OPTIONAL MATCH (production)-[relationship]-()
 
 			WITH production, COLLECT(relationship) AS relationships
-				FOREACH (relationship IN relationships | DELETE relationship)
-				SET production.name = $name
+
+			FOREACH (relationship IN relationships | DELETE relationship)
+
+			SET production.name = $name
 		`
 	};
 
@@ -92,7 +94,8 @@ const getDeleteQuery = () => `
 	MATCH (production:Production { uuid: $uuid })
 
 	WITH production, production.name AS name
-		DETACH DELETE production
+
+	DETACH DELETE production
 
 	RETURN
 		'production' AS model,


### PR DESCRIPTION
For ease of reading:

Lines subsequent to `WITH` statements should only be indented when they form part of the statement, i.e. `COLLECT`, `ORDER BY`.

Separate commands should not be indented.