### PR TITLE
Revise theatre delete failure response

### DIFF
--- a/src/models/Theatre.js
+++ b/src/models/Theatre.js
@@ -22,11 +22,13 @@ export default class Theatre extends Base {
 
 		if (isDeleted) return { model, name };
 
+		this.name = name;
+
 		this.addPropertyError('associations', 'productions');
 
 		this.setErrorStatus();
 
-		return { theatre: this };
+		return this;
 
 	}
 

--- a/test-unit/src/models/Theatre.test.js
+++ b/test-unit/src/models/Theatre.test.js
@@ -81,7 +81,7 @@ describe('Theatre model', () => {
 				expect(instance.addPropertyError.calledWithExactly('associations', 'productions')).to.be.true;
 				expect(instance.setErrorStatus.calledOnce).to.be.true;
 				expect(instance.setErrorStatus.calledWithExactly()).to.be.true;
-				expect(result).to.deep.eq({ theatre: instance });
+				expect(result).to.deep.eq(instance);
 
 			});
 


### PR DESCRIPTION
Revise the structure of the response provided from a failed delete request (owing to existence of dependent associations) so that it is the same as that from a successful delete request.

This allows the CMS to accommodate the same structure in either scenario.