### PR TITLE
Rename associations to dependentAssociations

### DIFF
--- a/src/models/Theatre.js
+++ b/src/models/Theatre.js
@@ -24,7 +24,7 @@ export default class Theatre extends Base {
 
 		this.name = name;
 
-		this.addPropertyError('associations', 'productions');
+		this.addPropertyError('dependentAssociations', 'productions');
 
 		this.setErrorStatus();
 

--- a/test-unit/src/models/Theatre.test.js
+++ b/test-unit/src/models/Theatre.test.js
@@ -78,7 +78,7 @@ describe('Theatre model', () => {
 					{ query: 'getDeleteQuery response', params: instance }
 				)).to.be.true;
 				expect(instance.addPropertyError.calledOnce).to.be.true;
-				expect(instance.addPropertyError.calledWithExactly('associations', 'productions')).to.be.true;
+				expect(instance.addPropertyError.calledWithExactly('dependentAssociations', 'productions')).to.be.true;
 				expect(instance.setErrorStatus.calledOnce).to.be.true;
 				expect(instance.setErrorStatus.calledWithExactly()).to.be.true;
 				expect(result).to.deep.eq(instance);


### PR DESCRIPTION
Other instances with associations can be deleted, so this PR renames `associations` to `dependentAssociations` to make clear the specific nature of the associations that prevent a delete from occurring.