### PR TITLE
Upgrade ESLint version ^4.11.0 -> ^7.5.0

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,7 @@
   "extends": ["eslint:recommended"],
   "parserOptions": {
       "sourceType": "module",
-      "ecmaVersion": 2018
+      "ecmaVersion": 2020
   },
   "rules": {
     "eqeqeq": 2,

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@babel/register": "^7.4.4",
     "chai": "^3.5.0",
     "chai-http": "^4.3.0",
-    "eslint": "^4.11.0",
+    "eslint": "^7.5.0",
     "lintspaces-cli": "^0.6.0",
     "mocha": "^3.2.0",
     "node-mocks-http": "^1.6.6",

--- a/src/lib/has-errors.js
+++ b/src/lib/has-errors.js
@@ -6,7 +6,7 @@ const isObjectWithErrors = item => isObjectWithKeys(item) && hasErrors(item);
 
 export const hasErrors = instance => {
 
-	for (const prop in instance) if (instance.hasOwnProperty(prop)) {
+	for (const prop in instance) if (Object.prototype.hasOwnProperty.call(instance, prop)) {
 
 		const value = instance[prop];
 

--- a/src/lib/prepare-as-params.js
+++ b/src/lib/prepare-as-params.js
@@ -15,7 +15,7 @@ export const prepareAsParams = instance => {
 
 			accumulator[key] =
 				instance[key]
-					.filter(item => !item.hasOwnProperty('name') || !!item.name.length)
+					.filter(item => !Object.prototype.hasOwnProperty.call(item, 'name') || !!item.name.length)
 					.map((item, index, array) => {
 
 						if (isObjectWithKeys(item)) {

--- a/src/neo4j/query.js
+++ b/src/neo4j/query.js
@@ -12,24 +12,16 @@ export const neo4jQuery = async (queryData, queryOpts = {}) => {
 
 	const session = driver.session();
 
-	try {
+	const response = await session.run(query, params);
 
-		const response = await session.run(query, params);
+	session.close();
 
-		session.close();
+	const results = convertRecordsToObjects(response);
 
-		const results = convertRecordsToObjects(response);
+	if (!results.length && !isOptionalResult) throw new Error('Not Found');
 
-		if (!results.length && !isOptionalResult) throw new Error('Not Found');
-
-		return isArrayResult
-			? results
-			: results[0];
-
-	} catch (error) {
-
-		throw error;
-
-	}
+	return isArrayResult
+		? results
+		: results[0];
 
 };


### PR DESCRIPTION
This PR updates the version of [`eslint`](https://www.npmjs.com/package/eslint) package as a preliminary measure to allow [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) syntax, which will be applied in a subsequent PR.

`eslint` started supporting the optional chaining syntax as of the most recent release: [v7.5.0](https://github.com/eslint/eslint/releases/tag/v7.5.0) (released 3 days ago).

### References:
- [npm: eslint](https://www.npmjs.com/package/eslint).
- [GitHub: eslint/eslint](https://github.com/eslint/eslint).
- [ESLint: no-prototype-builtins](https://eslint.org/docs/rules/no-prototype-builtins): explanation of why it does not allow `instance.hasOwnProperty(prop)`.
- [ESLint: no-useless-catch](https://eslint.org/docs/rules/no-useless-catch).
- [MDN: Optional chaining (?.)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining).