### PR TITLE
Apply source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
     "unit-test": "mocha --require @babel/register test-unit/mocha.env.js test-unit/**/*.test.js",
     "int-test-resources": "docker-compose -f ./docker/docker-compose.yml up",
     "int-test": "mocha --require @babel/register test-int/mocha.env.js test-int/**/*.test.js",
-    "build": "babel src --out-dir built",
-    "watch": "babel src --watch --out-dir built",
-    "start": "node built/setup.js && npm run watch & nodemon built/app.js"
+    "build": "babel src --out-dir built --source-maps inline",
+    "watch": "babel src --watch --out-dir built --source-maps inline",
+    "setup": "node --require source-map-support/register built/setup.js",
+    "start": "npm run setup && npm run watch & nodemon --require source-map-support/register built/app.js"
   },
   "pre-commit": [
     "lint-check",
@@ -30,6 +31,7 @@
     "express": "^4.17.1",
     "morgan": "^1.5.1",
     "neo4j-driver": "^4.0.2",
+    "source-map-support": "^0.5.19",
     "uuid": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Currently error stacktraces will refer to transpiled code, but it would be much more useful and convenient for the stracktrace to refer to the source code.

This PR applies source maps to achieve this.

#### Before:
```
Error: foobar
    at Playtext.show (/Users/andy.gout/Documents/theatrebase-api/built/models/Base.js:131:11)
    at callInstanceMethod (/Users/andy.gout/Documents/theatrebase-api/built/lib/call-class-methods.js:12:49)
    at showRoute (/Users/andy.gout/Documents/theatrebase-api/built/controllers/playtexts.js:39:89)
    at Layer.handle [as handle_request] (/Users/andy.gout/Documents/theatrebase-api/node_modules/express/lib/router/layer.js:95:5)
    at next (/Users/andy.gout/Documents/theatrebase-api/node_modules/express/lib/router/route.js:137:13)
    at Route.dispatch (/Users/andy.gout/Documents/theatrebase-api/node_modules/express/lib/router/route.js:112:3)
    at Layer.handle [as handle_request] (/Users/andy.gout/Documents/theatrebase-api/node_modules/express/lib/router/layer.js:95:5)
    at /Users/andy.gout/Documents/theatrebase-api/node_modules/express/lib/router/index.js:281:22
    at param (/Users/andy.gout/Documents/theatrebase-api/node_modules/express/lib/router/index.js:354:14)
    at param (/Users/andy.gout/Documents/theatrebase-api/node_modules/express/lib/router/index.js:365:14)
```

#### After:
```
Error: foobar
    at Playtext.show (/Users/andy.gout/Documents/theatrebase-api/src/models/Base.js:150:9)
    at callInstanceMethod (/Users/andy.gout/Documents/theatrebase-api/src/lib/call-class-methods.js:7:26)
    at showRoute (/Users/andy.gout/Documents/theatrebase-api/src/controllers/playtexts.js:24:2)
    at Layer.handle [as handle_request] (/Users/andy.gout/Documents/theatrebase-api/node_modules/express/lib/router/layer.js:95:5)
    at next (/Users/andy.gout/Documents/theatrebase-api/node_modules/express/lib/router/route.js:137:13)
    at Route.dispatch (/Users/andy.gout/Documents/theatrebase-api/node_modules/express/lib/router/route.js:112:3)
    at Layer.handle [as handle_request] (/Users/andy.gout/Documents/theatrebase-api/node_modules/express/lib/router/layer.js:95:5)
    at /Users/andy.gout/Documents/theatrebase-api/node_modules/express/lib/router/index.js:281:22
    at param (/Users/andy.gout/Documents/theatrebase-api/node_modules/express/lib/router/index.js:354:14)
    at param (/Users/andy.gout/Documents/theatrebase-api/node_modules/express/lib/router/index.js:365:14)
```

### References:
- [Babel - @babel/cli: Compile with Source Maps](https://babeljs.io/docs/en/babel-cli#compile-with-source-maps).

### New dependencies:
- [npm: source-map-support](https://www.npmjs.com/package/source-map-support).