### PR TITLE
Limit list size to 100

### DIFF
--- a/src/neo4j/cypher-queries/shared.js
+++ b/src/neo4j/cypher-queries/shared.js
@@ -72,6 +72,8 @@ const getListQuery = model => {
 			n.uuid AS uuid,
 			n.name AS name
 			${theatreObject}
+
+		LIMIT 100
 	`;
 
 };

--- a/test-unit/src/neo4j/cypher-queries/shared.test.js
+++ b/test-unit/src/neo4j/cypher-queries/shared.test.js
@@ -45,6 +45,8 @@ describe('Cypher Queries Shared module', () => {
 						n.uuid AS uuid,
 						n.name AS name
 						, { model: 'theatre', uuid: t.uuid, name: t.name } AS theatre
+
+					LIMIT 100
 				`));
 
 			});
@@ -219,6 +221,8 @@ describe('Cypher Queries Shared module', () => {
 						'theatre' AS model,
 						n.uuid AS uuid,
 						n.name AS name
+
+					LIMIT 100
 				`));
 
 			});


### PR DESCRIPTION
Pages such as people and character are going to becomes increasingly large (even in a developer environment) so makes sense to limit the number of instances returned by the list query until work on pagination can be done.

### References:
- [Neo4j docs - Cypher Manual: LIMIT](https://neo4j.com/docs/cypher-manual/current/clauses/limit).