### PR TITLE
Integration tests for model validation failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,5 +18,8 @@ jobs:
           name: Unit tests
           command: npm run unit-test
       - run:
+          name: Integration tests
+          command: npm run int-test
+      - run:
           name: End-to-end tests
           command: npm run e2e-test

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ or
 ## To run unit tests
 - `$ npm run unit-test`.
 
+## To run integration tests
+- `$ npm run int-test`.
+
 ## To run end-to-end tests
 - Download and run the [Docker Desktop app](https://www.docker.com/products/docker-desktop).
 - Stop any Neo4j databases running on the Desktop app.

--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
   "license": "MS-RSL",
   "main": "src/app.js",
   "scripts": {
-    "lint": "eslint --ext .js src/ test-e2e/ test-unit/",
+    "lint": "eslint --ext .js src/ test-e2e/ test-int/ test-unit/",
     "lintspaces": "git ls-files | xargs lintspaces -e .editorconfig",
     "lint-check": "npm run lint && npm run lintspaces",
     "unit-test": "mocha --require @babel/register test-unit/mocha.env.js test-unit/**/*.test.js",
+    "int-test": "mocha --require @babel/register test-int/mocha.env.js test-int/**/*.test.js",
     "e2e-test-resources": "docker-compose -f ./docker/docker-compose.yml up",
     "e2e-test": "mocha --require @babel/register test-e2e/mocha.env.js test-e2e/**/*.test.js",
     "build": "babel src --out-dir built --source-maps inline",
@@ -19,7 +20,8 @@
   },
   "pre-commit": [
     "lint-check",
-    "unit-test"
+    "unit-test",
+    "int-test"
   ],
   "engines": {
     "node": "14.5.0",

--- a/src/neo4j/get-driver.js
+++ b/src/neo4j/get-driver.js
@@ -2,7 +2,7 @@ import neo4j from 'neo4j-driver';
 
 const { DATABASE_URL, DATABASE_USERNAME, DATABASE_PASSWORD, NODE_ENV } = process.env;
 
-const driver = (NODE_ENV === 'unit-test')
+const driver = (NODE_ENV === 'unit-test' || NODE_ENV === 'int-test')
 	? null
 	: neo4j.driver(DATABASE_URL, neo4j.auth.basic(DATABASE_USERNAME, DATABASE_PASSWORD));
 

--- a/test-int/.eslintrc.json
+++ b/test-int/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+  "env": {
+    "es6": true,
+    "node": true,
+    "mocha": true
+  },
+  "rules": {
+  	"new-cap": 0
+  }
+}

--- a/test-int/mocha.env.js
+++ b/test-int/mocha.env.js
@@ -1,0 +1,1 @@
+process.env.NODE_ENV = 'int-test';

--- a/test-int/model-instance-validation-failures/character.test.js
+++ b/test-int/model-instance-validation-failures/character.test.js
@@ -1,0 +1,119 @@
+import { expect } from 'chai';
+import { createSandbox } from 'sinon';
+
+import Character from '../../src/models/Character';
+import * as neo4jQueryModule from '../../src/neo4j/query';
+
+describe('Character instance', () => {
+
+	const EMPTY_STRING = '';
+	const STRING_MAX_LENGTH = 1000;
+	const ABOVE_MAX_LENGTH_STRING = 'a'.repeat(STRING_MAX_LENGTH + 1);
+
+	const sandbox = createSandbox();
+
+	afterEach(() => {
+
+		sandbox.restore();
+
+	});
+
+	describe('input validation failure', () => {
+
+		beforeEach(() => {
+
+			sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ instanceCount: 0 });
+
+		});
+
+		describe('name value is empty string', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instance = new Character({ name: EMPTY_STRING });
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					model: 'character',
+					uuid: undefined,
+					name: EMPTY_STRING,
+					hasErrors: true,
+					errors: {
+						name: [
+							'Name is too short'
+						]
+					}
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+		describe('name value exceeds maximum limit', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instance = new Character({ name: ABOVE_MAX_LENGTH_STRING });
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					model: 'character',
+					uuid: undefined,
+					name: ABOVE_MAX_LENGTH_STRING,
+					hasErrors: true,
+					errors: {
+						name: [
+							'Name is too long'
+						]
+					}
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+	});
+
+	describe('database validation failure', () => {
+
+		beforeEach(() => {
+
+			sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ instanceCount: 1 });
+
+		});
+
+		describe('name value already exists in database', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instance = new Character({ name: 'Hamlet' });
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					model: 'character',
+					uuid: undefined,
+					name: 'Hamlet',
+					hasErrors: true,
+					errors: {
+						name: [
+							'Name already exists'
+						]
+					}
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+	});
+
+});

--- a/test-int/model-instance-validation-failures/person.test.js
+++ b/test-int/model-instance-validation-failures/person.test.js
@@ -1,0 +1,119 @@
+import { expect } from 'chai';
+import { createSandbox } from 'sinon';
+
+import Person from '../../src/models/Person';
+import * as neo4jQueryModule from '../../src/neo4j/query';
+
+describe('Person instance', () => {
+
+	const EMPTY_STRING = '';
+	const STRING_MAX_LENGTH = 1000;
+	const ABOVE_MAX_LENGTH_STRING = 'a'.repeat(STRING_MAX_LENGTH + 1);
+
+	const sandbox = createSandbox();
+
+	afterEach(() => {
+
+		sandbox.restore();
+
+	});
+
+	describe('input validation failure', () => {
+
+		beforeEach(() => {
+
+			sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ instanceCount: 0 });
+
+		});
+
+		describe('name value is empty string', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instance = new Person({ name: EMPTY_STRING });
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					model: 'person',
+					uuid: undefined,
+					name: EMPTY_STRING,
+					hasErrors: true,
+					errors: {
+						name: [
+							'Name is too short'
+						]
+					}
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+		describe('name value exceeds maximum limit', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instance = new Person({ name: ABOVE_MAX_LENGTH_STRING });
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					model: 'person',
+					uuid: undefined,
+					name: ABOVE_MAX_LENGTH_STRING,
+					hasErrors: true,
+					errors: {
+						name: [
+							'Name is too long'
+						]
+					}
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+	});
+
+	describe('database validation failure', () => {
+
+		beforeEach(() => {
+
+			sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ instanceCount: 1 });
+
+		});
+
+		describe('name value already exists in database', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instance = new Person({ name: 'Helen Mirren' });
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					model: 'person',
+					uuid: undefined,
+					name: 'Helen Mirren',
+					hasErrors: true,
+					errors: {
+						name: [
+							'Name already exists'
+						]
+					}
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+	});
+
+});

--- a/test-int/model-instance-validation-failures/playtext.test.js
+++ b/test-int/model-instance-validation-failures/playtext.test.js
@@ -1,0 +1,287 @@
+import { expect } from 'chai';
+import { createSandbox } from 'sinon';
+
+import Playtext from '../../src/models/Playtext';
+import * as neo4jQueryModule from '../../src/neo4j/query';
+
+describe('Playtext instance', () => {
+
+	const EMPTY_STRING = '';
+	const STRING_MAX_LENGTH = 1000;
+	const ABOVE_MAX_LENGTH_STRING = 'a'.repeat(STRING_MAX_LENGTH + 1);
+
+	const sandbox = createSandbox();
+
+	afterEach(() => {
+
+		sandbox.restore();
+
+	});
+
+	describe('input validation failure', () => {
+
+		beforeEach(() => {
+
+			sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ instanceCount: 0 });
+
+		});
+
+		describe('name value is empty string', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instance = new Playtext({ name: EMPTY_STRING });
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					model: 'playtext',
+					uuid: undefined,
+					name: EMPTY_STRING,
+					hasErrors: true,
+					errors: {
+						name: [
+							'Name is too short'
+						]
+					},
+					characters: []
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+		describe('name value exceeds maximum limit', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instance = new Playtext({ name: ABOVE_MAX_LENGTH_STRING });
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					model: 'playtext',
+					uuid: undefined,
+					name: ABOVE_MAX_LENGTH_STRING,
+					hasErrors: true,
+					errors: {
+						name: [
+							'Name is too long'
+						]
+					},
+					characters: []
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+		describe('character name value exceeds maximum limit', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instanceProps = {
+					name: 'Rosmersholm',
+					characters: [
+						{
+							name: ABOVE_MAX_LENGTH_STRING
+						}
+					]
+				};
+
+				const instance = new Playtext(instanceProps);
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					model: 'playtext',
+					uuid: undefined,
+					name: 'Rosmersholm',
+					hasErrors: true,
+					errors: {},
+					characters: [
+						{
+							model: 'character',
+							uuid: undefined,
+							name: ABOVE_MAX_LENGTH_STRING,
+							errors: {
+								name: [
+									'Name is too long'
+								]
+							}
+						}
+					]
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+		describe('duplicate character name values', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instanceProps = {
+					name: 'Rosmersholm',
+					characters: [
+						{
+							name: 'Johannes Rosmer'
+						},
+						{
+							name: 'Rebecca West'
+						},
+						{
+							name: 'Johannes Rosmer'
+						}
+					]
+				};
+
+				const instance = new Playtext(instanceProps);
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					model: 'playtext',
+					uuid: undefined,
+					name: 'Rosmersholm',
+					hasErrors: true,
+					errors: {},
+					characters: [
+						{
+							model: 'character',
+							uuid: undefined,
+							name: 'Johannes Rosmer',
+							errors: {
+								name: [
+									'Name has been duplicated in this group'
+								]
+							}
+						},
+						{
+							model: 'character',
+							uuid: undefined,
+							name: 'Rebecca West',
+							errors: {}
+						},
+						{
+							model: 'character',
+							uuid: undefined,
+							name: 'Johannes Rosmer',
+							errors: {
+								name: [
+									'Name has been duplicated in this group'
+								]
+							}
+						}
+					]
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+	});
+
+	describe('database validation failure', () => {
+
+		beforeEach(() => {
+
+			sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ instanceCount: 1 });
+
+		});
+
+		describe('name value already exists in database', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instance = new Playtext({ name: 'Rosmersholm' });
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					model: 'playtext',
+					uuid: undefined,
+					name: 'Rosmersholm',
+					hasErrors: true,
+					errors: {
+						name: [
+							'Name already exists'
+						]
+					},
+					characters: []
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+	});
+
+	describe('combined input and database validation failure', () => {
+
+		beforeEach(() => {
+
+			sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ instanceCount: 1 });
+
+		});
+
+		describe('character name value exceeds maximum limit and name value already exists in database', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instanceProps = {
+					name: 'Rosmersholm',
+					characters: [
+						{
+							name: ABOVE_MAX_LENGTH_STRING
+						}
+					]
+				};
+
+				const instance = new Playtext(instanceProps);
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					model: 'playtext',
+					uuid: undefined,
+					name: 'Rosmersholm',
+					hasErrors: true,
+					errors: {
+						name: [
+							'Name already exists'
+						]
+					},
+					characters: [
+						{
+							model: 'character',
+							uuid: undefined,
+							name: ABOVE_MAX_LENGTH_STRING,
+							errors: {
+								name: [
+									'Name is too long'
+								]
+							}
+						}
+					]
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+	});
+
+});

--- a/test-int/model-instance-validation-failures/production.test.js
+++ b/test-int/model-instance-validation-failures/production.test.js
@@ -1,0 +1,650 @@
+import { expect } from 'chai';
+import { createSandbox } from 'sinon';
+
+import Production from '../../src/models/Production';
+import * as neo4jQueryModule from '../../src/neo4j/query';
+
+describe('Production instance', () => {
+
+	const EMPTY_STRING = '';
+	const STRING_MAX_LENGTH = 1000;
+	const ABOVE_MAX_LENGTH_STRING = 'a'.repeat(STRING_MAX_LENGTH + 1);
+
+	const sandbox = createSandbox();
+
+	beforeEach(() => {
+
+		sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ instanceCount: 0 });
+
+	});
+
+	afterEach(() => {
+
+		sandbox.restore();
+
+	});
+
+	describe('input validation failure', () => {
+
+		describe('name value is empty string', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instanceProps = {
+					name: EMPTY_STRING,
+					theatre: {
+						name: 'National Theatre'
+					}
+				};
+
+				const instance = new Production(instanceProps);
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					model: 'production',
+					uuid: undefined,
+					name: EMPTY_STRING,
+					hasErrors: true,
+					errors: {
+						name: [
+							'Name is too short'
+						]
+					},
+					theatre: {
+						model: 'theatre',
+						uuid: undefined,
+						name: 'National Theatre',
+						errors: {}
+					},
+					playtext: {
+						model: 'playtext',
+						uuid: undefined,
+						name: '',
+						errors: {}
+					},
+					cast: []
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+		describe('name value exceeds maximum limit', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instanceProps = {
+					name: ABOVE_MAX_LENGTH_STRING,
+					theatre: {
+						name: 'National Theatre'
+					}
+				};
+
+				const instance = new Production(instanceProps);
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					model: 'production',
+					uuid: undefined,
+					name: ABOVE_MAX_LENGTH_STRING,
+					hasErrors: true,
+					errors: {
+						name: [
+							'Name is too long'
+						]
+					},
+					theatre: {
+						model: 'theatre',
+						uuid: undefined,
+						name: 'National Theatre',
+						errors: {}
+					},
+					playtext: {
+						model: 'playtext',
+						uuid: undefined,
+						name: '',
+						errors: {}
+					},
+					cast: []
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+		describe('theatre name value is empty string', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instanceProps = {
+					name: 'Hamlet',
+					theatre: {
+						name: EMPTY_STRING
+					}
+				};
+
+				const instance = new Production(instanceProps);
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					model: 'production',
+					uuid: undefined,
+					name: 'Hamlet',
+					hasErrors: true,
+					errors: {},
+					theatre: {
+						model: 'theatre',
+						uuid: undefined,
+						name: EMPTY_STRING,
+						errors: {
+							name: [
+								'Name is too short'
+							]
+						}
+					},
+					playtext: {
+						model: 'playtext',
+						uuid: undefined,
+						name: '',
+						errors: {}
+					},
+					cast: []
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+		describe('theatre name value exceeds maximum limit', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instanceProps = {
+					name: 'Hamlet',
+					theatre: {
+						name: ABOVE_MAX_LENGTH_STRING
+					}
+				};
+
+				const instance = new Production(instanceProps);
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					model: 'production',
+					uuid: undefined,
+					name: 'Hamlet',
+					hasErrors: true,
+					errors: {},
+					theatre: {
+						model: 'theatre',
+						uuid: undefined,
+						name: ABOVE_MAX_LENGTH_STRING,
+						errors: {
+							name: [
+								'Name is too long'
+							]
+						}
+					},
+					playtext: {
+						model: 'playtext',
+						uuid: undefined,
+						name: '',
+						errors: {}
+					},
+					cast: []
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+		describe('playtext name value exceeds maximum limit', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instanceProps = {
+					name: 'Hamlet',
+					theatre: {
+						name: 'National Theatre'
+					},
+					playtext: {
+						name: ABOVE_MAX_LENGTH_STRING
+					}
+				};
+
+				const instance = new Production(instanceProps);
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					model: 'production',
+					uuid: undefined,
+					name: 'Hamlet',
+					hasErrors: true,
+					errors: {},
+					theatre: {
+						model: 'theatre',
+						uuid: undefined,
+						name: 'National Theatre',
+						errors: {}
+					},
+					playtext: {
+						model: 'playtext',
+						uuid: undefined,
+						name: ABOVE_MAX_LENGTH_STRING,
+						errors: {
+							name: [
+								'Name is too long'
+							]
+						}
+					},
+					cast: []
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+		describe('cast member name value exceeds maximum limit', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instanceProps = {
+					name: 'Hamlet',
+					theatre: {
+						name: 'National Theatre'
+					},
+					cast: [
+						{
+							name: ABOVE_MAX_LENGTH_STRING,
+							roles: []
+						}
+					]
+				};
+
+				const instance = new Production(instanceProps);
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					model: 'production',
+					uuid: undefined,
+					name: 'Hamlet',
+					hasErrors: true,
+					errors: {},
+					theatre: {
+						model: 'theatre',
+						uuid: undefined,
+						name: 'National Theatre',
+						errors: {}
+					},
+					playtext: {
+						model: 'playtext',
+						uuid: undefined,
+						name: '',
+						errors: {}
+					},
+					cast: [
+						{
+							model: 'person',
+							uuid: undefined,
+							name: ABOVE_MAX_LENGTH_STRING,
+							errors: {
+								name: [
+									'Name is too long'
+								]
+							},
+							roles: []
+						}
+					]
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+		describe('duplicate cast member name values', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instanceProps = {
+					name: 'Hamlet',
+					theatre: {
+						name: 'National Theatre'
+					},
+					cast: [
+						{
+							name: 'Rory Kinnear',
+							roles: []
+						},
+						{
+							name: 'David Calder',
+							roles: []
+						},
+						{
+							name: 'Rory Kinnear',
+							roles: []
+						}
+					]
+				};
+
+				const instance = new Production(instanceProps);
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					model: 'production',
+					uuid: undefined,
+					name: 'Hamlet',
+					hasErrors: true,
+					errors: {},
+					theatre: {
+						model: 'theatre',
+						uuid: undefined,
+						name: 'National Theatre',
+						errors: {}
+					},
+					playtext: {
+						model: 'playtext',
+						uuid: undefined,
+						name: '',
+						errors: {}
+					},
+					cast: [
+						{
+							model: 'person',
+							uuid: undefined,
+							name: 'Rory Kinnear',
+							errors: {
+								name: [
+									'Name has been duplicated in this group'
+								]
+							},
+							roles: []
+						},
+						{
+							model: 'person',
+							uuid: undefined,
+							name: 'David Calder',
+							errors: {},
+							roles: []
+						},
+						{
+							model: 'person',
+							uuid: undefined,
+							name: 'Rory Kinnear',
+							errors: {
+								name: [
+									'Name has been duplicated in this group'
+								]
+							},
+							roles: []
+						}
+					]
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+		describe('cast member role name value exceeds maximum limit', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instanceProps = {
+					name: 'Hamlet',
+					theatre: {
+						name: 'National Theatre'
+					},
+					cast: [
+						{
+							name: 'Rory Kinnear',
+							roles: [
+								{
+									name: ABOVE_MAX_LENGTH_STRING,
+									characterName: ''
+								}
+							]
+						}
+					]
+				};
+
+				const instance = new Production(instanceProps);
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					model: 'production',
+					uuid: undefined,
+					name: 'Hamlet',
+					hasErrors: true,
+					errors: {},
+					theatre: {
+						model: 'theatre',
+						uuid: undefined,
+						name: 'National Theatre',
+						errors: {}
+					},
+					playtext: {
+						model: 'playtext',
+						uuid: undefined,
+						name: '',
+						errors: {}
+					},
+					cast: [
+						{
+							model: 'person',
+							uuid: undefined,
+							name: 'Rory Kinnear',
+							errors: {},
+							roles: [
+								{
+									model: 'role',
+									name: ABOVE_MAX_LENGTH_STRING,
+									characterName: '',
+									errors: {
+										name: [
+											'Name is too long'
+										]
+									}
+								}
+							]
+						}
+					]
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+		describe('cast member role characterName value exceeds maximum limit', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instanceProps = {
+					name: 'Hamlet',
+					theatre: {
+						name: 'National Theatre'
+					},
+					cast: [
+						{
+							name: 'Rory Kinnear',
+							roles: [
+								{
+									name: 'Hamlet',
+									characterName: ABOVE_MAX_LENGTH_STRING
+								}
+							]
+						}
+					]
+				};
+
+				const instance = new Production(instanceProps);
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					model: 'production',
+					uuid: undefined,
+					name: 'Hamlet',
+					hasErrors: true,
+					errors: {},
+					theatre: {
+						model: 'theatre',
+						uuid: undefined,
+						name: 'National Theatre',
+						errors: {}
+					},
+					playtext: {
+						model: 'playtext',
+						uuid: undefined,
+						name: '',
+						errors: {}
+					},
+					cast: [
+						{
+							model: 'person',
+							uuid: undefined,
+							name: 'Rory Kinnear',
+							errors: {},
+							roles: [
+								{
+									model: 'role',
+									name: 'Hamlet',
+									characterName: ABOVE_MAX_LENGTH_STRING,
+									errors: {
+										characterName: [
+											'Name is too long'
+										]
+									}
+								}
+							]
+						}
+					]
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+		describe('duplicate cast member role name values', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instanceProps = {
+					name: 'Hamlet',
+					theatre: {
+						name: 'National Theatre'
+					},
+					cast: [
+						{
+							name: 'David Calder',
+							roles: [
+								{
+									name: 'Polonius',
+									characterName: ''
+								},
+								{
+									name: 'Gravedigger',
+									characterName: ''
+								},
+								{
+									name: 'Polonius',
+									characterName: ''
+								}
+							]
+						}
+					]
+				};
+
+				const instance = new Production(instanceProps);
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					model: 'production',
+					uuid: undefined,
+					name: 'Hamlet',
+					hasErrors: true,
+					errors: {},
+					theatre: {
+						model: 'theatre',
+						uuid: undefined,
+						name: 'National Theatre',
+						errors: {}
+					},
+					playtext: {
+						model: 'playtext',
+						uuid: undefined,
+						name: '',
+						errors: {}
+					},
+					cast: [
+						{
+							model: 'person',
+							uuid: undefined,
+							name: 'David Calder',
+							errors: {},
+							roles: [
+								{
+									model: 'role',
+									name: 'Polonius',
+									characterName: '',
+									errors: {
+										name: [
+											'Name has been duplicated in this group'
+										]
+									}
+								},
+								{
+									model: 'role',
+									name: 'Gravedigger',
+									characterName: '',
+									errors: {}
+								},
+								{
+									model: 'role',
+									name: 'Polonius',
+									characterName: '',
+									errors: {
+										name: [
+											'Name has been duplicated in this group'
+										]
+									}
+								}
+							]
+						}
+					]
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+	});
+
+});

--- a/test-int/model-instance-validation-failures/theatre.test.js
+++ b/test-int/model-instance-validation-failures/theatre.test.js
@@ -1,0 +1,119 @@
+import { expect } from 'chai';
+import { createSandbox } from 'sinon';
+
+import Theatre from '../../src/models/Theatre';
+import * as neo4jQueryModule from '../../src/neo4j/query';
+
+describe('Theatre instance', () => {
+
+	const EMPTY_STRING = '';
+	const STRING_MAX_LENGTH = 1000;
+	const ABOVE_MAX_LENGTH_STRING = 'a'.repeat(STRING_MAX_LENGTH + 1);
+
+	const sandbox = createSandbox();
+
+	afterEach(() => {
+
+		sandbox.restore();
+
+	});
+
+	describe('input validation failure', () => {
+
+		beforeEach(() => {
+
+			sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ instanceCount: 0 });
+
+		});
+
+		describe('name value is empty string', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instance = new Theatre({ name: EMPTY_STRING });
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					model: 'theatre',
+					uuid: undefined,
+					name: EMPTY_STRING,
+					hasErrors: true,
+					errors: {
+						name: [
+							'Name is too short'
+						]
+					}
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+		describe('name value exceeds maximum limit', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instance = new Theatre({ name: ABOVE_MAX_LENGTH_STRING });
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					model: 'theatre',
+					uuid: undefined,
+					name: ABOVE_MAX_LENGTH_STRING,
+					hasErrors: true,
+					errors: {
+						name: [
+							'Name is too long'
+						]
+					}
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+	});
+
+	describe('database validation failure', () => {
+
+		beforeEach(() => {
+
+			sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ instanceCount: 1 });
+
+		});
+
+		describe('name value already exists in database', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instance = new Theatre({ name: 'National Theatre' });
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					model: 'theatre',
+					uuid: undefined,
+					name: 'National Theatre',
+					hasErrors: true,
+					errors: {
+						name: [
+							'Name already exists'
+						]
+					}
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+	});
+
+});


### PR DESCRIPTION
This PR adds integration tests to ensure that calling the `create` method of model instances returns an instance that contains requisite error messages in scenarios in which validation is expected to fail. Other than calls to the Neo4j database, no modules are stubbed out so as to ensure that all the various methods and modules are integrating as expected.

The `create` and `update` methods are identical except for that the latter does an initial check for the existence of the instance in the database before validation commences, so it felt sufficient to run these tests only on one of those two methods (the former was chosen so as not to have to accommodate that first call to the database with a stub).