### PR TITLE
Add default value of empty array for CastMember roles

### DIFF
--- a/src/models/CastMember.js
+++ b/src/models/CastMember.js
@@ -8,7 +8,11 @@ export default class CastMember extends Person {
 
 		super(props);
 
-		this.roles = props.roles.map(role => new Role(role));
+		const { roles } = props;
+
+		this.roles = roles
+			? roles.map(role => new Role(role))
+			: [];
 
 	}
 


### PR DESCRIPTION
Data submitted by the CMS will include a `roles` property for each cast member (as below):
```
{
	"name": "King Lear",
	"theatre": {
		"name": "Courtyard Theatre"
	},
	"cast": [
		{
			"name": "Ian McKellen",
			"roles": []
		}
	]
}
```

However, if submitting data via a cURL or Postman request, it may be desirable to omit this value if the roles are empty or unnamed:
```
{
	"name": "King Lear",
	"theatre": {
		"name": "Courtyard Theatre"
	},
	"cast": [
		{
			"name": "Ian McKellen"
		}
	]
}
```

This will result in `TypeError: Cannot read property 'map' of undefined` when the code reaches the line `this.roles = props.roles.map(role => new Role(role));` in the CastMember model.

This PR ensures in this scenario that `this.roles` is assigned a default value of `[]`.