### PR TITLE
Add default value of empty string for Role characterName

### DIFF
--- a/src/models/Role.js
+++ b/src/models/Role.js
@@ -8,7 +8,7 @@ export default class Role extends Base {
 		super(props);
 
 		this.model = 'role';
-		this.characterName = props.characterName.trim();
+		this.characterName = props.characterName?.trim() || '';
 
 	}
 


### PR DESCRIPTION
Data submitted by the CMS will include a `characterName` property for each role (as below):
```
{
	"name": "Hamlet",
	"theatre": {
		"name": "National Theatre"
	},
	"cast": [
		{
			"name": "Rory Kinnear",
			"roles": [
				{
					"name": "Hamlet",
					"characterName": ""
				}
			]
		}
	]
}
```

However, if submitting data via a cURL or Postman request, it may be desirable to omit this value if the characterName is not required:
```
{
	"name": "Hamlet",
	"theatre": {
		"name": "National Theatre"
	},
	"cast": [
		{
			"name": "Rory Kinnear",
			"roles": [
				{
					"name": "Hamlet"
				}
			]
		}
	]
}
```

This will result in `TypeError: Cannot read property 'trim' of undefined` when the code reaches the line `this.characterName = props.characterName.trim();` in the Role model.

This PR ensures in this scenario that `this.characterName` is assigned a default value of `''`.