### PR TITLE
Replace some 'describe' with 'context' in integration tests

### DIFF
--- a/test-int/instance-validation-failures/character.test.js
+++ b/test-int/instance-validation-failures/character.test.js
@@ -26,7 +26,7 @@ describe('Character instance', () => {
 
 		});
 
-		describe('name value is empty string', () => {
+		context('name value is empty string', () => {
 
 			it('assigns appropriate error', async () => {
 
@@ -52,7 +52,7 @@ describe('Character instance', () => {
 
 		});
 
-		describe('name value exceeds maximum limit', () => {
+		context('name value exceeds maximum limit', () => {
 
 			it('assigns appropriate error', async () => {
 
@@ -88,7 +88,7 @@ describe('Character instance', () => {
 
 		});
 
-		describe('name value already exists in database', () => {
+		context('name value already exists in database', () => {
 
 			it('assigns appropriate error', async () => {
 

--- a/test-int/instance-validation-failures/person.test.js
+++ b/test-int/instance-validation-failures/person.test.js
@@ -26,7 +26,7 @@ describe('Person instance', () => {
 
 		});
 
-		describe('name value is empty string', () => {
+		context('name value is empty string', () => {
 
 			it('assigns appropriate error', async () => {
 
@@ -52,7 +52,7 @@ describe('Person instance', () => {
 
 		});
 
-		describe('name value exceeds maximum limit', () => {
+		context('name value exceeds maximum limit', () => {
 
 			it('assigns appropriate error', async () => {
 
@@ -88,7 +88,7 @@ describe('Person instance', () => {
 
 		});
 
-		describe('name value already exists in database', () => {
+		context('name value already exists in database', () => {
 
 			it('assigns appropriate error', async () => {
 

--- a/test-int/instance-validation-failures/playtext.test.js
+++ b/test-int/instance-validation-failures/playtext.test.js
@@ -26,7 +26,7 @@ describe('Playtext instance', () => {
 
 		});
 
-		describe('name value is empty string', () => {
+		context('name value is empty string', () => {
 
 			it('assigns appropriate error', async () => {
 
@@ -53,7 +53,7 @@ describe('Playtext instance', () => {
 
 		});
 
-		describe('name value exceeds maximum limit', () => {
+		context('name value exceeds maximum limit', () => {
 
 			it('assigns appropriate error', async () => {
 
@@ -80,7 +80,7 @@ describe('Playtext instance', () => {
 
 		});
 
-		describe('character name value exceeds maximum limit', () => {
+		context('character name value exceeds maximum limit', () => {
 
 			it('assigns appropriate error', async () => {
 
@@ -123,7 +123,7 @@ describe('Playtext instance', () => {
 
 		});
 
-		describe('duplicate character name values', () => {
+		context('duplicate character name values', () => {
 
 			it('assigns appropriate error', async () => {
 
@@ -198,7 +198,7 @@ describe('Playtext instance', () => {
 
 		});
 
-		describe('name value already exists in database', () => {
+		context('name value already exists in database', () => {
 
 			it('assigns appropriate error', async () => {
 
@@ -235,7 +235,7 @@ describe('Playtext instance', () => {
 
 		});
 
-		describe('character name value exceeds maximum limit and name value already exists in database', () => {
+		context('character name value exceeds maximum limit and name value already exists in database', () => {
 
 			it('assigns appropriate error', async () => {
 

--- a/test-int/instance-validation-failures/production.test.js
+++ b/test-int/instance-validation-failures/production.test.js
@@ -26,7 +26,7 @@ describe('Production instance', () => {
 
 	describe('input validation failure', () => {
 
-		describe('name value is empty string', () => {
+		context('name value is empty string', () => {
 
 			it('assigns appropriate error', async () => {
 
@@ -72,7 +72,7 @@ describe('Production instance', () => {
 
 		});
 
-		describe('name value exceeds maximum limit', () => {
+		context('name value exceeds maximum limit', () => {
 
 			it('assigns appropriate error', async () => {
 
@@ -118,7 +118,7 @@ describe('Production instance', () => {
 
 		});
 
-		describe('theatre name value is empty string', () => {
+		context('theatre name value is empty string', () => {
 
 			it('assigns appropriate error', async () => {
 
@@ -164,7 +164,7 @@ describe('Production instance', () => {
 
 		});
 
-		describe('theatre name value exceeds maximum limit', () => {
+		context('theatre name value exceeds maximum limit', () => {
 
 			it('assigns appropriate error', async () => {
 
@@ -210,7 +210,7 @@ describe('Production instance', () => {
 
 		});
 
-		describe('playtext name value exceeds maximum limit', () => {
+		context('playtext name value exceeds maximum limit', () => {
 
 			it('assigns appropriate error', async () => {
 
@@ -259,7 +259,7 @@ describe('Production instance', () => {
 
 		});
 
-		describe('cast member name value exceeds maximum limit', () => {
+		context('cast member name value exceeds maximum limit', () => {
 
 			it('assigns appropriate error', async () => {
 
@@ -319,7 +319,7 @@ describe('Production instance', () => {
 
 		});
 
-		describe('duplicate cast member name values', () => {
+		context('duplicate cast member name values', () => {
 
 			it('assigns appropriate error', async () => {
 
@@ -405,7 +405,7 @@ describe('Production instance', () => {
 
 		});
 
-		describe('cast member role name value exceeds maximum limit', () => {
+		context('cast member role name value exceeds maximum limit', () => {
 
 			it('assigns appropriate error', async () => {
 
@@ -477,7 +477,7 @@ describe('Production instance', () => {
 
 		});
 
-		describe('cast member role characterName value exceeds maximum limit', () => {
+		context('cast member role characterName value exceeds maximum limit', () => {
 
 			it('assigns appropriate error', async () => {
 
@@ -549,7 +549,7 @@ describe('Production instance', () => {
 
 		});
 
-		describe('duplicate cast member role name values', () => {
+		context('duplicate cast member role name values', () => {
 
 			it('assigns appropriate error', async () => {
 

--- a/test-int/instance-validation-failures/theatre.test.js
+++ b/test-int/instance-validation-failures/theatre.test.js
@@ -26,7 +26,7 @@ describe('Theatre instance', () => {
 
 		});
 
-		describe('name value is empty string', () => {
+		context('name value is empty string', () => {
 
 			it('assigns appropriate error', async () => {
 
@@ -52,7 +52,7 @@ describe('Theatre instance', () => {
 
 		});
 
-		describe('name value exceeds maximum limit', () => {
+		context('name value exceeds maximum limit', () => {
 
 			it('assigns appropriate error', async () => {
 
@@ -88,7 +88,7 @@ describe('Theatre instance', () => {
 
 		});
 
-		describe('name value already exists in database', () => {
+		context('name value already exists in database', () => {
 
 			it('assigns appropriate error', async () => {
 


### PR DESCRIPTION
Where amends have been made, 'context' seems more semantically meaningful.