### PR TITLE
Revise lint configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,7 +20,7 @@
     "no-multi-spaces": 2,
     "no-multiple-empty-lines": [2, {"max": 1}],
     "no-undef": 2,
-    "no-underscore-dangle": 0,
+    "no-underscore-dangle": 2,
     "no-unused-vars": 2,
     "no-var": 2,
     "one-var": [2, "never"],

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "chai": "^3.5.0",
     "chai-http": "^4.3.0",
     "eslint": "^7.5.0",
+    "eslint-plugin-no-only-tests": "^2.4.0",
     "lintspaces-cli": "^0.6.0",
     "mocha": "^3.2.0",
     "node-mocks-http": "^1.6.6",

--- a/src/neo4j/convert-records-to-objects.js
+++ b/src/neo4j/convert-records-to-objects.js
@@ -10,7 +10,7 @@ export default response => {
 
 		record.keys.forEach((key, index) => {
 
-			object[key] = record._fields[index];
+			object[key] = record._fields[index]; // eslint-disable-line no-underscore-dangle
 
 			if (neo4j.isInt(object[key])) {
 

--- a/test-e2e/.eslintrc.json
+++ b/test-e2e/.eslintrc.json
@@ -1,10 +1,11 @@
 {
   "env": {
-    "es6": true,
-    "node": true,
     "mocha": true
   },
+  "plugins": [
+    "no-only-tests"
+  ],
   "rules": {
-  	"new-cap": 0
+    "no-only-tests/no-only-tests": 2
   }
 }

--- a/test-int/.eslintrc.json
+++ b/test-int/.eslintrc.json
@@ -1,10 +1,11 @@
 {
   "env": {
-    "es6": true,
-    "node": true,
     "mocha": true
   },
+  "plugins": [
+    "no-only-tests"
+  ],
   "rules": {
-  	"new-cap": 0
+    "no-only-tests/no-only-tests": 2
   }
 }

--- a/test-unit/.eslintrc.json
+++ b/test-unit/.eslintrc.json
@@ -1,10 +1,11 @@
 {
   "env": {
-    "es6": true,
-    "node": true,
     "mocha": true
   },
+  "plugins": [
+    "no-only-tests"
+  ],
   "rules": {
-  	"new-cap": 0
+    "no-only-tests/no-only-tests": 2
   }
 }

--- a/test-unit/src/controllers/characters.test.js
+++ b/test-unit/src/controllers/characters.test.js
@@ -57,7 +57,7 @@ describe('Characters controller', () => {
 			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledOnce).to.be.true;
 			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledWithExactly(
 				stubs.response,
-				stubs.models.Character()
+				stubs.models.Character() // eslint-disable-line new-cap
 			)).to.be.true;
 
 		});
@@ -71,7 +71,7 @@ describe('Characters controller', () => {
 			const result = await callFunction('createRoute');
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
-				stubs.response, stubs.next, stubs.models.Character(), 'create'
+				stubs.response, stubs.next, stubs.models.Character(), 'create' // eslint-disable-line new-cap
 			)).to.be.true;
 			expect(result).to.equal('callInstanceMethod response');
 
@@ -86,7 +86,7 @@ describe('Characters controller', () => {
 			const result = await callFunction('editRoute');
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
-				stubs.response, stubs.next, stubs.models.Character(), 'edit'
+				stubs.response, stubs.next, stubs.models.Character(), 'edit' // eslint-disable-line new-cap
 			)).to.be.true;
 			expect(result).to.equal('callInstanceMethod response');
 
@@ -101,7 +101,7 @@ describe('Characters controller', () => {
 			const result = await callFunction('updateRoute');
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
-				stubs.response, stubs.next, stubs.models.Character(), 'update'
+				stubs.response, stubs.next, stubs.models.Character(), 'update' // eslint-disable-line new-cap
 			)).to.be.true;
 			expect(result).to.equal('callInstanceMethod response');
 
@@ -116,7 +116,7 @@ describe('Characters controller', () => {
 			const result = await callFunction('deleteRoute');
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
-				stubs.response, stubs.next, stubs.models.Character(), 'delete'
+				stubs.response, stubs.next, stubs.models.Character(), 'delete' // eslint-disable-line new-cap
 			)).to.be.true;
 			expect(result).to.equal('callInstanceMethod response');
 
@@ -131,7 +131,7 @@ describe('Characters controller', () => {
 			const result = await callFunction('showRoute');
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
-				stubs.response, stubs.next, stubs.models.Character(), 'show'
+				stubs.response, stubs.next, stubs.models.Character(), 'show' // eslint-disable-line new-cap
 			)).to.be.true;
 			expect(result).to.equal('callInstanceMethod response');
 

--- a/test-unit/src/controllers/people.test.js
+++ b/test-unit/src/controllers/people.test.js
@@ -56,7 +56,7 @@ describe('People controller', () => {
 			expect(callFunction('newRoute')).to.equal('sendJsonResponse response');
 			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledOnce).to.be.true;
 			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledWithExactly(
-				stubs.response, stubs.models.Person()
+				stubs.response, stubs.models.Person() // eslint-disable-line new-cap
 			)).to.be.true;
 
 		});
@@ -70,7 +70,7 @@ describe('People controller', () => {
 			const result = await callFunction('createRoute');
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
-				stubs.response, stubs.next, stubs.models.Person(), 'create'
+				stubs.response, stubs.next, stubs.models.Person(), 'create' // eslint-disable-line new-cap
 			)).to.be.true;
 			expect(result).to.equal('callInstanceMethod response');
 
@@ -85,7 +85,7 @@ describe('People controller', () => {
 			const result = await callFunction('editRoute');
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
-				stubs.response, stubs.next, stubs.models.Person(), 'edit'
+				stubs.response, stubs.next, stubs.models.Person(), 'edit' // eslint-disable-line new-cap
 			)).to.be.true;
 			expect(result).to.equal('callInstanceMethod response');
 
@@ -100,7 +100,7 @@ describe('People controller', () => {
 			const result = await callFunction('updateRoute');
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
-				stubs.response, stubs.next, stubs.models.Person(), 'update'
+				stubs.response, stubs.next, stubs.models.Person(), 'update' // eslint-disable-line new-cap
 			)).to.be.true;
 			expect(result).to.equal('callInstanceMethod response');
 
@@ -115,7 +115,7 @@ describe('People controller', () => {
 			const result = await callFunction('deleteRoute');
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
-				stubs.response, stubs.next, stubs.models.Person(), 'delete'
+				stubs.response, stubs.next, stubs.models.Person(), 'delete' // eslint-disable-line new-cap
 			)).to.be.true;
 			expect(result).to.equal('callInstanceMethod response');
 
@@ -130,7 +130,7 @@ describe('People controller', () => {
 			const result = await callFunction('showRoute');
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
-				stubs.response, stubs.next, stubs.models.Person(), 'show'
+				stubs.response, stubs.next, stubs.models.Person(), 'show' // eslint-disable-line new-cap
 			)).to.be.true;
 			expect(result).to.equal('callInstanceMethod response');
 

--- a/test-unit/src/controllers/playtexts.test.js
+++ b/test-unit/src/controllers/playtexts.test.js
@@ -56,7 +56,7 @@ describe('Playtexts controller', () => {
 			expect(callFunction('newRoute')).to.equal('sendJsonResponse response');
 			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledOnce).to.be.true;
 			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledWithExactly(
-				stubs.response, stubs.models.Playtext()
+				stubs.response, stubs.models.Playtext() // eslint-disable-line new-cap
 			)).to.be.true;
 
 		});
@@ -70,7 +70,7 @@ describe('Playtexts controller', () => {
 			const result = await callFunction('createRoute');
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
-				stubs.response, stubs.next, stubs.models.Playtext(), 'create'
+				stubs.response, stubs.next, stubs.models.Playtext(), 'create' // eslint-disable-line new-cap
 			)).to.be.true;
 			expect(result).to.equal('callInstanceMethod response');
 
@@ -85,7 +85,7 @@ describe('Playtexts controller', () => {
 			const result = await callFunction('editRoute');
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
-				stubs.response, stubs.next, stubs.models.Playtext(), 'edit'
+				stubs.response, stubs.next, stubs.models.Playtext(), 'edit' // eslint-disable-line new-cap
 			)).to.be.true;
 			expect(result).to.equal('callInstanceMethod response');
 
@@ -100,7 +100,7 @@ describe('Playtexts controller', () => {
 			const result = await callFunction('updateRoute');
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
-				stubs.response, stubs.next, stubs.models.Playtext(), 'update'
+				stubs.response, stubs.next, stubs.models.Playtext(), 'update' // eslint-disable-line new-cap
 			)).to.be.true;
 			expect(result).to.equal('callInstanceMethod response');
 
@@ -115,7 +115,7 @@ describe('Playtexts controller', () => {
 			const result = await callFunction('deleteRoute');
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
-				stubs.response, stubs.next, stubs.models.Playtext(), 'delete'
+				stubs.response, stubs.next, stubs.models.Playtext(), 'delete' // eslint-disable-line new-cap
 			)).to.be.true;
 			expect(result).to.equal('callInstanceMethod response');
 
@@ -130,7 +130,7 @@ describe('Playtexts controller', () => {
 			const result = await callFunction('showRoute');
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
-				stubs.response, stubs.next, stubs.models.Playtext(), 'show'
+				stubs.response, stubs.next, stubs.models.Playtext(), 'show' // eslint-disable-line new-cap
 			)).to.be.true;
 			expect(result).to.equal('callInstanceMethod response');
 

--- a/test-unit/src/controllers/productions.test.js
+++ b/test-unit/src/controllers/productions.test.js
@@ -57,7 +57,7 @@ describe('Productions controller', () => {
 			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledOnce).to.be.true;
 			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledWithExactly(
 				stubs.response,
-				stubs.models.Production()
+				stubs.models.Production() // eslint-disable-line new-cap
 			)).to.be.true;
 
 		});
@@ -71,7 +71,7 @@ describe('Productions controller', () => {
 			const result = await callFunction('createRoute');
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
-				stubs.response, stubs.next, stubs.models.Production(), 'create'
+				stubs.response, stubs.next, stubs.models.Production(), 'create' // eslint-disable-line new-cap
 			)).to.be.true;
 			expect(result).to.equal('callInstanceMethod response');
 
@@ -86,7 +86,7 @@ describe('Productions controller', () => {
 			const result = await callFunction('editRoute');
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
-				stubs.response, stubs.next, stubs.models.Production(), 'edit'
+				stubs.response, stubs.next, stubs.models.Production(), 'edit' // eslint-disable-line new-cap
 			)).to.be.true;
 			expect(result).to.equal('callInstanceMethod response');
 
@@ -101,7 +101,7 @@ describe('Productions controller', () => {
 			const result = await callFunction('updateRoute');
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
-				stubs.response, stubs.next, stubs.models.Production(), 'update'
+				stubs.response, stubs.next, stubs.models.Production(), 'update' // eslint-disable-line new-cap
 			)).to.be.true;
 			expect(result).to.equal('callInstanceMethod response');
 
@@ -116,7 +116,7 @@ describe('Productions controller', () => {
 			const result = await callFunction('deleteRoute');
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
-				stubs.response, stubs.next, stubs.models.Production(), 'delete'
+				stubs.response, stubs.next, stubs.models.Production(), 'delete' // eslint-disable-line new-cap
 			)).to.be.true;
 			expect(result).to.equal('callInstanceMethod response');
 
@@ -131,7 +131,7 @@ describe('Productions controller', () => {
 			const result = await callFunction('showRoute');
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
-				stubs.response, stubs.next, stubs.models.Production(), 'show'
+				stubs.response, stubs.next, stubs.models.Production(), 'show' // eslint-disable-line new-cap
 			)).to.be.true;
 			expect(result).to.equal('callInstanceMethod response');
 

--- a/test-unit/src/controllers/theatres.test.js
+++ b/test-unit/src/controllers/theatres.test.js
@@ -56,7 +56,7 @@ describe('Theatres controller', () => {
 			expect(callFunction('newRoute')).to.equal('sendJsonResponse response');
 			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledOnce).to.be.true;
 			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledWithExactly(
-				stubs.response, stubs.models.Theatre()
+				stubs.response, stubs.models.Theatre() // eslint-disable-line new-cap
 			)).to.be.true;
 
 		});
@@ -70,7 +70,7 @@ describe('Theatres controller', () => {
 			const result = await callFunction('createRoute');
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
-				stubs.response, stubs.next, stubs.models.Theatre(), 'create'
+				stubs.response, stubs.next, stubs.models.Theatre(), 'create' // eslint-disable-line new-cap
 			)).to.be.true;
 			expect(result).to.equal('callInstanceMethod response');
 
@@ -85,7 +85,7 @@ describe('Theatres controller', () => {
 			const result = await callFunction('editRoute');
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
-				stubs.response, stubs.next, stubs.models.Theatre(), 'edit'
+				stubs.response, stubs.next, stubs.models.Theatre(), 'edit' // eslint-disable-line new-cap
 			)).to.be.true;
 			expect(result).to.equal('callInstanceMethod response');
 
@@ -100,7 +100,7 @@ describe('Theatres controller', () => {
 			const result = await callFunction('updateRoute');
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
-				stubs.response, stubs.next, stubs.models.Theatre(), 'update'
+				stubs.response, stubs.next, stubs.models.Theatre(), 'update' // eslint-disable-line new-cap
 			)).to.be.true;
 			expect(result).to.equal('callInstanceMethod response');
 
@@ -115,7 +115,7 @@ describe('Theatres controller', () => {
 			const result = await callFunction('deleteRoute');
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
-				stubs.response, stubs.next, stubs.models.Theatre(), 'delete'
+				stubs.response, stubs.next, stubs.models.Theatre(), 'delete' // eslint-disable-line new-cap
 			)).to.be.true;
 			expect(result).to.equal('callInstanceMethod response');
 
@@ -130,7 +130,7 @@ describe('Theatres controller', () => {
 			const result = await callFunction('showRoute');
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
 			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
-				stubs.response, stubs.next, stubs.models.Theatre(), 'show'
+				stubs.response, stubs.next, stubs.models.Theatre(), 'show' // eslint-disable-line new-cap
 			)).to.be.true;
 			expect(result).to.equal('callInstanceMethod response');
 

--- a/test-unit/src/lib/call-class-methods.test.js
+++ b/test-unit/src/lib/call-class-methods.test.js
@@ -80,7 +80,7 @@ describe('Call Class Methods module', () => {
 				sandbox.stub(character, method).callsFake(() => { return Promise.reject(notFoundError); });
 				await callClassMethods.callInstanceMethod(stubs.response, stubs.next, character, method);
 				expect(stubs.response.statusCode).to.equal(404);
-				expect(stubs.response._getData()).to.equal('Not Found');
+				expect(stubs.response._getData()).to.equal('Not Found'); // eslint-disable-line no-underscore-dangle
 				expect(stubs.sendJsonResponse.notCalled).to.be.true;
 				expect(stubs.next.called).to.be.false;
 

--- a/test-unit/src/lib/send-json-response.test.js
+++ b/test-unit/src/lib/send-json-response.test.js
@@ -10,8 +10,8 @@ describe('Send JSON Response module', () => {
 		const response = httpMocks.createResponse();
 		sendJsonResponse(response, { instanceProperty: 'instanceValue' });
 		expect(response.statusCode).to.equal(200);
-		expect(response._getHeaders()).to.deep.eq({ 'content-type': 'application/json' });
-		expect(response._getData()).to.equal('{"instanceProperty":"instanceValue"}');
+		expect(response._getHeaders()).to.deep.eq({ 'content-type': 'application/json' }); // eslint-disable-line no-underscore-dangle
+		expect(response._getData()).to.equal('{"instanceProperty":"instanceValue"}'); // eslint-disable-line no-underscore-dangle
 
 	});
 


### PR DESCRIPTION
- Enforces `no-underscore-dangle` and disables specific lines where it is used (rather than blanket disable).
- Enforces `no-only-tests` in test files, which requires dev dependency `eslint-plugin-no-only-tests`.
- Minimise content in test dir `eslintrc.json` files as they use what it is in the same file in the root dir.
- As a result of the previous point, `new-cap` is now enforced in test files, and so specific lines where it is used have been disabled.

### New dev dependencies:
- [npm: eslint-plugin-no-only-tests](https://www.npmjs.com/package/eslint-plugin-no-only-tests).
