### PR TITLE
Make production relationship to theatre non-mandatory

### DIFF
--- a/src/models/Production.js
+++ b/src/models/Production.js
@@ -24,7 +24,7 @@ export default class Production extends Base {
 
 		this.validateName({ requiresName: true });
 
-		this.theatre.validateName({ requiresName: true });
+		this.theatre.validateName({ requiresName: false });
 
 		this.playtext.validateName({ requiresName: false });
 

--- a/src/neo4j/cypher-queries/character.js
+++ b/src/neo4j/cypher-queries/character.js
@@ -67,7 +67,11 @@ const getShowQuery = () => `
 					model: 'production',
 					uuid: production.uuid,
 					name: production.name,
-					theatre: { model: 'theatre', uuid: theatre.uuid, name: theatre.name },
+					theatre:
+						CASE WHEN theatre IS NULL
+							THEN null
+							ELSE { model: 'theatre', uuid: theatre.uuid, name: theatre.name }
+						END,
 					performers: performers
 				}
 			END

--- a/src/neo4j/cypher-queries/person.js
+++ b/src/neo4j/cypher-queries/person.js
@@ -1,7 +1,9 @@
 const getShowQuery = () => `
 	MATCH (person:Person { uuid: $uuid })
 
-	OPTIONAL MATCH (person)-[role:PERFORMS_IN]->(production:Production)-[:PLAYS_AT]->(theatre:Theatre)
+	OPTIONAL MATCH (person)-[role:PERFORMS_IN]->(production:Production)
+
+	OPTIONAL MATCH (production)-[:PLAYS_AT]->(theatre:Theatre)
 
 	OPTIONAL MATCH (production)-[:PRODUCTION_OF]->(:Playtext)-[:INCLUDES_CHARACTER]->(character:Character)
 		WHERE role.roleName = character.name OR role.characterName = character.name
@@ -29,7 +31,11 @@ const getShowQuery = () => `
 					model: 'production',
 					uuid: production.uuid,
 					name: production.name,
-					theatre: { model: 'theatre', uuid: theatre.uuid, name: theatre.name },
+					theatre:
+						CASE WHEN theatre IS NULL
+							THEN null
+							ELSE { model: 'theatre', uuid: theatre.uuid, name: theatre.name }
+						END,
 					roles: roles
 				}
 			END

--- a/src/neo4j/cypher-queries/playtext.js
+++ b/src/neo4j/cypher-queries/playtext.js
@@ -60,7 +60,9 @@ const getShowQuery = () => `
 
 	OPTIONAL MATCH (playtext)-[characterRel:INCLUDES_CHARACTER]->(character:Character)
 
-	OPTIONAL MATCH (playtext)<-[:PRODUCTION_OF]-(production:Production)-[:PLAYS_AT]->(theatre:Theatre)
+	OPTIONAL MATCH (playtext)<-[:PRODUCTION_OF]-(production:Production)
+
+	OPTIONAL MATCH (production)-[:PLAYS_AT]->(theatre:Theatre)
 
 	WITH playtext, character, production, theatre
 		ORDER BY characterRel.position
@@ -86,7 +88,11 @@ const getShowQuery = () => `
 					model: 'production',
 					uuid: production.uuid,
 					name: production.name,
-					theatre: { model: 'theatre', uuid: theatre.uuid, name: theatre.name }
+					theatre:
+						CASE WHEN theatre IS NULL
+							THEN null
+							ELSE { model: 'theatre', uuid: theatre.uuid, name: theatre.name }
+						END
 				}
 			END
 		) AS productions

--- a/src/neo4j/cypher-queries/shared.js
+++ b/src/neo4j/cypher-queries/shared.js
@@ -57,15 +57,17 @@ const getDeleteQuery = model => `
 const getListQuery = model => {
 
 	const theatreRelationship = (model === 'production')
-		? '-[:PLAYS_AT]->(t:Theatre)'
+		? 'OPTIONAL MATCH (n)-[:PLAYS_AT]->(t:Theatre)'
 		: '';
 
 	const theatreObject = (model === 'production')
-		? ', { model: \'theatre\', uuid: t.uuid, name: t.name } AS theatre'
+		? ', CASE WHEN t IS NULL THEN null ELSE { model: \'theatre\', uuid: t.uuid, name: t.name } END AS theatre'
 		: '';
 
 	return `
-		MATCH (n:${capitalise(model)})${theatreRelationship}
+		MATCH (n:${capitalise(model)})
+
+		${theatreRelationship}
 
 		RETURN
 			'${model}' AS model,

--- a/test-e2e/crud/productions-api.test.js
+++ b/test-e2e/crud/productions-api.test.js
@@ -59,7 +59,6 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 	describe('CRUD with minimum range of attributes assigned values', () => {
 
 		const PRODUCTION_UUID = '0';
-		const THEATRE_UUID = '1';
 
 		const sandbox = createSandbox();
 
@@ -86,10 +85,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 			const response = await chai.request(app)
 				.post('/productions')
 				.send({
-					name: 'As You Like It',
-					theatre: {
-						name: 'Novello Theatre'
-					}
+					name: 'As You Like It'
 				});
 
 			const expectedResponseBody = {
@@ -99,7 +95,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 				errors: {},
 				theatre: {
 					model: 'theatre',
-					name: 'Novello Theatre',
+					name: '',
 					errors: {}
 				},
 				playtext: {
@@ -142,7 +138,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 				errors: {},
 				theatre: {
 					model: 'theatre',
-					name: 'Novello Theatre',
+					name: '',
 					errors: {}
 				},
 				playtext: {
@@ -179,10 +175,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 			const response = await chai.request(app)
 				.put(`/productions/${PRODUCTION_UUID}`)
 				.send({
-					name: 'The Tempest',
-					theatre: {
-						name: 'Novello Theatre'
-					}
+					name: 'The Tempest'
 				});
 
 			const expectedResponseBody = {
@@ -192,7 +185,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 				errors: {},
 				theatre: {
 					model: 'theatre',
-					name: 'Novello Theatre',
+					name: '',
 					errors: {}
 				},
 				playtext: {
@@ -232,11 +225,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 				model: 'production',
 				uuid: PRODUCTION_UUID,
 				name: 'The Tempest',
-				theatre: {
-					model: 'theatre',
-					uuid: THEATRE_UUID,
-					name: 'Novello Theatre'
-				},
+				theatre: null,
 				playtext: null,
 				cast: []
 			};
@@ -256,11 +245,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 					model: 'production',
 					uuid: PRODUCTION_UUID,
 					name: 'The Tempest',
-					theatre: {
-						model: 'theatre',
-						uuid: THEATRE_UUID,
-						name: 'Novello Theatre'
-					}
+					theatre: null
 				}
 			];
 

--- a/test-e2e/instance-validation-failures/productions-api.test.js
+++ b/test-e2e/instance-validation-failures/productions-api.test.js
@@ -4,7 +4,6 @@ import chaiHttp from 'chai-http';
 import app from '../../src/app';
 import countNodesWithLabel from '../test-helpers/neo4j/count-nodes-with-label';
 import createNode from '../test-helpers/neo4j/create-node';
-import createRelationship from '../test-helpers/neo4j/create-relationship';
 import matchNode from '../test-helpers/neo4j/match-node';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
 
@@ -29,10 +28,7 @@ describe('Instance validation failures: Productions API', () => {
 				const response = await chai.request(app)
 					.post('/productions')
 					.send({
-						name: '',
-						theatre: {
-							name: 'Almeida Theatre'
-						}
+						name: ''
 					});
 
 				const expectedResponseBody = {
@@ -46,7 +42,7 @@ describe('Instance validation failures: Productions API', () => {
 					},
 					theatre: {
 						model: 'theatre',
-						name: 'Almeida Theatre',
+						name: '',
 						errors: {}
 					},
 					playtext: {
@@ -69,8 +65,7 @@ describe('Instance validation failures: Productions API', () => {
 
 	describe('attempt to update instance', () => {
 
-		const MACBETH_ALMEIDA_PRODUCTION_UUID = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
-		const ALMEIDA_THEATRE_UUID = 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy';
+		const MACBETH_PRODUCTION_UUID = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
 
 		before(async () => {
 
@@ -79,21 +74,7 @@ describe('Instance validation failures: Productions API', () => {
 			await createNode({
 				label: 'Production',
 				name: 'Macbeth',
-				uuid: MACBETH_ALMEIDA_PRODUCTION_UUID
-			});
-
-			await createNode({
-				label: 'Theatre',
-				name: 'Almeida Theatre',
-				uuid: ALMEIDA_THEATRE_UUID
-			});
-
-			await createRelationship({
-				sourceLabel: 'Production',
-				sourceUuid: MACBETH_ALMEIDA_PRODUCTION_UUID,
-				destinationLabel: 'Theatre',
-				destinationUuid: ALMEIDA_THEATRE_UUID,
-				relationshipName: 'PLAYS_AT'
+				uuid: MACBETH_PRODUCTION_UUID
 			});
 
 		});
@@ -105,17 +86,14 @@ describe('Instance validation failures: Productions API', () => {
 				expect(await countNodesWithLabel('Production')).to.equal(1);
 
 				const response = await chai.request(app)
-					.put(`/productions/${MACBETH_ALMEIDA_PRODUCTION_UUID}`)
+					.put(`/productions/${MACBETH_PRODUCTION_UUID}`)
 					.send({
-						name: '',
-						theatre: {
-							name: 'Almeida Theatre'
-						}
+						name: ''
 					});
 
 				const expectedResponseBody = {
 					model: 'production',
-					uuid: MACBETH_ALMEIDA_PRODUCTION_UUID,
+					uuid: MACBETH_PRODUCTION_UUID,
 					name: '',
 					hasErrors: true,
 					errors: {
@@ -125,7 +103,7 @@ describe('Instance validation failures: Productions API', () => {
 					},
 					theatre: {
 						model: 'theatre',
-						name: 'Almeida Theatre',
+						name: '',
 						errors: {}
 					},
 					playtext: {
@@ -142,7 +120,7 @@ describe('Instance validation failures: Productions API', () => {
 				expect(await matchNode({
 					label: 'Production',
 					name: 'Macbeth',
-					uuid: MACBETH_ALMEIDA_PRODUCTION_UUID
+					uuid: MACBETH_PRODUCTION_UUID
 				})).to.be.true;
 
 			});

--- a/test-e2e/non-existent-instances/productions-api.test.js
+++ b/test-e2e/non-existent-instances/productions-api.test.js
@@ -39,10 +39,7 @@ describe('Non-existent instances: Productions API', () => {
 				const response = await chai.request(app)
 					.put(`/productions/${NON_EXISTENT_PRODUCTION_UUID}`)
 					.send({
-						name: 'The Tempest',
-						theatre: {
-							name: 'Novello Theatre'
-						}
+						name: 'The Tempest'
 					});
 
 				expect(response).to.have.status(404);

--- a/test-int/instance-validation-failures/production.test.js
+++ b/test-int/instance-validation-failures/production.test.js
@@ -30,10 +30,7 @@ describe('Production instance', () => {
 			it('assigns appropriate error', async () => {
 
 				const instanceProps = {
-					name: '',
-					theatre: {
-						name: 'National Theatre'
-					}
+					name: ''
 				};
 
 				const instance = new Production(instanceProps);
@@ -53,7 +50,7 @@ describe('Production instance', () => {
 					theatre: {
 						model: 'theatre',
 						uuid: undefined,
-						name: 'National Theatre',
+						name: '',
 						errors: {}
 					},
 					playtext: {
@@ -76,10 +73,7 @@ describe('Production instance', () => {
 			it('assigns appropriate error', async () => {
 
 				const instanceProps = {
-					name: ABOVE_MAX_LENGTH_STRING,
-					theatre: {
-						name: 'National Theatre'
-					}
+					name: ABOVE_MAX_LENGTH_STRING
 				};
 
 				const instance = new Production(instanceProps);
@@ -99,54 +93,8 @@ describe('Production instance', () => {
 					theatre: {
 						model: 'theatre',
 						uuid: undefined,
-						name: 'National Theatre',
-						errors: {}
-					},
-					playtext: {
-						model: 'playtext',
-						uuid: undefined,
 						name: '',
 						errors: {}
-					},
-					cast: []
-				};
-
-				expect(result).to.deep.equal(expectedResponseBody);
-
-			});
-
-		});
-
-		context('theatre name value is empty string', () => {
-
-			it('assigns appropriate error', async () => {
-
-				const instanceProps = {
-					name: 'Hamlet',
-					theatre: {
-						name: ''
-					}
-				};
-
-				const instance = new Production(instanceProps);
-
-				const result = await instance.create();
-
-				const expectedResponseBody = {
-					model: 'production',
-					uuid: undefined,
-					name: 'Hamlet',
-					hasErrors: true,
-					errors: {},
-					theatre: {
-						model: 'theatre',
-						uuid: undefined,
-						name: '',
-						errors: {
-							name: [
-								'Name is too short'
-							]
-						}
 					},
 					playtext: {
 						model: 'playtext',
@@ -215,9 +163,6 @@ describe('Production instance', () => {
 
 				const instanceProps = {
 					name: 'Hamlet',
-					theatre: {
-						name: 'National Theatre'
-					},
 					playtext: {
 						name: ABOVE_MAX_LENGTH_STRING
 					}
@@ -236,7 +181,7 @@ describe('Production instance', () => {
 					theatre: {
 						model: 'theatre',
 						uuid: undefined,
-						name: 'National Theatre',
+						name: '',
 						errors: {}
 					},
 					playtext: {
@@ -264,9 +209,6 @@ describe('Production instance', () => {
 
 				const instanceProps = {
 					name: 'Hamlet',
-					theatre: {
-						name: 'National Theatre'
-					},
 					cast: [
 						{
 							name: ABOVE_MAX_LENGTH_STRING,
@@ -288,7 +230,7 @@ describe('Production instance', () => {
 					theatre: {
 						model: 'theatre',
 						uuid: undefined,
-						name: 'National Theatre',
+						name: '',
 						errors: {}
 					},
 					playtext: {
@@ -324,9 +266,6 @@ describe('Production instance', () => {
 
 				const instanceProps = {
 					name: 'Hamlet',
-					theatre: {
-						name: 'National Theatre'
-					},
 					cast: [
 						{
 							name: 'Rory Kinnear',
@@ -356,7 +295,7 @@ describe('Production instance', () => {
 					theatre: {
 						model: 'theatre',
 						uuid: undefined,
-						name: 'National Theatre',
+						name: '',
 						errors: {}
 					},
 					playtext: {
@@ -410,9 +349,6 @@ describe('Production instance', () => {
 
 				const instanceProps = {
 					name: 'Hamlet',
-					theatre: {
-						name: 'National Theatre'
-					},
 					cast: [
 						{
 							name: 'Rory Kinnear',
@@ -439,7 +375,7 @@ describe('Production instance', () => {
 					theatre: {
 						model: 'theatre',
 						uuid: undefined,
-						name: 'National Theatre',
+						name: '',
 						errors: {}
 					},
 					playtext: {
@@ -482,9 +418,6 @@ describe('Production instance', () => {
 
 				const instanceProps = {
 					name: 'Hamlet',
-					theatre: {
-						name: 'National Theatre'
-					},
 					cast: [
 						{
 							name: 'Rory Kinnear',
@@ -511,7 +444,7 @@ describe('Production instance', () => {
 					theatre: {
 						model: 'theatre',
 						uuid: undefined,
-						name: 'National Theatre',
+						name: '',
 						errors: {}
 					},
 					playtext: {
@@ -554,9 +487,6 @@ describe('Production instance', () => {
 
 				const instanceProps = {
 					name: 'Hamlet',
-					theatre: {
-						name: 'National Theatre'
-					},
 					cast: [
 						{
 							name: 'David Calder',
@@ -591,7 +521,7 @@ describe('Production instance', () => {
 					theatre: {
 						model: 'theatre',
 						uuid: undefined,
-						name: 'National Theatre',
+						name: '',
 						errors: {}
 					},
 					playtext: {

--- a/test-unit/src/models/Production.test.js
+++ b/test-unit/src/models/Production.test.js
@@ -120,7 +120,7 @@ describe('Production model', () => {
 			expect(instance.validateName.calledOnce).to.be.true;
 			expect(instance.validateName.calledWithExactly({ requiresName: true })).to.be.true;
 			expect(instance.theatre.validateName.calledOnce).to.be.true;
-			expect(instance.theatre.validateName.calledWithExactly({ requiresName: true })).to.be.true;
+			expect(instance.theatre.validateName.calledWithExactly({ requiresName: false })).to.be.true;
 			expect(instance.playtext.validateName.calledOnce).to.be.true;
 			expect(instance.playtext.validateName.calledWithExactly({ requiresName: false })).to.be.true;
 			expect(stubs.getDuplicateNameIndicesModule.getDuplicateNameIndices.calledOnce).to.be.true;

--- a/test-unit/src/neo4j/cypher-queries/production.test.js
+++ b/test-unit/src/neo4j/cypher-queries/production.test.js
@@ -13,10 +13,11 @@ describe('Cypher Queries Production module', () => {
 			expect(removeWhitespace(result)).to.equal(removeWhitespace(`
 				CREATE (production:Production { uuid: $uuid, name: $name })
 
-				MERGE (theatre:Theatre { name: $theatre.name })
+				FOREACH (item IN CASE WHEN $theatre.name IS NOT NULL THEN [1] ELSE [] END |
+					MERGE (theatre:Theatre { name: $theatre.name })
 					ON CREATE SET theatre.uuid = $theatre.uuid
-
-				CREATE (production)-[:PLAYS_AT]->(theatre)
+					CREATE (production)-[:PLAYS_AT]->(theatre)
+				)
 
 				FOREACH (item IN CASE WHEN $playtext.name IS NOT NULL THEN [1] ELSE [] END |
 					MERGE (playtext:Playtext { name: $playtext.name })
@@ -41,7 +42,9 @@ describe('Cypher Queries Production module', () => {
 
 				WITH production
 
-				MATCH (production:Production { uuid: $uuid })-[:PLAYS_AT]->(theatre:Theatre)
+				MATCH (production:Production { uuid: $uuid })
+
+				OPTIONAL MATCH (production)-[:PLAYS_AT]->(theatre:Theatre)
 
 				OPTIONAL MATCH (production)-[:PRODUCTION_OF]->(playtext:Playtext)
 
@@ -65,7 +68,7 @@ describe('Cypher Queries Production module', () => {
 					'production' AS model,
 					production.uuid AS uuid,
 					production.name AS name,
-					{ name: theatre.name } AS theatre,
+					{ name: CASE WHEN theatre.name IS NULL THEN '' ELSE theatre.name END } AS theatre,
 					{ name: CASE WHEN playtext.name IS NULL THEN '' ELSE playtext.name END } AS playtext,
 					COLLECT(
 						CASE WHEN person IS NULL
@@ -93,10 +96,11 @@ describe('Cypher Queries Production module', () => {
 					FOREACH (relationship IN relationships | DELETE relationship)
 					SET production.name = $name
 
-				MERGE (theatre:Theatre { name: $theatre.name })
+				FOREACH (item IN CASE WHEN $theatre.name IS NOT NULL THEN [1] ELSE [] END |
+					MERGE (theatre:Theatre { name: $theatre.name })
 					ON CREATE SET theatre.uuid = $theatre.uuid
-
-				CREATE (production)-[:PLAYS_AT]->(theatre)
+					CREATE (production)-[:PLAYS_AT]->(theatre)
+				)
 
 				FOREACH (item IN CASE WHEN $playtext.name IS NOT NULL THEN [1] ELSE [] END |
 					MERGE (playtext:Playtext { name: $playtext.name })
@@ -121,7 +125,9 @@ describe('Cypher Queries Production module', () => {
 
 				WITH production
 
-				MATCH (production:Production { uuid: $uuid })-[:PLAYS_AT]->(theatre:Theatre)
+				MATCH (production:Production { uuid: $uuid })
+
+				OPTIONAL MATCH (production)-[:PLAYS_AT]->(theatre:Theatre)
 
 				OPTIONAL MATCH (production)-[:PRODUCTION_OF]->(playtext:Playtext)
 
@@ -145,7 +151,7 @@ describe('Cypher Queries Production module', () => {
 					'production' AS model,
 					production.uuid AS uuid,
 					production.name AS name,
-					{ name: theatre.name } AS theatre,
+					{ name: CASE WHEN theatre.name IS NULL THEN '' ELSE theatre.name END } AS theatre,
 					{ name: CASE WHEN playtext.name IS NULL THEN '' ELSE playtext.name END } AS playtext,
 					COLLECT(
 						CASE WHEN person IS NULL

--- a/test-unit/src/neo4j/cypher-queries/shared.test.js
+++ b/test-unit/src/neo4j/cypher-queries/shared.test.js
@@ -38,13 +38,15 @@ describe('Cypher Queries Shared module', () => {
 				expect(stubs.capitalise.calledOnce).to.be.true;
 				expect(stubs.capitalise.calledWithExactly('production')).to.be.true;
 				expect(removeWhitespace(result)).to.equal(removeWhitespace(`
-					MATCH (n:Production)-[:PLAYS_AT]->(t:Theatre)
+					MATCH (n:Production)
+
+					OPTIONAL MATCH (n)-[:PLAYS_AT]->(t:Theatre)
 
 					RETURN
 						'production' AS model,
 						n.uuid AS uuid,
 						n.name AS name
-						, { model: 'theatre', uuid: t.uuid, name: t.name } AS theatre
+						, CASE WHEN t IS NULL THEN null ELSE { model: 'theatre', uuid: t.uuid, name: t.name } END AS theatre
 
 					LIMIT 100
 				`));


### PR DESCRIPTION
It is possible that there will be a need for production instances that do not have an associated theatre, e.g. when a production is first announced by producers that is yet to find a venue.

Therefore, this PR makes a production instance having an associated theatre instance non-mandatory (it is now essentially the same relationship that production instances have with playtext instances).

The constraint remains that inhibits the deletion of theatre instances if they have associations with production instances, although by virtue of this change, they can no longer be considered **dependent** associations, so a future PR will either amend the wording or remove the inhibitor altogether.

However, it should be borne in mind that while the associations are no longer dependent ones, the inhibitor is nevertheless useful in preventing the accidental deletion of theatres with which many productions are associated. While an "Are you sure?" modal in the CMS could be employed, this would not prevent mistakes happening via direct API calls (e.g. cURL or Postman), and so to enforce the deletion of a theatre by making the user first remove the relationships one-by-one via its associated productions is not a bad sanity check: the more associations that must first be removed, the larger a sanity check is resultantly enforced.