### PR TITLE
Rename dependentAssociations -> associations

### DIFF
--- a/src/models/Theatre.js
+++ b/src/models/Theatre.js
@@ -24,7 +24,7 @@ export default class Theatre extends Base {
 
 		this.name = name;
 
-		this.addPropertyError('dependentAssociations', 'productions');
+		this.addPropertyError('associations', 'productions');
 
 		this.setErrorStatus();
 

--- a/test-e2e/instance-validation-failures/theatres-api.test.js
+++ b/test-e2e/instance-validation-failures/theatres-api.test.js
@@ -222,7 +222,7 @@ describe('Instance validation failures: Theatres API', () => {
 
 		});
 
-		context('instance has dependent associations', () => {
+		context('instance has associations', () => {
 
 			it('returns instance with appropriate errors attached', async () => {
 
@@ -237,7 +237,7 @@ describe('Instance validation failures: Theatres API', () => {
 					name: 'Almeida Theatre',
 					hasErrors: true,
 					errors: {
-						dependentAssociations: [
+						associations: [
 							'productions'
 						]
 					}

--- a/test-unit/src/models/Theatre.test.js
+++ b/test-unit/src/models/Theatre.test.js
@@ -33,9 +33,9 @@ describe('Theatre model', () => {
 
 	describe('delete method', () => {
 
-		context('no dependent associations', () => {
+		context('instance has no associations', () => {
 
-			it('deletes', async () => {
+			it('deletes instance and returns object with its model and name properties', async () => {
 
 				stubs.neo4jQuery.resolves({ model: 'theatre', name: 'Almeida Theatre', isDeleted: true });
 				spy(instance, 'addPropertyError');
@@ -59,7 +59,7 @@ describe('Theatre model', () => {
 
 		});
 
-		context('dependent associations', () => {
+		context('instance has associations', () => {
 
 			it('returns instance without deleting', async () => {
 
@@ -78,7 +78,7 @@ describe('Theatre model', () => {
 					{ query: 'getDeleteQuery response', params: instance }
 				)).to.be.true;
 				expect(instance.addPropertyError.calledOnce).to.be.true;
-				expect(instance.addPropertyError.calledWithExactly('dependentAssociations', 'productions')).to.be.true;
+				expect(instance.addPropertyError.calledWithExactly('associations', 'productions')).to.be.true;
 				expect(instance.setErrorStatus.calledOnce).to.be.true;
 				expect(instance.setErrorStatus.calledWithExactly()).to.be.true;
 				expect(result).to.deep.eq(instance);


### PR DESCRIPTION
Now that a production instance does not need to have an associated theatre instance, the association can no longer be deemed dependent.