### PR TITLE
Remove unused production delete Cypher query

### DIFF
--- a/src/neo4j/cypher-queries/index.js
+++ b/src/neo4j/cypher-queries/index.js
@@ -10,7 +10,6 @@ import {
 	getCreateQuery as getProductionCreateQuery,
 	getEditQuery as getProductionEditQuery,
 	getUpdateQuery as getProductionUpdateQuery,
-	getDeleteQuery as getProductionDeleteQuery,
 	getShowQuery as getProductionShowQuery
 } from './production';
 import * as sharedQueries from './shared';
@@ -35,7 +34,6 @@ const getUpdateQueries = {
 };
 
 const getDeleteQueries = {
-	production: getProductionDeleteQuery,
 	theatre: getTheatreDeleteQuery
 };
 

--- a/src/neo4j/cypher-queries/production.js
+++ b/src/neo4j/cypher-queries/production.js
@@ -93,18 +93,6 @@ const getEditQuery = () => `
 
 const getUpdateQuery = () => getCreateUpdateQuery('update');
 
-const getDeleteQuery = () => `
-	MATCH (production:Production { uuid: $uuid })
-
-	WITH production, production.name AS name
-
-	DETACH DELETE production
-
-	RETURN
-		'production' AS model,
-		name
-`;
-
 const getShowQuery = () => `
 	MATCH (production:Production { uuid: $uuid })
 
@@ -153,6 +141,5 @@ export {
 	getCreateQuery,
 	getEditQuery,
 	getUpdateQuery,
-	getDeleteQuery,
 	getShowQuery
 };

--- a/test-unit/src/models/Base.test.js
+++ b/test-unit/src/models/Base.test.js
@@ -39,9 +39,9 @@ describe('Base model', () => {
 				production: sandbox.stub(cypherQueries.getUpdateQueries, 'production')
 			},
 			getDeleteQueries: {
-				production:
-					sandbox.stub(cypherQueries.getDeleteQueries, 'production')
-						.returns('getDeleteProductionQuery response')
+				theatre:
+					sandbox.stub(cypherQueries.getDeleteQueries, 'theatre')
+						.returns('getDeleteTheatreQuery response')
 			},
 			getShowQueries: {
 				theatre:
@@ -567,14 +567,14 @@ describe('Base model', () => {
 
 			it('deletes using model-specific query', async () => {
 
-				instance.model = 'production';
+				instance.model = 'theatre';
 				const result = await instance.delete();
 				expect(stubs.getDeleteQueries[instance.model].calledOnce).to.be.true;
 				expect(stubs.getDeleteQueries[instance.model].calledWithExactly()).to.be.true;
 				expect(stubs.sharedQueries.getDeleteQuery.notCalled).to.be.true;
 				expect(stubs.neo4jQuery.calledOnce).to.be.true;
 				expect(stubs.neo4jQuery.calledWithExactly(
-					{ query: 'getDeleteProductionQuery response', params: instance }
+					{ query: 'getDeleteTheatreQuery response', params: instance }
 				)).to.be.true;
 				expect(result).to.deep.eq(neo4jQueryMockResponse);
 
@@ -589,7 +589,7 @@ describe('Base model', () => {
 				const result = await instance.delete();
 				expect(stubs.sharedQueries.getDeleteQuery.calledOnce).to.be.true;
 				expect(stubs.sharedQueries.getDeleteQuery.calledWithExactly(instance.model)).to.be.true;
-				expect(stubs.getDeleteQueries.production.notCalled).to.be.true;
+				expect(stubs.getDeleteQueries.theatre.notCalled).to.be.true;
 				expect(stubs.neo4jQuery.calledOnce).to.be.true;
 				expect(stubs.neo4jQuery.calledWithExactly(
 					{ query: 'getDeleteQuery response', params: instance }


### PR DESCRIPTION
The production-specific delete query has exactly the same logic that would be obtained from using the shared query, and so this PR switches it to use that instead.