### PR TITLE
Add articles to UUID variables names in end-to-end tests

### DIFF
--- a/test-e2e/instance-validation-failures/people-api.test.js
+++ b/test-e2e/instance-validation-failures/people-api.test.js
@@ -194,7 +194,7 @@ describe('Instance validation failures: People API', () => {
 	describe('attempt to delete instance', () => {
 
 		const JUDI_DENCH_PERSON_UUID = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
-		const MIDSUMMER_NIGHTS_DREAM_ROSE_PRODUCTION_UUID = 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy';
+		const A_MIDSUMMER_NIGHTS_DREAM_ROSE_PRODUCTION_UUID = 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy';
 
 		before(async () => {
 
@@ -209,14 +209,14 @@ describe('Instance validation failures: People API', () => {
 			await createNode({
 				label: 'Production',
 				name: 'A Midsummer Night\'s Dream',
-				uuid: MIDSUMMER_NIGHTS_DREAM_ROSE_PRODUCTION_UUID
+				uuid: A_MIDSUMMER_NIGHTS_DREAM_ROSE_PRODUCTION_UUID
 			});
 
 			await createRelationship({
 				sourceLabel: 'Person',
 				sourceUuid: JUDI_DENCH_PERSON_UUID,
 				destinationLabel: 'Production',
-				destinationUuid: MIDSUMMER_NIGHTS_DREAM_ROSE_PRODUCTION_UUID,
+				destinationUuid: A_MIDSUMMER_NIGHTS_DREAM_ROSE_PRODUCTION_UUID,
 				relationshipName: 'PERFORMS_IN'
 			});
 

--- a/test-e2e/model-interaction/cast-member-same-role-of-playtext.test.js
+++ b/test-e2e/model-interaction/cast-member-same-role-of-playtext.test.js
@@ -11,10 +11,10 @@ describe('Cast member performing same role in different productions of same play
 	chai.use(chaiHttp);
 
 	const TITANIA_CHARACTER_UUID = '1';
-	const MIDSUMMER_NIGHTS_DREAM_ROYAL_SHAKESPEARE_PRODUCTION_UUID = '2';
+	const A_MIDSUMMER_NIGHTS_DREAM_ROYAL_SHAKESPEARE_PRODUCTION_UUID = '2';
 	const ROYAL_SHAKESPEARE_THEATRE_UUID = '3';
 	const JUDI_DENCH_PERSON_UUID = '5';
-	const MIDSUMMER_NIGHTS_DREAM_ROSE_PRODUCTION_UUID = '6';
+	const A_MIDSUMMER_NIGHTS_DREAM_ROSE_PRODUCTION_UUID = '6';
 	const ROSE_THEATRE_UUID = '7';
 
 	let titaniaCharacter;
@@ -93,10 +93,10 @@ describe('Cast member performing same role in different productions of same play
 			.get(`/characters/${TITANIA_CHARACTER_UUID}`);
 
 		midsummerNightsDreamRoyalShakespeareProduction = await chai.request(app)
-			.get(`/productions/${MIDSUMMER_NIGHTS_DREAM_ROYAL_SHAKESPEARE_PRODUCTION_UUID}`);
+			.get(`/productions/${A_MIDSUMMER_NIGHTS_DREAM_ROYAL_SHAKESPEARE_PRODUCTION_UUID}`);
 
 		midsummerNightsDreamRoseProduction = await chai.request(app)
-			.get(`/productions/${MIDSUMMER_NIGHTS_DREAM_ROSE_PRODUCTION_UUID}`);
+			.get(`/productions/${A_MIDSUMMER_NIGHTS_DREAM_ROSE_PRODUCTION_UUID}`);
 
 		judiDenchPerson = await chai.request(app)
 			.get(`/people/${JUDI_DENCH_PERSON_UUID}`);
@@ -115,7 +115,7 @@ describe('Cast member performing same role in different productions of same play
 
 			const expectedMidsummerNightsDreamRoyalShakespeareProduction = {
 				model: 'production',
-				uuid: MIDSUMMER_NIGHTS_DREAM_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
+				uuid: A_MIDSUMMER_NIGHTS_DREAM_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
 				name: 'A Midsummer Night\'s Dream',
 				theatre: {
 					model: 'theatre',
@@ -135,7 +135,7 @@ describe('Cast member performing same role in different productions of same play
 
 			const expectedMidsummerNightsDreamRoseProduction = {
 				model: 'production',
-				uuid: MIDSUMMER_NIGHTS_DREAM_ROSE_PRODUCTION_UUID,
+				uuid: A_MIDSUMMER_NIGHTS_DREAM_ROSE_PRODUCTION_UUID,
 				name: 'A Midsummer Night\'s Dream',
 				theatre: {
 					model: 'theatre',
@@ -157,12 +157,12 @@ describe('Cast member performing same role in different productions of same play
 
 			const midsummerNightsDreamRoyalShakespeareProductionCredit =
 				productions.find(production =>
-					production.uuid === MIDSUMMER_NIGHTS_DREAM_ROYAL_SHAKESPEARE_PRODUCTION_UUID
+					production.uuid === A_MIDSUMMER_NIGHTS_DREAM_ROYAL_SHAKESPEARE_PRODUCTION_UUID
 				);
 
 			const midsummerNightsDreamRoseProductionCredit =
 				productions.find(production =>
-					production.uuid === MIDSUMMER_NIGHTS_DREAM_ROSE_PRODUCTION_UUID
+					production.uuid === A_MIDSUMMER_NIGHTS_DREAM_ROSE_PRODUCTION_UUID
 				);
 
 			expect(productions.length).to.equal(2);
@@ -236,7 +236,7 @@ describe('Cast member performing same role in different productions of same play
 
 			const expectedmidsummerNightsDreamRoyalShakespeareProductionCredit = {
 				model: 'production',
-				uuid: MIDSUMMER_NIGHTS_DREAM_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
+				uuid: A_MIDSUMMER_NIGHTS_DREAM_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
 				name: 'A Midsummer Night\'s Dream',
 				theatre: {
 					model: 'theatre',
@@ -254,7 +254,7 @@ describe('Cast member performing same role in different productions of same play
 
 			const expectedmidsummerNightsDreamRoseProductionCredit = {
 				model: 'production',
-				uuid: MIDSUMMER_NIGHTS_DREAM_ROSE_PRODUCTION_UUID,
+				uuid: A_MIDSUMMER_NIGHTS_DREAM_ROSE_PRODUCTION_UUID,
 				name: 'A Midsummer Night\'s Dream',
 				theatre: {
 					model: 'theatre',
@@ -274,11 +274,11 @@ describe('Cast member performing same role in different productions of same play
 
 			const midsummerNightsDreamRoyalShakespeareProductionCredit =
 				productions.find(production =>
-					production.uuid === MIDSUMMER_NIGHTS_DREAM_ROYAL_SHAKESPEARE_PRODUCTION_UUID
+					production.uuid === A_MIDSUMMER_NIGHTS_DREAM_ROYAL_SHAKESPEARE_PRODUCTION_UUID
 				);
 
 			const midsummerNightsDreamRoseProductionCredit =
-				productions.find(production => production.uuid === MIDSUMMER_NIGHTS_DREAM_ROSE_PRODUCTION_UUID);
+				productions.find(production => production.uuid === A_MIDSUMMER_NIGHTS_DREAM_ROSE_PRODUCTION_UUID);
 
 			expect(productions.length).to.equal(2);
 			expect(expectedmidsummerNightsDreamRoyalShakespeareProductionCredit)

--- a/test-e2e/model-interaction/cast-member-with-multiple-productions.test.js
+++ b/test-e2e/model-interaction/cast-member-with-multiple-productions.test.js
@@ -10,7 +10,7 @@ describe('Cast member with multiple production credits', () => {
 
 	chai.use(chaiHttp);
 
-	const TEMPEST_ROYAL_SHAKESPEARE_PRODUCTION_UUID = '0';
+	const THE_TEMPEST_ROYAL_SHAKESPEARE_PRODUCTION_UUID = '0';
 	const ROYAL_SHAKESPEARE_THEATRE_UUID = '1';
 	const PATRICK_STEWART_PERSON_UUID = '3';
 	const MACBETH_GIELGUD_PRODUCTION_UUID = '4';
@@ -97,7 +97,7 @@ describe('Cast member with multiple production credits', () => {
 			.get(`/people/${PATRICK_STEWART_PERSON_UUID}`);
 
 		tempestRoyalShakespeareProduction = await chai.request(app)
-			.get(`/productions/${TEMPEST_ROYAL_SHAKESPEARE_PRODUCTION_UUID}`);
+			.get(`/productions/${THE_TEMPEST_ROYAL_SHAKESPEARE_PRODUCTION_UUID}`);
 
 		macbethGielgudProduction = await chai.request(app)
 			.get(`/productions/${MACBETH_GIELGUD_PRODUCTION_UUID}`);
@@ -119,7 +119,7 @@ describe('Cast member with multiple production credits', () => {
 
 			const expectedTempestRoyalShakespeareProductionCredit = {
 				model: 'production',
-				uuid: TEMPEST_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
+				uuid: THE_TEMPEST_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
 				name: 'The Tempest',
 				theatre: {
 					model: 'theatre',
@@ -174,7 +174,7 @@ describe('Cast member with multiple production credits', () => {
 			const { productions } = patrickStewartPerson.body;
 
 			const tempestRoyalShakespeareProductionCredit =
-				productions.find(production => production.uuid === TEMPEST_ROYAL_SHAKESPEARE_PRODUCTION_UUID);
+				productions.find(production => production.uuid === THE_TEMPEST_ROYAL_SHAKESPEARE_PRODUCTION_UUID);
 
 			const macbethGielgudProductionCredit =
 				productions.find(production => production.uuid === MACBETH_GIELGUD_PRODUCTION_UUID);

--- a/test-e2e/model-interaction/character-in-multiple-playtexts.test.js
+++ b/test-e2e/model-interaction/character-in-multiple-playtexts.test.js
@@ -13,14 +13,14 @@ describe('Character in multiple playtexts', () => {
 	const HENRY_IV_PART_1_PLAYTEXT_UUID = '0';
 	const SIR_JOHN_FALSTAFF_CHARACTER_UUID = '1';
 	const HENRY_IV_PART_2_PLAYTEXT_UUID = '2';
-	const MERRY_WIVES_OF_WINDSOR_PLAYTEXT_UUID = '4';
+	const THE_MERRY_WIVES_OF_WINDSOR_PLAYTEXT_UUID = '4';
 	const HENRY_IV_PART_1_NATIONAL_PRODUCTION_UUID = '6';
 	const NATIONAL_THEATRE_UUID = '7';
 	const MICHAEL_GAMBON_PERSON_UUID = '9';
 	const HENRY_IV_PART_2_GLOBE_PRODUCTION_UUID = '10';
 	const GLOBE_THEATRE_UUID = '11';
 	const ROGER_ALLAM_PERSON_UUID = '13';
-	const MERRY_WIVES_OF_WINDSOR_SWAN_PRODUCTION_UUID = '14';
+	const THE_MERRY_WIVES_OF_WINDSOR_SWAN_PRODUCTION_UUID = '14';
 	const SWAN_THEATRE_UUID = '15';
 	const RICHARD_CORDERY_PERSON_UUID = '17';
 
@@ -151,7 +151,7 @@ describe('Character in multiple playtexts', () => {
 			.get(`/playtexts/${HENRY_IV_PART_2_PLAYTEXT_UUID}`);
 
 		merryWivesOfWindsorPlaytext = await chai.request(app)
-			.get(`/playtexts/${MERRY_WIVES_OF_WINDSOR_PLAYTEXT_UUID}`);
+			.get(`/playtexts/${THE_MERRY_WIVES_OF_WINDSOR_PLAYTEXT_UUID}`);
 
 	});
 
@@ -179,7 +179,7 @@ describe('Character in multiple playtexts', () => {
 
 			const expectedMerryWivesOfWindsorPlaytextCredit = {
 				model: 'playtext',
-				uuid: MERRY_WIVES_OF_WINDSOR_PLAYTEXT_UUID,
+				uuid: THE_MERRY_WIVES_OF_WINDSOR_PLAYTEXT_UUID,
 				name: 'The Merry Wives of Windsor'
 			};
 
@@ -192,7 +192,7 @@ describe('Character in multiple playtexts', () => {
 				playtexts.find(playtext => playtext.uuid === HENRY_IV_PART_2_PLAYTEXT_UUID);
 
 			const merryWivesOfWindsorPlaytextCredit =
-				playtexts.find(playtext => playtext.uuid === MERRY_WIVES_OF_WINDSOR_PLAYTEXT_UUID);
+				playtexts.find(playtext => playtext.uuid === THE_MERRY_WIVES_OF_WINDSOR_PLAYTEXT_UUID);
 
 			expect(playtexts.length).to.equal(3);
 			expect(expectedHenryIVPart1PlaytextCredit)
@@ -248,7 +248,7 @@ describe('Character in multiple playtexts', () => {
 
 			const expectedMerryWivesOfWindsorSwanProductionCredit = {
 				model: 'production',
-				uuid: MERRY_WIVES_OF_WINDSOR_SWAN_PRODUCTION_UUID,
+				uuid: THE_MERRY_WIVES_OF_WINDSOR_SWAN_PRODUCTION_UUID,
 				name: 'The Merry Wives of Windsor',
 				theatre: {
 					model: 'theatre',
@@ -275,7 +275,7 @@ describe('Character in multiple playtexts', () => {
 				productions.find(production => production.uuid === HENRY_IV_PART_2_GLOBE_PRODUCTION_UUID);
 
 			const merryWivesOfWindsorSwanProductionCredit =
-				productions.find(production => production.uuid === MERRY_WIVES_OF_WINDSOR_SWAN_PRODUCTION_UUID);
+				productions.find(production => production.uuid === THE_MERRY_WIVES_OF_WINDSOR_SWAN_PRODUCTION_UUID);
 
 			expect(productions.length).to.equal(3);
 			expect(expectedHenryIVPart1NationalProductionCredit)

--- a/test-e2e/model-interaction/theatre-with-multiple-productions.test.js
+++ b/test-e2e/model-interaction/theatre-with-multiple-productions.test.js
@@ -10,7 +10,7 @@ describe('Theatre with multiple productions', () => {
 
 	chai.use(chaiHttp);
 
-	const STREETCAR_NAMED_DESIRE_DONMAR_PRODUCTION_UUID = '0';
+	const A_STREETCAR_NAMED_DESIRE_DONMAR_PRODUCTION_UUID = '0';
 	const DONMAR_WAREHOUSE_THEATRE_UUID = '1';
 	const LIFE_IS_A_DREAM_DONMAR_PRODUCTION_UUID = '3';
 	const RED_DONMAR_PRODUCTION_UUID = '6';
@@ -61,7 +61,7 @@ describe('Theatre with multiple productions', () => {
 			.get(`/theatres/${DONMAR_WAREHOUSE_THEATRE_UUID}`);
 
 		streetcarNamedDesireDonmarProduction = await chai.request(app)
-			.get(`/productions/${STREETCAR_NAMED_DESIRE_DONMAR_PRODUCTION_UUID}`);
+			.get(`/productions/${A_STREETCAR_NAMED_DESIRE_DONMAR_PRODUCTION_UUID}`);
 
 		lifeIsADreamDonmarProduction = await chai.request(app)
 			.get(`/productions/${LIFE_IS_A_DREAM_DONMAR_PRODUCTION_UUID}`);
@@ -83,7 +83,7 @@ describe('Theatre with multiple productions', () => {
 
 			const expectedStreetcarNamedDesireDonmarProductionCredit = {
 				model: 'production',
-				uuid: STREETCAR_NAMED_DESIRE_DONMAR_PRODUCTION_UUID,
+				uuid: A_STREETCAR_NAMED_DESIRE_DONMAR_PRODUCTION_UUID,
 				name: 'A Streetcar Named Desire'
 			};
 
@@ -102,7 +102,7 @@ describe('Theatre with multiple productions', () => {
 			const { productions } = donmarWarehouseTheatre.body;
 
 			const streetcarNamedDesireDonmarProductionCredit =
-				productions.find(production => production.uuid === STREETCAR_NAMED_DESIRE_DONMAR_PRODUCTION_UUID);
+				productions.find(production => production.uuid === A_STREETCAR_NAMED_DESIRE_DONMAR_PRODUCTION_UUID);
 
 			const lifeIsADreamDonmarProductionCredit =
 				productions.find(production => production.uuid === LIFE_IS_A_DREAM_DONMAR_PRODUCTION_UUID);


### PR DESCRIPTION
There is currently inconsistency in the variable names used for UUID values in the end-to-end tests.

This PR makes things consistent by applying articles to those without.