### PR TITLE
Apply repeated Cypher query actions to MATCH results without collecting

### DIFF
--- a/src/neo4j/cypher-queries/playtext.js
+++ b/src/neo4j/cypher-queries/playtext.js
@@ -7,9 +7,9 @@ const getCreateUpdateQuery = action => {
 
 			OPTIONAL MATCH (playtext)-[relationship:INCLUDES_CHARACTER]->(:Character)
 
-			WITH playtext, COLLECT(relationship) AS relationships
+			DELETE relationship
 
-			FOREACH (relationship IN relationships | DELETE relationship)
+			WITH DISTINCT playtext
 
 			SET playtext.name = $name
 		`

--- a/src/neo4j/cypher-queries/production.js
+++ b/src/neo4j/cypher-queries/production.js
@@ -7,9 +7,9 @@ const getCreateUpdateQuery = action => {
 
 			OPTIONAL MATCH (production)-[relationship]-()
 
-			WITH production, COLLECT(relationship) AS relationships
+			DELETE relationship
 
-			FOREACH (relationship IN relationships | DELETE relationship)
+			WITH DISTINCT production
 
 			SET production.name = $name
 		`

--- a/test-unit/src/neo4j/cypher-queries/production.test.js
+++ b/test-unit/src/neo4j/cypher-queries/production.test.js
@@ -92,9 +92,11 @@ describe('Cypher Queries Production module', () => {
 
 				OPTIONAL MATCH (production)-[relationship]-()
 
-				WITH production, COLLECT(relationship) AS relationships
-					FOREACH (relationship IN relationships | DELETE relationship)
-					SET production.name = $name
+				DELETE relationship
+
+				WITH DISTINCT production
+
+				SET production.name = $name
 
 				FOREACH (item IN CASE WHEN $theatre.name IS NOT NULL THEN [1] ELSE [] END |
 					MERGE (theatre:Theatre { name: $theatre.name })


### PR DESCRIPTION
From **Learning Cypher by Onofrio Panzarino** (p.77):

> The read phase is important because the write phase willm be executed for every item found in the read phase. For example, consider the following query:

```
MATCH (a:User {surname: "Roe"})
SET a.place = "London"
RETURN a
```

> In this query, the `SET` command will be executed once for each node found with the `MATCH` clause. Consequently, you usually won't need an explicit for-loop statement.

This PR revises two `FOREACH` loops accordingly, replacing the previous approach of collecting all the relationships and iterating over them to delete them one-by-one.

The `WITH DISTINCT production` is necessary else the subsequent parts of the query will be performed the same number of times as there were matched relationships (despite them having since been deleted), as the query is handling with a row for each of these matches (previously the `COLLECT` would take care of consolidating the relationships into a single row).