### PR TITLE
Ensure E2E tests cover ordering (ORDER BY usage)

### DIFF
--- a/test-e2e/instance-validation-failures/productions-api.test.js
+++ b/test-e2e/instance-validation-failures/productions-api.test.js
@@ -134,6 +134,7 @@ describe('Instance validation failures: Productions API', () => {
 
 		const OTHELLO_DONMAR_PRODUCTION_UUID = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
 		const DONMAR_WAREHOUSE_THEATRE_UUID = 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy';
+		const OTHELLO_PLAYTEXT_UUID = 'zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz';
 
 		before(async () => {
 
@@ -151,12 +152,26 @@ describe('Instance validation failures: Productions API', () => {
 				uuid: DONMAR_WAREHOUSE_THEATRE_UUID
 			});
 
+			await createNode({
+				label: 'Playtext',
+				name: 'Othello',
+				uuid: OTHELLO_PLAYTEXT_UUID
+			});
+
 			await createRelationship({
 				sourceLabel: 'Production',
 				sourceUuid: OTHELLO_DONMAR_PRODUCTION_UUID,
 				destinationLabel: 'Theatre',
 				destinationUuid: DONMAR_WAREHOUSE_THEATRE_UUID,
 				relationshipName: 'PLAYS_AT'
+			});
+
+			await createRelationship({
+				sourceLabel: 'Production',
+				sourceUuid: OTHELLO_DONMAR_PRODUCTION_UUID,
+				destinationLabel: 'Playtext',
+				destinationUuid: OTHELLO_PLAYTEXT_UUID,
+				relationshipName: 'PRODUCTION_OF'
 			});
 
 		});
@@ -177,6 +192,7 @@ describe('Instance validation failures: Productions API', () => {
 					hasErrors: true,
 					errors: {
 						associations: [
+							'Playtext',
 							'Theatre'
 						]
 					},

--- a/test-e2e/model-interaction/cast-member-with-multiple-productions.test.js
+++ b/test-e2e/model-interaction/cast-member-with-multiple-productions.test.js
@@ -10,18 +10,18 @@ describe('Cast member with multiple production credits', () => {
 
 	chai.use(chaiHttp);
 
-	const THE_TEMPEST_ROYAL_SHAKESPEARE_PRODUCTION_UUID = '0';
-	const ROYAL_SHAKESPEARE_THEATRE_UUID = '1';
-	const PATRICK_STEWART_PERSON_UUID = '3';
-	const MACBETH_GIELGUD_PRODUCTION_UUID = '4';
-	const GIELGUD_THEATRE_UUID = '5';
-	const WAITING_FOR_GODOT_HAYMARKET_PRODUCTION_UUID = '8';
-	const HAYMARKET_THEATRE_UUID = '9';
+	const THE_GREEKS_ALDWYCH_PRODUCTION_UUID = '0';
+	const ALDWYCH_THEATRE_UUID = '1';
+	const SUSANNAH_FELLOWS_PERSON_UUID = '3';
+	const CITY_OF_ANGELS_PRINCE_OF_WALES_PRODUCTION_UUID = '4';
+	const PRINCE_OF_WALES_THEATRE_UUID = '5';
+	const ENRON_CHICHESTER_FESTIVAL_PRODUCTION_UUID = '8';
+	const CHICHESTER_FESTIVAL_THEATRE_UUID = '9';
 
-	let patrickStewartPerson;
-	let tempestRoyalShakespeareProduction;
-	let macbethGielgudProduction;
-	let waitingForGodotHaymarketProduction;
+	let susannahFellowsPerson;
+	let theGreeksAldwychProduction;
+	let cityOfAngelsPrinceOfWalesProduction;
+	let enronChichesterFestivalProduction;
 
 	const sandbox = createSandbox();
 
@@ -36,16 +36,19 @@ describe('Cast member with multiple production credits', () => {
 		await chai.request(app)
 			.post('/productions')
 			.send({
-				name: 'The Tempest',
+				name: 'The Greeks',
 				theatre: {
-					name: 'Royal Shakespeare Theatre'
+					name: 'Aldwych Theatre'
 				},
 				cast: [
 					{
-						name: 'Patrick Stewart',
+						name: 'Susannah Fellows',
 						roles: [
 							{
-								name: 'Prospero'
+								name: 'Chorus'
+							},
+							{
+								name: 'Trojan slave'
 							}
 						]
 					}
@@ -55,16 +58,19 @@ describe('Cast member with multiple production credits', () => {
 		await chai.request(app)
 			.post('/productions')
 			.send({
-				name: 'Macbeth',
+				name: 'City of Angels',
 				theatre: {
-					name: 'Gielgud Theatre'
+					name: 'Prince of Wales Theatre'
 				},
 				cast: [
 					{
-						name: 'Patrick Stewart',
+						name: 'Susannah Fellows',
 						roles: [
 							{
-								name: 'Macbeth'
+								name: 'Alaura Kingsley'
+							},
+							{
+								name: 'Carla Haywood'
 							}
 						]
 					}
@@ -74,33 +80,39 @@ describe('Cast member with multiple production credits', () => {
 		await chai.request(app)
 			.post('/productions')
 			.send({
-				name: 'Waiting for Godot',
+				name: 'Enron',
 				theatre: {
-					name: 'Theatre Royal Haymarket'
+					name: 'Chichester Festival Theatre'
 				},
 				cast: [
 					{
-						name: 'Patrick Stewart',
+						name: 'Susannah Fellows',
 						roles: [
 							{
-								name: 'Vladimir'
+								name: 'Congresswoman'
+							},
+							{
+								name: 'Sheryl Sloman'
+							},
+							{
+								name: 'Irene Gant'
 							}
 						]
 					}
 				]
 			});
 
-		patrickStewartPerson = await chai.request(app)
-			.get(`/people/${PATRICK_STEWART_PERSON_UUID}`);
+		susannahFellowsPerson = await chai.request(app)
+			.get(`/people/${SUSANNAH_FELLOWS_PERSON_UUID}`);
 
-		tempestRoyalShakespeareProduction = await chai.request(app)
-			.get(`/productions/${THE_TEMPEST_ROYAL_SHAKESPEARE_PRODUCTION_UUID}`);
+		theGreeksAldwychProduction = await chai.request(app)
+			.get(`/productions/${THE_GREEKS_ALDWYCH_PRODUCTION_UUID}`);
 
-		macbethGielgudProduction = await chai.request(app)
-			.get(`/productions/${MACBETH_GIELGUD_PRODUCTION_UUID}`);
+		cityOfAngelsPrinceOfWalesProduction = await chai.request(app)
+			.get(`/productions/${CITY_OF_ANGELS_PRINCE_OF_WALES_PRODUCTION_UUID}`);
 
-		waitingForGodotHaymarketProduction = await chai.request(app)
-			.get(`/productions/${WAITING_FOR_GODOT_HAYMARKET_PRODUCTION_UUID}`);
+		enronChichesterFestivalProduction = await chai.request(app)
+			.get(`/productions/${ENRON_CHICHESTER_FESTIVAL_PRODUCTION_UUID}`);
 
 	});
 
@@ -110,165 +122,191 @@ describe('Cast member with multiple production credits', () => {
 
 	});
 
-	describe('Patrick Stewart (person)', () => {
+	describe('Susannah Fellows (person)', () => {
 
 		it('includes productions in which cast member performed (including characters they portrayed)', () => {
 
-			const expectedTempestRoyalShakespeareProductionCredit = {
-				model: 'production',
-				uuid: THE_TEMPEST_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
-				name: 'The Tempest',
-				theatre: {
-					model: 'theatre',
-					uuid: ROYAL_SHAKESPEARE_THEATRE_UUID,
-					name: 'Royal Shakespeare Theatre'
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: CITY_OF_ANGELS_PRINCE_OF_WALES_PRODUCTION_UUID,
+					name: 'City of Angels',
+					theatre: {
+						model: 'theatre',
+						uuid: PRINCE_OF_WALES_THEATRE_UUID,
+						name: 'Prince of Wales Theatre'
+					},
+					roles: [
+						{
+							model: 'character',
+							uuid: null,
+							name: 'Alaura Kingsley'
+						},
+						{
+							model: 'character',
+							uuid: null,
+							name: 'Carla Haywood'
+						}
+					]
 				},
-				roles: [
-					{
-						model: 'character',
-						uuid: null,
-						name: 'Prospero'
-					}
-				]
-			};
-
-			const expectedMacbethGielgudProductionCredit = {
-				model: 'production',
-				uuid: MACBETH_GIELGUD_PRODUCTION_UUID,
-				name: 'Macbeth',
-				theatre: {
-					model: 'theatre',
-					uuid: GIELGUD_THEATRE_UUID,
-					name: 'Gielgud Theatre'
+				{
+					model: 'production',
+					uuid: ENRON_CHICHESTER_FESTIVAL_PRODUCTION_UUID,
+					name: 'Enron',
+					theatre: {
+						model: 'theatre',
+						uuid: CHICHESTER_FESTIVAL_THEATRE_UUID,
+						name: 'Chichester Festival Theatre'
+					},
+					roles: [
+						{
+							model: 'character',
+							uuid: null,
+							name: 'Congresswoman'
+						},
+						{
+							model: 'character',
+							uuid: null,
+							name: 'Sheryl Sloman'
+						},
+						{
+							model: 'character',
+							uuid: null,
+							name: 'Irene Gant'
+						}
+					]
 				},
-				roles: [
-					{
-						model: 'character',
-						uuid: null,
-						name: 'Macbeth'
-					}
-				]
-			};
+				{
+					model: 'production',
+					uuid: THE_GREEKS_ALDWYCH_PRODUCTION_UUID,
+					name: 'The Greeks',
+					theatre: {
+						model: 'theatre',
+						uuid: ALDWYCH_THEATRE_UUID,
+						name: 'Aldwych Theatre'
+					},
+					roles: [
+						{
+							model: 'character',
+							uuid: null,
+							name: 'Chorus'
+						},
+						{
+							model: 'character',
+							uuid: null,
+							name: 'Trojan slave'
+						}
+					]
+				}
+			];
 
-			const expectedWaitingForGodotHaymarketProductionCredit = {
-				model: 'production',
-				uuid: WAITING_FOR_GODOT_HAYMARKET_PRODUCTION_UUID,
-				name: 'Waiting for Godot',
-				theatre: {
-					model: 'theatre',
-					uuid: HAYMARKET_THEATRE_UUID,
-					name: 'Theatre Royal Haymarket'
-				},
-				roles: [
-					{
-						model: 'character',
-						uuid: null,
-						name: 'Vladimir'
-					}
-				]
-			};
+			const { productions } = susannahFellowsPerson.body;
 
-			const { productions } = patrickStewartPerson.body;
-
-			const tempestRoyalShakespeareProductionCredit =
-				productions.find(production => production.uuid === THE_TEMPEST_ROYAL_SHAKESPEARE_PRODUCTION_UUID);
-
-			const macbethGielgudProductionCredit =
-				productions.find(production => production.uuid === MACBETH_GIELGUD_PRODUCTION_UUID);
-
-			const waitingForGodotHaymarketProductionCredit =
-				productions.find(production => production.uuid === WAITING_FOR_GODOT_HAYMARKET_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(3);
-			expect(expectedTempestRoyalShakespeareProductionCredit)
-				.to.deep.equal(tempestRoyalShakespeareProductionCredit);
-			expect(expectedMacbethGielgudProductionCredit).to.deep.equal(macbethGielgudProductionCredit);
-			expect(expectedWaitingForGodotHaymarketProductionCredit)
-				.to.deep.equal(waitingForGodotHaymarketProductionCredit);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
 	});
 
-	describe('The Tempest at Royal Shakespeare Theatre (production)', () => {
+	describe('The Greeks at Aldwych Theatre (production)', () => {
 
-		it('includes Patrick Stewart in its cast (including character he portrayed)', () => {
+		it('includes Susannah Fellows in its cast (including characters she portrayed)', () => {
 
-			const expectedCastMemberPatrickStewart = {
+			const expectedCastMemberSusannahFellows = {
 				model: 'person',
-				uuid: PATRICK_STEWART_PERSON_UUID,
-				name: 'Patrick Stewart',
+				uuid: SUSANNAH_FELLOWS_PERSON_UUID,
+				name: 'Susannah Fellows',
 				roles: [
 					{
 						model: 'character',
 						uuid: null,
-						name: 'Prospero'
+						name: 'Chorus'
+					},
+					{
+						model: 'character',
+						uuid: null,
+						name: 'Trojan slave'
 					}
 				]
 			};
 
-			const { cast } = tempestRoyalShakespeareProduction.body;
+			const { cast } = theGreeksAldwychProduction.body;
 
-			const castMemberPatrickStewart =
-				cast.find(castMember => castMember.uuid === PATRICK_STEWART_PERSON_UUID);
+			const castMemberSusannahFellows =
+				cast.find(castMember => castMember.uuid === SUSANNAH_FELLOWS_PERSON_UUID);
 
-			expect(expectedCastMemberPatrickStewart).to.deep.equal(castMemberPatrickStewart);
+			expect(expectedCastMemberSusannahFellows).to.deep.equal(castMemberSusannahFellows);
 
 		});
 
 	});
 
-	describe('Macbeth at Gielgud Theatre (production)', () => {
+	describe('City of Angels at Prince of Wales Theatre (production)', () => {
 
-		it('includes Patrick Stewart in its cast (including character he portrayed)', () => {
+		it('includes Susannah Fellows in its cast (including characters she portrayed)', () => {
 
-			const expectedCastMemberPatrickStewart = {
+			const expectedCastMemberSusannahFellows = {
 				model: 'person',
-				uuid: PATRICK_STEWART_PERSON_UUID,
-				name: 'Patrick Stewart',
+				uuid: SUSANNAH_FELLOWS_PERSON_UUID,
+				name: 'Susannah Fellows',
 				roles: [
 					{
 						model: 'character',
 						uuid: null,
-						name: 'Macbeth'
+						name: 'Alaura Kingsley'
+					},
+					{
+						model: 'character',
+						uuid: null,
+						name: 'Carla Haywood'
 					}
 				]
 			};
 
-			const { cast } = macbethGielgudProduction.body;
+			const { cast } = cityOfAngelsPrinceOfWalesProduction.body;
 
-			const castMemberPatrickStewart =
-				cast.find(castMember => castMember.uuid === PATRICK_STEWART_PERSON_UUID);
+			const castMemberSusannahFellows =
+				cast.find(castMember => castMember.uuid === SUSANNAH_FELLOWS_PERSON_UUID);
 
-			expect(expectedCastMemberPatrickStewart).to.deep.equal(castMemberPatrickStewart);
+			expect(expectedCastMemberSusannahFellows).to.deep.equal(castMemberSusannahFellows);
 
 		});
 
 	});
 
-	describe('Waiting for Godot at Theatre Royal Haymarket (production)', () => {
+	describe('Enron at Chichester Festival Theatre (production)', () => {
 
-		it('includes Patrick Stewart in its cast (including character he portrayed)', () => {
+		it('includes Susannah Fellows in its cast (including characters she portrayed)', () => {
 
-			const expectedCastMemberPatrickStewart = {
+			const expectedCastMemberSusannahFellows = {
 				model: 'person',
-				uuid: PATRICK_STEWART_PERSON_UUID,
-				name: 'Patrick Stewart',
+				uuid: SUSANNAH_FELLOWS_PERSON_UUID,
+				name: 'Susannah Fellows',
 				roles: [
 					{
 						model: 'character',
 						uuid: null,
-						name: 'Vladimir'
+						name: 'Congresswoman'
+					},
+					{
+						model: 'character',
+						uuid: null,
+						name: 'Sheryl Sloman'
+					},
+					{
+						model: 'character',
+						uuid: null,
+						name: 'Irene Gant'
 					}
 				]
 			};
 
-			const { cast } = waitingForGodotHaymarketProduction.body;
+			const { cast } = enronChichesterFestivalProduction.body;
 
-			const castMemberPatrickStewart =
-				cast.find(castMember => castMember.uuid === PATRICK_STEWART_PERSON_UUID);
+			const castMemberSusannahFellows =
+				cast.find(castMember => castMember.uuid === SUSANNAH_FELLOWS_PERSON_UUID);
 
-			expect(expectedCastMemberPatrickStewart).to.deep.equal(castMemberPatrickStewart);
+			expect(expectedCastMemberSusannahFellows).to.deep.equal(castMemberSusannahFellows);
 
 		});
 

--- a/test-e2e/model-interaction/character-in-multiple-playtexts.test.js
+++ b/test-e2e/model-interaction/character-in-multiple-playtexts.test.js
@@ -162,125 +162,95 @@ describe('Character in multiple playtexts', () => {
 
 		it('includes playtexts in which character appears', () => {
 
-			const expectedHenryIVPart1PlaytextCredit = {
-				model: 'playtext',
-				uuid: HENRY_IV_PART_1_PLAYTEXT_UUID,
-				name: 'Henry IV: Part 1'
-			};
-
-			const expectedHenryIVPart2PlaytextCredit = {
-				model: 'playtext',
-				uuid: HENRY_IV_PART_2_PLAYTEXT_UUID,
-				name: 'Henry IV: Part 2'
-			};
-
-			const expectedMerryWivesOfWindsorPlaytextCredit = {
-				model: 'playtext',
-				uuid: THE_MERRY_WIVES_OF_WINDSOR_PLAYTEXT_UUID,
-				name: 'The Merry Wives of Windsor'
-			};
+			const expectedPlaytexts = [
+				{
+					model: 'playtext',
+					uuid: HENRY_IV_PART_1_PLAYTEXT_UUID,
+					name: 'Henry IV: Part 1'
+				},
+				{
+					model: 'playtext',
+					uuid: HENRY_IV_PART_2_PLAYTEXT_UUID,
+					name: 'Henry IV: Part 2'
+				},
+				{
+					model: 'playtext',
+					uuid: THE_MERRY_WIVES_OF_WINDSOR_PLAYTEXT_UUID,
+					name: 'The Merry Wives of Windsor'
+				}
+			];
 
 			const { playtexts } = sirJohnFalstaffCharacter.body;
 
-			const henryIVPart1PlaytextCredit =
-				playtexts.find(playtext => playtext.uuid === HENRY_IV_PART_1_PLAYTEXT_UUID);
-
-			const henryIVPart2PlaytextCredit =
-				playtexts.find(playtext => playtext.uuid === HENRY_IV_PART_2_PLAYTEXT_UUID);
-
-			const merryWivesOfWindsorPlaytextCredit =
-				playtexts.find(playtext => playtext.uuid === THE_MERRY_WIVES_OF_WINDSOR_PLAYTEXT_UUID);
-
-			expect(playtexts.length).to.equal(3);
-			expect(expectedHenryIVPart1PlaytextCredit)
-				.to.deep.equal(henryIVPart1PlaytextCredit);
-			expect(expectedHenryIVPart2PlaytextCredit)
-				.to.deep.equal(henryIVPart2PlaytextCredit);
-			expect(expectedMerryWivesOfWindsorPlaytextCredit)
-				.to.deep.equal(merryWivesOfWindsorPlaytextCredit);
+			expect(playtexts).to.deep.equal(expectedPlaytexts);
 
 		});
 
 		it('includes productions of playtexts in which character appears (including cast member who portrayed them)', () => {
 
-			const expectedHenryIVPart1NationalProductionCredit = {
-				model: 'production',
-				uuid: HENRY_IV_PART_1_NATIONAL_PRODUCTION_UUID,
-				name: 'Henry IV: Part 1',
-				theatre: {
-					model: 'theatre',
-					uuid: NATIONAL_THEATRE_UUID,
-					name: 'National Theatre'
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: HENRY_IV_PART_1_NATIONAL_PRODUCTION_UUID,
+					name: 'Henry IV: Part 1',
+					theatre: {
+						model: 'theatre',
+						uuid: NATIONAL_THEATRE_UUID,
+						name: 'National Theatre'
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: MICHAEL_GAMBON_PERSON_UUID,
+							name: 'Michael Gambon',
+							roleName: 'Sir John Falstaff',
+							otherRoles: []
+						}
+					]
 				},
-				performers: [
-					{
-						model: 'person',
-						uuid: MICHAEL_GAMBON_PERSON_UUID,
-						name: 'Michael Gambon',
-						roleName: 'Sir John Falstaff',
-						otherRoles: []
-					}
-				]
-			};
-
-			const expectedHenryIVPart2GlobeProductionCredit = {
-				model: 'production',
-				uuid: HENRY_IV_PART_2_GLOBE_PRODUCTION_UUID,
-				name: 'Henry IV: Part 2',
-				theatre: {
-					model: 'theatre',
-					uuid: GLOBE_THEATRE_UUID,
-					name: 'Globe Theatre'
+				{
+					model: 'production',
+					uuid: HENRY_IV_PART_2_GLOBE_PRODUCTION_UUID,
+					name: 'Henry IV: Part 2',
+					theatre: {
+						model: 'theatre',
+						uuid: GLOBE_THEATRE_UUID,
+						name: 'Globe Theatre'
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: ROGER_ALLAM_PERSON_UUID,
+							name: 'Roger Allam',
+							roleName: 'Sir John Falstaff',
+							otherRoles: []
+						}
+					]
 				},
-				performers: [
-					{
-						model: 'person',
-						uuid: ROGER_ALLAM_PERSON_UUID,
-						name: 'Roger Allam',
-						roleName: 'Sir John Falstaff',
-						otherRoles: []
-					}
-				]
-			};
-
-			const expectedMerryWivesOfWindsorSwanProductionCredit = {
-				model: 'production',
-				uuid: THE_MERRY_WIVES_OF_WINDSOR_SWAN_PRODUCTION_UUID,
-				name: 'The Merry Wives of Windsor',
-				theatre: {
-					model: 'theatre',
-					uuid: SWAN_THEATRE_UUID,
-					name: 'Swan Theatre'
-				},
-				performers: [
-					{
-						model: 'person',
-						uuid: RICHARD_CORDERY_PERSON_UUID,
-						name: 'Richard Cordery',
-						roleName: 'Sir John Falstaff',
-						otherRoles: []
-					}
-				]
-			};
+				{
+					model: 'production',
+					uuid: THE_MERRY_WIVES_OF_WINDSOR_SWAN_PRODUCTION_UUID,
+					name: 'The Merry Wives of Windsor',
+					theatre: {
+						model: 'theatre',
+						uuid: SWAN_THEATRE_UUID,
+						name: 'Swan Theatre'
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: RICHARD_CORDERY_PERSON_UUID,
+							name: 'Richard Cordery',
+							roleName: 'Sir John Falstaff',
+							otherRoles: []
+						}
+					]
+				}
+			];
 
 			const { productions } = sirJohnFalstaffCharacter.body;
 
-			const henryIVPart1NationalProductionCredit =
-				productions.find(production => production.uuid === HENRY_IV_PART_1_NATIONAL_PRODUCTION_UUID);
-
-			const henryIVPart2NationalProductionCredit =
-				productions.find(production => production.uuid === HENRY_IV_PART_2_GLOBE_PRODUCTION_UUID);
-
-			const merryWivesOfWindsorSwanProductionCredit =
-				productions.find(production => production.uuid === THE_MERRY_WIVES_OF_WINDSOR_SWAN_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(3);
-			expect(expectedHenryIVPart1NationalProductionCredit)
-				.to.deep.equal(henryIVPart1NationalProductionCredit);
-			expect(expectedHenryIVPart2GlobeProductionCredit)
-				.to.deep.equal(henryIVPart2NationalProductionCredit);
-			expect(expectedMerryWivesOfWindsorSwanProductionCredit)
-				.to.deep.equal(merryWivesOfWindsorSwanProductionCredit);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 

--- a/test-e2e/model-interaction/playtext-with-multiple-productions.test.js
+++ b/test-e2e/model-interaction/playtext-with-multiple-productions.test.js
@@ -93,57 +93,42 @@ describe('Playtext with multiple productions', () => {
 
 		it('includes productions of playtext', () => {
 
-			const expectedMeasureForMeasureNationalProductionCredit = {
-				model: 'production',
-				uuid: MEASURE_FOR_MEASURE_NATIONAL_PRODUCTION_UUID,
-				name: 'Measure for Measure',
-				theatre: {
-					model: 'theatre',
-					uuid: NATIONAL_THEATRE_UUID,
-					name: 'National Theatre'
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: MEASURE_FOR_MEASURE_ALMEIDA_PRODUCTION_UUID,
+					name: 'Measure for Measure',
+					theatre: {
+						model: 'theatre',
+						uuid: ALMEIDA_THEATRE_UUID,
+						name: 'Almeida Theatre'
+					}
+				},
+				{
+					model: 'production',
+					uuid: MEASURE_FOR_MEASURE_DONMAR_PRODUCTION_UUID,
+					name: 'Measure for Measure',
+					theatre: {
+						model: 'theatre',
+						uuid: DONMAR_WAREHOUSE_THEATRE_UUID,
+						name: 'Donmar Warehouse'
+					}
+				},
+				{
+					model: 'production',
+					uuid: MEASURE_FOR_MEASURE_NATIONAL_PRODUCTION_UUID,
+					name: 'Measure for Measure',
+					theatre: {
+						model: 'theatre',
+						uuid: NATIONAL_THEATRE_UUID,
+						name: 'National Theatre'
+					}
 				}
-			};
-
-			const expectedMeasureForMeasureAlmeidaProductionCredit = {
-				model: 'production',
-				uuid: MEASURE_FOR_MEASURE_ALMEIDA_PRODUCTION_UUID,
-				name: 'Measure for Measure',
-				theatre: {
-					model: 'theatre',
-					uuid: ALMEIDA_THEATRE_UUID,
-					name: 'Almeida Theatre'
-				}
-			};
-
-			const expectedMeasureForMeasureDonmarProductionCredit = {
-				model: 'production',
-				uuid: MEASURE_FOR_MEASURE_DONMAR_PRODUCTION_UUID,
-				name: 'Measure for Measure',
-				theatre: {
-					model: 'theatre',
-					uuid: DONMAR_WAREHOUSE_THEATRE_UUID,
-					name: 'Donmar Warehouse'
-				}
-			};
+			];
 
 			const { productions } = measureForMeasurePlaytext.body;
 
-			const measureForMeasureNationalProductionCredit =
-				productions.find(production => production.uuid === MEASURE_FOR_MEASURE_NATIONAL_PRODUCTION_UUID);
-
-			const measureForMeasureAlmeidaProductionCredit =
-				productions.find(production => production.uuid === MEASURE_FOR_MEASURE_ALMEIDA_PRODUCTION_UUID);
-
-			const measureForMeasureDonmarProductionCredit =
-				productions.find(production => production.uuid === MEASURE_FOR_MEASURE_DONMAR_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(3);
-			expect(expectedMeasureForMeasureNationalProductionCredit)
-				.to.deep.equal(measureForMeasureNationalProductionCredit);
-			expect(expectedMeasureForMeasureAlmeidaProductionCredit)
-				.to.deep.equal(measureForMeasureAlmeidaProductionCredit);
-			expect(expectedMeasureForMeasureDonmarProductionCredit)
-				.to.deep.equal(measureForMeasureDonmarProductionCredit);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 

--- a/test-e2e/model-interaction/theatre-with-multiple-productions.test.js
+++ b/test-e2e/model-interaction/theatre-with-multiple-productions.test.js
@@ -81,40 +81,27 @@ describe('Theatre with multiple productions', () => {
 
 		it('includes productions at this theatre', () => {
 
-			const expectedStreetcarNamedDesireDonmarProductionCredit = {
-				model: 'production',
-				uuid: A_STREETCAR_NAMED_DESIRE_DONMAR_PRODUCTION_UUID,
-				name: 'A Streetcar Named Desire'
-			};
-
-			const expectedLifeIsADreamDonmarProductionCredit = {
-				model: 'production',
-				uuid: LIFE_IS_A_DREAM_DONMAR_PRODUCTION_UUID,
-				name: 'Life is a Dream'
-			};
-
-			const expectedRedDonmarProductionCredit = {
-				model: 'production',
-				uuid: RED_DONMAR_PRODUCTION_UUID,
-				name: 'Red'
-			};
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: A_STREETCAR_NAMED_DESIRE_DONMAR_PRODUCTION_UUID,
+					name: 'A Streetcar Named Desire'
+				},
+				{
+					model: 'production',
+					uuid: LIFE_IS_A_DREAM_DONMAR_PRODUCTION_UUID,
+					name: 'Life is a Dream'
+				},
+				{
+					model: 'production',
+					uuid: RED_DONMAR_PRODUCTION_UUID,
+					name: 'Red'
+				}
+			];
 
 			const { productions } = donmarWarehouseTheatre.body;
 
-			const streetcarNamedDesireDonmarProductionCredit =
-				productions.find(production => production.uuid === A_STREETCAR_NAMED_DESIRE_DONMAR_PRODUCTION_UUID);
-
-			const lifeIsADreamDonmarProductionCredit =
-				productions.find(production => production.uuid === LIFE_IS_A_DREAM_DONMAR_PRODUCTION_UUID);
-
-			const redDonmarProductionCredit =
-				productions.find(production => production.uuid === RED_DONMAR_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(3);
-			expect(expectedStreetcarNamedDesireDonmarProductionCredit)
-				.to.deep.equal(streetcarNamedDesireDonmarProductionCredit);
-			expect(expectedLifeIsADreamDonmarProductionCredit).to.deep.equal(lifeIsADreamDonmarProductionCredit);
-			expect(expectedRedDonmarProductionCredit).to.deep.equal(redDonmarProductionCredit);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 


### PR DESCRIPTION
Revises end-to-end (E2E) tests to ensure that all `ORDER BY` clause usage in Cypher queries is accounted for in some form.