### PR TITLE
Remove unnecessary ORDER BY value from theatre Cypher query

### DIFF
--- a/src/neo4j/cypher-queries/theatre.js
+++ b/src/neo4j/cypher-queries/theatre.js
@@ -4,7 +4,7 @@ const getShowQuery = () => `
 	OPTIONAL MATCH (theatre)<-[:PLAYS_AT]-(production:Production)
 
 	WITH theatre, production
-		ORDER BY production.name, theatre.name
+		ORDER BY production.name
 
 	RETURN
 		'theatre' AS model,


### PR DESCRIPTION
Order the theatre results by `theatre.name` has no effect as the theatre in each row will be the same, i.e. the subject of the query.

Therefore we only need to worry about sorting the results by `production.name`.