### PR TITLE
Remove Base model expectations from extension model unit tests

### DIFF
--- a/test-unit/src/models/CastMember.test.js
+++ b/test-unit/src/models/CastMember.test.js
@@ -138,8 +138,6 @@ describe('Cast Member model', () => {
 					spy(instance, 'addPropertyError');
 					instance.validateNamePresenceIfRoles();
 					expect(instance.addPropertyError.notCalled).to.be.true;
-					expect(instance.errors).not.to.have.property('name');
-					expect(instance.errors).to.deep.equal({});
 
 				});
 
@@ -153,9 +151,6 @@ describe('Cast Member model', () => {
 					spy(instance, 'addPropertyError');
 					instance.validateNamePresenceIfRoles();
 					expect(instance.addPropertyError.notCalled).to.be.true;
-					expect(instance.errors).not.to.have.property('name');
-					expect(instance.errors).to.deep.equal({});
-
 				});
 
 			});
@@ -168,8 +163,6 @@ describe('Cast Member model', () => {
 					spy(instance, 'addPropertyError');
 					instance.validateNamePresenceIfRoles();
 					expect(instance.addPropertyError.notCalled).to.be.true;
-					expect(instance.errors).not.to.have.property('name');
-					expect(instance.errors).to.deep.equal({});
 
 				});
 
@@ -189,10 +182,6 @@ describe('Cast Member model', () => {
 					'name',
 					'Name is required if cast member has named roles'
 				)).to.be.true;
-				expect(instance.errors)
-					.to.have.property('name')
-					.that.is.an('array')
-					.that.deep.eq([	'Name is required if cast member has named roles']);
 
 			});
 

--- a/test-unit/src/models/Role.test.js
+++ b/test-unit/src/models/Role.test.js
@@ -92,8 +92,6 @@ describe('Role model', () => {
 				spy(instance, 'addPropertyError');
 				instance.validateCharacterNameHasRoleName();
 				expect(instance.addPropertyError.notCalled).to.be.true;
-				expect(instance.errors).not.to.have.property('characterName');
-				expect(instance.errors).to.deep.equal({});
 
 			});
 
@@ -111,10 +109,6 @@ describe('Role model', () => {
 					'name',
 					'Role name is required when character name is present'
 				)).to.be.true;
-				expect(instance.errors)
-					.to.have.property('name')
-					.that.is.an('array')
-					.that.deep.eq(['Role name is required when character name is present']);
 
 			});
 
@@ -134,8 +128,6 @@ describe('Role model', () => {
 					spy(instance, 'addPropertyError');
 					instance.validateRoleNameCharacterNameDisparity();
 					expect(instance.addPropertyError.notCalled).to.be.true;
-					expect(instance.errors).not.to.have.property('characterName');
-					expect(instance.errors).to.deep.equal({});
 
 				});
 
@@ -149,8 +141,6 @@ describe('Role model', () => {
 					spy(instance, 'addPropertyError');
 					instance.validateRoleNameCharacterNameDisparity();
 					expect(instance.addPropertyError.notCalled).to.be.true;
-					expect(instance.errors).not.to.have.property('characterName');
-					expect(instance.errors).to.deep.equal({});
 
 				});
 
@@ -164,8 +154,6 @@ describe('Role model', () => {
 					spy(instance, 'addPropertyError');
 					instance.validateRoleNameCharacterNameDisparity();
 					expect(instance.addPropertyError.notCalled).to.be.true;
-					expect(instance.errors).not.to.have.property('characterName');
-					expect(instance.errors).to.deep.equal({});
 
 				});
 
@@ -185,10 +173,6 @@ describe('Role model', () => {
 					'characterName',
 					'Character name is only required if different from role name'
 				)).to.be.true;
-				expect(instance.errors)
-					.to.have.property('characterName')
-					.that.is.an('array')
-					.that.deep.eq(['Character name is only required if different from role name']);
 
 			});
 


### PR DESCRIPTION
The unit tests should only be testing what happens within the method itself.

Some unit tests for models that extend from the Base model class will include in their expectations something that is handled by the Base model class. All it needs to test is that the correct base model class method is called and with the correct arguments. The integration between the Base model class and other model classes that extend from it are covered by the integration tests.

This PR removes the unnecessary expectations from the extension model unit tests (CastMember and Role).