### PR TITLE
Revise Cypher CASE WHEN statements

### DIFF
--- a/src/neo4j/cypher-queries/character.js
+++ b/src/neo4j/cypher-queries/character.js
@@ -11,7 +11,7 @@ const getShowQuery = () => `
 
 	WITH character, variantNamedRole,
 		COLLECT(
-			CASE WHEN playtext IS NULL
+			CASE playtext WHEN NULL
 				THEN null
 				ELSE { model: 'playtext', uuid: playtext.uuid, name: playtext.name }
 			END
@@ -37,7 +37,7 @@ const getShowQuery = () => `
 
 	WITH character, playtexts, variantNames, production, theatre, person, role,
 		COLLECT(
-			CASE WHEN otherRole IS NULL
+			CASE otherRole WHEN NULL
 				THEN null
 				ELSE { model: 'character', uuid: otherCharacter.uuid, name: otherRole.roleName }
 			END
@@ -62,14 +62,14 @@ const getShowQuery = () => `
 		playtexts,
 		variantNames,
 		COLLECT(
-			CASE WHEN production IS NULL
+			CASE production WHEN NULL
 				THEN null
 				ELSE {
 					model: 'production',
 					uuid: production.uuid,
 					name: production.name,
 					theatre:
-						CASE WHEN theatre IS NULL
+						CASE theatre WHEN NULL
 							THEN null
 							ELSE { model: 'theatre', uuid: theatre.uuid, name: theatre.name }
 						END,

--- a/src/neo4j/cypher-queries/person.js
+++ b/src/neo4j/cypher-queries/person.js
@@ -13,7 +13,7 @@ const getShowQuery = () => `
 
 	WITH person, production, theatre,
 		COLLECT(
-			CASE WHEN role.roleName IS NULL
+			CASE role.roleName WHEN NULL
 				THEN { name: 'Performer' }
 				ELSE { model: 'character', uuid: character.uuid, name: role.roleName }
 			END
@@ -26,14 +26,14 @@ const getShowQuery = () => `
 		person.name AS name,
 		person.differentiator AS differentiator,
 		COLLECT(
-			CASE WHEN production IS NULL
+			CASE production WHEN NULL
 				THEN null
 				ELSE {
 					model: 'production',
 					uuid: production.uuid,
 					name: production.name,
 					theatre:
-						CASE WHEN theatre IS NULL
+						CASE theatre WHEN NULL
 							THEN null
 							ELSE { model: 'theatre', uuid: theatre.uuid, name: theatre.name }
 						END,

--- a/src/neo4j/cypher-queries/playtext.js
+++ b/src/neo4j/cypher-queries/playtext.js
@@ -32,12 +32,16 @@ const getCreateUpdateQuery = action => {
 			WITH
 				playtext,
 				characterParam,
-				CASE WHEN existingCharacter IS NULL
-					THEN { uuid: characterParam.uuid, name: characterParam.name, differentiator: characterParam.differentiator }
+				CASE existingCharacter WHEN NULL
+					THEN {
+						uuid: characterParam.uuid,
+						name: characterParam.name,
+						differentiator: characterParam.differentiator
+					}
 					ELSE existingCharacter
 				END AS characterProps
 
-			FOREACH (item IN CASE WHEN characterParam IS NOT NULL THEN [1] ELSE [] END |
+			FOREACH (item IN CASE characterParam WHEN NULL THEN [] ELSE [1] END |
 				MERGE (character:Character { uuid: characterProps.uuid, name: characterProps.name })
 					ON CREATE SET character.differentiator = characterProps.differentiator
 
@@ -67,7 +71,7 @@ const getEditQuery = () => `
 		playtext.name AS name,
 		playtext.differentiator AS differentiator,
 		COLLECT(
-			CASE WHEN character IS NULL
+			CASE character WHEN NULL
 				THEN null
 				ELSE { name: character.name, differentiator: character.differentiator }
 			END
@@ -90,7 +94,7 @@ const getShowQuery = () => `
 
 	WITH playtext, production, theatre,
 		COLLECT(
-			CASE WHEN character IS NULL
+			CASE character WHEN NULL
 				THEN null
 				ELSE { model: 'character', uuid: character.uuid, name: character.name }
 			END
@@ -104,14 +108,14 @@ const getShowQuery = () => `
 		playtext.differentiator AS differentiator,
 		characters,
 		COLLECT(
-			CASE WHEN production IS NULL
+			CASE production WHEN NULL
 				THEN null
 				ELSE {
 					model: 'production',
 					uuid: production.uuid,
 					name: production.name,
 					theatre:
-						CASE WHEN theatre IS NULL
+						CASE theatre WHEN NULL
 							THEN null
 							ELSE { model: 'theatre', uuid: theatre.uuid, name: theatre.name }
 						END

--- a/src/neo4j/cypher-queries/production.js
+++ b/src/neo4j/cypher-queries/production.js
@@ -27,12 +27,12 @@ const getCreateUpdateQuery = action => {
 
 		WITH
 			production,
-			CASE WHEN existingTheatre IS NULL
+			CASE existingTheatre WHEN NULL
 				THEN { uuid: $theatre.uuid, name: $theatre.name, differentiator: $theatre.differentiator }
 				ELSE existingTheatre
 			END AS theatreProps
 
-		FOREACH (item IN CASE WHEN $theatre.name IS NOT NULL THEN [1] ELSE [] END |
+		FOREACH (item IN CASE $theatre.name WHEN NULL THEN [] ELSE [1] END |
 			MERGE (theatre:Theatre { uuid: theatreProps.uuid, name: theatreProps.name })
 				ON CREATE SET theatre.differentiator = theatreProps.differentiator
 
@@ -48,12 +48,12 @@ const getCreateUpdateQuery = action => {
 
 		WITH
 			production,
-			CASE WHEN existingPlaytext IS NULL
+			CASE existingPlaytext WHEN NULL
 				THEN { uuid: $playtext.uuid, name: $playtext.name, differentiator: $playtext.differentiator }
 				ELSE existingPlaytext
 			END AS playtextProps
 
-		FOREACH (item IN CASE WHEN $playtext.name IS NOT NULL THEN [1] ELSE [] END |
+		FOREACH (item IN CASE $playtext.name WHEN NULL THEN [] ELSE [1] END |
 			MERGE (playtext:Playtext { uuid: playtextProps.uuid, name: playtextProps.name })
 				ON CREATE SET playtext.differentiator = playtextProps.differentiator
 
@@ -72,7 +72,7 @@ const getCreateUpdateQuery = action => {
 			WITH
 				production,
 				castMemberParam,
-				CASE WHEN existingPerson IS NULL
+				CASE existingPerson WHEN NULL
 					THEN {
 						uuid: castMemberParam.uuid,
 						name: castMemberParam.name,
@@ -81,7 +81,7 @@ const getCreateUpdateQuery = action => {
 					ELSE existingPerson
 				END AS castMemberProps
 
-			FOREACH (item IN CASE WHEN castMemberParam IS NOT NULL THEN [1] ELSE [] END |
+			FOREACH (item IN CASE castMemberParam WHEN NULL THEN [] ELSE [1] END |
 				MERGE (person:Person { uuid: castMemberProps.uuid, name: castMemberProps.name })
 					ON CREATE SET person.differentiator = castMemberProps.differentiator
 
@@ -119,11 +119,11 @@ const getEditQuery = () => `
 
 	WITH production, theatre, playtext, person,
 		COLLECT(
-			CASE WHEN role.roleName IS NULL
+			CASE role.roleName WHEN NULL
 				THEN null
 				ELSE {
 					name: role.roleName,
-					characterName: CASE WHEN role.characterName IS NULL THEN '' ELSE role.characterName END
+					characterName: CASE role.characterName WHEN NULL THEN '' ELSE role.characterName END
 				}
 			END
 		) + [{ name: '', characterName: '' }] AS roles
@@ -133,15 +133,15 @@ const getEditQuery = () => `
 		production.uuid AS uuid,
 		production.name AS name,
 		{
-			name: CASE WHEN theatre.name IS NULL THEN '' ELSE theatre.name END,
-			differentiator: CASE WHEN theatre.differentiator IS NULL THEN '' ELSE theatre.differentiator END
+			name: CASE theatre.name WHEN NULL THEN '' ELSE theatre.name END,
+			differentiator: CASE theatre.differentiator WHEN NULL THEN '' ELSE theatre.differentiator END
 		} AS theatre,
 		{
-			name: CASE WHEN playtext.name IS NULL THEN '' ELSE playtext.name END,
-			differentiator: CASE WHEN playtext.differentiator IS NULL THEN '' ELSE playtext.differentiator END
+			name: CASE playtext.name WHEN NULL THEN '' ELSE playtext.name END,
+			differentiator: CASE playtext.differentiator WHEN NULL THEN '' ELSE playtext.differentiator END
 		} AS playtext,
 		COLLECT(
-			CASE WHEN person IS NULL
+			CASE person WHEN NULL
 				THEN null
 				ELSE { name: person.name, differentiator: person.differentiator, roles: roles }
 			END
@@ -168,7 +168,7 @@ const getShowQuery = () => `
 
 	WITH production, theatre, playtext, person,
 		COLLECT(
-			CASE WHEN role.roleName IS NULL
+			CASE role.roleName WHEN NULL
 				THEN { name: 'Performer' }
 				ELSE { model: 'character', uuid: character.uuid, name: role.roleName }
 			END
@@ -178,16 +178,16 @@ const getShowQuery = () => `
 		'production' AS model,
 		production.uuid AS uuid,
 		production.name AS name,
-		CASE WHEN theatre IS NULL
+		CASE theatre WHEN NULL
 			THEN null
 			ELSE { model: 'theatre', uuid: theatre.uuid, name: theatre.name }
 		END AS theatre,
-		CASE WHEN playtext IS NULL
+		CASE playtext WHEN NULL
 			THEN null
 			ELSE { model: 'playtext', uuid: playtext.uuid, name: playtext.name }
 		END AS playtext,
 		COLLECT(
-			CASE WHEN person IS NULL
+			CASE person WHEN NULL
 				THEN null
 				ELSE { model: 'person', uuid: person.uuid, name: person.name, roles: roles }
 			END

--- a/src/neo4j/cypher-queries/shared.js
+++ b/src/neo4j/cypher-queries/shared.js
@@ -64,9 +64,9 @@ const getDeleteQuery = model => {
 			-[]-(undeleteableInstanceAssociate)
 
 		UNWIND
-			CASE WHEN undeleteableInstanceAssociate IS NOT NULL
-				THEN LABELS(undeleteableInstanceAssociate)
-				ELSE [null]
+			CASE undeleteableInstanceAssociate WHEN NULL
+				THEN [null]
+				ELSE LABELS(undeleteableInstanceAssociate)
 			END AS associateLabel
 
 			WITH
@@ -108,7 +108,7 @@ const getListQuery = model => {
 		: '';
 
 	const theatreObject = (model === 'production')
-		? `, CASE WHEN t IS NULL
+		? `, CASE t WHEN NULL
 				THEN null
 				ELSE { model: 'theatre', uuid: t.uuid, name: t.name, differentiator: t.differentiator }
 			END AS theatre`

--- a/src/neo4j/cypher-queries/theatre.js
+++ b/src/neo4j/cypher-queries/theatre.js
@@ -12,7 +12,7 @@ const getShowQuery = () => `
 		theatre.name AS name,
 		theatre.differentiator AS differentiator,
 		COLLECT(
-			CASE WHEN production IS NULL
+			CASE production WHEN NULL
 				THEN null
 				ELSE { model: 'production', uuid: production.uuid, name: production.name }
 			END

--- a/test-unit/src/neo4j/cypher-queries/playtext.test.js
+++ b/test-unit/src/neo4j/cypher-queries/playtext.test.js
@@ -25,12 +25,16 @@ describe('Cypher Queries Playtext module', () => {
 					WITH
 						playtext,
 						characterParam,
-						CASE WHEN existingCharacter IS NULL
-							THEN { uuid: characterParam.uuid, name: characterParam.name, differentiator: characterParam.differentiator }
+						CASE existingCharacter WHEN NULL
+							THEN {
+								uuid: characterParam.uuid,
+								name: characterParam.name,
+								differentiator: characterParam.differentiator
+							}
 							ELSE existingCharacter
 						END AS characterProps
 
-					FOREACH (item IN CASE WHEN characterParam IS NOT NULL THEN [1] ELSE [] END |
+					FOREACH (item IN CASE characterParam WHEN NULL THEN [] ELSE [1] END |
 						MERGE (character:Character { uuid: characterProps.uuid, name: characterProps.name })
 							ON CREATE SET character.differentiator = characterProps.differentiator
 
@@ -52,7 +56,7 @@ describe('Cypher Queries Playtext module', () => {
 					playtext.name AS name,
 					playtext.differentiator AS differentiator,
 					COLLECT(
-						CASE WHEN character IS NULL
+						CASE character WHEN NULL
 							THEN null
 							ELSE { name: character.name, differentiator: character.differentiator }
 						END
@@ -93,12 +97,12 @@ describe('Cypher Queries Playtext module', () => {
 					WITH
 						playtext,
 						characterParam,
-						CASE WHEN existingCharacter IS NULL
+						CASE existingCharacter WHEN NULL
 							THEN { uuid: characterParam.uuid, name: characterParam.name, differentiator: characterParam.differentiator }
 							ELSE existingCharacter
 						END AS characterProps
 
-					FOREACH (item IN CASE WHEN characterParam IS NOT NULL THEN [1] ELSE [] END |
+					FOREACH (item IN CASE characterParam WHEN NULL THEN [] ELSE [1] END |
 						MERGE (character:Character { uuid: characterProps.uuid, name: characterProps.name })
 							ON CREATE SET character.differentiator = characterProps.differentiator
 
@@ -120,7 +124,7 @@ describe('Cypher Queries Playtext module', () => {
 					playtext.name AS name,
 					playtext.differentiator AS differentiator,
 					COLLECT(
-						CASE WHEN character IS NULL
+						CASE character WHEN NULL
 							THEN null
 							ELSE { name: character.name, differentiator: character.differentiator }
 						END

--- a/test-unit/src/neo4j/cypher-queries/production.test.js
+++ b/test-unit/src/neo4j/cypher-queries/production.test.js
@@ -22,12 +22,12 @@ describe('Cypher Queries Production module', () => {
 
 				WITH
 					production,
-					CASE WHEN existingTheatre IS NULL
+					CASE existingTheatre WHEN NULL
 						THEN { uuid: $theatre.uuid, name: $theatre.name, differentiator: $theatre.differentiator }
 						ELSE existingTheatre
 					END AS theatreProps
 
-				FOREACH (item IN CASE WHEN $theatre.name IS NOT NULL THEN [1] ELSE [] END |
+				FOREACH (item IN CASE $theatre.name WHEN NULL THEN [] ELSE [1] END |
 					MERGE (theatre:Theatre { uuid: theatreProps.uuid, name: theatreProps.name })
 						ON CREATE SET theatre.differentiator = theatreProps.differentiator
 
@@ -43,12 +43,12 @@ describe('Cypher Queries Production module', () => {
 
 				WITH
 					production,
-					CASE WHEN existingPlaytext IS NULL
+					CASE existingPlaytext WHEN NULL
 						THEN { uuid: $playtext.uuid, name: $playtext.name, differentiator: $playtext.differentiator }
 						ELSE existingPlaytext
 					END AS playtextProps
 
-				FOREACH (item IN CASE WHEN $playtext.name IS NOT NULL THEN [1] ELSE [] END |
+				FOREACH (item IN CASE $playtext.name WHEN NULL THEN [] ELSE [1] END |
 					MERGE (playtext:Playtext { uuid: playtextProps.uuid, name: playtextProps.name })
 						ON CREATE SET playtext.differentiator = playtextProps.differentiator
 
@@ -67,7 +67,7 @@ describe('Cypher Queries Production module', () => {
 					WITH
 						production,
 						castMemberParam,
-						CASE WHEN existingPerson IS NULL
+						CASE existingPerson WHEN NULL
 							THEN {
 								uuid: castMemberParam.uuid,
 								name: castMemberParam.name,
@@ -76,7 +76,7 @@ describe('Cypher Queries Production module', () => {
 							ELSE existingPerson
 						END AS castMemberProps
 
-					FOREACH (item IN CASE WHEN castMemberParam IS NOT NULL THEN [1] ELSE [] END |
+					FOREACH (item IN CASE castMemberParam WHEN NULL THEN [] ELSE [1] END |
 						MERGE (person:Person { uuid: castMemberProps.uuid, name: castMemberProps.name })
 							ON CREATE SET person.differentiator = castMemberProps.differentiator
 
@@ -106,11 +106,11 @@ describe('Cypher Queries Production module', () => {
 
 				WITH production, theatre, playtext, person,
 					COLLECT(
-						CASE WHEN role.roleName IS NULL
+						CASE role.roleName WHEN NULL
 							THEN null
 							ELSE {
 								name: role.roleName,
-								characterName: CASE WHEN role.characterName IS NULL THEN '' ELSE role.characterName END
+								characterName: CASE role.characterName WHEN NULL THEN '' ELSE role.characterName END
 							}
 						END
 					) + [{ name: '', characterName: '' }] AS roles
@@ -120,15 +120,15 @@ describe('Cypher Queries Production module', () => {
 					production.uuid AS uuid,
 					production.name AS name,
 					{
-						name: CASE WHEN theatre.name IS NULL THEN '' ELSE theatre.name END,
-						differentiator: CASE WHEN theatre.differentiator IS NULL THEN '' ELSE theatre.differentiator END
+						name: CASE theatre.name WHEN NULL THEN '' ELSE theatre.name END,
+						differentiator: CASE theatre.differentiator WHEN NULL THEN '' ELSE theatre.differentiator END
 					} AS theatre,
 					{
-						name: CASE WHEN playtext.name IS NULL THEN '' ELSE playtext.name END,
-						differentiator: CASE WHEN playtext.differentiator IS NULL THEN '' ELSE playtext.differentiator END
+						name: CASE playtext.name WHEN NULL THEN '' ELSE playtext.name END,
+						differentiator: CASE playtext.differentiator WHEN NULL THEN '' ELSE playtext.differentiator END
 					} AS playtext,
 					COLLECT(
-						CASE WHEN person IS NULL
+						CASE person WHEN NULL
 							THEN null
 							ELSE { name: person.name, differentiator: person.differentiator, roles: roles }
 						END
@@ -164,12 +164,12 @@ describe('Cypher Queries Production module', () => {
 
 				WITH
 					production,
-					CASE WHEN existingTheatre IS NULL
+					CASE existingTheatre WHEN NULL
 						THEN { uuid: $theatre.uuid, name: $theatre.name, differentiator: $theatre.differentiator }
 						ELSE existingTheatre
 					END AS theatreProps
 
-				FOREACH (item IN CASE WHEN $theatre.name IS NOT NULL THEN [1] ELSE [] END |
+				FOREACH (item IN CASE $theatre.name WHEN NULL THEN [] ELSE [1] END |
 					MERGE (theatre:Theatre { uuid: theatreProps.uuid, name: theatreProps.name })
 						ON CREATE SET theatre.differentiator = theatreProps.differentiator
 
@@ -185,12 +185,12 @@ describe('Cypher Queries Production module', () => {
 
 				WITH
 					production,
-					CASE WHEN existingPlaytext IS NULL
+					CASE existingPlaytext WHEN NULL
 						THEN { uuid: $playtext.uuid, name: $playtext.name, differentiator: $playtext.differentiator }
 						ELSE existingPlaytext
 					END AS playtextProps
 
-				FOREACH (item IN CASE WHEN $playtext.name IS NOT NULL THEN [1] ELSE [] END |
+				FOREACH (item IN CASE $playtext.name WHEN NULL THEN [] ELSE [1] END |
 					MERGE (playtext:Playtext { uuid: playtextProps.uuid, name: playtextProps.name })
 						ON CREATE SET playtext.differentiator = playtextProps.differentiator
 
@@ -209,7 +209,7 @@ describe('Cypher Queries Production module', () => {
 					WITH
 						production,
 						castMemberParam,
-						CASE WHEN existingPerson IS NULL
+						CASE existingPerson WHEN NULL
 							THEN {
 								uuid: castMemberParam.uuid,
 								name: castMemberParam.name,
@@ -218,7 +218,7 @@ describe('Cypher Queries Production module', () => {
 							ELSE existingPerson
 						END AS castMemberProps
 
-					FOREACH (item IN CASE WHEN castMemberParam IS NOT NULL THEN [1] ELSE [] END |
+					FOREACH (item IN CASE castMemberParam WHEN NULL THEN [] ELSE [1] END |
 						MERGE (person:Person { uuid: castMemberProps.uuid, name: castMemberProps.name })
 							ON CREATE SET person.differentiator = castMemberProps.differentiator
 
@@ -248,11 +248,11 @@ describe('Cypher Queries Production module', () => {
 
 				WITH production, theatre, playtext, person,
 					COLLECT(
-						CASE WHEN role.roleName IS NULL
+						CASE role.roleName WHEN NULL
 							THEN null
 							ELSE {
 								name: role.roleName,
-								characterName: CASE WHEN role.characterName IS NULL THEN '' ELSE role.characterName END
+								characterName: CASE role.characterName WHEN NULL THEN '' ELSE role.characterName END
 							}
 						END
 					) + [{ name: '', characterName: '' }] AS roles
@@ -262,15 +262,15 @@ describe('Cypher Queries Production module', () => {
 					production.uuid AS uuid,
 					production.name AS name,
 					{
-						name: CASE WHEN theatre.name IS NULL THEN '' ELSE theatre.name END,
-						differentiator: CASE WHEN theatre.differentiator IS NULL THEN '' ELSE theatre.differentiator END
+						name: CASE theatre.name WHEN NULL THEN '' ELSE theatre.name END,
+						differentiator: CASE theatre.differentiator WHEN NULL THEN '' ELSE theatre.differentiator END
 					} AS theatre,
 					{
-						name: CASE WHEN playtext.name IS NULL THEN '' ELSE playtext.name END,
-						differentiator: CASE WHEN playtext.differentiator IS NULL THEN '' ELSE playtext.differentiator END
+						name: CASE playtext.name WHEN NULL THEN '' ELSE playtext.name END,
+						differentiator: CASE playtext.differentiator WHEN NULL THEN '' ELSE playtext.differentiator END
 					} AS playtext,
 					COLLECT(
-						CASE WHEN person IS NULL
+						CASE person WHEN NULL
 							THEN null
 							ELSE { name: person.name, differentiator: person.differentiator, roles: roles }
 						END

--- a/test-unit/src/neo4j/cypher-queries/shared.test.js
+++ b/test-unit/src/neo4j/cypher-queries/shared.test.js
@@ -46,7 +46,7 @@ describe('Cypher Queries Shared module', () => {
 						'production' AS model,
 						n.uuid AS uuid,
 						n.name AS name
-						, CASE WHEN t IS NULL
+						, CASE t WHEN NULL
 							THEN null
 							ELSE { model: 'theatre', uuid: t.uuid, name: t.name, differentiator: t.differentiator }
 						END AS theatre
@@ -198,9 +198,9 @@ describe('Cypher Queries Shared module', () => {
 						-[]-(undeleteableInstanceAssociate)
 
 					UNWIND
-						CASE WHEN undeleteableInstanceAssociate IS NOT NULL
-							THEN LABELS(undeleteableInstanceAssociate)
-							ELSE [null]
+						CASE undeleteableInstanceAssociate WHEN NULL
+							THEN [null]
+							ELSE LABELS(undeleteableInstanceAssociate)
 						END AS associateLabel
 
 						WITH


### PR DESCRIPTION
Revises Cypher `CASE WHEN` statements to use a slightly shorter expression.

### References:
- [Stack Overflow - Cypher: Use UNWIND with potentially empty collection](https://stackoverflow.com/questions/29840801/cypher-use-unwind-with-potentially-empty-collection/32545006#answer-32545006).