### PR TITLE
Rename matchNode E2E test helper to isNodeExistent

### DIFF
--- a/test-e2e/instance-validation-failures/characters-api.test.js
+++ b/test-e2e/instance-validation-failures/characters-api.test.js
@@ -5,7 +5,7 @@ import app from '../../src/app';
 import countNodesWithLabel from '../test-helpers/neo4j/count-nodes-with-label';
 import createNode from '../test-helpers/neo4j/create-node';
 import createRelationship from '../test-helpers/neo4j/create-relationship';
-import matchNode from '../test-helpers/neo4j/match-node';
+import isNodeExistent from '../test-helpers/neo4j/is-node-existent';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
 
 describe('Instance validation failures: Characters API', () => {
@@ -148,7 +148,7 @@ describe('Instance validation failures: Characters API', () => {
 				expect(response).to.have.status(200);
 				expect(response.body).to.deep.equal(expectedResponseBody);
 				expect(await countNodesWithLabel('Character')).to.equal(2);
-				expect(await matchNode({
+				expect(await isNodeExistent({
 					label: 'Character',
 					name: 'Viola',
 					uuid: VIOLA_CHARACTER_UUID
@@ -189,7 +189,7 @@ describe('Instance validation failures: Characters API', () => {
 				expect(response).to.have.status(200);
 				expect(response.body).to.deep.equal(expectedResponseBody);
 				expect(await countNodesWithLabel('Character')).to.equal(2);
-				expect(await matchNode({
+				expect(await isNodeExistent({
 					label: 'Character',
 					name: 'Viola',
 					uuid: VIOLA_CHARACTER_UUID

--- a/test-e2e/instance-validation-failures/people-api.test.js
+++ b/test-e2e/instance-validation-failures/people-api.test.js
@@ -5,7 +5,7 @@ import app from '../../src/app';
 import countNodesWithLabel from '../test-helpers/neo4j/count-nodes-with-label';
 import createNode from '../test-helpers/neo4j/create-node';
 import createRelationship from '../test-helpers/neo4j/create-relationship';
-import matchNode from '../test-helpers/neo4j/match-node';
+import isNodeExistent from '../test-helpers/neo4j/is-node-existent';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
 
 describe('Instance validation failures: People API', () => {
@@ -148,7 +148,7 @@ describe('Instance validation failures: People API', () => {
 				expect(response).to.have.status(200);
 				expect(response.body).to.deep.equal(expectedResponseBody);
 				expect(await countNodesWithLabel('Person')).to.equal(2);
-				expect(await matchNode({
+				expect(await isNodeExistent({
 					label: 'Person',
 					name: 'Judi Dench',
 					uuid: JUDI_DENCH_PERSON_UUID
@@ -189,7 +189,7 @@ describe('Instance validation failures: People API', () => {
 				expect(response).to.have.status(200);
 				expect(response.body).to.deep.equal(expectedResponseBody);
 				expect(await countNodesWithLabel('Person')).to.equal(2);
-				expect(await matchNode({
+				expect(await isNodeExistent({
 					label: 'Person',
 					name: 'Judi Dench',
 					uuid: JUDI_DENCH_PERSON_UUID

--- a/test-e2e/instance-validation-failures/playtexts-api.test.js
+++ b/test-e2e/instance-validation-failures/playtexts-api.test.js
@@ -5,7 +5,7 @@ import app from '../../src/app';
 import countNodesWithLabel from '../test-helpers/neo4j/count-nodes-with-label';
 import createNode from '../test-helpers/neo4j/create-node';
 import createRelationship from '../test-helpers/neo4j/create-relationship';
-import matchNode from '../test-helpers/neo4j/match-node';
+import isNodeExistent from '../test-helpers/neo4j/is-node-existent';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
 
 describe('Instance validation failures: Playtexts API', () => {
@@ -151,7 +151,7 @@ describe('Instance validation failures: Playtexts API', () => {
 				expect(response).to.have.status(200);
 				expect(response.body).to.deep.equal(expectedResponseBody);
 				expect(await countNodesWithLabel('Playtext')).to.equal(2);
-				expect(await matchNode({
+				expect(await isNodeExistent({
 					label: 'Playtext',
 					name: 'Ghosts',
 					uuid: GHOSTS_PLAYTEXT_UUID
@@ -193,7 +193,7 @@ describe('Instance validation failures: Playtexts API', () => {
 				expect(response).to.have.status(200);
 				expect(response.body).to.deep.equal(expectedResponseBody);
 				expect(await countNodesWithLabel('Playtext')).to.equal(2);
-				expect(await matchNode({
+				expect(await isNodeExistent({
 					label: 'Playtext',
 					name: 'Ghosts',
 					uuid: GHOSTS_PLAYTEXT_UUID

--- a/test-e2e/instance-validation-failures/productions-api.test.js
+++ b/test-e2e/instance-validation-failures/productions-api.test.js
@@ -5,7 +5,7 @@ import app from '../../src/app';
 import countNodesWithLabel from '../test-helpers/neo4j/count-nodes-with-label';
 import createNode from '../test-helpers/neo4j/create-node';
 import createRelationship from '../test-helpers/neo4j/create-relationship';
-import matchNode from '../test-helpers/neo4j/match-node';
+import isNodeExistent from '../test-helpers/neo4j/is-node-existent';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
 
 describe('Instance validation failures: Productions API', () => {
@@ -122,7 +122,7 @@ describe('Instance validation failures: Productions API', () => {
 				expect(response).to.have.status(200);
 				expect(response.body).to.deep.equal(expectedResponseBody);
 				expect(await countNodesWithLabel('Production')).to.equal(1);
-				expect(await matchNode({
+				expect(await isNodeExistent({
 					label: 'Production',
 					name: 'Macbeth',
 					uuid: MACBETH_PRODUCTION_UUID

--- a/test-e2e/instance-validation-failures/theatres-api.test.js
+++ b/test-e2e/instance-validation-failures/theatres-api.test.js
@@ -5,7 +5,7 @@ import app from '../../src/app';
 import countNodesWithLabel from '../test-helpers/neo4j/count-nodes-with-label';
 import createNode from '../test-helpers/neo4j/create-node';
 import createRelationship from '../test-helpers/neo4j/create-relationship';
-import matchNode from '../test-helpers/neo4j/match-node';
+import isNodeExistent from '../test-helpers/neo4j/is-node-existent';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
 
 describe('Instance validation failures: Theatres API', () => {
@@ -148,7 +148,7 @@ describe('Instance validation failures: Theatres API', () => {
 				expect(response).to.have.status(200);
 				expect(response.body).to.deep.equal(expectedResponseBody);
 				expect(await countNodesWithLabel('Theatre')).to.equal(2);
-				expect(await matchNode({
+				expect(await isNodeExistent({
 					label: 'Theatre',
 					name: 'Almeida Theatre',
 					uuid: ALMEIDA_THEATRE_UUID
@@ -189,7 +189,7 @@ describe('Instance validation failures: Theatres API', () => {
 				expect(response).to.have.status(200);
 				expect(response.body).to.deep.equal(expectedResponseBody);
 				expect(await countNodesWithLabel('Theatre')).to.equal(2);
-				expect(await matchNode({
+				expect(await isNodeExistent({
 					label: 'Theatre',
 					name: 'Almeida Theatre',
 					uuid: ALMEIDA_THEATRE_UUID

--- a/test-e2e/test-helpers/neo4j/is-node-existent.js
+++ b/test-e2e/test-helpers/neo4j/is-node-existent.js
@@ -6,7 +6,7 @@ export default async opts => {
 
 	const params = { name, uuid };
 
-	const matchNodeQuery = `
+	const isNodeExistentQuery = `
 		MATCH (n:${label} { name: $name, uuid: $uuid })
 
 		RETURN
@@ -16,7 +16,7 @@ export default async opts => {
 			END AS exists
 	`;
 
-	const { exists } = await neo4jQuery({ query: matchNodeQuery, params });
+	const { exists } = await neo4jQuery({ query: isNodeExistentQuery, params });
 
 	return exists;
 


### PR DESCRIPTION
The value returned by the `matchNode` helper function is a boolean that indicates whether the node exists in the database or not, so this PR renames the function to `isNodeExistent` to be more accurate and instructive as to its usage.