### PR TITLE
Fix character show Cypher query

### DIFF
--- a/src/neo4j/cypher-queries/character.js
+++ b/src/neo4j/cypher-queries/character.js
@@ -9,13 +9,7 @@ const getShowQuery = () => `
 	OPTIONAL MATCH (playtext)<-[:PRODUCTION_OF]-(:Production)<-[variantNamedRole:PERFORMS_IN]-(:Person)
 		WHERE character.name <> variantNamedRole.roleName AND character.name = variantNamedRole.characterName
 
-	WITH character, variantNamedRole,
-		COLLECT(
-			CASE playtext WHEN NULL
-				THEN null
-				ELSE { model: 'playtext', uuid: playtext.uuid, name: playtext.name }
-			END
-		) AS playtexts
+	WITH character, playtext, variantNamedRole
 		ORDER BY variantNamedRole.roleName
 
 	OPTIONAL MATCH (playtext)<-[productionRel:PRODUCTION_OF]-(production:Production)<-[role:PERFORMS_IN]-(person:Person)
@@ -31,11 +25,11 @@ const getShowQuery = () => `
 
 	OPTIONAL MATCH (production)-[:PLAYS_AT]->(theatre:Theatre)
 
-	WITH character, playtexts, production, theatre, person, role, otherRole, otherCharacter,
+	WITH character, playtext, production, theatre, person, role, otherRole, otherCharacter,
 		COLLECT(DISTINCT(variantNamedRole.roleName)) AS variantNames
 		ORDER BY otherRole.rolePosition
 
-	WITH character, playtexts, variantNames, production, theatre, person, role,
+	WITH character, playtext, variantNames, production, theatre, person, role,
 		COLLECT(
 			CASE otherRole WHEN NULL
 				THEN null
@@ -44,7 +38,7 @@ const getShowQuery = () => `
 		) AS otherRoles
 		ORDER BY role.castMemberPosition
 
-	WITH character, playtexts, variantNames, production, theatre,
+	WITH character, playtext, variantNames, production, theatre,
 		COLLECT({
 			model: 'person',
 			uuid: person.uuid,
@@ -59,7 +53,12 @@ const getShowQuery = () => `
 		character.uuid AS uuid,
 		character.name AS name,
 		character.differentiator AS differentiator,
-		playtexts,
+		COLLECT(
+			CASE playtext WHEN NULL
+				THEN null
+				ELSE { model: 'playtext', uuid: playtext.uuid, name: playtext.name }
+			END
+		) AS playtexts,
 		variantNames,
 		COLLECT(
 			CASE production WHEN NULL

--- a/test-e2e/model-interaction/same-name-characters-productions.test.js
+++ b/test-e2e/model-interaction/same-name-characters-productions.test.js
@@ -1,0 +1,213 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import { createSandbox } from 'sinon';
+import { v4 as uuid } from 'uuid';
+
+import app from '../../src/app';
+import purgeDatabase from '../test-helpers/neo4j/purge-database';
+
+describe('Different characters with same name production credits', () => {
+
+	chai.use(chaiHttp);
+
+	const DEMETRIUS_CHARACTER_1_UUID = '2';
+	const DEMETRIUS_CHARACTER_2_UUID = '4';
+	const A_MIDSUMMER_NIGHTS_DREAM_NOVELLO_PRODUCTION_UUID = '6';
+	const NOVELLO_THEATRE_UUID = '7';
+	const OSCAR_PEARCE_PERSON_UUID = '9';
+	const TITUS_ANDRONICUS_GLOBE_PRODUCTION_UUID = '11';
+	const GLOBE_THEATRE_UUID = '12';
+	const SAM_ALEXANDER_PERSON_UUID = '15';
+
+	let demetriusCharacter1;
+	let demetriusCharacter2;
+
+	const sandbox = createSandbox();
+
+	before(async () => {
+
+		let uuidCallCount = 0;
+
+		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+
+		await purgeDatabase();
+
+		await chai.request(app)
+			.post('/playtexts')
+			.send({
+				name: 'A Midsummer Night\'s Dream',
+				characters: [
+					{
+						name: 'Lysander'
+					},
+					{
+						name: 'Demetrius',
+						differentiator: '1'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/playtexts')
+			.send({
+				name: 'Titus Andronicus',
+				characters: [
+					{
+						name: 'Demetrius',
+						differentiator: '2'
+					},
+					{
+						name: 'Chiron'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'A Midsummer Night\'s Dream',
+				theatre: {
+					name: 'Novello Theatre'
+				},
+				playtext: {
+					name: 'A Midsummer Night\'s Dream'
+				},
+				cast: [
+					{
+						name: 'Oscar Pearce',
+						roles: [
+							{
+								name: 'Demetrius'
+							}
+						]
+					},
+					{
+						name: 'Trystan Gravelle',
+						roles: [
+							{
+								name: 'Lysander'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Titus Andronicus',
+				theatre: {
+					name: 'Shakespeare\'s Globe'
+				},
+				playtext: {
+					name: 'Titus Andronicus'
+				},
+				cast: [
+					{
+						name: 'Richard Riddell',
+						roles: [
+							{
+								name: 'Chiron'
+							}
+						]
+					},
+					{
+						name: 'Sam Alexander',
+						roles: [
+							{
+								name: 'Demetrius'
+							}
+						]
+					}
+				]
+			});
+
+		demetriusCharacter1 = await chai.request(app)
+			.get(`/characters/${DEMETRIUS_CHARACTER_1_UUID}`);
+
+		demetriusCharacter2 = await chai.request(app)
+			.get(`/characters/${DEMETRIUS_CHARACTER_2_UUID}`);
+
+	});
+
+	after(() => {
+
+		sandbox.restore();
+
+	});
+
+	describe('Demetrius (character) (#1)', () => {
+
+		it('includes productions in which character was portrayed (i.e. excludes productions of different character with same name)', () => {
+
+			const expectedAMidsummerNightsDreamNovelloProductionCredit = {
+				model: 'production',
+				uuid: A_MIDSUMMER_NIGHTS_DREAM_NOVELLO_PRODUCTION_UUID,
+				name: 'A Midsummer Night\'s Dream',
+				theatre: {
+					model: 'theatre',
+					uuid: NOVELLO_THEATRE_UUID,
+					name: 'Novello Theatre'
+				},
+				performers: [
+					{
+						model: 'person',
+						uuid: OSCAR_PEARCE_PERSON_UUID,
+						name: 'Oscar Pearce',
+						roleName: 'Demetrius',
+						otherRoles: []
+					}
+				]
+			};
+
+			const { productions } = demetriusCharacter1.body;
+
+			const aMidsummerNightsDreamNovelloProductionCredit =
+				productions.find(production => production.uuid === A_MIDSUMMER_NIGHTS_DREAM_NOVELLO_PRODUCTION_UUID);
+
+			expect(productions.length).to.equal(1);
+			expect(expectedAMidsummerNightsDreamNovelloProductionCredit)
+				.to.deep.equal(aMidsummerNightsDreamNovelloProductionCredit);
+
+		});
+
+	});
+
+	describe('Demetrius (character) (#2)', () => {
+
+		it('includes productions in which character was portrayed (i.e. excludes productions of different character with same name)', () => {
+
+			const expectedTitusAndronicusGlobeProductionCredit = {
+				model: 'production',
+				uuid: TITUS_ANDRONICUS_GLOBE_PRODUCTION_UUID,
+				name: 'Titus Andronicus',
+				theatre: {
+					model: 'theatre',
+					uuid: GLOBE_THEATRE_UUID,
+					name: 'Shakespeare\'s Globe'
+				},
+				performers: [
+					{
+						model: 'person',
+						uuid: SAM_ALEXANDER_PERSON_UUID,
+						name: 'Sam Alexander',
+						roleName: 'Demetrius',
+						otherRoles: []
+					}
+				]
+			};
+
+			const { productions } = demetriusCharacter2.body;
+
+			const titusAndronicusGlobeProductionCredit =
+				productions.find(production => production.uuid === TITUS_ANDRONICUS_GLOBE_PRODUCTION_UUID);
+
+			expect(productions.length).to.equal(1);
+			expect(expectedTitusAndronicusGlobeProductionCredit)
+				.to.deep.equal(titusAndronicusGlobeProductionCredit);
+
+		});
+
+	});
+
+});


### PR DESCRIPTION
The character show Cypher query was capturing portrayals of the character where the character name matched but which were not related to the production in which the portrayal happened.

This PR fixes the Cypher query to ensure that character portrayals are specifically those related to productions of the playtext(s) in which they appear.

#### Demetrius (1) before:

(Demetrius from A Midsummer Night's Dream - their **Productions** credits incorrectly include portrayals of the different but identically-named Demetrius from Titus Andronicus)

<img width="659" alt="demetrius-1-before" src="https://user-images.githubusercontent.com/10484515/92089110-a3c29500-edc5-11ea-8650-8a3d3ccbfe0d.png">

#### Demetrius (2) before:

(Demetrius from Titus Andronicus - their **Productions** credits incorrectly include portrayals of the different but identically-named Demetrius from A Midsummer Night's Dream)

<img width="659" alt="demetrius-2-before" src="https://user-images.githubusercontent.com/10484515/92089135-aa510c80-edc5-11ea-8d4b-37dbc75b66d4.png">

#### Demetrius (1) after:
<img width="659" alt="demetrius-1-after" src="https://user-images.githubusercontent.com/10484515/92089147-acb36680-edc5-11ea-9bea-44709d851468.png">

#### Demetrius (2) after:
<img width="659" alt="demetrius-2-after" src="https://user-images.githubusercontent.com/10484515/92089160-afae5700-edc5-11ea-817a-a7a1acdbdff2.png">