### PR TITLE
Prevent instance mutation in prepareAsParams

### DIFF
--- a/src/lib/prepare-as-params.js
+++ b/src/lib/prepare-as-params.js
@@ -20,7 +20,7 @@ export const prepareAsParams = instance => {
 
 						if (isObjectWithKeys(item)) {
 
-							if (array.length > 1) item.position = index;
+							if (array.length > 1) item = { ...item, position: index };
 
 							return prepareAsParams(item);
 

--- a/test-unit/src/lib/prepare-as-params.test.js
+++ b/test-unit/src/lib/prepare-as-params.test.js
@@ -30,10 +30,71 @@ describe('Prepare As Params module', () => {
 
 	it('returns new object with modifications but will not mutate input object', () => {
 
-		const instance = { uuid: '' };
+		stubs.isObjectWithKeys
+			.onFirstCall().returns(false)
+			.onSecondCall().returns(false)
+			.onThirdCall().returns(true)
+			.onCall(3).returns(false)
+			.onCall(4).returns(false)
+			.onCall(5).returns(true)
+			.onCall(6).returns(false)
+			.onCall(7).returns(false)
+			.onCall(8).returns(true)
+			.onCall(9).returns(false)
+			.onCall(10).returns(false)
+			.onCall(11).returns(false)
+			.onCall(12).returns(true)
+			.onCall(13).returns(false)
+			.onCall(14).returns(false)
+			.onCall(15).returns(true)
+			.onCall(16).returns(false)
+			.onCall(17).returns(false)
+			.onCall(18).returns(true)
+			.onCall(19).returns(false)
+			.onCall(20).returns(false)
+			.onCall(21).returns(false);
+		const instance = {
+			uuid: '',
+			items: [
+				{
+					name: 'Foo',
+					nestedItems: [
+						{
+							name: 'Baz'
+						},
+						{
+							name: 'Qux'
+						}
+					]
+				},
+				{
+					name: 'Bar',
+					nestedItems: [
+						{
+							name: 'Quux'
+						},
+						{
+							name: 'Quuz'
+						}
+					]
+				}
+			]
+		};
 		const result = prepareAsParams(instance);
 		expect(result.uuid).to.equal('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
+		expect(result.items[0].position).to.equal(0);
+		expect(result.items[0].nestedItems[0].position).to.equal(0);
+		expect(result.items[0].nestedItems[1].position).to.equal(1);
+		expect(result.items[1].position).to.equal(1);
+		expect(result.items[1].nestedItems[0].position).to.equal(0);
+		expect(result.items[1].nestedItems[1].position).to.equal(1);
 		expect(instance.uuid).to.equal('');
+		expect(instance.items[0]).not.to.have.property('position');
+		expect(instance.items[0].nestedItems[0]).not.to.have.property('position');
+		expect(instance.items[0].nestedItems[1]).not.to.have.property('position');
+		expect(instance.items[1]).not.to.have.property('position');
+		expect(instance.items[1].nestedItems[0]).not.to.have.property('position');
+		expect(instance.items[1].nestedItems[0]).not.to.have.property('position');
 
 	});
 


### PR DESCRIPTION
The `prepareAsParams()` function is mutating objects in arrays of the original input instance when they should remain untouched and return a completely new object. The effect is caused by objects in JavaScript always being passed by reference.

This issue was identified when using `params: prepareAsParams(this)` as an argument in the `validateUniquenessInDatabase()` method `neo4jQuery()` call (this change has not yet been merged because of this issue). Then when editing a playtext instance with more than one character (i.e. the condition for the `position` property to be applied), if the uniqueness in database check (which calls `prepareAsParams(this)`) was run but the playtext instance failed any of its validation checks, the characters would display the `position` property, which should only exist on the newly-created instance from `prepareAsParams()`.

This PR fixes that issue by ensuring a copy is made of objects in arrays rather than mutating the existing one.

Maybe using Immutable.JS would have prevented this from happening… 🤔

### Example:

`prepareAsParams()` function `instance` argument:
```js
{
	uuid: '',
	items: [
		{
			name: 'Foo',
			nestedItems: [
				{
					name: 'Baz'
				},
				{
					name: 'Qux'
				}
			]
		},
		{
			name: 'Bar',
			nestedItems: [
				{
					name: 'Quux'
				},
				{
					name: 'Quuz'
				}
			]
		}
	]
};
```

#### Resultant effect of `prepareAsParams()` (before):

Instance state (`position` property should not be present on objects in arrays):
```js
{
	"uuid": "",
	"items": [
		{
			"name": "Foo",
			"nestedItems": [
				{
					"name": "Baz",
					"position": 0
				},
				{
					"name": "Qux",
					"position": 1
				}
			],
			"position": 0
		},
		{
			"name": "Bar",
			"nestedItems": [
				{
					"name": "Quux",
					"position": 0
				},
				{
					"name": "Quuz",
					"position": 1
				}
			],
			"position": 1
		}
	]
}
```

Return value from `prepareAsParams()` (`position` property is present on objects in arrays, as required):
```js
{
	"uuid": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
	"items": [
		{
			"name": "Foo",
			"nestedItems": [
				{
					"name": "Baz",
					"position": 0
				},
				{
					"name": "Qux",
					"position": 1
				}
			],
			"position": 0
		},
		{
			"name": "Bar",
			"nestedItems": [
				{
					"name": "Quux",
					"position": 0
				},
				{
					"name": "Quuz",
					"position": 1
				}
			],
			"position": 1
		}
	]
}
```

#### Resultant effect of `prepareAsParams()` (after):

Instance state (`position` property is now absent from objects in arrays, as required):
```js
{
	"uuid": "",
	"items": [
		{
			"name": "Foo",
			"nestedItems": [
				{
					"name": "Baz"
				},
				{
					"name": "Qux"
				}
			]
		},
		{
			"name": "Bar",
			"nestedItems": [
				{
					"name": "Quux"
				},
				{
					"name": "Quuz"
				}
			]
		}
	]
}
```

Return value from `prepareAsParams()` (`position` property is present on objects in arrays, as required):
```js
{
	"uuid": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
	"items": [
		{
			"name": "Foo",
			"nestedItems": [
				{
					"name": "Baz",
					"position": 0
				},
				{
					"name": "Qux",
					"position": 1
				}
			],
			"position": 0
		},
		{
			"name": "Bar",
			"nestedItems": [
				{
					"name": "Quux",
					"position": 0
				},
				{
					"name": "Quuz",
					"position": 1
				}
			],
			"position": 1
		}
	]
}
```