### PR TITLE
Fix casing for differentiator-associated names

### DIFF
--- a/src/models/Base.js
+++ b/src/models/Base.js
@@ -19,7 +19,7 @@ export default class Base {
 
 	}
 
-	hasdifferentiatorProperty () {
+	hasDifferentiatorProperty () {
 
 		return Object.prototype.hasOwnProperty.call(this, 'differentiator');
 
@@ -35,7 +35,7 @@ export default class Base {
 
 		this.validateName({ isRequired: true });
 
-		this.validatedifferentiator();
+		this.validateDifferentiator();
 
 	}
 
@@ -45,7 +45,7 @@ export default class Base {
 
 	}
 
-	validatedifferentiator () {
+	validateDifferentiator () {
 
 		this.validateStringForProperty('differentiator', { isRequired: false });
 
@@ -73,7 +73,7 @@ export default class Base {
 
 			this.addPropertyError('name', uniquenessErrorMessage);
 
-			if (this.hasdifferentiatorProperty()) this.addPropertyError('differentiator', uniquenessErrorMessage);
+			if (this.hasDifferentiatorProperty()) this.addPropertyError('differentiator', uniquenessErrorMessage);
 
 			if (this.hasQualifierProperty()) this.addPropertyError('qualifier', uniquenessErrorMessage);
 
@@ -202,14 +202,14 @@ export default class Base {
 			return new this.constructor({
 				model,
 				name,
-				...(this.hasdifferentiatorProperty() && { differentiator })
+				...(this.hasDifferentiatorProperty() && { differentiator })
 			});
 
 		}
 
 		this.name = name;
 
-		if (this.hasdifferentiatorProperty()) this.differentiator = differentiator;
+		if (this.hasDifferentiatorProperty()) this.differentiator = differentiator;
 
 		associatedModels.forEach(associatedModel => this.addPropertyError('associations', associatedModel));
 

--- a/src/models/CastMember.js
+++ b/src/models/CastMember.js
@@ -20,7 +20,7 @@ export default class CastMember extends Person {
 
 		this.validateName({ isRequired: false });
 
-		this.validatedifferentiator();
+		this.validateDifferentiator();
 
 		this.validateUniquenessInGroup({ isDuplicate: opts.isDuplicate });
 

--- a/src/models/Playtext.js
+++ b/src/models/Playtext.js
@@ -28,7 +28,7 @@ export default class Playtext extends Base {
 
 		this.validateName({ isRequired: true });
 
-		this.validatedifferentiator();
+		this.validateDifferentiator();
 
 		const duplicateCharacterIndices = getDuplicateIndices(this.characters);
 
@@ -36,7 +36,7 @@ export default class Playtext extends Base {
 
 			character.validateName({ isRequired: false });
 
-			character.validatedifferentiator();
+			character.validateDifferentiator();
 
 			character.validateQualifier();
 

--- a/src/models/Production.js
+++ b/src/models/Production.js
@@ -26,11 +26,11 @@ export default class Production extends Base {
 
 		this.theatre.validateName({ isRequired: false });
 
-		this.theatre.validatedifferentiator();
+		this.theatre.validateDifferentiator();
 
 		this.playtext.validateName({ isRequired: false });
 
-		this.playtext.validatedifferentiator();
+		this.playtext.validateDifferentiator();
 
 		const duplicateCastMemberIndices = getDuplicateIndices(this.cast);
 

--- a/test-unit/src/models/Base.test.js
+++ b/test-unit/src/models/Base.test.js
@@ -106,14 +106,14 @@ describe('Base model', () => {
 
 	});
 
-	describe('hasdifferentiatorProperty method', () => {
+	describe('hasDifferentiatorProperty method', () => {
 
 		context('instance has differentiator property', () => {
 
 			it('returns true', () => {
 
 				instance.differentiator = '';
-				const result = instance.hasdifferentiatorProperty();
+				const result = instance.hasDifferentiatorProperty();
 				expect(result).to.be.true;
 
 			});
@@ -124,7 +124,7 @@ describe('Base model', () => {
 
 			it('returns false', () => {
 
-				const result = instance.hasdifferentiatorProperty();
+				const result = instance.hasDifferentiatorProperty();
 				expect(result).to.be.false;
 
 			});
@@ -165,12 +165,12 @@ describe('Base model', () => {
 		it('will call validateName method', () => {
 
 			spy(instance, 'validateName');
-			spy(instance, 'validatedifferentiator');
+			spy(instance, 'validateDifferentiator');
 			instance.runInputValidations();
 			expect(instance.validateName.calledOnce).to.be.true;
 			expect(instance.validateName.calledWithExactly({ isRequired: true })).to.be.true;
-			expect(instance.validatedifferentiator.calledOnce).to.be.true;
-			expect(instance.validatedifferentiator.calledWithExactly()).to.be.true;
+			expect(instance.validateDifferentiator.calledOnce).to.be.true;
+			expect(instance.validateDifferentiator.calledWithExactly()).to.be.true;
 
 		});
 
@@ -189,12 +189,12 @@ describe('Base model', () => {
 
 	});
 
-	describe('validatedifferentiator method', () => {
+	describe('validateDifferentiator method', () => {
 
 		it('will call validateStringForProperty method', () => {
 
 			spy(instance, 'validateStringForProperty');
-			instance.validatedifferentiator();
+			instance.validateDifferentiator();
 			expect(instance.validateStringForProperty.calledOnce).to.be.true;
 			expect(instance.validateStringForProperty.calledWithExactly(
 				'differentiator', { isRequired: false })
@@ -261,12 +261,12 @@ describe('Base model', () => {
 
 			it('will not call addPropertyError method', () => {
 
-				spy(instance, 'hasdifferentiatorProperty');
+				spy(instance, 'hasDifferentiatorProperty');
 				spy(instance, 'hasQualifierProperty');
 				spy(instance, 'addPropertyError');
 				const opts = { isDuplicate: false };
 				instance.validateUniquenessInGroup(opts);
-				expect(instance.hasdifferentiatorProperty.notCalled).to.be.true;
+				expect(instance.hasDifferentiatorProperty.notCalled).to.be.true;
 				expect(instance.hasQualifierProperty.notCalled).to.be.true;
 				expect(instance.addPropertyError.notCalled).to.be.true;
 
@@ -280,12 +280,12 @@ describe('Base model', () => {
 
 				it('will call addPropertyError method with group context error text for name property only', () => {
 
-					spy(instance, 'hasdifferentiatorProperty');
+					spy(instance, 'hasDifferentiatorProperty');
 					spy(instance, 'addPropertyError');
 					const opts = { isDuplicate: true };
 					instance.validateUniquenessInGroup(opts);
-					expect(instance.hasdifferentiatorProperty.calledOnce).to.be.true;
-					expect(instance.hasdifferentiatorProperty.calledWithExactly()).to.be.true;
+					expect(instance.hasDifferentiatorProperty.calledOnce).to.be.true;
+					expect(instance.hasDifferentiatorProperty.calledWithExactly()).to.be.true;
 					expect(instance.addPropertyError.calledOnce).to.be.true;
 					expect(instance.addPropertyError.calledWithExactly(
 						'name', 'This item has been duplicated within the group'
@@ -300,13 +300,13 @@ describe('Base model', () => {
 				it('will call addPropertyError method with group context error text for name and differentiator properties', () => {
 
 					instance.differentiator = '';
-					spy(instance, 'hasdifferentiatorProperty');
+					spy(instance, 'hasDifferentiatorProperty');
 					spy(instance, 'hasQualifierProperty');
 					spy(instance, 'addPropertyError');
 					const opts = { isDuplicate: true };
 					instance.validateUniquenessInGroup(opts);
-					expect(instance.hasdifferentiatorProperty.calledOnce).to.be.true;
-					expect(instance.hasdifferentiatorProperty.calledWithExactly()).to.be.true;
+					expect(instance.hasDifferentiatorProperty.calledOnce).to.be.true;
+					expect(instance.hasDifferentiatorProperty.calledWithExactly()).to.be.true;
 					expect(instance.hasQualifierProperty.calledOnce).to.be.true;
 					expect(instance.hasQualifierProperty.calledWithExactly()).to.be.true;
 					expect(instance.addPropertyError.calledTwice).to.be.true;
@@ -326,13 +326,13 @@ describe('Base model', () => {
 				it('will call addPropertyError method with group context error text for name and qualifier properties', () => {
 
 					instance.qualifier = '';
-					spy(instance, 'hasdifferentiatorProperty');
+					spy(instance, 'hasDifferentiatorProperty');
 					spy(instance, 'hasQualifierProperty');
 					spy(instance, 'addPropertyError');
 					const opts = { isDuplicate: true };
 					instance.validateUniquenessInGroup(opts);
-					expect(instance.hasdifferentiatorProperty.calledOnce).to.be.true;
-					expect(instance.hasdifferentiatorProperty.calledWithExactly()).to.be.true;
+					expect(instance.hasDifferentiatorProperty.calledOnce).to.be.true;
+					expect(instance.hasDifferentiatorProperty.calledWithExactly()).to.be.true;
 					expect(instance.hasQualifierProperty.calledOnce).to.be.true;
 					expect(instance.hasQualifierProperty.calledWithExactly()).to.be.true;
 					expect(instance.addPropertyError.calledTwice).to.be.true;
@@ -353,13 +353,13 @@ describe('Base model', () => {
 
 					instance.differentiator = '';
 					instance.qualifier = '';
-					spy(instance, 'hasdifferentiatorProperty');
+					spy(instance, 'hasDifferentiatorProperty');
 					spy(instance, 'hasQualifierProperty');
 					spy(instance, 'addPropertyError');
 					const opts = { isDuplicate: true };
 					instance.validateUniquenessInGroup(opts);
-					expect(instance.hasdifferentiatorProperty.calledOnce).to.be.true;
-					expect(instance.hasdifferentiatorProperty.calledWithExactly()).to.be.true;
+					expect(instance.hasDifferentiatorProperty.calledOnce).to.be.true;
+					expect(instance.hasDifferentiatorProperty.calledWithExactly()).to.be.true;
 					expect(instance.hasQualifierProperty.calledOnce).to.be.true;
 					expect(instance.hasQualifierProperty.calledWithExactly()).to.be.true;
 					expect(instance.addPropertyError.calledThrice).to.be.true;

--- a/test-unit/src/models/CastMember.test.js
+++ b/test-unit/src/models/CastMember.test.js
@@ -75,13 +75,13 @@ describe('Cast Member model', () => {
 		it('calls instance validate method and associated models\' validate methods', () => {
 
 			spy(instance, 'validateName');
-			spy(instance, 'validatedifferentiator');
+			spy(instance, 'validateDifferentiator');
 			spy(instance, 'validateUniquenessInGroup');
 			spy(instance, 'validateNamePresenceIfRoles');
 			instance.runInputValidations({ isDuplicate: false });
 			assert.callOrder(
 				instance.validateName,
-				instance.validatedifferentiator,
+				instance.validateDifferentiator,
 				instance.validateUniquenessInGroup,
 				instance.validateNamePresenceIfRoles,
 				stubs.getDuplicateIndicesModule.getDuplicateIndices,
@@ -94,8 +94,8 @@ describe('Cast Member model', () => {
 			);
 			expect(instance.validateName.calledOnce).to.be.true;
 			expect(instance.validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.validatedifferentiator.calledOnce).to.be.true;
-			expect(instance.validatedifferentiator.calledWithExactly()).to.be.true;
+			expect(instance.validateDifferentiator.calledOnce).to.be.true;
+			expect(instance.validateDifferentiator.calledWithExactly()).to.be.true;
 			expect(instance.validateUniquenessInGroup.calledOnce).to.be.true;
 			expect(instance.validateUniquenessInGroup.calledWithExactly({ isDuplicate: false })).to.be.true;
 			expect(instance.validateNamePresenceIfRoles.calledOnce).to.be.true;

--- a/test-unit/src/models/Playtext.test.js
+++ b/test-unit/src/models/Playtext.test.js
@@ -128,29 +128,29 @@ describe('Playtext model', () => {
 		it('calls instance validate method and associated models\' validate methods', () => {
 
 			spy(instance, 'validateName');
-			spy(instance, 'validatedifferentiator');
+			spy(instance, 'validateDifferentiator');
 			instance.runInputValidations();
 			assert.callOrder(
 				instance.validateName,
-				instance.validatedifferentiator,
+				instance.validateDifferentiator,
 				stubs.getDuplicateIndicesModule.getDuplicateIndices,
 				instance.characters[0].validateName,
-				instance.characters[0].validatedifferentiator,
+				instance.characters[0].validateDifferentiator,
 				instance.characters[0].validateQualifier,
 				instance.characters[0].validateUniquenessInGroup
 			);
 			expect(instance.validateName.calledOnce).to.be.true;
 			expect(instance.validateName.calledWithExactly({ isRequired: true })).to.be.true;
-			expect(instance.validatedifferentiator.calledOnce).to.be.true;
-			expect(instance.validatedifferentiator.calledWithExactly()).to.be.true;
+			expect(instance.validateDifferentiator.calledOnce).to.be.true;
+			expect(instance.validateDifferentiator.calledWithExactly()).to.be.true;
 			expect(stubs.getDuplicateIndicesModule.getDuplicateIndices.calledOnce).to.be.true;
 			expect(stubs.getDuplicateIndicesModule.getDuplicateIndices.calledWithExactly(
 				instance.characters
 			)).to.be.true;
 			expect(instance.characters[0].validateName.calledOnce).to.be.true;
 			expect(instance.characters[0].validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.characters[0].validatedifferentiator.calledOnce).to.be.true;
-			expect(instance.characters[0].validatedifferentiator.calledWithExactly()).to.be.true;
+			expect(instance.characters[0].validateDifferentiator.calledOnce).to.be.true;
+			expect(instance.characters[0].validateDifferentiator.calledWithExactly()).to.be.true;
 			expect(instance.characters[0].validateQualifier.calledOnce).to.be.true;
 			expect(instance.characters[0].validateQualifier.calledWithExactly()).to.be.true;
 			expect(instance.characters[0].validateUniquenessInGroup.calledOnce).to.be.true;

--- a/test-unit/src/models/Production.test.js
+++ b/test-unit/src/models/Production.test.js
@@ -113,9 +113,9 @@ describe('Production model', () => {
 			assert.callOrder(
 				instance.validateName,
 				instance.theatre.validateName,
-				instance.theatre.validatedifferentiator,
+				instance.theatre.validateDifferentiator,
 				instance.playtext.validateName,
-				instance.playtext.validatedifferentiator,
+				instance.playtext.validateDifferentiator,
 				stubs.getDuplicateIndicesModule.getDuplicateIndices,
 				instance.cast[0].runInputValidations
 			);
@@ -123,12 +123,12 @@ describe('Production model', () => {
 			expect(instance.validateName.calledWithExactly({ isRequired: true })).to.be.true;
 			expect(instance.theatre.validateName.calledOnce).to.be.true;
 			expect(instance.theatre.validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.theatre.validatedifferentiator.calledOnce).to.be.true;
-			expect(instance.theatre.validatedifferentiator.calledWithExactly()).to.be.true;
+			expect(instance.theatre.validateDifferentiator.calledOnce).to.be.true;
+			expect(instance.theatre.validateDifferentiator.calledWithExactly()).to.be.true;
 			expect(instance.playtext.validateName.calledOnce).to.be.true;
 			expect(instance.playtext.validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.playtext.validatedifferentiator.calledOnce).to.be.true;
-			expect(instance.playtext.validatedifferentiator.calledWithExactly()).to.be.true;
+			expect(instance.playtext.validateDifferentiator.calledOnce).to.be.true;
+			expect(instance.playtext.validateDifferentiator.calledWithExactly()).to.be.true;
 			expect(stubs.getDuplicateIndicesModule.getDuplicateIndices.calledOnce).to.be.true;
 			expect(stubs.getDuplicateIndicesModule.getDuplicateIndices.calledWithExactly(instance.cast)).to.be.true;
 			expect(instance.cast[0].runInputValidations.calledOnce).to.be.true;


### PR DESCRIPTION
A botched find and replace (replacing `disambiguator` with `differentiator`) resulted in all instances being lowercased when some should have remained capitalised becaise they form part of a camelCase method name.