### PR TITLE
Invert model constructor unit test 'context' + 'describe' blocks

### DIFF
--- a/test-unit/src/models/Character.test.js
+++ b/test-unit/src/models/Character.test.js
@@ -12,9 +12,9 @@ describe('Character model', () => {
 
 	describe('constructor method', () => {
 
-		context('instance is subject', () => {
+		describe('qualifier property', () => {
 
-			describe('qualifier property', () => {
+			context('instance is subject', () => {
 
 				it('will not assign any value if absent from props', () => {
 
@@ -34,11 +34,7 @@ describe('Character model', () => {
 
 			});
 
-		});
-
-		context('instance is not subject, i.e. it is an association of another instance', () => {
-
-			describe('qualifier property', () => {
+			context('instance is not subject, i.e. it is an association of another instance', () => {
 
 				it('assigns empty string if absent from props', () => {
 

--- a/test-unit/src/models/Playtext.test.js
+++ b/test-unit/src/models/Playtext.test.js
@@ -59,9 +59,9 @@ describe('Playtext model', () => {
 
 	describe('constructor method', () => {
 
-		context('instance is subject', () => {
+		describe('characters property', () => {
 
-			describe('characters property', () => {
+			context('instance is subject', () => {
 
 				it('assigns empty array if absent from props', () => {
 
@@ -91,11 +91,7 @@ describe('Playtext model', () => {
 
 			});
 
-		});
-
-		context('instance is not subject, i.e. it is an association of another instance', () => {
-
-			describe('characters property', () => {
+			context('instance is not subject, i.e. it is an association of another instance', () => {
 
 				it('will not assign any value if absent from props', () => {
 


### PR DESCRIPTION
Switching the `context` and `describe` blocks means that the property in the `describe` block only needs to be declared once.