### PR TITLE
Fix Role model constructor characterName property unit test

### DIFF
--- a/test-unit/src/models/Role.test.js
+++ b/test-unit/src/models/Role.test.js
@@ -29,7 +29,7 @@ describe('Role model', () => {
 
 			it('assigns empty string if absent from props', () => {
 
-				const instance = new Role({ name: 'Hamlet, Prince of Denmark', characterName: '' });
+				const instance = new Role({ name: 'Hamlet, Prince of Denmark' });
 				expect(instance.characterName).to.equal('');
 
 			});


### PR DESCRIPTION
Test did not correspond with its description.

This PR corrects the test.