### PR TITLE
Add playtext character groups

### DIFF
--- a/src/controllers/model-template-props/playtext.js
+++ b/src/controllers/model-template-props/playtext.js
@@ -4,7 +4,8 @@ export default {
 		{
 			name: '',
 			differentiator: '',
-			qualifier: ''
+			qualifier: '',
+			group: ''
 		}
 	]
 };

--- a/src/lib/get-duplicate-indices.js
+++ b/src/lib/get-duplicate-indices.js
@@ -8,6 +8,7 @@ export const getDuplicateIndices = arrayOfObjects => {
 				object.name === comparisonObject.name &&
 				object.differentiator === comparisonObject.differentiator &&
 				object.qualifier === comparisonObject.qualifier &&
+				object.group === comparisonObject.group &&
 				index !== comparisonIndex
 			);
 

--- a/src/models/Base.js
+++ b/src/models/Base.js
@@ -31,6 +31,12 @@ export default class Base {
 
 	}
 
+	hasGroupProperty () {
+
+		return Object.prototype.hasOwnProperty.call(this, 'group');
+
+	}
+
 	runInputValidations () {
 
 		this.validateName({ isRequired: true });
@@ -76,6 +82,8 @@ export default class Base {
 			if (this.hasDifferentiatorProperty()) this.addPropertyError('differentiator', uniquenessErrorMessage);
 
 			if (this.hasQualifierProperty()) this.addPropertyError('qualifier', uniquenessErrorMessage);
+
+			if (this.hasGroupProperty()) this.addPropertyError('group', uniquenessErrorMessage);
 
 		}
 

--- a/src/models/Character.js
+++ b/src/models/Character.js
@@ -6,13 +6,24 @@ export default class Character extends Base {
 
 		super(props);
 
-		const { uuid, differentiator, qualifier, isAssociation } = props;
+		const { uuid, differentiator, qualifier, group, isAssociation } = props;
 
 		this.model = 'character';
 		this.uuid = uuid;
 		this.differentiator = differentiator?.trim() || '';
 
-		if (isAssociation) this.qualifier = qualifier?.trim() || '';
+		if (isAssociation) {
+
+			this.qualifier = qualifier?.trim() || '';
+			this.group = group?.trim() || '';
+
+		}
+
+	}
+
+	validateGroup () {
+
+		this.validateStringForProperty('group', { isRequired: false });
 
 	}
 

--- a/src/models/Playtext.js
+++ b/src/models/Playtext.js
@@ -40,6 +40,8 @@ export default class Playtext extends Base {
 
 			character.validateQualifier();
 
+			character.validateGroup();
+
 			character.validateUniquenessInGroup({ isDuplicate: duplicateCharacterIndices.includes(index) });
 
 		});

--- a/src/neo4j/cypher-queries/person.js
+++ b/src/neo4j/cypher-queries/person.js
@@ -6,11 +6,9 @@ const getShowQuery = () => `
 	OPTIONAL MATCH (production)-[:PLAYS_AT]->(theatre:Theatre)
 
 	OPTIONAL MATCH (production)-[:PRODUCTION_OF]->(:Playtext)-[characterRel:INCLUDES_CHARACTER]->(character:Character)
-		WHERE
-			(role.roleName = character.name OR role.characterName = character.name) AND
-			((role.qualifier IS NULL AND characterRel.qualifier IS NULL) OR role.qualifier = characterRel.qualifier)
+		WHERE role.roleName = character.name OR role.characterName = character.name
 
-	WITH person, production, theatre, role, character
+	WITH DISTINCT person, production, theatre, role, character
 		ORDER BY role.rolePosition
 
 	WITH person, production, theatre,

--- a/src/neo4j/cypher-queries/production.js
+++ b/src/neo4j/cypher-queries/production.js
@@ -163,11 +163,9 @@ const getShowQuery = () => `
 
 	OPTIONAL MATCH (person)-[role]->(production)-[playtextRel]->
 		(playtext)-[characterRel:INCLUDES_CHARACTER]->(character:Character)
-		WHERE
-			(role.roleName = character.name OR role.characterName = character.name) AND
-			((role.qualifier IS NULL AND characterRel.qualifier IS NULL) OR role.qualifier = characterRel.qualifier)
+		WHERE role.roleName = character.name OR role.characterName = character.name
 
-	WITH production, theatre, playtext, person, role, character
+	WITH DISTINCT production, theatre, playtext, person, role, character
 		ORDER BY role.castMemberPosition, role.rolePosition
 
 	WITH production, theatre, playtext, person,

--- a/test-e2e/crud/playtexts-api.test.js
+++ b/test-e2e/crud/playtexts-api.test.js
@@ -29,6 +29,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 						name: '',
 						differentiator: '',
 						qualifier: '',
+						group: '',
 						errors: {}
 					}
 				]
@@ -83,6 +84,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 						name: '',
 						differentiator: '',
 						qualifier: '',
+						group: '',
 						errors: {}
 					}
 				]
@@ -111,6 +113,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 						name: '',
 						differentiator: '',
 						qualifier: '',
+						group: '',
 						errors: {}
 					}
 				]
@@ -143,6 +146,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 						name: '',
 						differentiator: '',
 						qualifier: '',
+						group: '',
 						errors: {}
 					}
 				]
@@ -164,7 +168,13 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 				uuid: PLAYTEXT_UUID,
 				name: 'The Cherry Orchard',
 				differentiator: null,
-				characters: [],
+				characterGroups: [
+					{
+						model: 'characterGroup',
+						name: null,
+						characters: []
+					}
+				],
 				productions: []
 			};
 
@@ -276,6 +286,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 						name: 'Irina Nikolayevna Arkadina',
 						differentiator: '',
 						qualifier: '',
+						group: '',
 						errors: {}
 					},
 					{
@@ -283,6 +294,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 						name: 'Konstantin Gavrilovich Treplyov',
 						differentiator: '',
 						qualifier: '',
+						group: '',
 						errors: {}
 					},
 					{
@@ -290,6 +302,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 						name: 'Boris Alexeyevich Trigorin',
 						differentiator: '',
 						qualifier: '',
+						group: '',
 						errors: {}
 					},
 					{
@@ -297,6 +310,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 						name: '',
 						differentiator: '',
 						qualifier: '',
+						group: '',
 						errors: {}
 					}
 				]
@@ -318,24 +332,30 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 				uuid: PLAYTEXT_UUID,
 				name: 'The Seagull',
 				differentiator: null,
-				characters: [
+				characterGroups: [
 					{
-						model: 'character',
-						uuid: IRINA_NIKOLAYEVNA_ARKADINA_UUID,
-						name: 'Irina Nikolayevna Arkadina',
-						qualifier: null
-					},
-					{
-						model: 'character',
-						uuid: KONSTANTIN_GAVRILOVICH_TREPLYOV_UUID,
-						name: 'Konstantin Gavrilovich Treplyov',
-						qualifier: null
-					},
-					{
-						model: 'character',
-						uuid: BORIS_ALEXEYEVICH_TRIGORIN_UUID,
-						name: 'Boris Alexeyevich Trigorin',
-						qualifier: null
+						model: 'characterGroup',
+						name: null,
+						characters: [
+							{
+								model: 'character',
+								uuid: IRINA_NIKOLAYEVNA_ARKADINA_UUID,
+								name: 'Irina Nikolayevna Arkadina',
+								qualifier: null
+							},
+							{
+								model: 'character',
+								uuid: KONSTANTIN_GAVRILOVICH_TREPLYOV_UUID,
+								name: 'Konstantin Gavrilovich Treplyov',
+								qualifier: null
+							},
+							{
+								model: 'character',
+								uuid: BORIS_ALEXEYEVICH_TRIGORIN_UUID,
+								name: 'Boris Alexeyevich Trigorin',
+								qualifier: null
+							}
+						]
 					}
 				],
 				productions: []
@@ -363,6 +383,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 						name: 'Irina Nikolayevna Arkadina',
 						differentiator: '',
 						qualifier: '',
+						group: '',
 						errors: {}
 					},
 					{
@@ -370,6 +391,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 						name: 'Konstantin Gavrilovich Treplyov',
 						differentiator: '',
 						qualifier: '',
+						group: '',
 						errors: {}
 					},
 					{
@@ -377,6 +399,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 						name: 'Boris Alexeyevich Trigorin',
 						differentiator: '',
 						qualifier: '',
+						group: '',
 						errors: {}
 					},
 					{
@@ -384,6 +407,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 						name: '',
 						differentiator: '',
 						qualifier: '',
+						group: '',
 						errors: {}
 					}
 				]
@@ -404,13 +428,16 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 					name: 'Three Sisters',
 					characters: [
 						{
-							name: 'Olga Sergeyevna Prozorova'
+							name: 'Olga Sergeyevna Prozorova',
+							group: 'The Prozorovs'
 						},
 						{
-							name: 'Maria Sergeyevna Kulygina'
+							name: 'Maria Sergeyevna Kulygina',
+							group: 'The Prozorovs'
 						},
 						{
-							name: 'Irina Sergeyevna Prozorova'
+							name: 'Irina Sergeyevna Prozorova',
+							group: 'The Prozorovs'
 						}
 					]
 				});
@@ -427,6 +454,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 						name: 'Olga Sergeyevna Prozorova',
 						differentiator: '',
 						qualifier: '',
+						group: 'The Prozorovs',
 						errors: {}
 					},
 					{
@@ -434,6 +462,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 						name: 'Maria Sergeyevna Kulygina',
 						differentiator: '',
 						qualifier: '',
+						group: 'The Prozorovs',
 						errors: {}
 					},
 					{
@@ -441,6 +470,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 						name: 'Irina Sergeyevna Prozorova',
 						differentiator: '',
 						qualifier: '',
+						group: 'The Prozorovs',
 						errors: {}
 					},
 					{
@@ -448,6 +478,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 						name: '',
 						differentiator: '',
 						qualifier: '',
+						group: '',
 						errors: {}
 					}
 				]
@@ -469,24 +500,30 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 				uuid: PLAYTEXT_UUID,
 				name: 'Three Sisters',
 				differentiator: null,
-				characters: [
+				characterGroups: [
 					{
-						model: 'character',
-						uuid: OLGA_SERGEYEVNA_PROZOROVA_UUID,
-						name: 'Olga Sergeyevna Prozorova',
-						qualifier: null
-					},
-					{
-						model: 'character',
-						uuid: MARIA_SERGEYEVNA_KULYGINA_UUID,
-						name: 'Maria Sergeyevna Kulygina',
-						qualifier: null
-					},
-					{
-						model: 'character',
-						uuid: IRINA_SERGEYEVNA_PROZOROVA_UUID,
-						name: 'Irina Sergeyevna Prozorova',
-						qualifier: null
+						model: 'characterGroup',
+						name: 'The Prozorovs',
+						characters: [
+							{
+								model: 'character',
+								uuid: OLGA_SERGEYEVNA_PROZOROVA_UUID,
+								name: 'Olga Sergeyevna Prozorova',
+								qualifier: null
+							},
+							{
+								model: 'character',
+								uuid: MARIA_SERGEYEVNA_KULYGINA_UUID,
+								name: 'Maria Sergeyevna Kulygina',
+								qualifier: null
+							},
+							{
+								model: 'character',
+								uuid: IRINA_SERGEYEVNA_PROZOROVA_UUID,
+								name: 'Irina Sergeyevna Prozorova',
+								qualifier: null
+							}
+						]
 					}
 				],
 				productions: []
@@ -538,6 +575,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 						name: '',
 						differentiator: '',
 						qualifier: '',
+						group: '',
 						errors: {}
 					}
 				]

--- a/test-e2e/model-interaction/character-different-groups-same-playtext.test.js
+++ b/test-e2e/model-interaction/character-different-groups-same-playtext.test.js
@@ -1,0 +1,846 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import { createSandbox } from 'sinon';
+import { v4 as uuid } from 'uuid';
+
+import app from '../../src/app';
+import purgeDatabase from '../test-helpers/neo4j/purge-database';
+
+describe('Character with multiple appearances in the same playtext in different groups', () => {
+
+	chai.use(chaiHttp);
+
+	const THREE_WINTERS_PLAYTEXT_UUID = '8';
+	const ALISA_KOS_CHARACTER_UUID = '9';
+	const MAŠA_KOS_CHARACTER_UUID = '10';
+	const ALEKSANDER_KING_CHARACTER_UUID = '12';
+	const ROSE_KING_CHARACTER_UUID = '14';
+	const THREE_WINTERS_NATIONAL_PRODUCTION_UUID = '16';
+	const NATIONAL_THEATRE_UUID = '17';
+	const SIOBHAN_FINNERAN_PERSON_UUID = '19';
+	const JO_HERBERT_PERSON_UUID = '20';
+	const JAMES_LAURENSON_PERSON_UUID = '21';
+	const JODIE_MCNEE_PERSON_UUID = '22';
+	const ALEX_PRICE_PERSON_UUID = '23';
+	const BEBE_SANDERS_PERSON_UUID = '24';
+
+	let alisaKosCharacter;
+	let mašaKosCharacter;
+	let aleksanderKingCharacter;
+	let roseKingCharacter;
+	let threeWintersPlaytext;
+	let threeWintersNationalProduction;
+	let siobhanFinneranPerson;
+	let joHerbertPerson;
+	let jamesLaurensonPerson;
+	let jodieMcNeePerson;
+	let alexPricePerson;
+	let bebeSandersPerson;
+
+	const sandbox = createSandbox();
+
+	before(async () => {
+
+		let uuidCallCount = 0;
+
+		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+
+		await purgeDatabase();
+
+		await chai.request(app)
+			.post('/playtexts')
+			.send({
+				name: '3 Winters',
+				characters: [
+					{
+						name: 'Alisa Kos',
+						group: '2011'
+					},
+					{
+						name: 'Maša Kos',
+						group: '2011'
+					},
+					{
+						name: 'Maša Kos',
+						group: '1990'
+					},
+					{
+						name: 'Aleksander King',
+						group: '1990'
+					},
+					{
+						name: 'Alisa Kos',
+						group: '1990'
+					},
+					{
+						name: 'Rose King',
+						group: '1945'
+					},
+					{
+						name: 'Aleksander King',
+						group: '1945'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: '3 Winters',
+				theatre: {
+					name: 'National Theatre'
+				},
+				playtext: {
+					name: '3 Winters'
+				},
+				cast: [
+					{
+						name: 'Siobhan Finneran',
+						roles: [
+							{
+								name: 'Maša Kos'
+							}
+						]
+					},
+					{
+						name: 'Jo Herbert',
+						roles: [
+							{
+								name: 'Rose King'
+							}
+						]
+					},
+					{
+						name: 'James Laurenson',
+						roles: [
+							{
+								name: 'Aleksander King',
+								qualifier: '1990'
+							}
+						]
+					},
+					{
+						name: 'Jodie McNee',
+						roles: [
+							{
+								name: 'Alisa Kos',
+								qualifier: '2011'
+							}
+						]
+					},
+					{
+						name: 'Alex Price',
+						roles: [
+							{
+								name: 'Aleksander King',
+								qualifier: '1945'
+							}
+						]
+					},
+					{
+						name: 'Bebe Sanders',
+						roles: [
+							{
+								name: 'Alisa Kos',
+								qualifier: '1990'
+							}
+						]
+					}
+				]
+			});
+
+		alisaKosCharacter = await chai.request(app)
+			.get(`/characters/${ALISA_KOS_CHARACTER_UUID}`);
+
+		mašaKosCharacter = await chai.request(app)
+			.get(`/characters/${MAŠA_KOS_CHARACTER_UUID}`);
+
+		aleksanderKingCharacter = await chai.request(app)
+			.get(`/characters/${ALEKSANDER_KING_CHARACTER_UUID}`);
+
+		roseKingCharacter = await chai.request(app)
+			.get(`/characters/${ROSE_KING_CHARACTER_UUID}`);
+
+		threeWintersPlaytext = await chai.request(app)
+			.get(`/playtexts/${THREE_WINTERS_PLAYTEXT_UUID}`);
+
+		threeWintersNationalProduction = await chai.request(app)
+			.get(`/productions/${THREE_WINTERS_NATIONAL_PRODUCTION_UUID}`);
+
+		siobhanFinneranPerson = await chai.request(app)
+			.get(`/people/${SIOBHAN_FINNERAN_PERSON_UUID}`);
+
+		joHerbertPerson = await chai.request(app)
+			.get(`/people/${JO_HERBERT_PERSON_UUID}`);
+
+		jamesLaurensonPerson = await chai.request(app)
+			.get(`/people/${JAMES_LAURENSON_PERSON_UUID}`);
+
+		jodieMcNeePerson = await chai.request(app)
+			.get(`/people/${JODIE_MCNEE_PERSON_UUID}`);
+
+		alexPricePerson = await chai.request(app)
+			.get(`/people/${ALEX_PRICE_PERSON_UUID}`);
+
+		bebeSandersPerson = await chai.request(app)
+			.get(`/people/${BEBE_SANDERS_PERSON_UUID}`);
+
+	});
+
+	after(() => {
+
+		sandbox.restore();
+
+	});
+
+	describe('Alisa Kos (character)', () => {
+
+		it('includes playtexts in which character appears, including the groups applied', () => {
+
+			const expectedThreeWintersPlaytextCredit = {
+				model: 'playtext',
+				uuid: THREE_WINTERS_PLAYTEXT_UUID,
+				name: '3 Winters',
+				qualifiers: [],
+				groups: [
+					'2011',
+					'1990'
+				]
+			};
+
+			const { playtexts } = alisaKosCharacter.body;
+
+			const threeWintersPlaytextCredit =
+				playtexts.find(playtext => playtext.uuid === THREE_WINTERS_PLAYTEXT_UUID);
+
+			expect(playtexts.length).to.equal(1);
+			expect(threeWintersPlaytextCredit).to.deep.equal(expectedThreeWintersPlaytextCredit);
+
+		});
+
+		it('includes productions in which character is portrayed, including by which performer and in which group', () => {
+
+			const expectedThreeWintersNationalProductionCredit = {
+				model: 'production',
+				uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
+				name: '3 Winters',
+				theatre: {
+					model: 'theatre',
+					uuid: NATIONAL_THEATRE_UUID,
+					name: 'National Theatre'
+				},
+				performers: [
+					{
+						model: 'person',
+						uuid: JODIE_MCNEE_PERSON_UUID,
+						name: 'Jodie McNee',
+						roleName: 'Alisa Kos',
+						qualifier: '2011',
+						otherRoles: []
+					},
+					{
+						model: 'person',
+						uuid: BEBE_SANDERS_PERSON_UUID,
+						name: 'Bebe Sanders',
+						roleName: 'Alisa Kos',
+						qualifier: '1990',
+						otherRoles: []
+					}
+				]
+			};
+
+			const { productions } = alisaKosCharacter.body;
+
+			const threeWintersNationalProductionCredit =
+				productions.find(production => production.uuid === THREE_WINTERS_NATIONAL_PRODUCTION_UUID);
+
+			expect(productions.length).to.equal(1);
+			expect(threeWintersNationalProductionCredit).to.deep.equal(expectedThreeWintersNationalProductionCredit);
+
+		});
+
+	});
+
+	describe('Maša Kos (character)', () => {
+
+		it('includes playtexts in which character appears, including the groups applied', () => {
+
+			const expectedThreeWintersPlaytextCredit = {
+				model: 'playtext',
+				uuid: THREE_WINTERS_PLAYTEXT_UUID,
+				name: '3 Winters',
+				qualifiers: [],
+				groups: [
+					'2011',
+					'1990'
+				]
+			};
+
+			const { playtexts } = mašaKosCharacter.body;
+
+			const threeWintersPlaytextCredit =
+				playtexts.find(playtext => playtext.uuid === THREE_WINTERS_PLAYTEXT_UUID);
+
+			expect(playtexts.length).to.equal(1);
+			expect(threeWintersPlaytextCredit).to.deep.equal(expectedThreeWintersPlaytextCredit);
+
+		});
+
+		it('includes productions in which character is portrayed, including by which performer and excluding group as not applied', () => {
+
+			const expectedThreeWintersNationalProductionCredit = {
+				model: 'production',
+				uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
+				name: '3 Winters',
+				theatre: {
+					model: 'theatre',
+					uuid: NATIONAL_THEATRE_UUID,
+					name: 'National Theatre'
+				},
+				performers: [
+					{
+						model: 'person',
+						uuid: SIOBHAN_FINNERAN_PERSON_UUID,
+						name: 'Siobhan Finneran',
+						roleName: 'Maša Kos',
+						qualifier: null,
+						otherRoles: []
+					}
+				]
+			};
+
+			const { productions } = mašaKosCharacter.body;
+
+			const threeWintersNationalProductionCredit =
+				productions.find(production => production.uuid === THREE_WINTERS_NATIONAL_PRODUCTION_UUID);
+
+			expect(productions.length).to.equal(1);
+			expect(threeWintersNationalProductionCredit).to.deep.equal(expectedThreeWintersNationalProductionCredit);
+
+		});
+
+	});
+
+	describe('Aleksander King (character)', () => {
+
+		it('includes playtexts in which character appears, including the groups applied', () => {
+
+			const expectedThreeWintersPlaytextCredit = {
+				model: 'playtext',
+				uuid: THREE_WINTERS_PLAYTEXT_UUID,
+				name: '3 Winters',
+				qualifiers: [],
+				groups: [
+					'1990',
+					'1945'
+				]
+			};
+
+			const { playtexts } = aleksanderKingCharacter.body;
+
+			const threeWintersPlaytextCredit =
+				playtexts.find(playtext => playtext.uuid === THREE_WINTERS_PLAYTEXT_UUID);
+
+			expect(playtexts.length).to.equal(1);
+			expect(threeWintersPlaytextCredit).to.deep.equal(expectedThreeWintersPlaytextCredit);
+
+		});
+
+		it('includes productions in which character is portrayed, including by which performer and in which group', () => {
+
+			const expectedThreeWintersNationalProductionCredit = {
+				model: 'production',
+				uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
+				name: '3 Winters',
+				theatre: {
+					model: 'theatre',
+					uuid: NATIONAL_THEATRE_UUID,
+					name: 'National Theatre'
+				},
+				performers: [
+					{
+						model: 'person',
+						uuid: JAMES_LAURENSON_PERSON_UUID,
+						name: 'James Laurenson',
+						roleName: 'Aleksander King',
+						qualifier: '1990',
+						otherRoles: []
+					},
+					{
+						model: 'person',
+						uuid: ALEX_PRICE_PERSON_UUID,
+						name: 'Alex Price',
+						roleName: 'Aleksander King',
+						qualifier: '1945',
+						otherRoles: []
+					}
+				]
+			};
+
+			const { productions } = aleksanderKingCharacter.body;
+
+			const threeWintersNationalProductionCredit =
+				productions.find(production => production.uuid === THREE_WINTERS_NATIONAL_PRODUCTION_UUID);
+
+			expect(productions.length).to.equal(1);
+			expect(threeWintersNationalProductionCredit).to.deep.equal(expectedThreeWintersNationalProductionCredit);
+
+		});
+
+	});
+
+	describe('Rose King (character)', () => {
+
+		it('includes playtexts in which character appears, including the groups applied', () => {
+
+			const expectedThreeWintersPlaytextCredit = {
+				model: 'playtext',
+				uuid: THREE_WINTERS_PLAYTEXT_UUID,
+				name: '3 Winters',
+				qualifiers: [],
+				groups: [
+					'1945'
+				]
+			};
+
+			const { playtexts } = roseKingCharacter.body;
+
+			const threeWintersPlaytextCredit =
+				playtexts.find(playtext => playtext.uuid === THREE_WINTERS_PLAYTEXT_UUID);
+
+			expect(playtexts.length).to.equal(1);
+			expect(threeWintersPlaytextCredit).to.deep.equal(expectedThreeWintersPlaytextCredit);
+
+		});
+
+		it('includes productions in which character is portrayed, including by which performer and excluding group as not applied', () => {
+
+			const expectedThreeWintersNationalProductionCredit = {
+				model: 'production',
+				uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
+				name: '3 Winters',
+				theatre: {
+					model: 'theatre',
+					uuid: NATIONAL_THEATRE_UUID,
+					name: 'National Theatre'
+				},
+				performers: [
+					{
+						model: 'person',
+						uuid: JO_HERBERT_PERSON_UUID,
+						name: 'Jo Herbert',
+						roleName: 'Rose King',
+						qualifier: null,
+						otherRoles: []
+					}
+				]
+			};
+
+			const { productions } = roseKingCharacter.body;
+
+			const threeWintersNationalProductionCredit =
+				productions.find(production => production.uuid === THREE_WINTERS_NATIONAL_PRODUCTION_UUID);
+
+			expect(productions.length).to.equal(1);
+			expect(threeWintersNationalProductionCredit).to.deep.equal(expectedThreeWintersNationalProductionCredit);
+
+		});
+
+	});
+
+	describe('3 Winters (playtext)', () => {
+
+		it('includes its characters in their respective groups', () => {
+
+			const expectedCharacterGroups = [
+				{
+					name: '2011',
+					model: 'characterGroup',
+					characters: [
+						{
+							model: 'character',
+							uuid: ALISA_KOS_CHARACTER_UUID,
+							name: 'Alisa Kos',
+							qualifier: null
+						},
+						{
+							model: 'character',
+							uuid: MAŠA_KOS_CHARACTER_UUID,
+							name: 'Maša Kos',
+							qualifier: null
+						}
+					]
+				},
+				{
+					name: '1990',
+					model: 'characterGroup',
+					characters: [
+						{
+							model: 'character',
+							uuid: MAŠA_KOS_CHARACTER_UUID,
+							name: 'Maša Kos',
+							qualifier: null
+						},
+						{
+							model: 'character',
+							uuid: ALEKSANDER_KING_CHARACTER_UUID,
+							name: 'Aleksander King',
+							qualifier: null
+						},
+						{
+							model: 'character',
+							uuid: ALISA_KOS_CHARACTER_UUID,
+							name: 'Alisa Kos',
+							qualifier: null
+						}
+					]
+				},
+				{
+					name: '1945',
+					model: 'characterGroup',
+					characters: [
+						{
+							model: 'character',
+							uuid: ROSE_KING_CHARACTER_UUID,
+							name: 'Rose King',
+							qualifier: null
+						},
+						{
+							model: 'character',
+							uuid: ALEKSANDER_KING_CHARACTER_UUID,
+							name: 'Aleksander King',
+							qualifier: null
+						}
+					]
+				}
+			];
+
+			const { characterGroups } = threeWintersPlaytext.body;
+
+			expect(characterGroups).to.deep.equal(expectedCharacterGroups);
+
+		});
+
+	});
+
+	describe('3 Winters at National Theatre (production)', () => {
+
+		it('includes the portrayers of the characters in its cast with their corresponding qualifiers', () => {
+
+			const expectedSiobhanFinneranCastMember = {
+				model: 'person',
+				uuid: SIOBHAN_FINNERAN_PERSON_UUID,
+				name: 'Siobhan Finneran',
+				roles: [
+					{
+						model: 'character',
+						uuid: MAŠA_KOS_CHARACTER_UUID,
+						name: 'Maša Kos',
+						qualifier: null
+					}
+				]
+			};
+
+			const expectedJoHerbertCastMember = {
+				model: 'person',
+				uuid: JO_HERBERT_PERSON_UUID,
+				name: 'Jo Herbert',
+				roles: [
+					{
+						model: 'character',
+						uuid: ROSE_KING_CHARACTER_UUID,
+						name: 'Rose King',
+						qualifier: null
+					}
+				]
+			};
+
+			const expectedJamesLaurensonCastMember = {
+				model: 'person',
+				uuid: JAMES_LAURENSON_PERSON_UUID,
+				name: 'James Laurenson',
+				roles: [
+					{
+						model: 'character',
+						uuid: ALEKSANDER_KING_CHARACTER_UUID,
+						name: 'Aleksander King',
+						qualifier: '1990'
+					}
+				]
+			};
+
+			const expectedJodieMcNeeCastMember = {
+				model: 'person',
+				uuid: JODIE_MCNEE_PERSON_UUID,
+				name: 'Jodie McNee',
+				roles: [
+					{
+						model: 'character',
+						uuid: ALISA_KOS_CHARACTER_UUID,
+						name: 'Alisa Kos',
+						qualifier: '2011'
+					}
+				]
+			};
+
+			const expectedAlexPriceCastMember = {
+				model: 'person',
+				uuid: ALEX_PRICE_PERSON_UUID,
+				name: 'Alex Price',
+				roles: [
+					{
+						model: 'character',
+						uuid: ALEKSANDER_KING_CHARACTER_UUID,
+						name: 'Aleksander King',
+						qualifier: '1945'
+					}
+				]
+			};
+
+			const expectedBebeSandersCastMember = {
+				model: 'person',
+				uuid: BEBE_SANDERS_PERSON_UUID,
+				name: 'Bebe Sanders',
+				roles: [
+					{
+						model: 'character',
+						uuid: ALISA_KOS_CHARACTER_UUID,
+						name: 'Alisa Kos',
+						qualifier: '1990'
+					}
+				]
+			};
+
+			const { cast } = threeWintersNationalProduction.body;
+
+			const siobhanFinneranCastMember =
+				cast.find(castMember => castMember.uuid === SIOBHAN_FINNERAN_PERSON_UUID);
+			const joHerbertCastMember = cast.find(castMember => castMember.uuid === JO_HERBERT_PERSON_UUID);
+			const jamesLaurensonCastMember = cast.find(castMember => castMember.uuid === JAMES_LAURENSON_PERSON_UUID);
+			const jodieMcNeeCastMember = cast.find(castMember => castMember.uuid === JODIE_MCNEE_PERSON_UUID);
+			const alexPriceCastMember = cast.find(castMember => castMember.uuid === ALEX_PRICE_PERSON_UUID);
+			const bebeSandersCastMember = cast.find(castMember => castMember.uuid === BEBE_SANDERS_PERSON_UUID);
+
+			expect(cast.length).to.equal(6);
+			expect(siobhanFinneranCastMember).to.deep.equal(expectedSiobhanFinneranCastMember);
+			expect(joHerbertCastMember).to.deep.equal(expectedJoHerbertCastMember);
+			expect(jamesLaurensonCastMember).to.deep.equal(expectedJamesLaurensonCastMember);
+			expect(jodieMcNeeCastMember).to.deep.equal(expectedJodieMcNeeCastMember);
+			expect(alexPriceCastMember).to.deep.equal(expectedAlexPriceCastMember);
+			expect(bebeSandersCastMember).to.deep.equal(expectedBebeSandersCastMember);
+
+		});
+
+	});
+
+	describe('Siobhan Finneran (person)', () => {
+
+		it('includes in their production credits their portrayal of Maša Kos without a qualifier as not required', () => {
+
+			const expectedThreeWintersNationalProductionCredit = {
+				model: 'production',
+				uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
+				name: '3 Winters',
+				theatre: {
+					model: 'theatre',
+					uuid: NATIONAL_THEATRE_UUID,
+					name: 'National Theatre'
+				},
+				roles: [
+					{
+						model: 'character',
+						uuid: MAŠA_KOS_CHARACTER_UUID,
+						name: 'Maša Kos',
+						qualifier: null
+					}
+				]
+			};
+
+			const { productions } = siobhanFinneranPerson.body;
+
+			const threeWintersNationalProductionCredit =
+				productions.find(production => production.uuid === THREE_WINTERS_NATIONAL_PRODUCTION_UUID);
+
+			expect(productions.length).to.equal(1);
+			expect(threeWintersNationalProductionCredit).to.deep.equal(expectedThreeWintersNationalProductionCredit);
+
+		});
+
+	});
+
+	describe('Jo Herbert (person)', () => {
+
+		it('includes in their production credits their portrayal of Rose King without a qualifier as not required', () => {
+
+			const expectedThreeWintersNationalProductionCredit = {
+				model: 'production',
+				uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
+				name: '3 Winters',
+				theatre: {
+					model: 'theatre',
+					uuid: NATIONAL_THEATRE_UUID,
+					name: 'National Theatre'
+				},
+				roles: [
+					{
+						model: 'character',
+						uuid: ROSE_KING_CHARACTER_UUID,
+						name: 'Rose King',
+						qualifier: null
+					}
+				]
+			};
+
+			const { productions } = joHerbertPerson.body;
+
+			const threeWintersNationalProductionCredit =
+				productions.find(production => production.uuid === THREE_WINTERS_NATIONAL_PRODUCTION_UUID);
+
+			expect(productions.length).to.equal(1);
+			expect(threeWintersNationalProductionCredit).to.deep.equal(expectedThreeWintersNationalProductionCredit);
+
+		});
+
+	});
+
+	describe('James Laurenson (person)', () => {
+
+		it('includes in their production credits their portrayal of Aleksander King with its corresponding qualifier (i.e. 1990)', () => {
+
+			const expectedThreeWintersNationalProductionCredit = {
+				model: 'production',
+				uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
+				name: '3 Winters',
+				theatre: {
+					model: 'theatre',
+					uuid: NATIONAL_THEATRE_UUID,
+					name: 'National Theatre'
+				},
+				roles: [
+					{
+						model: 'character',
+						uuid: ALEKSANDER_KING_CHARACTER_UUID,
+						name: 'Aleksander King',
+						qualifier: '1990'
+					}
+				]
+			};
+
+			const { productions } = jamesLaurensonPerson.body;
+
+			const threeWintersNationalProductionCredit =
+				productions.find(production => production.uuid === THREE_WINTERS_NATIONAL_PRODUCTION_UUID);
+
+			expect(productions.length).to.equal(1);
+			expect(threeWintersNationalProductionCredit).to.deep.equal(expectedThreeWintersNationalProductionCredit);
+
+		});
+
+	});
+
+	describe('Jodie McNee (person)', () => {
+
+		it('includes in their production credits their portrayal of Alisa Kos with its corresponding qualifier (i.e. 2011)', () => {
+
+			const expectedThreeWintersNationalProductionCredit = {
+				model: 'production',
+				uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
+				name: '3 Winters',
+				theatre: {
+					model: 'theatre',
+					uuid: NATIONAL_THEATRE_UUID,
+					name: 'National Theatre'
+				},
+				roles: [
+					{
+						model: 'character',
+						uuid: ALISA_KOS_CHARACTER_UUID,
+						name: 'Alisa Kos',
+						qualifier: '2011'
+					}
+				]
+			};
+
+			const { productions } = jodieMcNeePerson.body;
+
+			const threeWintersNationalProductionCredit =
+				productions.find(production => production.uuid === THREE_WINTERS_NATIONAL_PRODUCTION_UUID);
+
+			expect(productions.length).to.equal(1);
+			expect(threeWintersNationalProductionCredit).to.deep.equal(expectedThreeWintersNationalProductionCredit);
+
+		});
+
+	});
+
+	describe('Alex Price (person)', () => {
+
+		it('includes in their production credits their portrayal of Aleksander King with its corresponding qualifier (i.e. 1945)', () => {
+
+			const expectedThreeWintersNationalProductionCredit = {
+				model: 'production',
+				uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
+				name: '3 Winters',
+				theatre: {
+					model: 'theatre',
+					uuid: NATIONAL_THEATRE_UUID,
+					name: 'National Theatre'
+				},
+				roles: [
+					{
+						model: 'character',
+						uuid: ALEKSANDER_KING_CHARACTER_UUID,
+						name: 'Aleksander King',
+						qualifier: '1945'
+					}
+				]
+			};
+
+			const { productions } = alexPricePerson.body;
+
+			const threeWintersNationalProductionCredit =
+				productions.find(production => production.uuid === THREE_WINTERS_NATIONAL_PRODUCTION_UUID);
+
+			expect(productions.length).to.equal(1);
+			expect(threeWintersNationalProductionCredit).to.deep.equal(expectedThreeWintersNationalProductionCredit);
+
+		});
+
+	});
+
+	describe('Bebe Sanders (person)', () => {
+
+		it('includes in their production credits their portrayal of Alisa Kos with its corresponding qualifier (i.e. 1990)', () => {
+
+			const expectedThreeWintersNationalProductionCredit = {
+				model: 'production',
+				uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
+				name: '3 Winters',
+				theatre: {
+					model: 'theatre',
+					uuid: NATIONAL_THEATRE_UUID,
+					name: 'National Theatre'
+				},
+				roles: [
+					{
+						model: 'character',
+						uuid: ALISA_KOS_CHARACTER_UUID,
+						name: 'Alisa Kos',
+						qualifier: '1990'
+					}
+				]
+			};
+
+			const { productions } = bebeSandersPerson.body;
+
+			const threeWintersNationalProductionCredit =
+				productions.find(production => production.uuid === THREE_WINTERS_NATIONAL_PRODUCTION_UUID);
+
+			expect(productions.length).to.equal(1);
+			expect(threeWintersNationalProductionCredit).to.deep.equal(expectedThreeWintersNationalProductionCredit);
+
+		});
+
+	});
+
+});

--- a/test-e2e/model-interaction/character-in-multiple-playtexts.test.js
+++ b/test-e2e/model-interaction/character-in-multiple-playtexts.test.js
@@ -167,19 +167,22 @@ describe('Character in multiple playtexts', () => {
 					model: 'playtext',
 					uuid: HENRY_IV_PART_1_PLAYTEXT_UUID,
 					name: 'Henry IV: Part 1',
-					qualifiers: []
+					qualifiers: [],
+					groups: []
 				},
 				{
 					model: 'playtext',
 					uuid: HENRY_IV_PART_2_PLAYTEXT_UUID,
 					name: 'Henry IV: Part 2',
-					qualifiers: []
+					qualifiers: [],
+					groups: []
 				},
 				{
 					model: 'playtext',
 					uuid: THE_MERRY_WIVES_OF_WINDSOR_PLAYTEXT_UUID,
 					name: 'The Merry Wives of Windsor',
-					qualifiers: []
+					qualifiers: [],
+					groups: []
 				}
 			];
 
@@ -273,7 +276,7 @@ describe('Character in multiple playtexts', () => {
 				qualifier: null
 			};
 
-			const { characters } = henryIVPart1Playtext.body;
+			const { characterGroups: [{ characters }] } = henryIVPart1Playtext.body;
 
 			const sirJohnFalstaffCharacterCredit =
 				characters.find(character => character.uuid === SIR_JOHN_FALSTAFF_CHARACTER_UUID);
@@ -296,7 +299,7 @@ describe('Character in multiple playtexts', () => {
 				qualifier: null
 			};
 
-			const { characters } = henryIVPart2Playtext.body;
+			const { characterGroups: [{ characters }] } = henryIVPart2Playtext.body;
 
 			const sirJohnFalstaffCharacterCredit =
 				characters.find(character => character.uuid === SIR_JOHN_FALSTAFF_CHARACTER_UUID);
@@ -319,7 +322,7 @@ describe('Character in multiple playtexts', () => {
 				qualifier: null
 			};
 
-			const { characters } = merryWivesOfWindsorPlaytext.body;
+			const { characterGroups: [{ characters }] } = merryWivesOfWindsorPlaytext.body;
 
 			const sirJohnFalstaffCharacterCredit =
 				characters.find(character => character.uuid === SIR_JOHN_FALSTAFF_CHARACTER_UUID);

--- a/test-e2e/model-interaction/character-multiple-appearances-same-playtext.test.js
+++ b/test-e2e/model-interaction/character-multiple-appearances-same-playtext.test.js
@@ -155,7 +155,8 @@ describe('Character with multiple appearances in the same playtext under differe
 				qualifiers: [
 					'younger',
 					'older'
-				]
+				],
+				groups: []
 			};
 
 			const { playtexts } = esmeCharacter.body;
@@ -350,7 +351,7 @@ describe('Character with multiple appearances in the same playtext under differe
 				}
 			];
 
-			const { characters } = rockNRollPlaytext.body;
+			const { characterGroups: [{ characters }] } = rockNRollPlaytext.body;
 
 			expect(characters).to.deep.equal(expectedCharacters);
 

--- a/test-e2e/model-interaction/same-name-characters.test.js
+++ b/test-e2e/model-interaction/same-name-characters.test.js
@@ -258,7 +258,7 @@ describe('Different characters with same name production credits', () => {
 				}
 			];
 
-			const { characters } = aMidsummerNightsDreamPlaytext.body;
+			const { characterGroups: [{ characters }] } = aMidsummerNightsDreamPlaytext.body;
 
 			expect(characters).to.deep.equal(expectedCharacters);
 
@@ -286,7 +286,7 @@ describe('Different characters with same name production credits', () => {
 
 			];
 
-			const { characters } = titusAndronicusPlaytext.body;
+			const { characterGroups: [{ characters }] } = titusAndronicusPlaytext.body;
 
 			expect(characters).to.deep.equal(expectedCharacters);
 

--- a/test-e2e/uniqueness-in-db/playtexts-api.test.js
+++ b/test-e2e/uniqueness-in-db/playtexts-api.test.js
@@ -57,6 +57,7 @@ describe('Uniqueness in database: Playtexts API', () => {
 						name: '',
 						differentiator: '',
 						qualifier: '',
+						group: '',
 						errors: {}
 					}
 				]
@@ -123,6 +124,7 @@ describe('Uniqueness in database: Playtexts API', () => {
 						name: '',
 						differentiator: '',
 						qualifier: '',
+						group: '',
 						errors: {}
 					}
 				]
@@ -191,6 +193,7 @@ describe('Uniqueness in database: Playtexts API', () => {
 						name: '',
 						differentiator: '',
 						qualifier: '',
+						group: '',
 						errors: {}
 					}
 				]
@@ -224,6 +227,7 @@ describe('Uniqueness in database: Playtexts API', () => {
 						name: '',
 						differentiator: '',
 						qualifier: '',
+						group: '',
 						errors: {}
 					}
 				]
@@ -287,6 +291,7 @@ describe('Uniqueness in database: Playtexts API', () => {
 				name: 'Demetrius',
 				differentiator: '',
 				qualifier: '',
+				group: '',
 				errors: {}
 			};
 
@@ -317,6 +322,7 @@ describe('Uniqueness in database: Playtexts API', () => {
 				name: 'Demetrius',
 				differentiator: '1',
 				qualifier: '',
+				group: '',
 				errors: {}
 			};
 
@@ -346,6 +352,7 @@ describe('Uniqueness in database: Playtexts API', () => {
 				name: 'Demetrius',
 				differentiator: '',
 				qualifier: '',
+				group: '',
 				errors: {}
 			};
 
@@ -376,6 +383,7 @@ describe('Uniqueness in database: Playtexts API', () => {
 				name: 'Demetrius',
 				differentiator: '1',
 				qualifier: '',
+				group: '',
 				errors: {}
 			};
 

--- a/test-int/instance-validation-failures/playtext.test.js
+++ b/test-int/instance-validation-failures/playtext.test.js
@@ -140,6 +140,7 @@ describe('Playtext instance', () => {
 							name: ABOVE_MAX_LENGTH_STRING,
 							differentiator: '',
 							qualifier: '',
+							group: '',
 							errors: {
 								name: [
 									'Value is too long'
@@ -187,6 +188,7 @@ describe('Playtext instance', () => {
 							name: 'Johannes Rosmer',
 							differentiator: ABOVE_MAX_LENGTH_STRING,
 							qualifier: '',
+							group: '',
 							errors: {
 								differentiator: [
 									'Value is too long'
@@ -234,6 +236,7 @@ describe('Playtext instance', () => {
 							name: 'Johannes Rosmer',
 							differentiator: '',
 							qualifier: ABOVE_MAX_LENGTH_STRING,
+							group: '',
 							errors: {
 								qualifier: [
 									'Value is too long'
@@ -249,7 +252,7 @@ describe('Playtext instance', () => {
 
 		});
 
-		context('duplicate combinations of character name, differentiator, and qualifier values', () => {
+		context('character group value exceeds maximum limit', () => {
 
 			it('assigns appropriate error', async () => {
 
@@ -258,48 +261,7 @@ describe('Playtext instance', () => {
 					characters: [
 						{
 							name: 'Johannes Rosmer',
-							differentiator: '',
-							qualifier: ''
-						},
-						{
-							name: 'Rebecca West',
-							differentiator: '1',
-							qualifier: ''
-						},
-						{
-							name: 'Professor Kroll',
-							differentiator: '',
-							qualifier: ''
-						},
-						{
-							name: 'Ulrik Brendel',
-							differentiator: '1',
-							qualifier: ''
-						},
-						{
-							name: 'Peder Mortensgaard',
-							differentiator: '',
-							qualifier: ''
-						},
-						{
-							name: 'Johannes Rosmer',
-							differentiator: '',
-							qualifier: ''
-						},
-						{
-							name: 'Rebecca West',
-							differentiator: '1',
-							qualifier: ''
-						},
-						{
-							name: 'Professor Kroll',
-							differentiator: '1',
-							qualifier: ''
-						},
-						{
-							name: 'Ulrik Brendel',
-							differentiator: '2',
-							qualifier: ''
+							group: ABOVE_MAX_LENGTH_STRING
 						}
 					]
 				};
@@ -322,6 +284,105 @@ describe('Playtext instance', () => {
 							name: 'Johannes Rosmer',
 							differentiator: '',
 							qualifier: '',
+							group: ABOVE_MAX_LENGTH_STRING,
+							errors: {
+								group: [
+									'Value is too long'
+								]
+							}
+						}
+					]
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+		context('duplicate combinations of character name, differentiator, qualifier, and group values', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instanceProps = {
+					name: 'Rosmersholm',
+					characters: [
+						{
+							name: 'Johannes Rosmer',
+							differentiator: '',
+							qualifier: '',
+							group: ''
+						},
+						{
+							name: 'Rebecca West',
+							differentiator: '1',
+							qualifier: '',
+							group: ''
+						},
+						{
+							name: 'Professor Kroll',
+							differentiator: '',
+							qualifier: '',
+							group: ''
+						},
+						{
+							name: 'Ulrik Brendel',
+							differentiator: '1',
+							qualifier: '',
+							group: ''
+						},
+						{
+							name: 'Peder Mortensgaard',
+							differentiator: '',
+							qualifier: '',
+							group: ''
+						},
+						{
+							name: 'Johannes Rosmer',
+							differentiator: '',
+							qualifier: '',
+							group: ''
+						},
+						{
+							name: 'Rebecca West',
+							differentiator: '1',
+							qualifier: '',
+							group: ''
+						},
+						{
+							name: 'Professor Kroll',
+							differentiator: '1',
+							qualifier: '',
+							group: ''
+						},
+						{
+							name: 'Ulrik Brendel',
+							differentiator: '2',
+							qualifier: '',
+							group: ''
+						}
+					]
+				};
+
+				const instance = new Playtext(instanceProps);
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					model: 'playtext',
+					uuid: undefined,
+					name: 'Rosmersholm',
+					differentiator: '',
+					hasErrors: true,
+					errors: {},
+					characters: [
+						{
+							model: 'character',
+							uuid: undefined,
+							name: 'Johannes Rosmer',
+							differentiator: '',
+							qualifier: '',
+							group: '',
 							errors: {
 								name: [
 									'This item has been duplicated within the group'
@@ -330,6 +391,9 @@ describe('Playtext instance', () => {
 									'This item has been duplicated within the group'
 								],
 								qualifier: [
+									'This item has been duplicated within the group'
+								],
+								group: [
 									'This item has been duplicated within the group'
 								]
 							}
@@ -340,6 +404,7 @@ describe('Playtext instance', () => {
 							name: 'Rebecca West',
 							differentiator: '1',
 							qualifier: '',
+							group: '',
 							errors: {
 								name: [
 									'This item has been duplicated within the group'
@@ -348,6 +413,9 @@ describe('Playtext instance', () => {
 									'This item has been duplicated within the group'
 								],
 								qualifier: [
+									'This item has been duplicated within the group'
+								],
+								group: [
 									'This item has been duplicated within the group'
 								]
 							}
@@ -358,6 +426,7 @@ describe('Playtext instance', () => {
 							name: 'Professor Kroll',
 							differentiator: '',
 							qualifier: '',
+							group: '',
 							errors: {}
 						},
 						{
@@ -366,6 +435,7 @@ describe('Playtext instance', () => {
 							name: 'Ulrik Brendel',
 							differentiator: '1',
 							qualifier: '',
+							group: '',
 							errors: {}
 						},
 						{
@@ -374,6 +444,7 @@ describe('Playtext instance', () => {
 							name: 'Peder Mortensgaard',
 							differentiator: '',
 							qualifier: '',
+							group: '',
 							errors: {}
 						},
 						{
@@ -382,6 +453,7 @@ describe('Playtext instance', () => {
 							name: 'Johannes Rosmer',
 							differentiator: '',
 							qualifier: '',
+							group: '',
 							errors: {
 								name: [
 									'This item has been duplicated within the group'
@@ -390,6 +462,9 @@ describe('Playtext instance', () => {
 									'This item has been duplicated within the group'
 								],
 								qualifier: [
+									'This item has been duplicated within the group'
+								],
+								group: [
 									'This item has been duplicated within the group'
 								]
 							}
@@ -400,6 +475,7 @@ describe('Playtext instance', () => {
 							name: 'Rebecca West',
 							differentiator: '1',
 							qualifier: '',
+							group: '',
 							errors: {
 								name: [
 									'This item has been duplicated within the group'
@@ -408,6 +484,9 @@ describe('Playtext instance', () => {
 									'This item has been duplicated within the group'
 								],
 								qualifier: [
+									'This item has been duplicated within the group'
+								],
+								group: [
 									'This item has been duplicated within the group'
 								]
 							}
@@ -418,6 +497,7 @@ describe('Playtext instance', () => {
 							name: 'Professor Kroll',
 							differentiator: '1',
 							qualifier: '',
+							group: '',
 							errors: {}
 						},
 						{
@@ -426,6 +506,7 @@ describe('Playtext instance', () => {
 							name: 'Ulrik Brendel',
 							differentiator: '2',
 							qualifier: '',
+							group: '',
 							errors: {}
 						}
 					]
@@ -526,6 +607,7 @@ describe('Playtext instance', () => {
 							name: ABOVE_MAX_LENGTH_STRING,
 							differentiator: '',
 							qualifier: '',
+							group: '',
 							errors: {
 								name: [
 									'Value is too long'

--- a/test-unit/src/lib/get-duplicate-indices.test.js
+++ b/test-unit/src/lib/get-duplicate-indices.test.js
@@ -67,30 +67,90 @@ describe('Get Duplicate Indices module', () => {
 
 		});
 
-		context('array items with differentiator and qualifier', () => {
+		context('array items with group', () => {
 
 			it('returns an empty array', () => {
 
 				const result = getDuplicateIndices(
 					[
-						{ name: 'Foo', differentiator: '', qualifier: '' },
-						{ name: 'Foo', differentiator: '1', qualifier: '' },
-						{ name: 'Foo', differentiator: '2', qualifier: '' },
-						{ name: 'Foo', differentiator: '', qualifier: 'younger' },
-						{ name: 'Foo', differentiator: '', qualifier: 'older' },
-						{ name: 'Foo', differentiator: '1', qualifier: 'younger' },
-						{ name: 'Foo', differentiator: '1', qualifier: 'older' },
-						{ name: 'Foo', differentiator: '2', qualifier: 'younger' },
-						{ name: 'Foo', differentiator: '2', qualifier: 'older' },
-						{ name: 'Bar', differentiator: '', qualifier: '' },
-						{ name: 'Bar', differentiator: '1', qualifier: '' },
-						{ name: 'Bar', differentiator: '2', qualifier: '' },
-						{ name: 'Bar', differentiator: '', qualifier: 'younger' },
-						{ name: 'Bar', differentiator: '', qualifier: 'older' },
-						{ name: 'Bar', differentiator: '1', qualifier: 'younger' },
-						{ name: 'Bar', differentiator: '1', qualifier: 'older' },
-						{ name: 'Bar', differentiator: '2', qualifier: 'younger' },
-						{ name: 'Bar', differentiator: '2', qualifier: 'older' }
+						{ name: 'Alisa Kos', group: '' },
+						{ name: 'Lucija Kos', group: '' },
+						{ name: 'Aleksander King', group: '' },
+						{ name: 'Alisa Kos', group: '2011' },
+						{ name: 'Lucija Kos', group: '2011' },
+						{ name: 'Aleksander King', group: '1990' },
+						{ name: 'Alisa Kos', group: '1990' },
+						{ name: 'Lucija Kos', group: '1990' },
+						{ name: 'Aleksander King', group: '1945' }
+					]
+				);
+
+				expect(result).to.deep.equal([]);
+
+			});
+
+		});
+
+		context('array items with differentiator, qualifier, and group', () => {
+
+			it('returns an empty array', () => {
+
+				const result = getDuplicateIndices(
+					[
+						{ name: 'Foo', differentiator: '', qualifier: '', group: '' },
+						{ name: 'Foo', differentiator: '1', qualifier: '', group: '' },
+						{ name: 'Foo', differentiator: '2', qualifier: '', group: '' },
+						{ name: 'Foo', differentiator: '', qualifier: 'younger', group: '' },
+						{ name: 'Foo', differentiator: '', qualifier: 'older', group: '' },
+						{ name: 'Foo', differentiator: '', qualifier: '', group: 'Romans' },
+						{ name: 'Foo', differentiator: '', qualifier: '', group: 'Goths' },
+						{ name: 'Foo', differentiator: '', qualifier: 'younger', group: 'Romans' },
+						{ name: 'Foo', differentiator: '', qualifier: 'younger', group: 'Goths' },
+						{ name: 'Foo', differentiator: '', qualifier: 'older', group: 'Romans' },
+						{ name: 'Foo', differentiator: '', qualifier: 'older', group: 'Goths' },
+						{ name: 'Foo', differentiator: '1', qualifier: 'younger', group: '' },
+						{ name: 'Foo', differentiator: '1', qualifier: 'older', group: '' },
+						{ name: 'Foo', differentiator: '1', qualifier: '', group: 'Romans' },
+						{ name: 'Foo', differentiator: '1', qualifier: '', group: 'Goths' },
+						{ name: 'Foo', differentiator: '1', qualifier: 'younger', group: 'Romans' },
+						{ name: 'Foo', differentiator: '1', qualifier: 'younger', group: 'Goths' },
+						{ name: 'Foo', differentiator: '1', qualifier: 'older', group: 'Romans' },
+						{ name: 'Foo', differentiator: '1', qualifier: 'older', group: 'Goths' },
+						{ name: 'Foo', differentiator: '2', qualifier: 'younger', group: '' },
+						{ name: 'Foo', differentiator: '2', qualifier: 'older', group: '' },
+						{ name: 'Foo', differentiator: '2', qualifier: '', group: 'Romans' },
+						{ name: 'Foo', differentiator: '2', qualifier: '', group: 'Goths' },
+						{ name: 'Foo', differentiator: '2', qualifier: 'younger', group: 'Romans' },
+						{ name: 'Foo', differentiator: '2', qualifier: 'younger', group: 'Goths' },
+						{ name: 'Foo', differentiator: '2', qualifier: 'older', group: 'Romans' },
+						{ name: 'Foo', differentiator: '2', qualifier: 'older', group: 'Goths' },
+						{ name: 'Bar', differentiator: '', qualifier: '', group: '' },
+						{ name: 'Bar', differentiator: '1', qualifier: '', group: '' },
+						{ name: 'Bar', differentiator: '2', qualifier: '', group: '' },
+						{ name: 'Bar', differentiator: '', qualifier: 'younger', group: '' },
+						{ name: 'Bar', differentiator: '', qualifier: 'older', group: '' },
+						{ name: 'Bar', differentiator: '', qualifier: '', group: 'Romans' },
+						{ name: 'Bar', differentiator: '', qualifier: '', group: 'Goths' },
+						{ name: 'Bar', differentiator: '', qualifier: 'younger', group: 'Romans' },
+						{ name: 'Bar', differentiator: '', qualifier: 'younger', group: 'Goths' },
+						{ name: 'Bar', differentiator: '', qualifier: 'older', group: 'Romans' },
+						{ name: 'Bar', differentiator: '', qualifier: 'older', group: 'Goths' },
+						{ name: 'Bar', differentiator: '1', qualifier: 'younger', group: '' },
+						{ name: 'Bar', differentiator: '1', qualifier: 'older', group: '' },
+						{ name: 'Bar', differentiator: '1', qualifier: '', group: 'Romans' },
+						{ name: 'Bar', differentiator: '1', qualifier: '', group: 'Goths' },
+						{ name: 'Bar', differentiator: '1', qualifier: 'younger', group: 'Romans' },
+						{ name: 'Bar', differentiator: '1', qualifier: 'younger', group: 'Goths' },
+						{ name: 'Bar', differentiator: '1', qualifier: 'older', group: 'Romans' },
+						{ name: 'Bar', differentiator: '1', qualifier: 'older', group: 'Goths' },
+						{ name: 'Bar', differentiator: '2', qualifier: 'younger', group: '' },
+						{ name: 'Bar', differentiator: '2', qualifier: 'older', group: '' },
+						{ name: 'Bar', differentiator: '2', qualifier: '', group: 'Romans' },
+						{ name: 'Bar', differentiator: '2', qualifier: '', group: 'Goths' },
+						{ name: 'Bar', differentiator: '2', qualifier: 'younger', group: 'Romans' },
+						{ name: 'Bar', differentiator: '2', qualifier: 'younger', group: 'Goths' },
+						{ name: 'Bar', differentiator: '2', qualifier: 'older', group: 'Romans' },
+						{ name: 'Bar', differentiator: '2', qualifier: 'older', group: 'Goths' }
 					]
 				);
 
@@ -310,7 +370,7 @@ describe('Get Duplicate Indices module', () => {
 
 		});
 
-		context('array items with differentiator and qualifier', () => {
+		context('array items with group', () => {
 
 			context('single pair of duplicate items', () => {
 
@@ -318,10 +378,79 @@ describe('Get Duplicate Indices module', () => {
 
 					const result = getDuplicateIndices(
 						[
-							{ name: 'Foo', differentiator: '1', qualifier: 'younger' },
-							{ name: 'Bar', differentiator: '1', qualifier: 'younger' },
-							{ name: 'Foo', differentiator: '1', qualifier: 'younger' },
-							{ name: 'Baz', differentiator: '1', qualifier: 'younger' }
+							{ name: 'Alisa Kos', group: '2011' },
+							{ name: 'Lucija Kos', group: '2011' },
+							{ name: 'Aleksander King', group: '1990' },
+							{ name: 'Alisa Kos', group: '1990' },
+							{ name: 'Lucija Kos', group: '2011' },
+							{ name: 'Aleksander King', group: '1945' }
+						]
+					);
+
+					expect(result).to.deep.equal([1, 4]);
+
+				});
+
+			});
+
+			context('two pairs of duplicate items', () => {
+
+				it('returns an array of indices of duplicate items', () => {
+
+					const result = getDuplicateIndices(
+						[
+							{ name: 'Alisa Kos', group: '2011' },
+							{ name: 'Lucija Kos', group: '2011' },
+							{ name: 'Aleksander King', group: '' },
+							{ name: 'Alisa Kos', group: '1990' },
+							{ name: 'Lucija Kos', group: '2011' },
+							{ name: 'Aleksander King', group: '' }
+						]
+					);
+
+					expect(result).to.deep.equal([1, 2, 4, 5]);
+
+				});
+
+			});
+
+			context('two pairs of duplicate items, and a single pair of duplicate items with empty string name values', () => {
+
+				it('returns an array of indices of duplicate items, ignoring items with empty string name values', () => {
+
+					const result = getDuplicateIndices(
+						[
+							{ name: 'Alisa Kos', group: '2011' },
+							{ name: 'Lucija Kos', group: '2011' },
+							{ name: '', group: '' },
+							{ name: 'Aleksander King', group: '' },
+							{ name: 'Alisa Kos', group: '1990' },
+							{ name: 'Lucija Kos', group: '2011' },
+							{ name: '', group: '' },
+							{ name: 'Aleksander King', group: '' }
+						]
+					);
+
+					expect(result).to.deep.equal([1, 3, 5, 7]);
+
+				});
+
+			});
+
+		});
+
+		context('array items with differentiator, qualifier, and group', () => {
+
+			context('single pair of duplicate items', () => {
+
+				it('returns an array of indices of duplicate items', () => {
+
+					const result = getDuplicateIndices(
+						[
+							{ name: 'Foo', differentiator: '1', qualifier: 'younger', group: 'Romans' },
+							{ name: 'Bar', differentiator: '1', qualifier: 'younger', group: 'Romans' },
+							{ name: 'Foo', differentiator: '1', qualifier: 'younger', group: 'Romans' },
+							{ name: 'Baz', differentiator: '1', qualifier: 'younger', group: 'Romans' }
 						]
 					);
 
@@ -337,12 +466,12 @@ describe('Get Duplicate Indices module', () => {
 
 					const result = getDuplicateIndices(
 						[
-							{ name: 'Foo', differentiator: '1', qualifier: 'younger' },
-							{ name: 'Bar', differentiator: '1', qualifier: 'younger' },
-							{ name: 'Baz', differentiator: '1', qualifier: 'younger' },
-							{ name: 'Foo', differentiator: '1', qualifier: 'younger' },
-							{ name: 'Bar', differentiator: '1', qualifier: 'younger' },
-							{ name: 'Qux', differentiator: '1', qualifier: 'younger' }
+							{ name: 'Foo', differentiator: '1', qualifier: 'younger', group: 'Romans' },
+							{ name: 'Bar', differentiator: '1', qualifier: 'younger', group: 'Romans' },
+							{ name: 'Baz', differentiator: '1', qualifier: 'younger', group: 'Romans' },
+							{ name: 'Foo', differentiator: '1', qualifier: 'younger', group: 'Romans' },
+							{ name: 'Bar', differentiator: '1', qualifier: 'younger', group: 'Romans' },
+							{ name: 'Qux', differentiator: '1', qualifier: 'younger', group: 'Romans' }
 						]
 					);
 
@@ -358,14 +487,14 @@ describe('Get Duplicate Indices module', () => {
 
 					const result = getDuplicateIndices(
 						[
-							{ name: 'Foo', differentiator: '1', qualifier: 'younger' },
-							{ name: 'Bar', differentiator: '1', qualifier: 'younger' },
-							{ name: '', differentiator: '1', qualifier: 'younger' },
-							{ name: 'Baz', differentiator: '1', qualifier: 'younger' },
-							{ name: 'Foo', differentiator: '1', qualifier: 'younger' },
-							{ name: 'Bar', differentiator: '1', qualifier: 'younger' },
-							{ name: '', differentiator: '1', qualifier: 'younger' },
-							{ name: 'Qux', differentiator: '1', qualifier: 'younger' }
+							{ name: 'Foo', differentiator: '1', qualifier: 'younger', group: 'Romans' },
+							{ name: 'Bar', differentiator: '1', qualifier: 'younger', group: 'Romans' },
+							{ name: '', differentiator: '1', qualifier: 'younger', group: 'Romans' },
+							{ name: 'Baz', differentiator: '1', qualifier: 'younger', group: 'Romans' },
+							{ name: 'Foo', differentiator: '1', qualifier: 'younger', group: 'Romans' },
+							{ name: 'Bar', differentiator: '1', qualifier: 'younger', group: 'Romans' },
+							{ name: '', differentiator: '1', qualifier: 'younger', group: 'Romans' },
+							{ name: 'Qux', differentiator: '1', qualifier: 'younger', group: 'Romans' }
 						]
 					);
 

--- a/test-unit/src/models/Base.test.js
+++ b/test-unit/src/models/Base.test.js
@@ -174,6 +174,33 @@ describe('Base model', () => {
 
 	});
 
+	describe('hasGroupProperty method', () => {
+
+		context('instance has group property', () => {
+
+			it('returns true', () => {
+
+				instance.group = '';
+				const result = instance.hasGroupProperty();
+				expect(result).to.be.true;
+
+			});
+
+		});
+
+		context('instance does not have group property', () => {
+
+			it('returns false', () => {
+
+				const result = instance.hasGroupProperty();
+				expect(result).to.be.false;
+
+			});
+
+		});
+
+	});
+
 	describe('runInputValidations method', () => {
 
 		it('will call validateName method', () => {
@@ -277,11 +304,13 @@ describe('Base model', () => {
 
 				spy(instance, 'hasDifferentiatorProperty');
 				spy(instance, 'hasQualifierProperty');
+				spy(instance, 'hasGroupProperty');
 				spy(instance, 'addPropertyError');
 				const opts = { isDuplicate: false };
 				instance.validateUniquenessInGroup(opts);
 				expect(instance.hasDifferentiatorProperty.notCalled).to.be.true;
 				expect(instance.hasQualifierProperty.notCalled).to.be.true;
+				expect(instance.hasGroupProperty.notCalled).to.be.true;
 				expect(instance.addPropertyError.notCalled).to.be.true;
 
 			});
@@ -290,7 +319,7 @@ describe('Base model', () => {
 
 		context('invalid data', () => {
 
-			context('instance does not have differentiator or qualifier property', () => {
+			context('instance does not have differentiator, qualifier, or group property', () => {
 
 				it('will call addPropertyError method with group context error text for name property only', () => {
 
@@ -316,6 +345,7 @@ describe('Base model', () => {
 					instance.differentiator = '';
 					spy(instance, 'hasDifferentiatorProperty');
 					spy(instance, 'hasQualifierProperty');
+					spy(instance, 'hasGroupProperty');
 					spy(instance, 'addPropertyError');
 					const opts = { isDuplicate: true };
 					instance.validateUniquenessInGroup(opts);
@@ -323,6 +353,8 @@ describe('Base model', () => {
 					expect(instance.hasDifferentiatorProperty.calledWithExactly()).to.be.true;
 					expect(instance.hasQualifierProperty.calledOnce).to.be.true;
 					expect(instance.hasQualifierProperty.calledWithExactly()).to.be.true;
+					expect(instance.hasGroupProperty.calledOnce).to.be.true;
+					expect(instance.hasGroupProperty.calledWithExactly()).to.be.true;
 					expect(instance.addPropertyError.calledTwice).to.be.true;
 					expect(instance.addPropertyError.firstCall.calledWithExactly(
 						'name', 'This item has been duplicated within the group'
@@ -342,6 +374,7 @@ describe('Base model', () => {
 					instance.qualifier = '';
 					spy(instance, 'hasDifferentiatorProperty');
 					spy(instance, 'hasQualifierProperty');
+					spy(instance, 'hasGroupProperty');
 					spy(instance, 'addPropertyError');
 					const opts = { isDuplicate: true };
 					instance.validateUniquenessInGroup(opts);
@@ -349,6 +382,8 @@ describe('Base model', () => {
 					expect(instance.hasDifferentiatorProperty.calledWithExactly()).to.be.true;
 					expect(instance.hasQualifierProperty.calledOnce).to.be.true;
 					expect(instance.hasQualifierProperty.calledWithExactly()).to.be.true;
+					expect(instance.hasGroupProperty.calledOnce).to.be.true;
+					expect(instance.hasGroupProperty.calledWithExactly()).to.be.true;
 					expect(instance.addPropertyError.calledTwice).to.be.true;
 					expect(instance.addPropertyError.firstCall.calledWithExactly(
 						'name', 'This item has been duplicated within the group'
@@ -361,14 +396,14 @@ describe('Base model', () => {
 
 			});
 
-			context('instance has differentiator and qualifier property', () => {
+			context('instance has group property', () => {
 
-				it('will call addPropertyError method with group context error text for name, differentiator, and qualifier properties', () => {
+				it('will call addPropertyError method with group context error text for name and group properties', () => {
 
-					instance.differentiator = '';
-					instance.qualifier = '';
+					instance.group = '';
 					spy(instance, 'hasDifferentiatorProperty');
 					spy(instance, 'hasQualifierProperty');
+					spy(instance, 'hasGroupProperty');
 					spy(instance, 'addPropertyError');
 					const opts = { isDuplicate: true };
 					instance.validateUniquenessInGroup(opts);
@@ -376,7 +411,40 @@ describe('Base model', () => {
 					expect(instance.hasDifferentiatorProperty.calledWithExactly()).to.be.true;
 					expect(instance.hasQualifierProperty.calledOnce).to.be.true;
 					expect(instance.hasQualifierProperty.calledWithExactly()).to.be.true;
-					expect(instance.addPropertyError.calledThrice).to.be.true;
+					expect(instance.hasGroupProperty.calledOnce).to.be.true;
+					expect(instance.hasGroupProperty.calledWithExactly()).to.be.true;
+					expect(instance.addPropertyError.calledTwice).to.be.true;
+					expect(instance.addPropertyError.firstCall.calledWithExactly(
+						'name', 'This item has been duplicated within the group'
+					)).to.be.true;
+					expect(instance.addPropertyError.secondCall.calledWithExactly(
+						'group', 'This item has been duplicated within the group'
+					)).to.be.true;
+
+				});
+
+			});
+
+			context('instance has differentiator, qualifier, and group property', () => {
+
+				it('will call addPropertyError method with group context error text for name, differentiator, qualifier, and group properties', () => {
+
+					instance.differentiator = '';
+					instance.qualifier = '';
+					instance.group = '';
+					spy(instance, 'hasDifferentiatorProperty');
+					spy(instance, 'hasQualifierProperty');
+					spy(instance, 'hasGroupProperty');
+					spy(instance, 'addPropertyError');
+					const opts = { isDuplicate: true };
+					instance.validateUniquenessInGroup(opts);
+					expect(instance.hasDifferentiatorProperty.calledOnce).to.be.true;
+					expect(instance.hasDifferentiatorProperty.calledWithExactly()).to.be.true;
+					expect(instance.hasQualifierProperty.calledOnce).to.be.true;
+					expect(instance.hasQualifierProperty.calledWithExactly()).to.be.true;
+					expect(instance.hasGroupProperty.calledOnce).to.be.true;
+					expect(instance.hasGroupProperty.calledWithExactly()).to.be.true;
+					expect(instance.addPropertyError.callCount).to.equal(4);
 					expect(instance.addPropertyError.firstCall.calledWithExactly(
 						'name', 'This item has been duplicated within the group'
 					)).to.be.true;
@@ -385,6 +453,9 @@ describe('Base model', () => {
 					)).to.be.true;
 					expect(instance.addPropertyError.thirdCall.calledWithExactly(
 						'qualifier', 'This item has been duplicated within the group'
+					)).to.be.true;
+					expect(instance.addPropertyError.getCall(3).calledWithExactly(
+						'group', 'This item has been duplicated within the group'
 					)).to.be.true;
 
 				});

--- a/test-unit/src/models/Character.test.js
+++ b/test-unit/src/models/Character.test.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { spy } from 'sinon';
 
 import Character from '../../../src/models/Character';
 
@@ -103,6 +104,81 @@ describe('Character model', () => {
 				});
 
 			});
+
+		});
+
+		describe('group property', () => {
+
+			context('instance is subject', () => {
+
+				it('will not assign any value if absent from props', () => {
+
+					const instance = new Character({ name: 'Tamora' });
+					expect(instance).not.to.have.property('characters');
+
+				});
+
+				it('will not assign any value if included in props', () => {
+
+					const instance = new Character({ name: 'Tamora', group: 'Goths' });
+					expect(instance).not.to.have.property('group');
+
+				});
+
+			});
+
+			context('instance is not subject, i.e. it is an association of another instance', () => {
+
+				it('assigns empty string if absent from props', () => {
+
+					const instance = new Character({ name: 'Tamora', isAssociation: true });
+					expect(instance.group).to.equal('');
+
+				});
+
+				it('assigns empty string if included in props but value is empty string', () => {
+
+					const instance = new Character({ name: 'Tamora', group: '', isAssociation: true });
+					expect(instance.group).to.equal('');
+
+				});
+
+				it('assigns empty string if included in props but value is whitespace-only string', () => {
+
+					const instance = new Character({ name: 'Tamora', group: ' ', isAssociation: true });
+					expect(instance.group).to.equal('');
+
+				});
+
+				it('assigns value if included in props and value is string with length', () => {
+
+					const instance = new Character({ name: 'Tamora', group: 'Goths', isAssociation: true });
+					expect(instance.group).to.equal('Goths');
+
+				});
+
+				it('trims value before assigning', () => {
+
+					const instance = new Character({ name: 'Tamora', group: ' Goths ', isAssociation: true });
+					expect(instance.group).to.equal('Goths');
+
+				});
+
+			});
+
+		});
+
+	});
+
+	describe('validateGroup method', () => {
+
+		it('will call validateStringForProperty method', () => {
+
+			const instance = new Character({ name: 'Bottom', group: 'The Mechanicals', isAssociation: true });
+			spy(instance, 'validateStringForProperty');
+			instance.validateGroup();
+			expect(instance.validateStringForProperty.calledOnce).to.be.true;
+			expect(instance.validateStringForProperty.calledWithExactly('group', { isRequired: false })).to.be.true;
 
 		});
 

--- a/test-unit/src/models/Playtext.test.js
+++ b/test-unit/src/models/Playtext.test.js
@@ -177,6 +177,7 @@ describe('Playtext model', () => {
 				instance.characters[0].validateName,
 				instance.characters[0].validateDifferentiator,
 				instance.characters[0].validateQualifier,
+				instance.characters[0].validateGroup,
 				instance.characters[0].validateUniquenessInGroup
 			);
 			expect(instance.validateName.calledOnce).to.be.true;
@@ -193,6 +194,8 @@ describe('Playtext model', () => {
 			expect(instance.characters[0].validateDifferentiator.calledWithExactly()).to.be.true;
 			expect(instance.characters[0].validateQualifier.calledOnce).to.be.true;
 			expect(instance.characters[0].validateQualifier.calledWithExactly()).to.be.true;
+			expect(instance.characters[0].validateGroup.calledOnce).to.be.true;
+			expect(instance.characters[0].validateGroup.calledWithExactly()).to.be.true;
 			expect(instance.characters[0].validateUniquenessInGroup.calledOnce).to.be.true;
 			expect(instance.characters[0].validateUniquenessInGroup.calledWithExactly(
 				{ isDuplicate: false }

--- a/test-unit/src/neo4j/cypher-queries/playtext.test.js
+++ b/test-unit/src/neo4j/cypher-queries/playtext.test.js
@@ -30,7 +30,8 @@ describe('Cypher Queries Playtext module', () => {
 								uuid: characterParam.uuid,
 								name: characterParam.name,
 								differentiator: characterParam.differentiator,
-								qualifier: characterParam.qualifier
+								qualifier: characterParam.qualifier,
+								group: characterParam.group
 							}
 							ELSE existingCharacter
 						END AS characterProps
@@ -40,8 +41,11 @@ describe('Cypher Queries Playtext module', () => {
 							ON CREATE SET character.differentiator = characterProps.differentiator
 
 						CREATE (playtext)-
-							[:INCLUDES_CHARACTER { position: characterParam.position, qualifier: characterParam.qualifier }]->
-							(character)
+							[:INCLUDES_CHARACTER {
+								position: characterParam.position,
+								qualifier: characterParam.qualifier,
+								group: characterParam.group
+							}]->(character)
 					)
 
 				WITH DISTINCT playtext
@@ -64,7 +68,8 @@ describe('Cypher Queries Playtext module', () => {
 							ELSE {
 								name: character.name,
 								differentiator: character.differentiator,
-								qualifier: characterRel.qualifier
+								qualifier: characterRel.qualifier,
+								group: characterRel.group
 							}
 						END
 					) + [{ name: '' }] AS characters
@@ -109,7 +114,8 @@ describe('Cypher Queries Playtext module', () => {
 								uuid: characterParam.uuid,
 								name: characterParam.name,
 								differentiator: characterParam.differentiator,
-								qualifier: characterParam.qualifier
+								qualifier: characterParam.qualifier,
+								group: characterParam.group
 							}
 							ELSE existingCharacter
 						END AS characterProps
@@ -119,8 +125,11 @@ describe('Cypher Queries Playtext module', () => {
 							ON CREATE SET character.differentiator = characterProps.differentiator
 
 						CREATE (playtext)-
-							[:INCLUDES_CHARACTER { position: characterParam.position, qualifier: characterParam.qualifier }]->
-							(character)
+							[:INCLUDES_CHARACTER {
+								position: characterParam.position,
+								qualifier: characterParam.qualifier,
+								group: characterParam.group
+							}]->(character)
 					)
 
 				WITH DISTINCT playtext
@@ -143,7 +152,8 @@ describe('Cypher Queries Playtext module', () => {
 							ELSE {
 								name: character.name,
 								differentiator: character.differentiator,
-								qualifier: characterRel.qualifier
+								qualifier: characterRel.qualifier,
+								group: characterRel.group
 							}
 						END
 					) + [{ name: '' }] AS characters


### PR DESCRIPTION
Playtexts can often divide their characters into groups.

This PR adds a `group` property to characters being added to a playtext. In the database, the property will live on the relationship between the character and the playtext (rather than on the character itself as this grouping may only apply in the context of its relationship to that specific playtext).

The decision was made to add a `group` property to each individual character rather than a `characterGroup` object in which the characters were nested (which would admittedly prevent repetition of the `group` name value for all its members) so as to allow for the structure of the user-submitted data to remain consistent in both scenarios of the presence and absence of groups, e.g.

#### Different data structure for each scenario:
- presence of groups:
```
{
	characterGroups: [
		{
			name: "Romans",
			characters: [
				{
					name: "Titus Andronicus"
				},
				{
					name: "Lucius"
				}
			]
		},
		{
			name: "Goths",
			characters: [
				{
					name: "Tamora"
				},
				{
					name: "Alarbus"
				}
			]
		}
	]
}
```
- absence of groups:
```
{
	characters: [
		{
			name: "Winnie"
		},
		{
			name: "Willie"
		}
	]
}
```

**vs.**

#### Consistent data structure for each scenario:
- presence of absence of groups:
```
{
	characters: [
		{
			name: "Titus Andronicus",
			group: "Romans"
		},
		{
			name: "Lucius",
			group: "Romans"
		},
		{
			name: "Tamora",
			group: "Goths"
		},
		{
			name: "Alarbus",
			group: "Goths"
		}
	]
}
```

```
{
	characters: [
		{
			name: "Winnie"
		},
		{
			name: "Willie"
		}
	]
}
```

More vitally, this means that the structure in the Neo4j database remains consistent, which is especially important given that data is queried on a pattern-matching basis, i.e. the same pattern in a query can be used to capture characters regardless of whether they are in a group or not (thought it is still equally easy to apply a conditional of whether they are in a group or not by examining the presence of the `group` property).

When returning data to display on the front-end, the Neo4j Cypher query applies `characterGroups` whether they exist or not, and so responds with a normalised structure that the front-end apps handle.

An example of a playtext that groups its characters is 3 Winters by Tena Stivičić, in which the characters are grouped by the three titular winters over which the action takes place: 1945, 1990, and 1945. Also noteworthy is that some characters appear in more than one group, at different stages of their life.

#### 3 Winters (playtext) characters:
<img width="592" alt="3-winters-characters" src="https://user-images.githubusercontent.com/10484515/93671906-aa782a00-fa9e-11ea-8ebb-edd5d0c8c61f.png">

---

#### 3 Winters at National Theatre (production) cast:
<img width="748" alt="3-winters-cast" src="https://user-images.githubusercontent.com/10484515/93671908-af3cde00-fa9e-11ea-9799-dde613004019.png">

---

#### 3 Winters (playtext):
<img width="211" alt="3-winters-playtext" src="https://user-images.githubusercontent.com/10484515/93671914-b9f77300-fa9e-11ea-8056-a23693b09ed2.png">

---

#### 3 Winters at National Theatre (production):
<img width="311" alt="3-winters-national-production" src="https://user-images.githubusercontent.com/10484515/93671918-c24fae00-fa9e-11ea-9e9c-eb3dbf859638.png">

---

#### Alisa Kos (character):
<img width="708" alt="alisa-kos-character" src="https://user-images.githubusercontent.com/10484515/93671919-c976bc00-fa9e-11ea-9095-a7c9881549d2.png">

---

#### Jodie McNee (person):
<img width="326" alt="jodie-mcnee-person" src="https://user-images.githubusercontent.com/10484515/93671923-cf6c9d00-fa9e-11ea-89ad-f1a6db8b4dfc.png">

---

#### Bebe Sanders (person):
<img width="329" alt="bebe-sanders-person" src="https://user-images.githubusercontent.com/10484515/93671927-d693ab00-fa9e-11ea-9887-1e6827d9ae15.png">

---

#### Maša Kos (character):
<img width="491" alt="masa-kos-character" src="https://user-images.githubusercontent.com/10484515/93671947-eb703e80-fa9e-11ea-8333-26e2be33ab60.png">

---

#### Siobhan Finneran (person):
<img width="309" alt="siobhan-finneran-person" src="https://user-images.githubusercontent.com/10484515/93671951-f1feb600-fa9e-11ea-9560-bc7737986dbd.png">