### PR TITLE
Add database seeds to demonstrate playtext character groups

### DIFF
--- a/db-seeding/seeds/playtexts/3-winters.json
+++ b/db-seeding/seeds/playtexts/3-winters.json
@@ -1,0 +1,89 @@
+{
+	"name": "3 Winters",
+	"characters": [
+		{
+			"name": "Alisa Kos",
+			"group": "2011"
+		},
+		{
+			"name": "Lucija Kos",
+			"group": "2011"
+		},
+		{
+			"name": "Maša Kos",
+			"group": "2011"
+		},
+		{
+			"name": "Vlado Kos",
+			"group": "2011"
+		},
+		{
+			"name": "Dunja King",
+			"group": "2011"
+		},
+		{
+			"name": "Marko Horvat",
+			"group": "2011"
+		},
+		{
+			"name": "Maša Kos",
+			"group": "1990"
+		},
+		{
+			"name": "Vlado Kos",
+			"group": "1990"
+		},
+		{
+			"name": "Dunja King",
+			"group": "1990"
+		},
+		{
+			"name": "Karl Dolinar",
+			"group": "1990"
+		},
+		{
+			"name": "Karolina Amruš",
+			"group": "1990"
+		},
+		{
+			"name": "Igor Maljević",
+			"group": "1990"
+		},
+		{
+			"name": "Aleksander King",
+			"group": "1990"
+		},
+		{
+			"name": "Alisa Kos",
+			"group": "1990"
+		},
+		{
+			"name": "Lucija Kos",
+			"group": "1990"
+		},
+		{
+			"name": "Marko Horvat",
+			"group": "1990"
+		},
+		{
+			"name": "Rose King",
+			"group": "1945"
+		},
+		{
+			"name": "Aleksander King",
+			"group": "1945"
+		},
+		{
+			"name": "Monika Zima",
+			"group": "1945"
+		},
+		{
+			"name": "Karolina Amruš",
+			"group": "1945"
+		},
+		{
+			"name": "Marinko",
+			"group": "1945"
+		}
+	]
+}

--- a/db-seeding/seeds/productions/3-winters.json
+++ b/db-seeding/seeds/productions/3-winters.json
@@ -1,0 +1,160 @@
+{
+	"name": "3 Winters",
+	"theatre": {
+		"name": "National Theatre"
+	},
+	"playtext": {
+		"name": "3 Winters"
+	},
+	"cast": [
+		{
+			"name": "Charlotte Beaumont",
+			"roles": [
+				{
+					"name": "Lucija Kos",
+					"qualifier": "1990"
+				}
+			]
+		},
+		{
+			"name": "Lucy Black",
+			"roles": [
+				{
+					"name": "Dunja King"
+				}
+			]
+		},
+		{
+			"name": "Susan Engel",
+			"roles": [
+				{
+					"name": "Karolina Amruš",
+					"qualifier": "1990"
+				}
+			]
+		},
+		{
+			"name": "Siobhan Finneran",
+			"roles": [
+				{
+					"name": "Maša Kos"
+				}
+			]
+		},
+		{
+			"name": "Daniel Flynn",
+			"roles": [
+				{
+					"name": "Karl Dolinar"
+				}
+			]
+		},
+		{
+			"name": "Hermoine Gulliford",
+			"roles": [
+				{
+					"name": "Karolina Amruš",
+					"qualifier": "1945"
+				}
+			]
+		},
+		{
+			"name": "Jo Herbert",
+			"roles": [
+				{
+					"name": "Rose King"
+				}
+			]
+		},
+		{
+			"name": "Alex Jordan",
+			"roles": [
+				{
+					"name": "Marko Horvat",
+					"qualifier": "1990"
+				}
+			]
+		},
+		{
+			"name": "Gerald Kyd",
+			"roles": [
+				{
+					"name": "Marinko"
+				},
+				{
+					"name": "Marko Horvat",
+					"qualifier": "2011"
+				}
+			]
+		},
+		{
+			"name": "James Laurenson",
+			"roles": [
+				{
+					"name": "Aleksander King",
+					"qualifier": "1990"
+				}
+			]
+		},
+		{
+			"name": "Jonny Magnanti",
+			"roles": [
+				{
+					"name": "Igor Maljević"
+				}
+			]
+		},
+		{
+			"name": "Jodie McNee",
+			"roles": [
+				{
+					"name": "Alisa Kos",
+					"qualifier": "2011"
+				}
+			]
+		},
+		{
+			"name": "Alex Price",
+			"roles": [
+				{
+					"name": "Aleksander King",
+					"qualifier": "1945"
+				}
+			]
+		},
+		{
+			"name": "Adrian Rawlins",
+			"roles": [
+				{
+					"name": "Vlado Kos"
+				}
+			]
+		},
+		{
+			"name": "Sophie Rundle",
+			"roles": [
+				{
+					"name": "Lucija Kos",
+					"qualifier": "2011"
+				}
+			]
+		},
+		{
+			"name": "Bebe Sanders",
+			"roles": [
+				{
+					"name": "Alisa Kos",
+					"qualifier": "1990"
+				}
+			]
+		},
+		{
+			"name": "Josie Walker",
+			"roles": [
+				{
+					"name": "Monika Zima"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
Database seeds to demonstrate the playtext character `group` property added in this PR: https://github.com/andygout/theatrebase-api/pull/227.