### PR TITLE
Revise end-to-end test results acquisition

### DIFF
--- a/test-e2e/model-interaction/cast-member-diff-roles-of-playtext.test.js
+++ b/test-e2e/model-interaction/cast-member-diff-roles-of-playtext.test.js
@@ -145,59 +145,52 @@ describe('Cast member performing different roles in different productions of sam
 
 		it('includes productions in which character was portrayed (including performers who portrayed them)', () => {
 
-			const expectedKingLearRoyalShakespeareProduction = {
-				model: 'production',
-				uuid: KING_LEAR_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
-				name: 'King Lear',
-				theatre: {
-					model: 'theatre',
-					uuid: ROYAL_SHAKESPEARE_THEATRE_UUID,
-					name: 'Royal Shakespeare Theatre'
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: KING_LEAR_BARBICAN_PRODUCTION_UUID,
+					name: 'King Lear',
+					theatre: {
+						model: 'theatre',
+						uuid: BARBICAN_THEATRE_UUID,
+						name: 'Barbican'
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: ANTONY_SHER_PERSON_UUID,
+							name: 'Antony Sher',
+							roleName: 'King Lear',
+							qualifier: null,
+							otherRoles: []
+						}
+					]
 				},
-				performers: [
-					{
-						model: 'person',
-						uuid: MICHAEL_GAMBON_PERSON_UUID,
-						name: 'Michael Gambon',
-						roleName: 'King Lear',
-						qualifier: null,
-						otherRoles: []
-					}
-				]
-			};
-
-			const expectedKingLearBarbicanProduction = {
-				model: 'production',
-				uuid: KING_LEAR_BARBICAN_PRODUCTION_UUID,
-				name: 'King Lear',
-				theatre: {
-					model: 'theatre',
-					uuid: BARBICAN_THEATRE_UUID,
-					name: 'Barbican'
-				},
-				performers: [
-					{
-						model: 'person',
-						uuid: ANTONY_SHER_PERSON_UUID,
-						name: 'Antony Sher',
-						roleName: 'King Lear',
-						qualifier: null,
-						otherRoles: []
-					}
-				]
-			};
+				{
+					model: 'production',
+					uuid: KING_LEAR_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
+					name: 'King Lear',
+					theatre: {
+						model: 'theatre',
+						uuid: ROYAL_SHAKESPEARE_THEATRE_UUID,
+						name: 'Royal Shakespeare Theatre'
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: MICHAEL_GAMBON_PERSON_UUID,
+							name: 'Michael Gambon',
+							roleName: 'King Lear',
+							qualifier: null,
+							otherRoles: []
+						}
+					]
+				}
+			];
 
 			const { productions } = kingLearCharacter.body;
 
-			const kingLearRoyalShakespeareProduction =
-				productions.find(production => production.uuid === KING_LEAR_ROYAL_SHAKESPEARE_PRODUCTION_UUID);
-
-			const kingLearBarbicanProduction =
-				productions.find(production => production.uuid === KING_LEAR_BARBICAN_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(2);
-			expect(kingLearRoyalShakespeareProduction).to.deep.equal(expectedKingLearRoyalShakespeareProduction);
-			expect(kingLearBarbicanProduction).to.deep.equal(expectedKingLearBarbicanProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -207,59 +200,52 @@ describe('Cast member performing different roles in different productions of sam
 
 		it('includes productions in which character was portrayed (including performers who portrayed them)', () => {
 
-			const expectedKingLearRoyalShakespeareProduction = {
-				model: 'production',
-				uuid: KING_LEAR_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
-				name: 'King Lear',
-				theatre: {
-					model: 'theatre',
-					uuid: ROYAL_SHAKESPEARE_THEATRE_UUID,
-					name: 'Royal Shakespeare Theatre'
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: KING_LEAR_BARBICAN_PRODUCTION_UUID,
+					name: 'King Lear',
+					theatre: {
+						model: 'theatre',
+						uuid: BARBICAN_THEATRE_UUID,
+						name: 'Barbican'
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: GRAHAM_TURNER_PERSON_UUID,
+							name: 'Graham Turner',
+							roleName: 'Fool',
+							qualifier: null,
+							otherRoles: []
+						}
+					]
 				},
-				performers: [
-					{
-						model: 'person',
-						uuid: ANTONY_SHER_PERSON_UUID,
-						name: 'Antony Sher',
-						roleName: 'Fool',
-						qualifier: null,
-						otherRoles: []
-					}
-				]
-			};
-
-			const expectedKingLearBarbicanProduction = {
-				model: 'production',
-				uuid: KING_LEAR_BARBICAN_PRODUCTION_UUID,
-				name: 'King Lear',
-				theatre: {
-					model: 'theatre',
-					uuid: BARBICAN_THEATRE_UUID,
-					name: 'Barbican'
-				},
-				performers: [
-					{
-						model: 'person',
-						uuid: GRAHAM_TURNER_PERSON_UUID,
-						name: 'Graham Turner',
-						roleName: 'Fool',
-						qualifier: null,
-						otherRoles: []
-					}
-				]
-			};
+				{
+					model: 'production',
+					uuid: KING_LEAR_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
+					name: 'King Lear',
+					theatre: {
+						model: 'theatre',
+						uuid: ROYAL_SHAKESPEARE_THEATRE_UUID,
+						name: 'Royal Shakespeare Theatre'
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: ANTONY_SHER_PERSON_UUID,
+							name: 'Antony Sher',
+							roleName: 'Fool',
+							qualifier: null,
+							otherRoles: []
+						}
+					]
+				}
+			];
 
 			const { productions } = foolCharacter.body;
 
-			const kingLearRoyalShakespeareProduction =
-				productions.find(production => production.uuid === KING_LEAR_ROYAL_SHAKESPEARE_PRODUCTION_UUID);
-
-			const kingLearBarbicanProduction =
-				productions.find(production => production.uuid === KING_LEAR_BARBICAN_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(2);
-			expect(kingLearRoyalShakespeareProduction).to.deep.equal(expectedKingLearRoyalShakespeareProduction);
-			expect(kingLearBarbicanProduction).to.deep.equal(expectedKingLearBarbicanProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -269,42 +255,38 @@ describe('Cast member performing different roles in different productions of sam
 
 		it('includes cast with Michael Gambon as King Lear and Antony Sher as Fool', () => {
 
-			const expectedCastMemberMichaelGambon = {
-				model: 'person',
-				uuid: MICHAEL_GAMBON_PERSON_UUID,
-				name: 'Michael Gambon',
-				roles: [
-					{
-						model: 'character',
-						uuid: KING_LEAR_CHARACTER_UUID,
-						name: 'King Lear',
-						qualifier: null
-					}
-				]
-			};
-
-			const expectedCastMemberAntonySher = {
-				model: 'person',
-				uuid: ANTONY_SHER_PERSON_UUID,
-				name: 'Antony Sher',
-				roles: [
-					{
-						model: 'character',
-						uuid: FOOL_CHARACTER_UUID,
-						name: 'Fool',
-						qualifier: null
-					}
-				]
-			};
+			const expectedCast = [
+				{
+					model: 'person',
+					uuid: MICHAEL_GAMBON_PERSON_UUID,
+					name: 'Michael Gambon',
+					roles: [
+						{
+							model: 'character',
+							uuid: KING_LEAR_CHARACTER_UUID,
+							name: 'King Lear',
+							qualifier: null
+						}
+					]
+				},
+				{
+					model: 'person',
+					uuid: ANTONY_SHER_PERSON_UUID,
+					name: 'Antony Sher',
+					roles: [
+						{
+							model: 'character',
+							uuid: FOOL_CHARACTER_UUID,
+							name: 'Fool',
+							qualifier: null
+						}
+					]
+				}
+			];
 
 			const { cast } = kingLearRoyalShakespeareProduction.body;
 
-			const castMemberMichaelGambon = cast.find(castMember => castMember.uuid === MICHAEL_GAMBON_PERSON_UUID);
-			const castMemberAntonySher = cast.find(castMember => castMember.uuid === ANTONY_SHER_PERSON_UUID);
-
-			expect(cast.length).to.equal(2);
-			expect(castMemberMichaelGambon).to.deep.equal(expectedCastMemberMichaelGambon);
-			expect(castMemberAntonySher).to.deep.equal(expectedCastMemberAntonySher);
+			expect(cast).to.deep.equal(expectedCast);
 
 		});
 
@@ -314,42 +296,38 @@ describe('Cast member performing different roles in different productions of sam
 
 		it('includes cast with Antony Sher as King Lear and Graham Turner as Fool', () => {
 
-			const expectedCastMemberAntonySher = {
-				model: 'person',
-				uuid: ANTONY_SHER_PERSON_UUID,
-				name: 'Antony Sher',
-				roles: [
-					{
-						model: 'character',
-						uuid: KING_LEAR_CHARACTER_UUID,
-						name: 'King Lear',
-						qualifier: null
-					}
-				]
-			};
-
-			const expectedCastMemberGrahamTurner = {
-				model: 'person',
-				uuid: GRAHAM_TURNER_PERSON_UUID,
-				name: 'Graham Turner',
-				roles: [
-					{
-						model: 'character',
-						uuid: FOOL_CHARACTER_UUID,
-						name: 'Fool',
-						qualifier: null
-					}
-				]
-			};
+			const expectedCast = [
+				{
+					model: 'person',
+					uuid: ANTONY_SHER_PERSON_UUID,
+					name: 'Antony Sher',
+					roles: [
+						{
+							model: 'character',
+							uuid: KING_LEAR_CHARACTER_UUID,
+							name: 'King Lear',
+							qualifier: null
+						}
+					]
+				},
+				{
+					model: 'person',
+					uuid: GRAHAM_TURNER_PERSON_UUID,
+					name: 'Graham Turner',
+					roles: [
+						{
+							model: 'character',
+							uuid: FOOL_CHARACTER_UUID,
+							name: 'Fool',
+							qualifier: null
+						}
+					]
+				}
+			];
 
 			const { cast } = kingLearBarbicanProduction.body;
 
-			const castMemberAntonySher = cast.find(castMember => castMember.uuid === ANTONY_SHER_PERSON_UUID);
-			const castMemberGrahamTurner = cast.find(castMember => castMember.uuid === GRAHAM_TURNER_PERSON_UUID);
-
-			expect(cast.length).to.equal(2);
-			expect(castMemberAntonySher).to.deep.equal(expectedCastMemberAntonySher);
-			expect(castMemberGrahamTurner).to.deep.equal(expectedCastMemberGrahamTurner);
+			expect(cast).to.deep.equal(expectedCast);
 
 		});
 
@@ -359,32 +337,30 @@ describe('Cast member performing different roles in different productions of sam
 
 		it('includes production with his portrayal of King Lear', () => {
 
-			const expectedProduction = {
-				model: 'production',
-				uuid: KING_LEAR_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
-				name: 'King Lear',
-				theatre: {
-					model: 'theatre',
-					uuid: ROYAL_SHAKESPEARE_THEATRE_UUID,
-					name: 'Royal Shakespeare Theatre'
-				},
-				roles: [
-					{
-						model: 'character',
-						uuid: KING_LEAR_CHARACTER_UUID,
-						name: 'King Lear',
-						qualifier: null
-					}
-				]
-			};
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: KING_LEAR_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
+					name: 'King Lear',
+					theatre: {
+						model: 'theatre',
+						uuid: ROYAL_SHAKESPEARE_THEATRE_UUID,
+						name: 'Royal Shakespeare Theatre'
+					},
+					roles: [
+						{
+							model: 'character',
+							uuid: KING_LEAR_CHARACTER_UUID,
+							name: 'King Lear',
+							qualifier: null
+						}
+					]
+				}
+			];
 
 			const { productions } = michaelGambonPerson.body;
 
-			const production =
-				productions.find(production => production.uuid === KING_LEAR_ROYAL_SHAKESPEARE_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(production).to.deep.equal(expectedProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -394,55 +370,48 @@ describe('Cast member performing different roles in different productions of sam
 
 		it('includes production with his respective portrayals of King Lear and the Fool', () => {
 
-			const expectedKingLearRoyalShakespeareProduction = {
-				model: 'production',
-				uuid: KING_LEAR_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
-				name: 'King Lear',
-				theatre: {
-					model: 'theatre',
-					uuid: ROYAL_SHAKESPEARE_THEATRE_UUID,
-					name: 'Royal Shakespeare Theatre'
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: KING_LEAR_BARBICAN_PRODUCTION_UUID,
+					name: 'King Lear',
+					theatre: {
+						model: 'theatre',
+						uuid: BARBICAN_THEATRE_UUID,
+						name: 'Barbican'
+					},
+					roles: [
+						{
+							model: 'character',
+							uuid: KING_LEAR_CHARACTER_UUID,
+							name: 'King Lear',
+							qualifier: null
+						}
+					]
 				},
-				roles: [
-					{
-						model: 'character',
-						uuid: FOOL_CHARACTER_UUID,
-						name: 'Fool',
-						qualifier: null
-					}
-				]
-			};
-
-			const expectedKingLearBarbicanProduction = {
-				model: 'production',
-				uuid: KING_LEAR_BARBICAN_PRODUCTION_UUID,
-				name: 'King Lear',
-				theatre: {
-					model: 'theatre',
-					uuid: BARBICAN_THEATRE_UUID,
-					name: 'Barbican'
-				},
-				roles: [
-					{
-						model: 'character',
-						uuid: KING_LEAR_CHARACTER_UUID,
-						name: 'King Lear',
-						qualifier: null
-					}
-				]
-			};
+				{
+					model: 'production',
+					uuid: KING_LEAR_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
+					name: 'King Lear',
+					theatre: {
+						model: 'theatre',
+						uuid: ROYAL_SHAKESPEARE_THEATRE_UUID,
+						name: 'Royal Shakespeare Theatre'
+					},
+					roles: [
+						{
+							model: 'character',
+							uuid: FOOL_CHARACTER_UUID,
+							name: 'Fool',
+							qualifier: null
+						}
+					]
+				}
+			];
 
 			const { productions } = antonySherPerson.body;
 
-			const kingLearRoyalShakespeareProduction =
-				productions.find(production => production.uuid === KING_LEAR_ROYAL_SHAKESPEARE_PRODUCTION_UUID);
-
-			const kingLearBarbicanProduction =
-				productions.find(production => production.uuid === KING_LEAR_BARBICAN_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(2);
-			expect(kingLearRoyalShakespeareProduction).to.deep.equal(expectedKingLearRoyalShakespeareProduction);
-			expect(kingLearBarbicanProduction).to.deep.equal(expectedKingLearBarbicanProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -452,31 +421,30 @@ describe('Cast member performing different roles in different productions of sam
 
 		it('includes production with his portrayal of the Fool', () => {
 
-			const expectedProduction = {
-				model: 'production',
-				uuid: KING_LEAR_BARBICAN_PRODUCTION_UUID,
-				name: 'King Lear',
-				theatre: {
-					model: 'theatre',
-					uuid: BARBICAN_THEATRE_UUID,
-					name: 'Barbican'
-				},
-				roles: [
-					{
-						model: 'character',
-						uuid: FOOL_CHARACTER_UUID,
-						name: 'Fool',
-						qualifier: null
-					}
-				]
-			};
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: KING_LEAR_BARBICAN_PRODUCTION_UUID,
+					name: 'King Lear',
+					theatre: {
+						model: 'theatre',
+						uuid: BARBICAN_THEATRE_UUID,
+						name: 'Barbican'
+					},
+					roles: [
+						{
+							model: 'character',
+							uuid: FOOL_CHARACTER_UUID,
+							name: 'Fool',
+							qualifier: null
+						}
+					]
+				}
+			];
 
 			const { productions } = grahamTurnerPerson.body;
 
-			const production = productions.find(production => production.uuid === KING_LEAR_BARBICAN_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(production).to.deep.equal(expectedProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 

--- a/test-e2e/model-interaction/cast-member-same-role-of-playtext.test.js
+++ b/test-e2e/model-interaction/cast-member-same-role-of-playtext.test.js
@@ -113,60 +113,52 @@ describe('Cast member performing same role in different productions of same play
 
 		it('includes productions in which character was portrayed (including performers who portrayed them)', () => {
 
-			const expectedAMidsummerNightsDreamRoyalShakespeareProduction = {
-				model: 'production',
-				uuid: A_MIDSUMMER_NIGHTS_DREAM_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
-				name: 'A Midsummer Night\'s Dream',
-				theatre: {
-					model: 'theatre',
-					uuid: ROYAL_SHAKESPEARE_THEATRE_UUID,
-					name: 'Royal Shakespeare Theatre'
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: A_MIDSUMMER_NIGHTS_DREAM_ROSE_PRODUCTION_UUID,
+					name: 'A Midsummer Night\'s Dream',
+					theatre: {
+						model: 'theatre',
+						uuid: ROSE_THEATRE_UUID,
+						name: 'Rose Theatre'
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: JUDI_DENCH_PERSON_UUID,
+							name: 'Judi Dench',
+							roleName: 'Titania, Faerie Queene',
+							qualifier: null,
+							otherRoles: []
+						}
+					]
 				},
-				performers: [
-					{
-						model: 'person',
-						uuid: JUDI_DENCH_PERSON_UUID,
-						name: 'Judi Dench',
-						roleName: 'Titania',
-						qualifier: null,
-						otherRoles: []
-					}
-				]
-			};
-
-			const expectedAMidsummerNightsDreamRoseProduction = {
-				model: 'production',
-				uuid: A_MIDSUMMER_NIGHTS_DREAM_ROSE_PRODUCTION_UUID,
-				name: 'A Midsummer Night\'s Dream',
-				theatre: {
-					model: 'theatre',
-					uuid: ROSE_THEATRE_UUID,
-					name: 'Rose Theatre'
-				},
-				performers: [
-					{
-						model: 'person',
-						uuid: JUDI_DENCH_PERSON_UUID,
-						name: 'Judi Dench',
-						roleName: 'Titania, Faerie Queene',
-						qualifier: null,
-						otherRoles: []
-					}
-				]
-			};
+				{
+					model: 'production',
+					uuid: A_MIDSUMMER_NIGHTS_DREAM_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
+					name: 'A Midsummer Night\'s Dream',
+					theatre: {
+						model: 'theatre',
+						uuid: ROYAL_SHAKESPEARE_THEATRE_UUID,
+						name: 'Royal Shakespeare Theatre'
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: JUDI_DENCH_PERSON_UUID,
+							name: 'Judi Dench',
+							roleName: 'Titania',
+							qualifier: null,
+							otherRoles: []
+						}
+					]
+				}
+			];
 
 			const { productions } = titaniaCharacter.body;
 
-			const aMidsummerNightsDreamRoyalShakespeareProduction =
-				productions.find(production => production.uuid === A_MIDSUMMER_NIGHTS_DREAM_ROYAL_SHAKESPEARE_PRODUCTION_UUID);
-
-			const aMidsummerNightsDreamRoseProduction =
-				productions.find(production => production.uuid === A_MIDSUMMER_NIGHTS_DREAM_ROSE_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(2);
-			expect(aMidsummerNightsDreamRoyalShakespeareProduction)
-				.to.deep.equal(expectedAMidsummerNightsDreamRoyalShakespeareProduction);
-			expect(aMidsummerNightsDreamRoseProduction).to.deep.equal(expectedAMidsummerNightsDreamRoseProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -176,26 +168,25 @@ describe('Cast member performing same role in different productions of same play
 
 		it('includes cast with Judi Dench as Titania, Queen of the Fairies under a variant name (Titania)', () => {
 
-			const expectedCastMemberJudiDench = {
-				model: 'person',
-				uuid: JUDI_DENCH_PERSON_UUID,
-				name: 'Judi Dench',
-				roles: [
-					{
-						model: 'character',
-						uuid: TITANIA_CHARACTER_UUID,
-						name: 'Titania',
-						qualifier: null
-					}
-				]
-			};
+			const expectedCast = [
+				{
+					model: 'person',
+					uuid: JUDI_DENCH_PERSON_UUID,
+					name: 'Judi Dench',
+					roles: [
+						{
+							model: 'character',
+							uuid: TITANIA_CHARACTER_UUID,
+							name: 'Titania',
+							qualifier: null
+						}
+					]
+				}
+			];
 
 			const { cast } = aMidsummerNightsDreamRoyalShakespeareProduction.body;
 
-			const castMemberJudiDench = cast.find(castMember => castMember.uuid === JUDI_DENCH_PERSON_UUID);
-
-			expect(cast.length).to.equal(1);
-			expect(castMemberJudiDench).to.deep.equal(expectedCastMemberJudiDench);
+			expect(cast).to.deep.equal(expectedCast);
 
 		});
 
@@ -205,26 +196,25 @@ describe('Cast member performing same role in different productions of same play
 
 		it('includes cast with Judi Dench as Titania, Queen of the Fairies under a variant name (Titania, Faerie Queene)', () => {
 
-			const expectedCastMemberJudiDench = {
-				model: 'person',
-				uuid: JUDI_DENCH_PERSON_UUID,
-				name: 'Judi Dench',
-				roles: [
-					{
-						model: 'character',
-						uuid: TITANIA_CHARACTER_UUID,
-						name: 'Titania, Faerie Queene',
-						qualifier: null
-					}
-				]
-			};
+			const expectedCast = [
+				{
+					model: 'person',
+					uuid: JUDI_DENCH_PERSON_UUID,
+					name: 'Judi Dench',
+					roles: [
+						{
+							model: 'character',
+							uuid: TITANIA_CHARACTER_UUID,
+							name: 'Titania, Faerie Queene',
+							qualifier: null
+						}
+					]
+				}
+			];
 
 			const { cast } = aMidsummerNightsDreamRoseProduction.body;
 
-			const castMemberJudiDench = cast.find(castMember => castMember.uuid === JUDI_DENCH_PERSON_UUID);
-
-			expect(cast.length).to.equal(1);
-			expect(castMemberJudiDench).to.deep.equal(expectedCastMemberJudiDench);
+			expect(cast).to.deep.equal(expectedCast);
 
 		});
 
@@ -234,58 +224,48 @@ describe('Cast member performing same role in different productions of same play
 
 		it('includes production with her respective portrayals of Titania', () => {
 
-			const expectedAMidsummerNightsDreamRoyalShakespeareProduction = {
-				model: 'production',
-				uuid: A_MIDSUMMER_NIGHTS_DREAM_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
-				name: 'A Midsummer Night\'s Dream',
-				theatre: {
-					model: 'theatre',
-					uuid: ROYAL_SHAKESPEARE_THEATRE_UUID,
-					name: 'Royal Shakespeare Theatre'
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: A_MIDSUMMER_NIGHTS_DREAM_ROSE_PRODUCTION_UUID,
+					name: 'A Midsummer Night\'s Dream',
+					theatre: {
+						model: 'theatre',
+						uuid: ROSE_THEATRE_UUID,
+						name: 'Rose Theatre'
+					},
+					roles: [
+						{
+							model: 'character',
+							uuid: TITANIA_CHARACTER_UUID,
+							name: 'Titania, Faerie Queene',
+							qualifier: null
+						}
+					]
 				},
-				roles: [
-					{
-						model: 'character',
-						uuid: TITANIA_CHARACTER_UUID,
-						name: 'Titania',
-						qualifier: null
-					}
-				]
-			};
-
-			const expectedAMidsummerNightsDreamRoseProduction = {
-				model: 'production',
-				uuid: A_MIDSUMMER_NIGHTS_DREAM_ROSE_PRODUCTION_UUID,
-				name: 'A Midsummer Night\'s Dream',
-				theatre: {
-					model: 'theatre',
-					uuid: ROSE_THEATRE_UUID,
-					name: 'Rose Theatre'
-				},
-				roles: [
-					{
-						model: 'character',
-						uuid: TITANIA_CHARACTER_UUID,
-						name: 'Titania, Faerie Queene',
-						qualifier: null
-					}
-				]
-			};
+				{
+					model: 'production',
+					uuid: A_MIDSUMMER_NIGHTS_DREAM_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
+					name: 'A Midsummer Night\'s Dream',
+					theatre: {
+						model: 'theatre',
+						uuid: ROYAL_SHAKESPEARE_THEATRE_UUID,
+						name: 'Royal Shakespeare Theatre'
+					},
+					roles: [
+						{
+							model: 'character',
+							uuid: TITANIA_CHARACTER_UUID,
+							name: 'Titania',
+							qualifier: null
+						}
+					]
+				}
+			];
 
 			const { productions } = judiDenchPerson.body;
 
-			const aMidsummerNightsDreamRoyalShakespeareProduction =
-				productions.find(production =>
-					production.uuid === A_MIDSUMMER_NIGHTS_DREAM_ROYAL_SHAKESPEARE_PRODUCTION_UUID
-				);
-
-			const aMidsummerNightsDreamRoseProduction =
-				productions.find(production => production.uuid === A_MIDSUMMER_NIGHTS_DREAM_ROSE_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(2);
-			expect(aMidsummerNightsDreamRoyalShakespeareProduction)
-				.to.deep.equal(expectedAMidsummerNightsDreamRoyalShakespeareProduction);
-			expect(aMidsummerNightsDreamRoseProduction).to.deep.equal(expectedAMidsummerNightsDreamRoseProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 

--- a/test-e2e/model-interaction/cast-member-with-multiple-productions.test.js
+++ b/test-e2e/model-interaction/cast-member-with-multiple-productions.test.js
@@ -219,33 +219,31 @@ describe('Cast member with multiple production credits', () => {
 
 		it('includes Susannah Fellows in its cast (including characters she portrayed)', () => {
 
-			const expectedCastMemberSusannahFellows = {
-				model: 'person',
-				uuid: SUSANNAH_FELLOWS_PERSON_UUID,
-				name: 'Susannah Fellows',
-				roles: [
-					{
-						model: 'character',
-						uuid: null,
-						name: 'Chorus',
-						qualifier: null
-					},
-					{
-						model: 'character',
-						uuid: null,
-						name: 'Trojan slave',
-						qualifier: null
-					}
-				]
-			};
+			const expectedCast = [
+				{
+					model: 'person',
+					uuid: SUSANNAH_FELLOWS_PERSON_UUID,
+					name: 'Susannah Fellows',
+					roles: [
+						{
+							model: 'character',
+							uuid: null,
+							name: 'Chorus',
+							qualifier: null
+						},
+						{
+							model: 'character',
+							uuid: null,
+							name: 'Trojan slave',
+							qualifier: null
+						}
+					]
+				}
+			];
 
 			const { cast } = theGreeksAldwychProduction.body;
 
-			const castMemberSusannahFellows =
-				cast.find(castMember => castMember.uuid === SUSANNAH_FELLOWS_PERSON_UUID);
-
-			expect(cast.length).to.equal(1);
-			expect(castMemberSusannahFellows).to.deep.equal(expectedCastMemberSusannahFellows);
+			expect(cast).to.deep.equal(expectedCast);
 
 		});
 
@@ -255,33 +253,31 @@ describe('Cast member with multiple production credits', () => {
 
 		it('includes Susannah Fellows in its cast (including characters she portrayed)', () => {
 
-			const expectedCastMemberSusannahFellows = {
-				model: 'person',
-				uuid: SUSANNAH_FELLOWS_PERSON_UUID,
-				name: 'Susannah Fellows',
-				roles: [
-					{
-						model: 'character',
-						uuid: null,
-						name: 'Alaura Kingsley',
-						qualifier: null
-					},
-					{
-						model: 'character',
-						uuid: null,
-						name: 'Carla Haywood',
-						qualifier: null
-					}
-				]
-			};
+			const expectedCast = [
+				{
+					model: 'person',
+					uuid: SUSANNAH_FELLOWS_PERSON_UUID,
+					name: 'Susannah Fellows',
+					roles: [
+						{
+							model: 'character',
+							uuid: null,
+							name: 'Alaura Kingsley',
+							qualifier: null
+						},
+						{
+							model: 'character',
+							uuid: null,
+							name: 'Carla Haywood',
+							qualifier: null
+						}
+					]
+				}
+			];
 
 			const { cast } = cityOfAngelsPrinceOfWalesProduction.body;
 
-			const castMemberSusannahFellows =
-				cast.find(castMember => castMember.uuid === SUSANNAH_FELLOWS_PERSON_UUID);
-
-			expect(cast.length).to.equal(1);
-			expect(castMemberSusannahFellows).to.deep.equal(expectedCastMemberSusannahFellows);
+			expect(cast).to.deep.equal(expectedCast);
 
 		});
 
@@ -291,39 +287,37 @@ describe('Cast member with multiple production credits', () => {
 
 		it('includes Susannah Fellows in its cast (including characters she portrayed)', () => {
 
-			const expectedCastMemberSusannahFellows = {
-				model: 'person',
-				uuid: SUSANNAH_FELLOWS_PERSON_UUID,
-				name: 'Susannah Fellows',
-				roles: [
-					{
-						model: 'character',
-						uuid: null,
-						name: 'Congresswoman',
-						qualifier: null
-					},
-					{
-						model: 'character',
-						uuid: null,
-						name: 'Sheryl Sloman',
-						qualifier: null
-					},
-					{
-						model: 'character',
-						uuid: null,
-						name: 'Irene Gant',
-						qualifier: null
-					}
-				]
-			};
+			const expectedCast = [
+				{
+					model: 'person',
+					uuid: SUSANNAH_FELLOWS_PERSON_UUID,
+					name: 'Susannah Fellows',
+					roles: [
+						{
+							model: 'character',
+							uuid: null,
+							name: 'Congresswoman',
+							qualifier: null
+						},
+						{
+							model: 'character',
+							uuid: null,
+							name: 'Sheryl Sloman',
+							qualifier: null
+						},
+						{
+							model: 'character',
+							uuid: null,
+							name: 'Irene Gant',
+							qualifier: null
+						}
+					]
+				}
+			];
 
 			const { cast } = enronChichesterFestivalProduction.body;
 
-			const castMemberSusannahFellows =
-				cast.find(castMember => castMember.uuid === SUSANNAH_FELLOWS_PERSON_UUID);
-
-			expect(cast.length).to.equal(1);
-			expect(castMemberSusannahFellows).to.deep.equal(expectedCastMemberSusannahFellows);
+			expect(cast).to.deep.equal(expectedCast);
 
 		});
 

--- a/test-e2e/model-interaction/character-different-groups-same-playtext.test.js
+++ b/test-e2e/model-interaction/character-different-groups-same-playtext.test.js
@@ -197,64 +197,61 @@ describe('Character with multiple appearances in the same playtext in different 
 
 		it('includes playtexts in which character appears, including the groups applied', () => {
 
-			const expectedThreeWintersPlaytext = {
-				model: 'playtext',
-				uuid: THREE_WINTERS_PLAYTEXT_UUID,
-				name: '3 Winters',
-				qualifiers: [],
-				groups: [
-					'2011',
-					'1990'
-				]
-			};
+			const expectedPlaytexts = [
+				{
+					model: 'playtext',
+					uuid: THREE_WINTERS_PLAYTEXT_UUID,
+					name: '3 Winters',
+					qualifiers: [],
+					groups: [
+						'2011',
+						'1990'
+					]
+				}
+			];
 
 			const { playtexts } = alisaKosCharacter.body;
 
-			const threeWintersPlaytext = playtexts.find(playtext => playtext.uuid === THREE_WINTERS_PLAYTEXT_UUID);
-
-			expect(playtexts.length).to.equal(1);
-			expect(threeWintersPlaytext).to.deep.equal(expectedThreeWintersPlaytext);
+			expect(playtexts).to.deep.equal(expectedPlaytexts);
 
 		});
 
 		it('includes productions in which character is portrayed, including by which performer and in which group', () => {
 
-			const expectedThreeWintersNationalProduction = {
-				model: 'production',
-				uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
-				name: '3 Winters',
-				theatre: {
-					model: 'theatre',
-					uuid: NATIONAL_THEATRE_UUID,
-					name: 'National Theatre'
-				},
-				performers: [
-					{
-						model: 'person',
-						uuid: JODIE_MCNEE_PERSON_UUID,
-						name: 'Jodie McNee',
-						roleName: 'Alisa Kos',
-						qualifier: '2011',
-						otherRoles: []
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
+					name: '3 Winters',
+					theatre: {
+						model: 'theatre',
+						uuid: NATIONAL_THEATRE_UUID,
+						name: 'National Theatre'
 					},
-					{
-						model: 'person',
-						uuid: BEBE_SANDERS_PERSON_UUID,
-						name: 'Bebe Sanders',
-						roleName: 'Alisa Kos',
-						qualifier: '1990',
-						otherRoles: []
-					}
-				]
-			};
+					performers: [
+						{
+							model: 'person',
+							uuid: JODIE_MCNEE_PERSON_UUID,
+							name: 'Jodie McNee',
+							roleName: 'Alisa Kos',
+							qualifier: '2011',
+							otherRoles: []
+						},
+						{
+							model: 'person',
+							uuid: BEBE_SANDERS_PERSON_UUID,
+							name: 'Bebe Sanders',
+							roleName: 'Alisa Kos',
+							qualifier: '1990',
+							otherRoles: []
+						}
+					]
+				}
+			];
 
 			const { productions } = alisaKosCharacter.body;
 
-			const threeWintersNationalProduction =
-				productions.find(production => production.uuid === THREE_WINTERS_NATIONAL_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(threeWintersNationalProduction).to.deep.equal(expectedThreeWintersNationalProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -264,56 +261,53 @@ describe('Character with multiple appearances in the same playtext in different 
 
 		it('includes playtexts in which character appears, including the groups applied', () => {
 
-			const expectedThreeWintersPlaytext = {
-				model: 'playtext',
-				uuid: THREE_WINTERS_PLAYTEXT_UUID,
-				name: '3 Winters',
-				qualifiers: [],
-				groups: [
-					'2011',
-					'1990'
-				]
-			};
+			const expectedPlaytexts = [
+				{
+					model: 'playtext',
+					uuid: THREE_WINTERS_PLAYTEXT_UUID,
+					name: '3 Winters',
+					qualifiers: [],
+					groups: [
+						'2011',
+						'1990'
+					]
+				}
+			];
 
 			const { playtexts } = mašaKosCharacter.body;
 
-			const threeWintersPlaytext = playtexts.find(playtext => playtext.uuid === THREE_WINTERS_PLAYTEXT_UUID);
-
-			expect(playtexts.length).to.equal(1);
-			expect(threeWintersPlaytext).to.deep.equal(expectedThreeWintersPlaytext);
+			expect(playtexts).to.deep.equal(expectedPlaytexts);
 
 		});
 
 		it('includes productions in which character is portrayed, including by which performer and excluding group as not applied', () => {
 
-			const expectedThreeWintersNationalProduction = {
-				model: 'production',
-				uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
-				name: '3 Winters',
-				theatre: {
-					model: 'theatre',
-					uuid: NATIONAL_THEATRE_UUID,
-					name: 'National Theatre'
-				},
-				performers: [
-					{
-						model: 'person',
-						uuid: SIOBHAN_FINNERAN_PERSON_UUID,
-						name: 'Siobhan Finneran',
-						roleName: 'Maša Kos',
-						qualifier: null,
-						otherRoles: []
-					}
-				]
-			};
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
+					name: '3 Winters',
+					theatre: {
+						model: 'theatre',
+						uuid: NATIONAL_THEATRE_UUID,
+						name: 'National Theatre'
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: SIOBHAN_FINNERAN_PERSON_UUID,
+							name: 'Siobhan Finneran',
+							roleName: 'Maša Kos',
+							qualifier: null,
+							otherRoles: []
+						}
+					]
+				}
+			];
 
 			const { productions } = mašaKosCharacter.body;
 
-			const threeWintersNationalProduction =
-				productions.find(production => production.uuid === THREE_WINTERS_NATIONAL_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(threeWintersNationalProduction).to.deep.equal(expectedThreeWintersNationalProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -323,64 +317,61 @@ describe('Character with multiple appearances in the same playtext in different 
 
 		it('includes playtexts in which character appears, including the groups applied', () => {
 
-			const expectedThreeWintersPlaytext = {
-				model: 'playtext',
-				uuid: THREE_WINTERS_PLAYTEXT_UUID,
-				name: '3 Winters',
-				qualifiers: [],
-				groups: [
-					'1990',
-					'1945'
-				]
-			};
+			const expectedPlaytexts = [
+				{
+					model: 'playtext',
+					uuid: THREE_WINTERS_PLAYTEXT_UUID,
+					name: '3 Winters',
+					qualifiers: [],
+					groups: [
+						'1990',
+						'1945'
+					]
+				}
+			];
 
 			const { playtexts } = aleksanderKingCharacter.body;
 
-			const threeWintersPlaytext = playtexts.find(playtext => playtext.uuid === THREE_WINTERS_PLAYTEXT_UUID);
-
-			expect(playtexts.length).to.equal(1);
-			expect(threeWintersPlaytext).to.deep.equal(expectedThreeWintersPlaytext);
+			expect(playtexts).to.deep.equal(expectedPlaytexts);
 
 		});
 
 		it('includes productions in which character is portrayed, including by which performer and in which group', () => {
 
-			const expectedThreeWintersNationalProduction = {
-				model: 'production',
-				uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
-				name: '3 Winters',
-				theatre: {
-					model: 'theatre',
-					uuid: NATIONAL_THEATRE_UUID,
-					name: 'National Theatre'
-				},
-				performers: [
-					{
-						model: 'person',
-						uuid: JAMES_LAURENSON_PERSON_UUID,
-						name: 'James Laurenson',
-						roleName: 'Aleksander King',
-						qualifier: '1990',
-						otherRoles: []
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
+					name: '3 Winters',
+					theatre: {
+						model: 'theatre',
+						uuid: NATIONAL_THEATRE_UUID,
+						name: 'National Theatre'
 					},
-					{
-						model: 'person',
-						uuid: ALEX_PRICE_PERSON_UUID,
-						name: 'Alex Price',
-						roleName: 'Aleksander King',
-						qualifier: '1945',
-						otherRoles: []
-					}
-				]
-			};
+					performers: [
+						{
+							model: 'person',
+							uuid: JAMES_LAURENSON_PERSON_UUID,
+							name: 'James Laurenson',
+							roleName: 'Aleksander King',
+							qualifier: '1990',
+							otherRoles: []
+						},
+						{
+							model: 'person',
+							uuid: ALEX_PRICE_PERSON_UUID,
+							name: 'Alex Price',
+							roleName: 'Aleksander King',
+							qualifier: '1945',
+							otherRoles: []
+						}
+					]
+				}
+			];
 
 			const { productions } = aleksanderKingCharacter.body;
 
-			const threeWintersNationalProduction =
-				productions.find(production => production.uuid === THREE_WINTERS_NATIONAL_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(threeWintersNationalProduction).to.deep.equal(expectedThreeWintersNationalProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -390,55 +381,52 @@ describe('Character with multiple appearances in the same playtext in different 
 
 		it('includes playtexts in which character appears, including the groups applied', () => {
 
-			const expectedThreeWintersPlaytext = {
-				model: 'playtext',
-				uuid: THREE_WINTERS_PLAYTEXT_UUID,
-				name: '3 Winters',
-				qualifiers: [],
-				groups: [
-					'1945'
-				]
-			};
+			const expectedPlaytexts = [
+				{
+					model: 'playtext',
+					uuid: THREE_WINTERS_PLAYTEXT_UUID,
+					name: '3 Winters',
+					qualifiers: [],
+					groups: [
+						'1945'
+					]
+				}
+			];
 
 			const { playtexts } = roseKingCharacter.body;
 
-			const threeWintersPlaytext = playtexts.find(playtext => playtext.uuid === THREE_WINTERS_PLAYTEXT_UUID);
-
-			expect(playtexts.length).to.equal(1);
-			expect(threeWintersPlaytext).to.deep.equal(expectedThreeWintersPlaytext);
+			expect(playtexts).to.deep.equal(expectedPlaytexts);
 
 		});
 
 		it('includes productions in which character is portrayed, including by which performer and excluding group as not applied', () => {
 
-			const expectedThreeWintersNationalProduction = {
-				model: 'production',
-				uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
-				name: '3 Winters',
-				theatre: {
-					model: 'theatre',
-					uuid: NATIONAL_THEATRE_UUID,
-					name: 'National Theatre'
-				},
-				performers: [
-					{
-						model: 'person',
-						uuid: JO_HERBERT_PERSON_UUID,
-						name: 'Jo Herbert',
-						roleName: 'Rose King',
-						qualifier: null,
-						otherRoles: []
-					}
-				]
-			};
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
+					name: '3 Winters',
+					theatre: {
+						model: 'theatre',
+						uuid: NATIONAL_THEATRE_UUID,
+						name: 'National Theatre'
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: JO_HERBERT_PERSON_UUID,
+							name: 'Jo Herbert',
+							roleName: 'Rose King',
+							qualifier: null,
+							otherRoles: []
+						}
+					]
+				}
+			];
 
 			const { productions } = roseKingCharacter.body;
 
-			const threeWintersNationalProduction =
-				productions.find(production => production.uuid === THREE_WINTERS_NATIONAL_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(threeWintersNationalProduction).to.deep.equal(expectedThreeWintersNationalProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -523,106 +511,90 @@ describe('Character with multiple appearances in the same playtext in different 
 
 		it('includes the portrayers of the characters in its cast with their corresponding qualifiers', () => {
 
-			const expectedSiobhanFinneranCastMember = {
-				model: 'person',
-				uuid: SIOBHAN_FINNERAN_PERSON_UUID,
-				name: 'Siobhan Finneran',
-				roles: [
-					{
-						model: 'character',
-						uuid: MAŠA_KOS_CHARACTER_UUID,
-						name: 'Maša Kos',
-						qualifier: null
-					}
-				]
-			};
-
-			const expectedJoHerbertCastMember = {
-				model: 'person',
-				uuid: JO_HERBERT_PERSON_UUID,
-				name: 'Jo Herbert',
-				roles: [
-					{
-						model: 'character',
-						uuid: ROSE_KING_CHARACTER_UUID,
-						name: 'Rose King',
-						qualifier: null
-					}
-				]
-			};
-
-			const expectedJamesLaurensonCastMember = {
-				model: 'person',
-				uuid: JAMES_LAURENSON_PERSON_UUID,
-				name: 'James Laurenson',
-				roles: [
-					{
-						model: 'character',
-						uuid: ALEKSANDER_KING_CHARACTER_UUID,
-						name: 'Aleksander King',
-						qualifier: '1990'
-					}
-				]
-			};
-
-			const expectedJodieMcNeeCastMember = {
-				model: 'person',
-				uuid: JODIE_MCNEE_PERSON_UUID,
-				name: 'Jodie McNee',
-				roles: [
-					{
-						model: 'character',
-						uuid: ALISA_KOS_CHARACTER_UUID,
-						name: 'Alisa Kos',
-						qualifier: '2011'
-					}
-				]
-			};
-
-			const expectedAlexPriceCastMember = {
-				model: 'person',
-				uuid: ALEX_PRICE_PERSON_UUID,
-				name: 'Alex Price',
-				roles: [
-					{
-						model: 'character',
-						uuid: ALEKSANDER_KING_CHARACTER_UUID,
-						name: 'Aleksander King',
-						qualifier: '1945'
-					}
-				]
-			};
-
-			const expectedBebeSandersCastMember = {
-				model: 'person',
-				uuid: BEBE_SANDERS_PERSON_UUID,
-				name: 'Bebe Sanders',
-				roles: [
-					{
-						model: 'character',
-						uuid: ALISA_KOS_CHARACTER_UUID,
-						name: 'Alisa Kos',
-						qualifier: '1990'
-					}
-				]
-			};
+			const expectedCast = [
+				{
+					model: 'person',
+					uuid: SIOBHAN_FINNERAN_PERSON_UUID,
+					name: 'Siobhan Finneran',
+					roles: [
+						{
+							model: 'character',
+							uuid: MAŠA_KOS_CHARACTER_UUID,
+							name: 'Maša Kos',
+							qualifier: null
+						}
+					]
+				},
+				{
+					model: 'person',
+					uuid: JO_HERBERT_PERSON_UUID,
+					name: 'Jo Herbert',
+					roles: [
+						{
+							model: 'character',
+							uuid: ROSE_KING_CHARACTER_UUID,
+							name: 'Rose King',
+							qualifier: null
+						}
+					]
+				},
+				{
+					model: 'person',
+					uuid: JAMES_LAURENSON_PERSON_UUID,
+					name: 'James Laurenson',
+					roles: [
+						{
+							model: 'character',
+							uuid: ALEKSANDER_KING_CHARACTER_UUID,
+							name: 'Aleksander King',
+							qualifier: '1990'
+						}
+					]
+				},
+				{
+					model: 'person',
+					uuid: JODIE_MCNEE_PERSON_UUID,
+					name: 'Jodie McNee',
+					roles: [
+						{
+							model: 'character',
+							uuid: ALISA_KOS_CHARACTER_UUID,
+							name: 'Alisa Kos',
+							qualifier: '2011'
+						}
+					]
+				},
+				{
+					model: 'person',
+					uuid: ALEX_PRICE_PERSON_UUID,
+					name: 'Alex Price',
+					roles: [
+						{
+							model: 'character',
+							uuid: ALEKSANDER_KING_CHARACTER_UUID,
+							name: 'Aleksander King',
+							qualifier: '1945'
+						}
+					]
+				},
+				{
+					model: 'person',
+					uuid: BEBE_SANDERS_PERSON_UUID,
+					name: 'Bebe Sanders',
+					roles: [
+						{
+							model: 'character',
+							uuid: ALISA_KOS_CHARACTER_UUID,
+							name: 'Alisa Kos',
+							qualifier: '1990'
+						}
+					]
+				}
+			];
 
 			const { cast } = threeWintersNationalProduction.body;
 
-			const siobhanFinneranCastMember = cast.find(castMember => castMember.uuid === SIOBHAN_FINNERAN_PERSON_UUID);
-			const joHerbertCastMember = cast.find(castMember => castMember.uuid === JO_HERBERT_PERSON_UUID);
-			const jamesLaurensonCastMember = cast.find(castMember => castMember.uuid === JAMES_LAURENSON_PERSON_UUID);
-			const jodieMcNeeCastMember = cast.find(castMember => castMember.uuid === JODIE_MCNEE_PERSON_UUID);
-			const alexPriceCastMember = cast.find(castMember => castMember.uuid === ALEX_PRICE_PERSON_UUID);
-			const bebeSandersCastMember = cast.find(castMember => castMember.uuid === BEBE_SANDERS_PERSON_UUID);
-
-			expect(cast.length).to.equal(6);
-			expect(siobhanFinneranCastMember).to.deep.equal(expectedSiobhanFinneranCastMember);
-			expect(joHerbertCastMember).to.deep.equal(expectedJoHerbertCastMember);
-			expect(jamesLaurensonCastMember).to.deep.equal(expectedJamesLaurensonCastMember);
-			expect(jodieMcNeeCastMember).to.deep.equal(expectedJodieMcNeeCastMember);
-			expect(alexPriceCastMember).to.deep.equal(expectedAlexPriceCastMember);
-			expect(bebeSandersCastMember).to.deep.equal(expectedBebeSandersCastMember);
+			expect(cast).to.deep.equal(expectedCast);
 
 		});
 
@@ -632,32 +604,30 @@ describe('Character with multiple appearances in the same playtext in different 
 
 		it('includes in their production credits their portrayal of Maša Kos without a qualifier as not required', () => {
 
-			const expectedThreeWintersNationalProduction = {
-				model: 'production',
-				uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
-				name: '3 Winters',
-				theatre: {
-					model: 'theatre',
-					uuid: NATIONAL_THEATRE_UUID,
-					name: 'National Theatre'
-				},
-				roles: [
-					{
-						model: 'character',
-						uuid: MAŠA_KOS_CHARACTER_UUID,
-						name: 'Maša Kos',
-						qualifier: null
-					}
-				]
-			};
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
+					name: '3 Winters',
+					theatre: {
+						model: 'theatre',
+						uuid: NATIONAL_THEATRE_UUID,
+						name: 'National Theatre'
+					},
+					roles: [
+						{
+							model: 'character',
+							uuid: MAŠA_KOS_CHARACTER_UUID,
+							name: 'Maša Kos',
+							qualifier: null
+						}
+					]
+				}
+			];
 
 			const { productions } = siobhanFinneranPerson.body;
 
-			const threeWintersNationalProduction =
-				productions.find(production => production.uuid === THREE_WINTERS_NATIONAL_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(threeWintersNationalProduction).to.deep.equal(expectedThreeWintersNationalProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -667,32 +637,30 @@ describe('Character with multiple appearances in the same playtext in different 
 
 		it('includes in their production credits their portrayal of Rose King without a qualifier as not required', () => {
 
-			const expectedThreeWintersNationalProduction = {
-				model: 'production',
-				uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
-				name: '3 Winters',
-				theatre: {
-					model: 'theatre',
-					uuid: NATIONAL_THEATRE_UUID,
-					name: 'National Theatre'
-				},
-				roles: [
-					{
-						model: 'character',
-						uuid: ROSE_KING_CHARACTER_UUID,
-						name: 'Rose King',
-						qualifier: null
-					}
-				]
-			};
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
+					name: '3 Winters',
+					theatre: {
+						model: 'theatre',
+						uuid: NATIONAL_THEATRE_UUID,
+						name: 'National Theatre'
+					},
+					roles: [
+						{
+							model: 'character',
+							uuid: ROSE_KING_CHARACTER_UUID,
+							name: 'Rose King',
+							qualifier: null
+						}
+					]
+				}
+			];
 
 			const { productions } = joHerbertPerson.body;
 
-			const threeWintersNationalProduction =
-				productions.find(production => production.uuid === THREE_WINTERS_NATIONAL_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(threeWintersNationalProduction).to.deep.equal(expectedThreeWintersNationalProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -702,32 +670,30 @@ describe('Character with multiple appearances in the same playtext in different 
 
 		it('includes in their production credits their portrayal of Aleksander King with its corresponding qualifier (i.e. 1990)', () => {
 
-			const expectedThreeWintersNationalProduction = {
-				model: 'production',
-				uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
-				name: '3 Winters',
-				theatre: {
-					model: 'theatre',
-					uuid: NATIONAL_THEATRE_UUID,
-					name: 'National Theatre'
-				},
-				roles: [
-					{
-						model: 'character',
-						uuid: ALEKSANDER_KING_CHARACTER_UUID,
-						name: 'Aleksander King',
-						qualifier: '1990'
-					}
-				]
-			};
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
+					name: '3 Winters',
+					theatre: {
+						model: 'theatre',
+						uuid: NATIONAL_THEATRE_UUID,
+						name: 'National Theatre'
+					},
+					roles: [
+						{
+							model: 'character',
+							uuid: ALEKSANDER_KING_CHARACTER_UUID,
+							name: 'Aleksander King',
+							qualifier: '1990'
+						}
+					]
+				}
+			];
 
 			const { productions } = jamesLaurensonPerson.body;
 
-			const threeWintersNationalProduction =
-				productions.find(production => production.uuid === THREE_WINTERS_NATIONAL_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(threeWintersNationalProduction).to.deep.equal(expectedThreeWintersNationalProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -737,32 +703,30 @@ describe('Character with multiple appearances in the same playtext in different 
 
 		it('includes in their production credits their portrayal of Alisa Kos with its corresponding qualifier (i.e. 2011)', () => {
 
-			const expectedThreeWintersNationalProduction = {
-				model: 'production',
-				uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
-				name: '3 Winters',
-				theatre: {
-					model: 'theatre',
-					uuid: NATIONAL_THEATRE_UUID,
-					name: 'National Theatre'
-				},
-				roles: [
-					{
-						model: 'character',
-						uuid: ALISA_KOS_CHARACTER_UUID,
-						name: 'Alisa Kos',
-						qualifier: '2011'
-					}
-				]
-			};
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
+					name: '3 Winters',
+					theatre: {
+						model: 'theatre',
+						uuid: NATIONAL_THEATRE_UUID,
+						name: 'National Theatre'
+					},
+					roles: [
+						{
+							model: 'character',
+							uuid: ALISA_KOS_CHARACTER_UUID,
+							name: 'Alisa Kos',
+							qualifier: '2011'
+						}
+					]
+				}
+			];
 
 			const { productions } = jodieMcNeePerson.body;
 
-			const threeWintersNationalProduction =
-				productions.find(production => production.uuid === THREE_WINTERS_NATIONAL_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(threeWintersNationalProduction).to.deep.equal(expectedThreeWintersNationalProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -772,32 +736,30 @@ describe('Character with multiple appearances in the same playtext in different 
 
 		it('includes in their production credits their portrayal of Aleksander King with its corresponding qualifier (i.e. 1945)', () => {
 
-			const expectedThreeWintersNationalProduction = {
-				model: 'production',
-				uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
-				name: '3 Winters',
-				theatre: {
-					model: 'theatre',
-					uuid: NATIONAL_THEATRE_UUID,
-					name: 'National Theatre'
-				},
-				roles: [
-					{
-						model: 'character',
-						uuid: ALEKSANDER_KING_CHARACTER_UUID,
-						name: 'Aleksander King',
-						qualifier: '1945'
-					}
-				]
-			};
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
+					name: '3 Winters',
+					theatre: {
+						model: 'theatre',
+						uuid: NATIONAL_THEATRE_UUID,
+						name: 'National Theatre'
+					},
+					roles: [
+						{
+							model: 'character',
+							uuid: ALEKSANDER_KING_CHARACTER_UUID,
+							name: 'Aleksander King',
+							qualifier: '1945'
+						}
+					]
+				}
+			];
 
 			const { productions } = alexPricePerson.body;
 
-			const threeWintersNationalProduction =
-				productions.find(production => production.uuid === THREE_WINTERS_NATIONAL_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(threeWintersNationalProduction).to.deep.equal(expectedThreeWintersNationalProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -807,32 +769,30 @@ describe('Character with multiple appearances in the same playtext in different 
 
 		it('includes in their production credits their portrayal of Alisa Kos with its corresponding qualifier (i.e. 1990)', () => {
 
-			const expectedThreeWintersNationalProduction = {
-				model: 'production',
-				uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
-				name: '3 Winters',
-				theatre: {
-					model: 'theatre',
-					uuid: NATIONAL_THEATRE_UUID,
-					name: 'National Theatre'
-				},
-				roles: [
-					{
-						model: 'character',
-						uuid: ALISA_KOS_CHARACTER_UUID,
-						name: 'Alisa Kos',
-						qualifier: '1990'
-					}
-				]
-			};
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
+					name: '3 Winters',
+					theatre: {
+						model: 'theatre',
+						uuid: NATIONAL_THEATRE_UUID,
+						name: 'National Theatre'
+					},
+					roles: [
+						{
+							model: 'character',
+							uuid: ALISA_KOS_CHARACTER_UUID,
+							name: 'Alisa Kos',
+							qualifier: '1990'
+						}
+					]
+				}
+			];
 
 			const { productions } = bebeSandersPerson.body;
 
-			const threeWintersNationalProduction =
-				productions.find(production => production.uuid === THREE_WINTERS_NATIONAL_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(threeWintersNationalProduction).to.deep.equal(expectedThreeWintersNationalProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 

--- a/test-e2e/model-interaction/character-in-multiple-productions-of-multiple-playtexts.test.js
+++ b/test-e2e/model-interaction/character-in-multiple-productions-of-multiple-playtexts.test.js
@@ -527,20 +527,18 @@ describe('Character in multiple productions of multiple playtexts', () => {
 
 		it('includes Sir John Falstaff in its characters', () => {
 
-			const expectedSirJohnFalstaffCharacter = {
-				model: 'character',
-				uuid: SIR_JOHN_FALSTAFF_CHARACTER_UUID,
-				name: 'Sir John Falstaff',
-				qualifier: null
-			};
+			const expectedCharacters = [
+				{
+					model: 'character',
+					uuid: SIR_JOHN_FALSTAFF_CHARACTER_UUID,
+					name: 'Sir John Falstaff',
+					qualifier: null
+				}
+			];
 
 			const { characterGroups: [{ characters }] } = henryIVPart1Playtext.body;
 
-			const sirJohnFalstaffCharacter =
-				characters.find(character => character.uuid === SIR_JOHN_FALSTAFF_CHARACTER_UUID);
-
-			expect(characters.length).to.equal(1);
-			expect(sirJohnFalstaffCharacter).to.deep.equal(expectedSirJohnFalstaffCharacter);
+			expect(characters).to.deep.equal(expectedCharacters);
 
 		});
 
@@ -550,20 +548,18 @@ describe('Character in multiple productions of multiple playtexts', () => {
 
 		it('includes Sir John Falstaff in its characters', () => {
 
-			const expectedSirJohnFalstaffCharacter = {
-				model: 'character',
-				uuid: SIR_JOHN_FALSTAFF_CHARACTER_UUID,
-				name: 'Sir John Falstaff',
-				qualifier: null
-			};
+			const expectedCharacters = [
+				{
+					model: 'character',
+					uuid: SIR_JOHN_FALSTAFF_CHARACTER_UUID,
+					name: 'Sir John Falstaff',
+					qualifier: null
+				}
+			];
 
 			const { characterGroups: [{ characters }] } = henryIVPart2Playtext.body;
 
-			const sirJohnFalstaffCharacter =
-				characters.find(character => character.uuid === SIR_JOHN_FALSTAFF_CHARACTER_UUID);
-
-			expect(characters.length).to.equal(1);
-			expect(sirJohnFalstaffCharacter).to.deep.equal(expectedSirJohnFalstaffCharacter);
+			expect(characters).to.deep.equal(expectedCharacters);
 
 		});
 
@@ -573,20 +569,18 @@ describe('Character in multiple productions of multiple playtexts', () => {
 
 		it('includes Sir John Falstaff in its characters', () => {
 
-			const expectedSirJohnFalstaffCharacter = {
-				model: 'character',
-				uuid: SIR_JOHN_FALSTAFF_CHARACTER_UUID,
-				name: 'Sir John Falstaff',
-				qualifier: null
-			};
+			const expectedCharacters = [
+				{
+					model: 'character',
+					uuid: SIR_JOHN_FALSTAFF_CHARACTER_UUID,
+					name: 'Sir John Falstaff',
+					qualifier: null
+				}
+			];
 
 			const { characterGroups: [{ characters }] } = merryWivesOfWindsorPlaytext.body;
 
-			const sirJohnFalstaffCharacter =
-				characters.find(character => character.uuid === SIR_JOHN_FALSTAFF_CHARACTER_UUID);
-
-			expect(characters.length).to.equal(1);
-			expect(sirJohnFalstaffCharacter).to.deep.equal(expectedSirJohnFalstaffCharacter);
+			expect(characters).to.deep.equal(expectedCharacters);
 
 		});
 

--- a/test-e2e/model-interaction/character-multiple-appearances-same-playtext.test.js
+++ b/test-e2e/model-interaction/character-multiple-appearances-same-playtext.test.js
@@ -18,6 +18,7 @@ describe('Character with multiple appearances in the same playtext under differe
 	const ROCK_N_ROLL_ROYAL_COURT_PRODUCTION_UUID = '12';
 	const ROYAL_COURT_THEATRE_UUID = '13';
 	const ALICE_EVE_PERSON_UUID = '15';
+	const BRIAN_COX_PERSON_UUID = '16';
 	const SINEAD_CUSACK_PERSON_UUID = '17';
 
 	let esmeCharacter;
@@ -148,78 +149,75 @@ describe('Character with multiple appearances in the same playtext under differe
 
 		it('includes playtexts in which character appears, including the qualifiers used', () => {
 
-			const expectedRockNRollPlaytext = {
-				model: 'playtext',
-				uuid: ROCK_N_ROLL_PLAYTEXT_UUID,
-				name: 'Rock \'n\' Roll',
-				qualifiers: [
-					'younger',
-					'older'
-				],
-				groups: []
-			};
+			const expectedPlaytexts = [
+				{
+					model: 'playtext',
+					uuid: ROCK_N_ROLL_PLAYTEXT_UUID,
+					name: 'Rock \'n\' Roll',
+					qualifiers: [
+						'younger',
+						'older'
+					],
+					groups: []
+				}
+			];
 
 			const { playtexts } = esmeCharacter.body;
 
-			const rockNRollPlaytext = playtexts.find(playtext => playtext.uuid === ROCK_N_ROLL_PLAYTEXT_UUID);
-
-			expect(playtexts.length).to.equal(1);
-			expect(rockNRollPlaytext).to.deep.equal(expectedRockNRollPlaytext);
+			expect(playtexts).to.deep.equal(expectedPlaytexts);
 
 		});
 
 		it('includes productions in which character is portrayed, including by which performer and under which qualifier', () => {
 
-			const expectedRockNRollRoyalCourtProduction = {
-				model: 'production',
-				uuid: ROCK_N_ROLL_ROYAL_COURT_PRODUCTION_UUID,
-				name: 'Rock \'n\' Roll',
-				theatre: {
-					model: 'theatre',
-					uuid: ROYAL_COURT_THEATRE_UUID,
-					name: 'Royal Court Theatre'
-				},
-				performers: [
-					{
-						model: 'person',
-						uuid: ALICE_EVE_PERSON_UUID,
-						name: 'Alice Eve',
-						roleName: 'Esme',
-						qualifier: 'younger',
-						otherRoles: [
-							{
-								model: 'character',
-								uuid: ALICE_CHARACTER_UUID,
-								name: 'Alice',
-								qualifier: null
-							}
-						]
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: ROCK_N_ROLL_ROYAL_COURT_PRODUCTION_UUID,
+					name: 'Rock \'n\' Roll',
+					theatre: {
+						model: 'theatre',
+						uuid: ROYAL_COURT_THEATRE_UUID,
+						name: 'Royal Court Theatre'
 					},
-					{
-						model: 'person',
-						uuid: SINEAD_CUSACK_PERSON_UUID,
-						name: 'Sinead Cusack',
-						roleName: 'Esme',
-						qualifier: 'older',
-						otherRoles: [
-							{
-								model: 'character',
-								uuid: ELEANOR_CHARACTER_UUID,
-								name: 'Eleanor',
-								qualifier: null
-							}
-						]
-					}
-				]
-			};
+					performers: [
+						{
+							model: 'person',
+							uuid: ALICE_EVE_PERSON_UUID,
+							name: 'Alice Eve',
+							roleName: 'Esme',
+							qualifier: 'younger',
+							otherRoles: [
+								{
+									model: 'character',
+									uuid: ALICE_CHARACTER_UUID,
+									name: 'Alice',
+									qualifier: null
+								}
+							]
+						},
+						{
+							model: 'person',
+							uuid: SINEAD_CUSACK_PERSON_UUID,
+							name: 'Sinead Cusack',
+							roleName: 'Esme',
+							qualifier: 'older',
+							otherRoles: [
+								{
+									model: 'character',
+									uuid: ELEANOR_CHARACTER_UUID,
+									name: 'Eleanor',
+									qualifier: null
+								}
+							]
+						}
+					]
+				}
+			];
 
 			const { productions } = esmeCharacter.body;
 
-			const rockNRollRoyalCourtProduction =
-				productions.find(production => production.uuid === ROCK_N_ROLL_ROYAL_COURT_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(rockNRollRoyalCourtProduction).to.deep.equal(expectedRockNRollRoyalCourtProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -229,41 +227,39 @@ describe('Character with multiple appearances in the same playtext under differe
 
 		it('includes productions in which character is portrayed, including performer\'s other roles with qualifiers', () => {
 
-			const expectedRockNRollRoyalCourtProduction = {
-				model: 'production',
-				uuid: ROCK_N_ROLL_ROYAL_COURT_PRODUCTION_UUID,
-				name: 'Rock \'n\' Roll',
-				theatre: {
-					model: 'theatre',
-					uuid: ROYAL_COURT_THEATRE_UUID,
-					name: 'Royal Court Theatre'
-				},
-				performers: [
-					{
-						model: 'person',
-						uuid: ALICE_EVE_PERSON_UUID,
-						name: 'Alice Eve',
-						roleName: 'Alice',
-						qualifier: null,
-						otherRoles: [
-							{
-								model: 'character',
-								uuid: ESME_CHARACTER_UUID,
-								name: 'Esme',
-								qualifier: 'younger'
-							}
-						]
-					}
-				]
-			};
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: ROCK_N_ROLL_ROYAL_COURT_PRODUCTION_UUID,
+					name: 'Rock \'n\' Roll',
+					theatre: {
+						model: 'theatre',
+						uuid: ROYAL_COURT_THEATRE_UUID,
+						name: 'Royal Court Theatre'
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: ALICE_EVE_PERSON_UUID,
+							name: 'Alice Eve',
+							roleName: 'Alice',
+							qualifier: null,
+							otherRoles: [
+								{
+									model: 'character',
+									uuid: ESME_CHARACTER_UUID,
+									name: 'Esme',
+									qualifier: 'younger'
+								}
+							]
+						}
+					]
+				}
+			];
 
 			const { productions } = aliceCharacter.body;
 
-			const rockNRollRoyalCourtProduction =
-				productions.find(production => production.uuid === ROCK_N_ROLL_ROYAL_COURT_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(rockNRollRoyalCourtProduction).to.deep.equal(expectedRockNRollRoyalCourtProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -273,41 +269,39 @@ describe('Character with multiple appearances in the same playtext under differe
 
 		it('includes productions in which character is portrayed, including performer\'s other roles with qualifiers', () => {
 
-			const expectedRockNRollRoyalCourtProduction = {
-				model: 'production',
-				uuid: ROCK_N_ROLL_ROYAL_COURT_PRODUCTION_UUID,
-				name: 'Rock \'n\' Roll',
-				theatre: {
-					model: 'theatre',
-					uuid: ROYAL_COURT_THEATRE_UUID,
-					name: 'Royal Court Theatre'
-				},
-				performers: [
-					{
-						model: 'person',
-						uuid: SINEAD_CUSACK_PERSON_UUID,
-						name: 'Sinead Cusack',
-						roleName: 'Eleanor',
-						qualifier: null,
-						otherRoles: [
-							{
-								model: 'character',
-								uuid: ESME_CHARACTER_UUID,
-								name: 'Esme',
-								qualifier: 'older'
-							}
-						]
-					}
-				]
-			};
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: ROCK_N_ROLL_ROYAL_COURT_PRODUCTION_UUID,
+					name: 'Rock \'n\' Roll',
+					theatre: {
+						model: 'theatre',
+						uuid: ROYAL_COURT_THEATRE_UUID,
+						name: 'Royal Court Theatre'
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: SINEAD_CUSACK_PERSON_UUID,
+							name: 'Sinead Cusack',
+							roleName: 'Eleanor',
+							qualifier: null,
+							otherRoles: [
+								{
+									model: 'character',
+									uuid: ESME_CHARACTER_UUID,
+									name: 'Esme',
+									qualifier: 'older'
+								}
+							]
+						}
+					]
+				}
+			];
 
 			const { productions } = eleanorCharacter.body;
 
-			const rockNRollRoyalCourtProduction =
-				productions.find(production => production.uuid === ROCK_N_ROLL_ROYAL_COURT_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(rockNRollRoyalCourtProduction).to.deep.equal(expectedRockNRollRoyalCourtProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -362,54 +356,63 @@ describe('Character with multiple appearances in the same playtext under differe
 
 		it('includes the portrayers of Esme in its cast with their corresponding qualifiers', () => {
 
-			const expectedAliceEveCastMember = {
-				model: 'person',
-				uuid: ALICE_EVE_PERSON_UUID,
-				name: 'Alice Eve',
-				roles: [
-					{
-						model: 'character',
-						uuid: ESME_CHARACTER_UUID,
-						name: 'Esme',
-						qualifier: 'younger'
-					},
-					{
-						model: 'character',
-						uuid: ALICE_CHARACTER_UUID,
-						name: 'Alice',
-						qualifier: null
-					}
-				]
-			};
-
-			const expectedSineadCusackCastMember = {
-				model: 'person',
-				uuid: SINEAD_CUSACK_PERSON_UUID,
-				name: 'Sinead Cusack',
-				roles: [
-					{
-						model: 'character',
-						uuid: ELEANOR_CHARACTER_UUID,
-						name: 'Eleanor',
-						qualifier: null
-					},
-					{
-						model: 'character',
-						uuid: ESME_CHARACTER_UUID,
-						name: 'Esme',
-						qualifier: 'older'
-					}
-				]
-			};
+			const expectedCast = [
+				{
+					model: 'person',
+					uuid: ALICE_EVE_PERSON_UUID,
+					name: 'Alice Eve',
+					roles: [
+						{
+							model: 'character',
+							uuid: ESME_CHARACTER_UUID,
+							name: 'Esme',
+							qualifier: 'younger'
+						},
+						{
+							model: 'character',
+							uuid: ALICE_CHARACTER_UUID,
+							name: 'Alice',
+							qualifier: null
+						}
+					]
+				},
+				{
+					model: 'person',
+					uuid: BRIAN_COX_PERSON_UUID,
+					name: 'Brian Cox',
+					roles: [
+						{
+							model: 'character',
+							uuid: MAX_CHARACTER_UUID,
+							name: 'Max',
+							qualifier: null
+						}
+					]
+				},
+				{
+					model: 'person',
+					uuid: SINEAD_CUSACK_PERSON_UUID,
+					name: 'Sinead Cusack',
+					roles: [
+						{
+							model: 'character',
+							uuid: ELEANOR_CHARACTER_UUID,
+							name: 'Eleanor',
+							qualifier: null
+						},
+						{
+							model: 'character',
+							uuid: ESME_CHARACTER_UUID,
+							name: 'Esme',
+							qualifier: 'older'
+						}
+					]
+				}
+			];
 
 			const { cast } = rockNRollRoyalCourtProduction.body;
 
-			const aliceEveCastMember = cast.find(castMember => castMember.uuid === ALICE_EVE_PERSON_UUID);
-			const sineadCusackCastMember = cast.find(castMember => castMember.uuid === SINEAD_CUSACK_PERSON_UUID);
-
-			expect(cast.length).to.equal(3);
-			expect(aliceEveCastMember).to.deep.equal(expectedAliceEveCastMember);
-			expect(sineadCusackCastMember).to.deep.equal(expectedSineadCusackCastMember);
+			expect(cast).to.deep.equal(expectedCast);
 
 		});
 
@@ -419,38 +422,36 @@ describe('Character with multiple appearances in the same playtext under differe
 
 		it('includes in their production credits their portrayal of Esme with its corresponding qualifier (i.e. younger)', () => {
 
-			const expectedRockNRollRoyalCourtProduction = {
-				model: 'production',
-				uuid: ROCK_N_ROLL_ROYAL_COURT_PRODUCTION_UUID,
-				name: 'Rock \'n\' Roll',
-				theatre: {
-					model: 'theatre',
-					uuid: ROYAL_COURT_THEATRE_UUID,
-					name: 'Royal Court Theatre'
-				},
-				roles: [
-					{
-						model: 'character',
-						uuid: ESME_CHARACTER_UUID,
-						name: 'Esme',
-						qualifier: 'younger'
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: ROCK_N_ROLL_ROYAL_COURT_PRODUCTION_UUID,
+					name: 'Rock \'n\' Roll',
+					theatre: {
+						model: 'theatre',
+						uuid: ROYAL_COURT_THEATRE_UUID,
+						name: 'Royal Court Theatre'
 					},
-					{
-						model: 'character',
-						uuid: ALICE_CHARACTER_UUID,
-						name: 'Alice',
-						qualifier: null
-					}
-				]
-			};
+					roles: [
+						{
+							model: 'character',
+							uuid: ESME_CHARACTER_UUID,
+							name: 'Esme',
+							qualifier: 'younger'
+						},
+						{
+							model: 'character',
+							uuid: ALICE_CHARACTER_UUID,
+							name: 'Alice',
+							qualifier: null
+						}
+					]
+				}
+			];
 
 			const { productions } = aliceEvePerson.body;
 
-			const rockNRollRoyalCourtProduction =
-				productions.find(production => production.uuid === ROCK_N_ROLL_ROYAL_COURT_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(rockNRollRoyalCourtProduction).to.deep.equal(expectedRockNRollRoyalCourtProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -460,38 +461,36 @@ describe('Character with multiple appearances in the same playtext under differe
 
 		it('includes in their production credits their portrayal of Esme with its corresponding qualifier (i.e. older)', () => {
 
-			const expectedRockNRollRoyalCourtProduction = {
-				model: 'production',
-				uuid: ROCK_N_ROLL_ROYAL_COURT_PRODUCTION_UUID,
-				name: 'Rock \'n\' Roll',
-				theatre: {
-					model: 'theatre',
-					uuid: ROYAL_COURT_THEATRE_UUID,
-					name: 'Royal Court Theatre'
-				},
-				roles: [
-					{
-						model: 'character',
-						uuid: ELEANOR_CHARACTER_UUID,
-						name: 'Eleanor',
-						qualifier: null
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: ROCK_N_ROLL_ROYAL_COURT_PRODUCTION_UUID,
+					name: 'Rock \'n\' Roll',
+					theatre: {
+						model: 'theatre',
+						uuid: ROYAL_COURT_THEATRE_UUID,
+						name: 'Royal Court Theatre'
 					},
-					{
-						model: 'character',
-						uuid: ESME_CHARACTER_UUID,
-						name: 'Esme',
-						qualifier: 'older'
-					}
-				]
-			};
+					roles: [
+						{
+							model: 'character',
+							uuid: ELEANOR_CHARACTER_UUID,
+							name: 'Eleanor',
+							qualifier: null
+						},
+						{
+							model: 'character',
+							uuid: ESME_CHARACTER_UUID,
+							name: 'Esme',
+							qualifier: 'older'
+						}
+					]
+				}
+			];
 
 			const { productions } = sineadCusackPerson.body;
 
-			const rockNRollRoyalCourtProduction =
-				productions.find(production => production.uuid === ROCK_N_ROLL_ROYAL_COURT_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(rockNRollRoyalCourtProduction).to.deep.equal(expectedRockNRollRoyalCourtProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 

--- a/test-e2e/model-interaction/character-portrayed-with-other-roles.test.js
+++ b/test-e2e/model-interaction/character-portrayed-with-other-roles.test.js
@@ -119,53 +119,51 @@ describe('Character portrayed with other roles', () => {
 
 		it('includes performers who portrayed them and the other roles they also played', () => {
 
-			const expectedWarHorseNationalProduction = {
-				model: 'production',
-				uuid: WAR_HORSE_NATIONAL_PRODUCTION_UUID,
-				name: 'War Horse',
-				theatre: {
-					model: 'theatre',
-					uuid: NATIONAL_THEATRE_UUID,
-					name: 'National Theatre'
-				},
-				performers: [
-					{
-						model: 'person',
-						uuid: STEPHEN_HARPER_PERSON_UUID,
-						name: 'Stephen Harper',
-						roleName: 'Joey\'s mother',
-						qualifier: null,
-						otherRoles: [
-							{
-								model: 'character',
-								uuid: DR_SCHWEYK_CHARACTER_UUID,
-								name: 'Dr Schweyk',
-								qualifier: null
-							},
-							{
-								model: 'character',
-								uuid: COCO_CHARACTER_UUID,
-								name: 'Coco',
-								qualifier: null
-							},
-							{
-								model: 'character',
-								uuid: GEORDIE_CHARACTER_UUID,
-								name: 'Geordie',
-								qualifier: null
-							}
-						]
-					}
-				]
-			};
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: WAR_HORSE_NATIONAL_PRODUCTION_UUID,
+					name: 'War Horse',
+					theatre: {
+						model: 'theatre',
+						uuid: NATIONAL_THEATRE_UUID,
+						name: 'National Theatre'
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: STEPHEN_HARPER_PERSON_UUID,
+							name: 'Stephen Harper',
+							roleName: 'Joey\'s mother',
+							qualifier: null,
+							otherRoles: [
+								{
+									model: 'character',
+									uuid: DR_SCHWEYK_CHARACTER_UUID,
+									name: 'Dr Schweyk',
+									qualifier: null
+								},
+								{
+									model: 'character',
+									uuid: COCO_CHARACTER_UUID,
+									name: 'Coco',
+									qualifier: null
+								},
+								{
+									model: 'character',
+									uuid: GEORDIE_CHARACTER_UUID,
+									name: 'Geordie',
+									qualifier: null
+								}
+							]
+						}
+					]
+				}
+			];
 
 			const { productions } = joeysMotherCharacter.body;
 
-			const warHorseNationalProduction =
-				productions.find(production => production.uuid === WAR_HORSE_NATIONAL_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(warHorseNationalProduction).to.deep.equal(expectedWarHorseNationalProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -175,53 +173,51 @@ describe('Character portrayed with other roles', () => {
 
 		it('includes performers who portrayed them and the other roles they also played', () => {
 
-			const expectedWarHorseNationalProduction = {
-				model: 'production',
-				uuid: WAR_HORSE_NATIONAL_PRODUCTION_UUID,
-				name: 'War Horse',
-				theatre: {
-					model: 'theatre',
-					uuid: NATIONAL_THEATRE_UUID,
-					name: 'National Theatre'
-				},
-				performers: [
-					{
-						model: 'person',
-						uuid: STEPHEN_HARPER_PERSON_UUID,
-						name: 'Stephen Harper',
-						roleName: 'Dr Schweyk',
-						qualifier: null,
-						otherRoles: [
-							{
-								model: 'character',
-								uuid: JOEYS_MOTHER_CHARACTER_UUID,
-								name: 'Joey\'s mother',
-								qualifier: null
-							},
-							{
-								model: 'character',
-								uuid: COCO_CHARACTER_UUID,
-								name: 'Coco',
-								qualifier: null
-							},
-							{
-								model: 'character',
-								uuid: GEORDIE_CHARACTER_UUID,
-								name: 'Geordie',
-								qualifier: null
-							}
-						]
-					}
-				]
-			};
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: WAR_HORSE_NATIONAL_PRODUCTION_UUID,
+					name: 'War Horse',
+					theatre: {
+						model: 'theatre',
+						uuid: NATIONAL_THEATRE_UUID,
+						name: 'National Theatre'
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: STEPHEN_HARPER_PERSON_UUID,
+							name: 'Stephen Harper',
+							roleName: 'Dr Schweyk',
+							qualifier: null,
+							otherRoles: [
+								{
+									model: 'character',
+									uuid: JOEYS_MOTHER_CHARACTER_UUID,
+									name: 'Joey\'s mother',
+									qualifier: null
+								},
+								{
+									model: 'character',
+									uuid: COCO_CHARACTER_UUID,
+									name: 'Coco',
+									qualifier: null
+								},
+								{
+									model: 'character',
+									uuid: GEORDIE_CHARACTER_UUID,
+									name: 'Geordie',
+									qualifier: null
+								}
+							]
+						}
+					]
+				}
+			];
 
 			const { productions } = drSchweykCharacter.body;
 
-			const warHorseNationalProduction =
-				productions.find(production => production.uuid === WAR_HORSE_NATIONAL_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(warHorseNationalProduction).to.deep.equal(expectedWarHorseNationalProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -231,53 +227,51 @@ describe('Character portrayed with other roles', () => {
 
 		it('includes performers who portrayed them and the other roles they also played', () => {
 
-			const expectedWarHorseNationalProduction = {
-				model: 'production',
-				uuid: WAR_HORSE_NATIONAL_PRODUCTION_UUID,
-				name: 'War Horse',
-				theatre: {
-					model: 'theatre',
-					uuid: NATIONAL_THEATRE_UUID,
-					name: 'National Theatre'
-				},
-				performers: [
-					{
-						model: 'person',
-						uuid: STEPHEN_HARPER_PERSON_UUID,
-						name: 'Stephen Harper',
-						roleName: 'Coco',
-						qualifier: null,
-						otherRoles: [
-							{
-								model: 'character',
-								uuid: JOEYS_MOTHER_CHARACTER_UUID,
-								name: 'Joey\'s mother',
-								qualifier: null
-							},
-							{
-								model: 'character',
-								uuid: DR_SCHWEYK_CHARACTER_UUID,
-								name: 'Dr Schweyk',
-								qualifier: null
-							},
-							{
-								model: 'character',
-								uuid: GEORDIE_CHARACTER_UUID,
-								name: 'Geordie',
-								qualifier: null
-							}
-						]
-					}
-				]
-			};
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: WAR_HORSE_NATIONAL_PRODUCTION_UUID,
+					name: 'War Horse',
+					theatre: {
+						model: 'theatre',
+						uuid: NATIONAL_THEATRE_UUID,
+						name: 'National Theatre'
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: STEPHEN_HARPER_PERSON_UUID,
+							name: 'Stephen Harper',
+							roleName: 'Coco',
+							qualifier: null,
+							otherRoles: [
+								{
+									model: 'character',
+									uuid: JOEYS_MOTHER_CHARACTER_UUID,
+									name: 'Joey\'s mother',
+									qualifier: null
+								},
+								{
+									model: 'character',
+									uuid: DR_SCHWEYK_CHARACTER_UUID,
+									name: 'Dr Schweyk',
+									qualifier: null
+								},
+								{
+									model: 'character',
+									uuid: GEORDIE_CHARACTER_UUID,
+									name: 'Geordie',
+									qualifier: null
+								}
+							]
+						}
+					]
+				}
+			];
 
 			const { productions } = cocoCharacter.body;
 
-			const warHorseNationalProduction =
-				productions.find(production => production.uuid === WAR_HORSE_NATIONAL_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(warHorseNationalProduction).to.deep.equal(expectedWarHorseNationalProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -287,53 +281,51 @@ describe('Character portrayed with other roles', () => {
 
 		it('includes performers who portrayed them and the other roles they also played', () => {
 
-			const expectedWarHorseNationalProduction = {
-				model: 'production',
-				uuid: WAR_HORSE_NATIONAL_PRODUCTION_UUID,
-				name: 'War Horse',
-				theatre: {
-					model: 'theatre',
-					uuid: NATIONAL_THEATRE_UUID,
-					name: 'National Theatre'
-				},
-				performers: [
-					{
-						model: 'person',
-						uuid: STEPHEN_HARPER_PERSON_UUID,
-						name: 'Stephen Harper',
-						roleName: 'Geordie',
-						qualifier: null,
-						otherRoles: [
-							{
-								model: 'character',
-								uuid: JOEYS_MOTHER_CHARACTER_UUID,
-								name: 'Joey\'s mother',
-								qualifier: null
-							},
-							{
-								model: 'character',
-								uuid: DR_SCHWEYK_CHARACTER_UUID,
-								name: 'Dr Schweyk',
-								qualifier: null
-							},
-							{
-								model: 'character',
-								uuid: COCO_CHARACTER_UUID,
-								name: 'Coco',
-								qualifier: null
-							}
-						]
-					}
-				]
-			};
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: WAR_HORSE_NATIONAL_PRODUCTION_UUID,
+					name: 'War Horse',
+					theatre: {
+						model: 'theatre',
+						uuid: NATIONAL_THEATRE_UUID,
+						name: 'National Theatre'
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: STEPHEN_HARPER_PERSON_UUID,
+							name: 'Stephen Harper',
+							roleName: 'Geordie',
+							qualifier: null,
+							otherRoles: [
+								{
+									model: 'character',
+									uuid: JOEYS_MOTHER_CHARACTER_UUID,
+									name: 'Joey\'s mother',
+									qualifier: null
+								},
+								{
+									model: 'character',
+									uuid: DR_SCHWEYK_CHARACTER_UUID,
+									name: 'Dr Schweyk',
+									qualifier: null
+								},
+								{
+									model: 'character',
+									uuid: COCO_CHARACTER_UUID,
+									name: 'Coco',
+									qualifier: null
+								}
+							]
+						}
+					]
+				}
+			];
 
 			const { productions } = geordieCharacter.body;
 
-			const warHorseNationalProduction =
-				productions.find(production => production.uuid === WAR_HORSE_NATIONAL_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(warHorseNationalProduction).to.deep.equal(expectedWarHorseNationalProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 

--- a/test-e2e/model-interaction/character-with-variant-names.test.js
+++ b/test-e2e/model-interaction/character-with-variant-names.test.js
@@ -10,17 +10,21 @@ describe('Character with variant names', () => {
 
 	chai.use(chaiHttp);
 
+	const HAMLET_CHARACTER_UUID = '6';
 	const CLAUDIUS_CHARACTER_UUID = '7';
 	const GHOST_CHARACTER_UUID = '8';
 	const FIRST_PLAYER_CHARACTER_UUID = '9';
 	const HAMLET_ALMEIDA_PRODUCTION_UUID = '10';
 	const ALMEIDA_THEATRE_UUID = '11';
+	const ANDREW_SCOTT_PERSON_UUID = '13';
 	const DAVID_RINTOUL_PERSON_UUID = '14';
 	const HAMLET_NOVELLO_PRODUCTION_UUID = '15';
 	const NOVELLO_THEATRE_UUID = '16';
+	const DAVID_TENNANT_PERSON_UUID = '18';
 	const PATRICK_STEWART_PERSON_UUID = '19';
 	const HAMLET_WYNDHAMS_PRODUCTION_UUID = '20';
 	const WYNDHAMS_THEATRE_UUID = '21';
+	const JUDE_LAW_PERSON_UUID = '23';
 	const PETER_EYRE_PERSON_UUID = '24';
 
 	let ghostCharacter;
@@ -213,105 +217,93 @@ describe('Character with variant names', () => {
 
 		it('includes productions in which character was portrayed (including performers who portrayed them)', () => {
 
-			const expectedHamletAlmeidaProduction = {
-				model: 'production',
-				uuid: HAMLET_ALMEIDA_PRODUCTION_UUID,
-				name: 'Hamlet',
-				theatre: {
-					model: 'theatre',
-					uuid: ALMEIDA_THEATRE_UUID,
-					name: 'Almeida Theatre'
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: HAMLET_ALMEIDA_PRODUCTION_UUID,
+					name: 'Hamlet',
+					theatre: {
+						model: 'theatre',
+						uuid: ALMEIDA_THEATRE_UUID,
+						name: 'Almeida Theatre'
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: DAVID_RINTOUL_PERSON_UUID,
+							name: 'David Rintoul',
+							roleName: 'Ghost',
+							qualifier: null,
+							otherRoles: [
+								{
+									model: 'character',
+									uuid: FIRST_PLAYER_CHARACTER_UUID,
+									name: 'Player King',
+									qualifier: null
+								}
+							]
+						}
+					]
 				},
-				performers: [
-					{
-						model: 'person',
-						uuid: DAVID_RINTOUL_PERSON_UUID,
-						name: 'David Rintoul',
-						roleName: 'Ghost',
-						qualifier: null,
-						otherRoles: [
-							{
-								model: 'character',
-								uuid: FIRST_PLAYER_CHARACTER_UUID,
-								name: 'Player King',
-								qualifier: null
-							}
-						]
-					}
-				]
-			};
-
-			const expectedHamletNovelloProduction = {
-				model: 'production',
-				uuid: HAMLET_NOVELLO_PRODUCTION_UUID,
-				name: 'Hamlet',
-				theatre: {
-					model: 'theatre',
-					uuid: NOVELLO_THEATRE_UUID,
-					name: 'Novello Theatre'
+				{
+					model: 'production',
+					uuid: HAMLET_NOVELLO_PRODUCTION_UUID,
+					name: 'Hamlet',
+					theatre: {
+						model: 'theatre',
+						uuid: NOVELLO_THEATRE_UUID,
+						name: 'Novello Theatre'
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: PATRICK_STEWART_PERSON_UUID,
+							name: 'Patrick Stewart',
+							roleName: 'Ghost of King Hamlet',
+							qualifier: null,
+							otherRoles: [
+								{
+									model: 'character',
+									uuid: CLAUDIUS_CHARACTER_UUID,
+									name: 'Claudius',
+									qualifier: null
+								}
+							]
+						}
+					]
 				},
-				performers: [
-					{
-						model: 'person',
-						uuid: PATRICK_STEWART_PERSON_UUID,
-						name: 'Patrick Stewart',
-						roleName: 'Ghost of King Hamlet',
-						qualifier: null,
-						otherRoles: [
-							{
-								model: 'character',
-								uuid: CLAUDIUS_CHARACTER_UUID,
-								name: 'Claudius',
-								qualifier: null
-							}
-						]
-					}
-				]
-			};
-
-			const expectedHamletWyndhamsProduction = {
-				model: 'production',
-				uuid: HAMLET_WYNDHAMS_PRODUCTION_UUID,
-				name: 'Hamlet',
-				theatre: {
-					model: 'theatre',
-					uuid: WYNDHAMS_THEATRE_UUID,
-					name: 'Wyndham\'s Theatre'
-				},
-				performers: [
-					{
-						model: 'person',
-						uuid: PETER_EYRE_PERSON_UUID,
-						name: 'Peter Eyre',
-						roleName: 'King Hamlet',
-						qualifier: null,
-						otherRoles: [
-							{
-								model: 'character',
-								uuid: FIRST_PLAYER_CHARACTER_UUID,
-								name: 'First Player',
-								qualifier: null
-							}
-						]
-					}
-				]
-			};
+				{
+					model: 'production',
+					uuid: HAMLET_WYNDHAMS_PRODUCTION_UUID,
+					name: 'Hamlet',
+					theatre: {
+						model: 'theatre',
+						uuid: WYNDHAMS_THEATRE_UUID,
+						name: 'Wyndham\'s Theatre'
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: PETER_EYRE_PERSON_UUID,
+							name: 'Peter Eyre',
+							roleName: 'King Hamlet',
+							qualifier: null,
+							otherRoles: [
+								{
+									model: 'character',
+									uuid: FIRST_PLAYER_CHARACTER_UUID,
+									name: 'First Player',
+									qualifier: null
+								}
+							]
+						}
+					]
+				}
+			];
 
 			const { productions } = ghostCharacter.body;
 
-			const hamletAlmeidaProduction =
-				productions.find(production => production.uuid === HAMLET_ALMEIDA_PRODUCTION_UUID);
-
-			const hamletNovelloProduction =
-				productions.find(production => production.uuid === HAMLET_NOVELLO_PRODUCTION_UUID);
-
-			const hamletWyndhamsProduction =
-				productions.find(production => production.uuid === HAMLET_WYNDHAMS_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(3);
-			expect(hamletAlmeidaProduction).to.deep.equal(expectedHamletAlmeidaProduction);
-			expect(hamletNovelloProduction).to.deep.equal(expectedHamletNovelloProduction);
-			expect(hamletWyndhamsProduction).to.deep.equal(expectedHamletWyndhamsProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -321,32 +313,44 @@ describe('Character with variant names', () => {
 
 		it('includes cast with David Rintoul as Ghost of King Hamlet under a variant name (Ghost)', () => {
 
-			const expectedCastMember = {
-				model: 'person',
-				uuid: DAVID_RINTOUL_PERSON_UUID,
-				name: 'David Rintoul',
-				roles: [
-					{
-						model: 'character',
-						uuid: GHOST_CHARACTER_UUID,
-						name: 'Ghost',
-						qualifier: null
-					},
-					{
-						model: 'character',
-						uuid: FIRST_PLAYER_CHARACTER_UUID,
-						name: 'Player King',
-						qualifier: null
-					}
-				]
-			};
+			const expectedCast = [
+				{
+					model: 'person',
+					uuid: ANDREW_SCOTT_PERSON_UUID,
+					name: 'Andrew Scott',
+					roles: [
+						{
+							model: 'character',
+							uuid: HAMLET_CHARACTER_UUID,
+							name: 'Hamlet',
+							qualifier: null
+						}
+					]
+				},
+				{
+					model: 'person',
+					uuid: DAVID_RINTOUL_PERSON_UUID,
+					name: 'David Rintoul',
+					roles: [
+						{
+							model: 'character',
+							uuid: GHOST_CHARACTER_UUID,
+							name: 'Ghost',
+							qualifier: null
+						},
+						{
+							model: 'character',
+							uuid: FIRST_PLAYER_CHARACTER_UUID,
+							name: 'Player King',
+							qualifier: null
+						}
+					]
+				}
+			];
 
 			const { cast } = hamletAlmeidaProduction.body;
 
-			const castMember = cast.find(castMember => castMember.uuid === DAVID_RINTOUL_PERSON_UUID);
-
-			expect(cast.length).to.equal(2);
-			expect(castMember).to.deep.equal(expectedCastMember);
+			expect(cast).to.deep.equal(expectedCast);
 
 		});
 
@@ -356,32 +360,44 @@ describe('Character with variant names', () => {
 
 		it('includes cast with Patrick Stewart as Ghost of King Hamlet under same name as in playtext (Ghost of King Hamlet)', () => {
 
-			const expectedCastMember = {
-				model: 'person',
-				uuid: PATRICK_STEWART_PERSON_UUID,
-				name: 'Patrick Stewart',
-				roles: [
-					{
-						model: 'character',
-						uuid: CLAUDIUS_CHARACTER_UUID,
-						name: 'Claudius',
-						qualifier: null
-					},
-					{
-						model: 'character',
-						uuid: GHOST_CHARACTER_UUID,
-						name: 'Ghost of King Hamlet',
-						qualifier: null
-					}
-				]
-			};
+			const expectedCast = [
+				{
+					model: 'person',
+					uuid: DAVID_TENNANT_PERSON_UUID,
+					name: 'David Tennant',
+					roles: [
+						{
+							model: 'character',
+							uuid: HAMLET_CHARACTER_UUID,
+							name: 'Hamlet',
+							qualifier: null
+						}
+					]
+				},
+				{
+					model: 'person',
+					uuid: PATRICK_STEWART_PERSON_UUID,
+					name: 'Patrick Stewart',
+					roles: [
+						{
+							model: 'character',
+							uuid: CLAUDIUS_CHARACTER_UUID,
+							name: 'Claudius',
+							qualifier: null
+						},
+						{
+							model: 'character',
+							uuid: GHOST_CHARACTER_UUID,
+							name: 'Ghost of King Hamlet',
+							qualifier: null
+						}
+					]
+				}
+			];
 
 			const { cast } = hamletNovelloProduction.body;
 
-			const castMember = cast.find(castMember => castMember.uuid === PATRICK_STEWART_PERSON_UUID);
-
-			expect(cast.length).to.equal(2);
-			expect(castMember).to.deep.equal(expectedCastMember);
+			expect(cast).to.deep.equal(expectedCast);
 
 		});
 
@@ -391,32 +407,44 @@ describe('Character with variant names', () => {
 
 		it('includes cast with Peter Eyre as Ghost of King Hamlet under a variant name (King Hamlet)', () => {
 
-			const expectedCastMember = {
-				model: 'person',
-				uuid: PETER_EYRE_PERSON_UUID,
-				name: 'Peter Eyre',
-				roles: [
-					{
-						model: 'character',
-						uuid: GHOST_CHARACTER_UUID,
-						name: 'King Hamlet',
-						qualifier: null
-					},
-					{
-						model: 'character',
-						uuid: FIRST_PLAYER_CHARACTER_UUID,
-						name: 'First Player',
-						qualifier: null
-					}
-				]
-			};
+			const expectedCast = [
+				{
+					model: 'person',
+					uuid: JUDE_LAW_PERSON_UUID,
+					name: 'Jude Law',
+					roles: [
+						{
+							model: 'character',
+							uuid: HAMLET_CHARACTER_UUID,
+							name: 'Hamlet',
+							qualifier: null
+						}
+					]
+				},
+				{
+					model: 'person',
+					uuid: PETER_EYRE_PERSON_UUID,
+					name: 'Peter Eyre',
+					roles: [
+						{
+							model: 'character',
+							uuid: GHOST_CHARACTER_UUID,
+							name: 'King Hamlet',
+							qualifier: null
+						},
+						{
+							model: 'character',
+							uuid: FIRST_PLAYER_CHARACTER_UUID,
+							name: 'First Player',
+							qualifier: null
+						}
+					]
+				}
+			];
 
 			const { cast } = hamletWyndhamsProduction.body;
 
-			const castMember = cast.find(castMember => castMember.uuid === PETER_EYRE_PERSON_UUID);
-
-			expect(cast.length).to.equal(2);
-			expect(castMember).to.deep.equal(expectedCastMember);
+			expect(cast).to.deep.equal(expectedCast);
 
 		});
 
@@ -426,37 +454,36 @@ describe('Character with variant names', () => {
 
 		it('includes production with his portrayal of Ghost of King Hamlet under a variant name (Ghost)', () => {
 
-			const expectedProduction = {
-				model: 'production',
-				uuid: HAMLET_ALMEIDA_PRODUCTION_UUID,
-				name: 'Hamlet',
-				theatre: {
-					model: 'theatre',
-					uuid: ALMEIDA_THEATRE_UUID,
-					name: 'Almeida Theatre'
-				},
-				roles: [
-					{
-						model: 'character',
-						uuid: GHOST_CHARACTER_UUID,
-						name: 'Ghost',
-						qualifier: null
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: HAMLET_ALMEIDA_PRODUCTION_UUID,
+					name: 'Hamlet',
+					theatre: {
+						model: 'theatre',
+						uuid: ALMEIDA_THEATRE_UUID,
+						name: 'Almeida Theatre'
 					},
-					{
-						model: 'character',
-						uuid: FIRST_PLAYER_CHARACTER_UUID,
-						name: 'Player King',
-						qualifier: null
-					}
-				]
-			};
+					roles: [
+						{
+							model: 'character',
+							uuid: GHOST_CHARACTER_UUID,
+							name: 'Ghost',
+							qualifier: null
+						},
+						{
+							model: 'character',
+							uuid: FIRST_PLAYER_CHARACTER_UUID,
+							name: 'Player King',
+							qualifier: null
+						}
+					]
+				}
+			];
 
 			const { productions } = davidRintoulPerson.body;
 
-			const production = productions.find(production => production.uuid === HAMLET_ALMEIDA_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(production).to.deep.equal(expectedProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -466,37 +493,36 @@ describe('Character with variant names', () => {
 
 		it('includes production with his portrayal of Ghost of King Hamlet under same name as in playtext (Ghost of King Hamlet)', () => {
 
-			const expectedProduction = {
-				model: 'production',
-				uuid: HAMLET_NOVELLO_PRODUCTION_UUID,
-				name: 'Hamlet',
-				theatre: {
-					model: 'theatre',
-					uuid: NOVELLO_THEATRE_UUID,
-					name: 'Novello Theatre'
-				},
-				roles: [
-					{
-						model: 'character',
-						uuid: CLAUDIUS_CHARACTER_UUID,
-						name: 'Claudius',
-						qualifier: null
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: HAMLET_NOVELLO_PRODUCTION_UUID,
+					name: 'Hamlet',
+					theatre: {
+						model: 'theatre',
+						uuid: NOVELLO_THEATRE_UUID,
+						name: 'Novello Theatre'
 					},
-					{
-						model: 'character',
-						uuid: GHOST_CHARACTER_UUID,
-						name: 'Ghost of King Hamlet',
-						qualifier: null
-					}
-				]
-			};
+					roles: [
+						{
+							model: 'character',
+							uuid: CLAUDIUS_CHARACTER_UUID,
+							name: 'Claudius',
+							qualifier: null
+						},
+						{
+							model: 'character',
+							uuid: GHOST_CHARACTER_UUID,
+							name: 'Ghost of King Hamlet',
+							qualifier: null
+						}
+					]
+				}
+			];
 
 			const { productions } = patrickStewartPerson.body;
 
-			const production = productions.find(production => production.uuid === HAMLET_NOVELLO_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(production).to.deep.equal(expectedProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -506,37 +532,36 @@ describe('Character with variant names', () => {
 
 		it('includes production with his portrayal of Ghost of King Hamlet under a variant name (King Hamlet)', () => {
 
-			const expectedProduction = {
-				model: 'production',
-				uuid: HAMLET_WYNDHAMS_PRODUCTION_UUID,
-				name: 'Hamlet',
-				theatre: {
-					model: 'theatre',
-					uuid: WYNDHAMS_THEATRE_UUID,
-					name: 'Wyndham\'s Theatre'
-				},
-				roles: [
-					{
-						model: 'character',
-						uuid: GHOST_CHARACTER_UUID,
-						name: 'King Hamlet',
-						qualifier: null
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: HAMLET_WYNDHAMS_PRODUCTION_UUID,
+					name: 'Hamlet',
+					theatre: {
+						model: 'theatre',
+						uuid: WYNDHAMS_THEATRE_UUID,
+						name: 'Wyndham\'s Theatre'
 					},
-					{
-						model: 'character',
-						uuid: FIRST_PLAYER_CHARACTER_UUID,
-						name: 'First Player',
-						qualifier: null
-					}
-				]
-			};
+					roles: [
+						{
+							model: 'character',
+							uuid: GHOST_CHARACTER_UUID,
+							name: 'King Hamlet',
+							qualifier: null
+						},
+						{
+							model: 'character',
+							uuid: FIRST_PLAYER_CHARACTER_UUID,
+							name: 'First Player',
+							qualifier: null
+						}
+					]
+				}
+			];
 
 			const { productions } = peterEyrePerson.body;
 
-			const production = productions.find(production => production.uuid === HAMLET_WYNDHAMS_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(production).to.deep.equal(expectedProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 

--- a/test-e2e/model-interaction/different-characters-with-same-name.test.js
+++ b/test-e2e/model-interaction/different-characters-with-same-name.test.js
@@ -19,8 +19,10 @@ describe('Different characters with the same name', () => {
 	const A_MIDSUMMER_NIGHTS_DREAM_NOVELLO_PRODUCTION_UUID = '12';
 	const NOVELLO_THEATRE_UUID = '13';
 	const OSCAR_PEARCE_PERSON_UUID = '15';
+	const TRYSTAN_GRAVELLE_PERSON_UUID = '16';
 	const TITUS_ANDRONICUS_GLOBE_PRODUCTION_UUID = '17';
 	const SHAKESPEARES_GLOBE_THEATRE_UUID = '18';
+	const RICHARD_RIDDELL_PERSON_UUID = '20';
 	const SAM_ALEXANDER_PERSON_UUID = '21';
 
 	let demetriusCharacter1;
@@ -168,35 +170,32 @@ describe('Different characters with the same name', () => {
 
 		it('includes productions in which character was portrayed (i.e. excludes productions of different character with same name)', () => {
 
-			const expectedAMidsummerNightsDreamNovelloProduction = {
-				model: 'production',
-				uuid: A_MIDSUMMER_NIGHTS_DREAM_NOVELLO_PRODUCTION_UUID,
-				name: 'A Midsummer Night\'s Dream',
-				theatre: {
-					model: 'theatre',
-					uuid: NOVELLO_THEATRE_UUID,
-					name: 'Novello Theatre'
-				},
-				performers: [
-					{
-						model: 'person',
-						uuid: OSCAR_PEARCE_PERSON_UUID,
-						name: 'Oscar Pearce',
-						roleName: 'Demetrius',
-						qualifier: null,
-						otherRoles: []
-					}
-				]
-			};
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: A_MIDSUMMER_NIGHTS_DREAM_NOVELLO_PRODUCTION_UUID,
+					name: 'A Midsummer Night\'s Dream',
+					theatre: {
+						model: 'theatre',
+						uuid: NOVELLO_THEATRE_UUID,
+						name: 'Novello Theatre'
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: OSCAR_PEARCE_PERSON_UUID,
+							name: 'Oscar Pearce',
+							roleName: 'Demetrius',
+							qualifier: null,
+							otherRoles: []
+						}
+					]
+				}
+			];
 
 			const { productions } = demetriusCharacter1.body;
 
-			const aMidsummerNightsDreamNovelloProduction =
-				productions.find(production => production.uuid === A_MIDSUMMER_NIGHTS_DREAM_NOVELLO_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(aMidsummerNightsDreamNovelloProduction)
-				.to.deep.equal(expectedAMidsummerNightsDreamNovelloProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -206,34 +205,32 @@ describe('Different characters with the same name', () => {
 
 		it('includes productions in which character was portrayed (i.e. excludes productions of different character with same name)', () => {
 
-			const expectedTitusAndronicusGlobeProduction = {
-				model: 'production',
-				uuid: TITUS_ANDRONICUS_GLOBE_PRODUCTION_UUID,
-				name: 'Titus Andronicus',
-				theatre: {
-					model: 'theatre',
-					uuid: SHAKESPEARES_GLOBE_THEATRE_UUID,
-					name: 'Shakespeare\'s Globe'
-				},
-				performers: [
-					{
-						model: 'person',
-						uuid: SAM_ALEXANDER_PERSON_UUID,
-						name: 'Sam Alexander',
-						roleName: 'Demetrius',
-						qualifier: null,
-						otherRoles: []
-					}
-				]
-			};
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: TITUS_ANDRONICUS_GLOBE_PRODUCTION_UUID,
+					name: 'Titus Andronicus',
+					theatre: {
+						model: 'theatre',
+						uuid: SHAKESPEARES_GLOBE_THEATRE_UUID,
+						name: 'Shakespeare\'s Globe'
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: SAM_ALEXANDER_PERSON_UUID,
+							name: 'Sam Alexander',
+							roleName: 'Demetrius',
+							qualifier: null,
+							otherRoles: []
+						}
+					]
+				}
+			];
 
 			const { productions } = demetriusCharacter2.body;
 
-			const titusAndronicusGlobeProduction =
-				productions.find(production => production.uuid === TITUS_ANDRONICUS_GLOBE_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(titusAndronicusGlobeProduction).to.deep.equal(expectedTitusAndronicusGlobeProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -298,26 +295,38 @@ describe('Different characters with the same name', () => {
 
 		it('includes cast with Oscar Pearce as Demetrius (#1)', () => {
 
-			const expectedCastMember = {
-				model: 'person',
-				uuid: OSCAR_PEARCE_PERSON_UUID,
-				name: 'Oscar Pearce',
-				roles: [
-					{
-						model: 'character',
-						uuid: DEMETRIUS_CHARACTER_1_UUID,
-						name: 'Demetrius',
-						qualifier: null
-					}
-				]
-			};
+			const expectedCast = [
+				{
+					model: 'person',
+					uuid: OSCAR_PEARCE_PERSON_UUID,
+					name: 'Oscar Pearce',
+					roles: [
+						{
+							model: 'character',
+							uuid: DEMETRIUS_CHARACTER_1_UUID,
+							name: 'Demetrius',
+							qualifier: null
+						}
+					]
+				},
+				{
+					model: 'person',
+					uuid: TRYSTAN_GRAVELLE_PERSON_UUID,
+					name: 'Trystan Gravelle',
+					roles: [
+						{
+							model: 'character',
+							uuid: LYSANDER_CHARACTER_UUID,
+							name: 'Lysander',
+							qualifier: null
+						}
+					]
+				}
+			];
 
 			const { cast } = aMidsummerNightsDreamNovelloProduction.body;
 
-			const castMember = cast.find(castMember => castMember.uuid === OSCAR_PEARCE_PERSON_UUID);
-
-			expect(cast.length).to.equal(2);
-			expect(castMember).to.deep.equal(expectedCastMember);
+			expect(cast).to.deep.equal(expectedCast);
 
 		});
 
@@ -327,26 +336,38 @@ describe('Different characters with the same name', () => {
 
 		it('includes cast with Sam Alexander as Demetrius (#2)', () => {
 
-			const expectedCastMember = {
-				model: 'person',
-				uuid: SAM_ALEXANDER_PERSON_UUID,
-				name: 'Sam Alexander',
-				roles: [
-					{
-						model: 'character',
-						uuid: DEMETRIUS_CHARACTER_2_UUID,
-						name: 'Demetrius',
-						qualifier: null
-					}
-				]
-			};
+			const expectedCast = [
+				{
+					model: 'person',
+					uuid: RICHARD_RIDDELL_PERSON_UUID,
+					name: 'Richard Riddell',
+					roles: [
+						{
+							model: 'character',
+							uuid: CHIRON_CHARACTER_UUID,
+							name: 'Chiron',
+							qualifier: null
+						}
+					]
+				},
+				{
+					model: 'person',
+					uuid: SAM_ALEXANDER_PERSON_UUID,
+					name: 'Sam Alexander',
+					roles: [
+						{
+							model: 'character',
+							uuid: DEMETRIUS_CHARACTER_2_UUID,
+							name: 'Demetrius',
+							qualifier: null
+						}
+					]
+				}
+			];
 
 			const { cast } = titusAndronicusGlobeProduction.body;
 
-			const castMember = cast.find(castMember => castMember.uuid === SAM_ALEXANDER_PERSON_UUID);
-
-			expect(cast.length).to.equal(2);
-			expect(castMember).to.deep.equal(expectedCastMember);
+			expect(cast).to.deep.equal(expectedCast);
 
 		});
 
@@ -356,33 +377,30 @@ describe('Different characters with the same name', () => {
 
 		it('includes in their production credits their portrayal of Demetrius (#1) (i.e. and not Demetrius (#2))', () => {
 
-			const expectedAMidsummerNightsDreamNovelloProduction = {
-				model: 'production',
-				uuid: A_MIDSUMMER_NIGHTS_DREAM_NOVELLO_PRODUCTION_UUID,
-				name: 'A Midsummer Night\'s Dream',
-				theatre: {
-					model: 'theatre',
-					uuid: NOVELLO_THEATRE_UUID,
-					name: 'Novello Theatre'
-				},
-				roles: [
-					{
-						model: 'character',
-						uuid: DEMETRIUS_CHARACTER_1_UUID,
-						name: 'Demetrius',
-						qualifier: null
-					}
-				]
-			};
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: A_MIDSUMMER_NIGHTS_DREAM_NOVELLO_PRODUCTION_UUID,
+					name: 'A Midsummer Night\'s Dream',
+					theatre: {
+						model: 'theatre',
+						uuid: NOVELLO_THEATRE_UUID,
+						name: 'Novello Theatre'
+					},
+					roles: [
+						{
+							model: 'character',
+							uuid: DEMETRIUS_CHARACTER_1_UUID,
+							name: 'Demetrius',
+							qualifier: null
+						}
+					]
+				}
+			];
 
 			const { productions } = oscarPearcePerson.body;
 
-			const aMidsummerNightsDreamNovelloProduction =
-				productions.find(production => production.uuid === A_MIDSUMMER_NIGHTS_DREAM_NOVELLO_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(aMidsummerNightsDreamNovelloProduction)
-				.to.deep.equal(expectedAMidsummerNightsDreamNovelloProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -392,32 +410,30 @@ describe('Different characters with the same name', () => {
 
 		it('includes in their production credits their portrayal of Demetrius (#2) (i.e. and not Demetrius (#1))', () => {
 
-			const expectedTitusAndronicusGlobeProduction = {
-				model: 'production',
-				uuid: TITUS_ANDRONICUS_GLOBE_PRODUCTION_UUID,
-				name: 'Titus Andronicus',
-				theatre: {
-					model: 'theatre',
-					uuid: SHAKESPEARES_GLOBE_THEATRE_UUID,
-					name: 'Shakespeare\'s Globe'
-				},
-				roles: [
-					{
-						model: 'character',
-						uuid: DEMETRIUS_CHARACTER_2_UUID,
-						name: 'Demetrius',
-						qualifier: null
-					}
-				]
-			};
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: TITUS_ANDRONICUS_GLOBE_PRODUCTION_UUID,
+					name: 'Titus Andronicus',
+					theatre: {
+						model: 'theatre',
+						uuid: SHAKESPEARES_GLOBE_THEATRE_UUID,
+						name: 'Shakespeare\'s Globe'
+					},
+					roles: [
+						{
+							model: 'character',
+							uuid: DEMETRIUS_CHARACTER_2_UUID,
+							name: 'Demetrius',
+							qualifier: null
+						}
+					]
+				}
+			];
 
 			const { productions } = samAlexanderPerson.body;
 
-			const titusAndronicusGlobeProduction =
-				productions.find(production => production.uuid === TITUS_ANDRONICUS_GLOBE_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(titusAndronicusGlobeProduction).to.deep.equal(expectedTitusAndronicusGlobeProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 

--- a/test-e2e/model-interaction/playtext-with-multiple-productions.test.js
+++ b/test-e2e/model-interaction/playtext-with-multiple-productions.test.js
@@ -138,7 +138,7 @@ describe('Playtext with multiple productions', () => {
 
 		it('attributes playtext as Measure for Measure', () => {
 
-			const expectedPlaytextMeasureForMeasure = {
+			const expectedPlaytext = {
 				model: 'playtext',
 				uuid: MEASURE_FOR_MEASURE_PLAYTEXT_UUID,
 				name: 'Measure for Measure'
@@ -146,7 +146,7 @@ describe('Playtext with multiple productions', () => {
 
 			const { playtext } = measureForMeasureNationalProduction.body;
 
-			expect(playtext).to.deep.equal(expectedPlaytextMeasureForMeasure);
+			expect(playtext).to.deep.equal(expectedPlaytext);
 
 		});
 
@@ -156,7 +156,7 @@ describe('Playtext with multiple productions', () => {
 
 		it('attributes playtext as Measure for Measure', () => {
 
-			const expectedPlaytextMeasureForMeasure = {
+			const expectedPlaytext = {
 				model: 'playtext',
 				uuid: MEASURE_FOR_MEASURE_PLAYTEXT_UUID,
 				name: 'Measure for Measure'
@@ -164,7 +164,7 @@ describe('Playtext with multiple productions', () => {
 
 			const { playtext } = measureForMeasureAlmeidaProduction.body;
 
-			expect(playtext).to.deep.equal(expectedPlaytextMeasureForMeasure);
+			expect(playtext).to.deep.equal(expectedPlaytext);
 
 		});
 
@@ -174,7 +174,7 @@ describe('Playtext with multiple productions', () => {
 
 		it('attributes playtext as Measure for Measure', () => {
 
-			const expectedPlaytextMeasureForMeasure = {
+			const expectedPlaytext = {
 				model: 'playtext',
 				uuid: MEASURE_FOR_MEASURE_PLAYTEXT_UUID,
 				name: 'Measure for Measure'
@@ -182,7 +182,7 @@ describe('Playtext with multiple productions', () => {
 
 			const { playtext } = measureForMeasureDonmarProduction.body;
 
-			expect(playtext).to.deep.equal(expectedPlaytextMeasureForMeasure);
+			expect(playtext).to.deep.equal(expectedPlaytext);
 
 		});
 

--- a/test-e2e/model-interaction/roles-with-alternating-cast.test.js
+++ b/test-e2e/model-interaction/roles-with-alternating-cast.test.js
@@ -162,103 +162,96 @@ describe('Roles with alternating cast', () => {
 
 		it('includes productions in which character was portrayed (including performers who portrayed them)', () => {
 
-			const expectedTrueWestCrucibleProduction = {
-				model: 'production',
-				uuid: TRUE_WEST_CRUCIBLE_PRODUCTION_UUID,
-				name: 'True West',
-				theatre: {
-					model: 'theatre',
-					uuid: CRUCIBLE_THEATRE_UUID,
-					name: 'Crucible Theatre'
-				},
-				performers: [
-					{
-						model: 'person',
-						uuid: NIGEL_HARMAN_PERSON_UUID,
-						name: 'Nigel Harman',
-						roleName: 'Austin',
-						qualifier: null,
-						otherRoles: [
-							{
-								model: 'character',
-								uuid: LEE_CHARACTER_UUID,
-								name: 'Lee',
-								qualifier: null
-							}
-						]
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: TRUE_WEST_CRUCIBLE_PRODUCTION_UUID,
+					name: 'True West',
+					theatre: {
+						model: 'theatre',
+						uuid: CRUCIBLE_THEATRE_UUID,
+						name: 'Crucible Theatre'
 					},
-					{
-						model: 'person',
-						uuid: JOHN_LIGHT_PERSON_UUID,
-						name: 'John Light',
-						roleName: 'Austin',
-						qualifier: null,
-						otherRoles: [
-							{
-								model: 'character',
-								uuid: LEE_CHARACTER_UUID,
-								name: 'Lee',
-								qualifier: null
-							}
-						]
-					}
-				]
-			};
-
-			const expectedTrueWestVaudevilleProduction = {
-				model: 'production',
-				uuid: TRUE_WEST_VAUDEVILLE_PRODUCTION_UUID,
-				name: 'True West',
-				theatre: {
-					model: 'theatre',
-					uuid: VAUDEVILLE_THEATRE_UUID,
-					name: 'Vaudeville Theatre'
+					performers: [
+						{
+							model: 'person',
+							uuid: NIGEL_HARMAN_PERSON_UUID,
+							name: 'Nigel Harman',
+							roleName: 'Austin',
+							qualifier: null,
+							otherRoles: [
+								{
+									model: 'character',
+									uuid: LEE_CHARACTER_UUID,
+									name: 'Lee',
+									qualifier: null
+								}
+							]
+						},
+						{
+							model: 'person',
+							uuid: JOHN_LIGHT_PERSON_UUID,
+							name: 'John Light',
+							roleName: 'Austin',
+							qualifier: null,
+							otherRoles: [
+								{
+									model: 'character',
+									uuid: LEE_CHARACTER_UUID,
+									name: 'Lee',
+									qualifier: null
+								}
+							]
+						}
+					]
 				},
-				performers: [
-					{
-						model: 'person',
-						uuid: KIT_HARINGTON_PERSON_UUID,
-						name: 'Kit Harington',
-						roleName: 'Austin',
-						qualifier: null,
-						otherRoles: [
-							{
-								model: 'character',
-								uuid: LEE_CHARACTER_UUID,
-								name: 'Lee',
-								qualifier: null
-							}
-						]
+				{
+					model: 'production',
+					uuid: TRUE_WEST_VAUDEVILLE_PRODUCTION_UUID,
+					name: 'True West',
+					theatre: {
+						model: 'theatre',
+						uuid: VAUDEVILLE_THEATRE_UUID,
+						name: 'Vaudeville Theatre'
 					},
-					{
-						model: 'person',
-						uuid: JOHNNY_FLYNN_PERSON_UUID,
-						name: 'Johnny Flynn',
-						roleName: 'Austin',
-						qualifier: null,
-						otherRoles: [
-							{
-								model: 'character',
-								uuid: LEE_CHARACTER_UUID,
-								name: 'Lee',
-								qualifier: null
-							}
-						]
-					}
-				]
-			};
+					performers: [
+						{
+							model: 'person',
+							uuid: KIT_HARINGTON_PERSON_UUID,
+							name: 'Kit Harington',
+							roleName: 'Austin',
+							qualifier: null,
+							otherRoles: [
+								{
+									model: 'character',
+									uuid: LEE_CHARACTER_UUID,
+									name: 'Lee',
+									qualifier: null
+								}
+							]
+						},
+						{
+							model: 'person',
+							uuid: JOHNNY_FLYNN_PERSON_UUID,
+							name: 'Johnny Flynn',
+							roleName: 'Austin',
+							qualifier: null,
+							otherRoles: [
+								{
+									model: 'character',
+									uuid: LEE_CHARACTER_UUID,
+									name: 'Lee',
+									qualifier: null
+								}
+							]
+						}
+					]
+				}
+			];
 
 			const { productions } = austinCharacter.body;
 
-			const trueWestCrucibleProduction =
-				productions.find(production => production.uuid === TRUE_WEST_CRUCIBLE_PRODUCTION_UUID);
-
-			const trueWestVaudevilleProduction =
-				productions.find(production => production.uuid === TRUE_WEST_VAUDEVILLE_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(2);
-			expect(trueWestCrucibleProduction).to.deep.equal(expectedTrueWestCrucibleProduction);
-			expect(trueWestVaudevilleProduction).to.deep.equal(expectedTrueWestVaudevilleProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -268,103 +261,96 @@ describe('Roles with alternating cast', () => {
 
 		it('includes productions in which character was portrayed (including performers who portrayed them)', () => {
 
-			const expectedTrueWestCrucibleProduction = {
-				model: 'production',
-				uuid: TRUE_WEST_CRUCIBLE_PRODUCTION_UUID,
-				name: 'True West',
-				theatre: {
-					model: 'theatre',
-					uuid: CRUCIBLE_THEATRE_UUID,
-					name: 'Crucible Theatre'
-				},
-				performers: [
-					{
-						model: 'person',
-						uuid: NIGEL_HARMAN_PERSON_UUID,
-						name: 'Nigel Harman',
-						roleName: 'Lee',
-						qualifier: null,
-						otherRoles: [
-							{
-								model: 'character',
-								uuid: AUSTIN_CHARACTER_UUID,
-								name: 'Austin',
-								qualifier: null
-							}
-						]
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: TRUE_WEST_CRUCIBLE_PRODUCTION_UUID,
+					name: 'True West',
+					theatre: {
+						model: 'theatre',
+						uuid: CRUCIBLE_THEATRE_UUID,
+						name: 'Crucible Theatre'
 					},
-					{
-						model: 'person',
-						uuid: JOHN_LIGHT_PERSON_UUID,
-						name: 'John Light',
-						roleName: 'Lee',
-						qualifier: null,
-						otherRoles: [
-							{
-								model: 'character',
-								uuid: AUSTIN_CHARACTER_UUID,
-								name: 'Austin',
-								qualifier: null
-							}
-						]
-					}
-				]
-			};
-
-			const expectedTrueWestVaudevilleProduction = {
-				model: 'production',
-				uuid: TRUE_WEST_VAUDEVILLE_PRODUCTION_UUID,
-				name: 'True West',
-				theatre: {
-					model: 'theatre',
-					uuid: VAUDEVILLE_THEATRE_UUID,
-					name: 'Vaudeville Theatre'
+					performers: [
+						{
+							model: 'person',
+							uuid: NIGEL_HARMAN_PERSON_UUID,
+							name: 'Nigel Harman',
+							roleName: 'Lee',
+							qualifier: null,
+							otherRoles: [
+								{
+									model: 'character',
+									uuid: AUSTIN_CHARACTER_UUID,
+									name: 'Austin',
+									qualifier: null
+								}
+							]
+						},
+						{
+							model: 'person',
+							uuid: JOHN_LIGHT_PERSON_UUID,
+							name: 'John Light',
+							roleName: 'Lee',
+							qualifier: null,
+							otherRoles: [
+								{
+									model: 'character',
+									uuid: AUSTIN_CHARACTER_UUID,
+									name: 'Austin',
+									qualifier: null
+								}
+							]
+						}
+					]
 				},
-				performers: [
-					{
-						model: 'person',
-						uuid: KIT_HARINGTON_PERSON_UUID,
-						name: 'Kit Harington',
-						roleName: 'Lee',
-						qualifier: null,
-						otherRoles: [
-							{
-								model: 'character',
-								uuid: AUSTIN_CHARACTER_UUID,
-								name: 'Austin',
-								qualifier: null
-							}
-						]
+				{
+					model: 'production',
+					uuid: TRUE_WEST_VAUDEVILLE_PRODUCTION_UUID,
+					name: 'True West',
+					theatre: {
+						model: 'theatre',
+						uuid: VAUDEVILLE_THEATRE_UUID,
+						name: 'Vaudeville Theatre'
 					},
-					{
-						model: 'person',
-						uuid: JOHNNY_FLYNN_PERSON_UUID,
-						name: 'Johnny Flynn',
-						roleName: 'Lee',
-						qualifier: null,
-						otherRoles: [
-							{
-								model: 'character',
-								uuid: AUSTIN_CHARACTER_UUID,
-								name: 'Austin',
-								qualifier: null
-							}
-						]
-					}
-				]
-			};
+					performers: [
+						{
+							model: 'person',
+							uuid: KIT_HARINGTON_PERSON_UUID,
+							name: 'Kit Harington',
+							roleName: 'Lee',
+							qualifier: null,
+							otherRoles: [
+								{
+									model: 'character',
+									uuid: AUSTIN_CHARACTER_UUID,
+									name: 'Austin',
+									qualifier: null
+								}
+							]
+						},
+						{
+							model: 'person',
+							uuid: JOHNNY_FLYNN_PERSON_UUID,
+							name: 'Johnny Flynn',
+							roleName: 'Lee',
+							qualifier: null,
+							otherRoles: [
+								{
+									model: 'character',
+									uuid: AUSTIN_CHARACTER_UUID,
+									name: 'Austin',
+									qualifier: null
+								}
+							]
+						}
+					]
+				}
+			];
 
 			const { productions } = leeCharacter.body;
 
-			const trueWestCrucibleProduction =
-				productions.find(production => production.uuid === TRUE_WEST_CRUCIBLE_PRODUCTION_UUID);
-
-			const trueWestVaudevilleProduction =
-				productions.find(production => production.uuid === TRUE_WEST_VAUDEVILLE_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(2);
-			expect(trueWestCrucibleProduction).to.deep.equal(expectedTrueWestCrucibleProduction);
-			expect(trueWestVaudevilleProduction).to.deep.equal(expectedTrueWestVaudevilleProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -374,54 +360,50 @@ describe('Roles with alternating cast', () => {
 
 		it('includes cast with Nigel Harman as Austin and Lee, and John Light as Lee and Austin', () => {
 
-			const expectedCastMemberNigelHarman = {
-				model: 'person',
-				uuid: NIGEL_HARMAN_PERSON_UUID,
-				name: 'Nigel Harman',
-				roles: [
-					{
-						model: 'character',
-						uuid: AUSTIN_CHARACTER_UUID,
-						name: 'Austin',
-						qualifier: null
-					},
-					{
-						model: 'character',
-						uuid: LEE_CHARACTER_UUID,
-						name: 'Lee',
-						qualifier: null
-					}
-				]
-			};
-
-			const expectedCastMemberJohnLight = {
-				model: 'person',
-				uuid: JOHN_LIGHT_PERSON_UUID,
-				name: 'John Light',
-				roles: [
-					{
-						model: 'character',
-						uuid: LEE_CHARACTER_UUID,
-						name: 'Lee',
-						qualifier: null
-					},
-					{
-						model: 'character',
-						uuid: AUSTIN_CHARACTER_UUID,
-						name: 'Austin',
-						qualifier: null
-					}
-				]
-			};
+			const expectedCast = [
+				{
+					model: 'person',
+					uuid: NIGEL_HARMAN_PERSON_UUID,
+					name: 'Nigel Harman',
+					roles: [
+						{
+							model: 'character',
+							uuid: AUSTIN_CHARACTER_UUID,
+							name: 'Austin',
+							qualifier: null
+						},
+						{
+							model: 'character',
+							uuid: LEE_CHARACTER_UUID,
+							name: 'Lee',
+							qualifier: null
+						}
+					]
+				},
+				{
+					model: 'person',
+					uuid: JOHN_LIGHT_PERSON_UUID,
+					name: 'John Light',
+					roles: [
+						{
+							model: 'character',
+							uuid: LEE_CHARACTER_UUID,
+							name: 'Lee',
+							qualifier: null
+						},
+						{
+							model: 'character',
+							uuid: AUSTIN_CHARACTER_UUID,
+							name: 'Austin',
+							qualifier: null
+						}
+					]
+				}
+			];
 
 			const { cast } = trueWestCrucibleProduction.body;
 
-			const castMemberNigelHarman = cast.find(castMember => castMember.uuid === NIGEL_HARMAN_PERSON_UUID);
-			const castMemberJohnLight = cast.find(castMember => castMember.uuid === JOHN_LIGHT_PERSON_UUID);
-
-			expect(cast.length).to.equal(2);
-			expect(castMemberNigelHarman).to.deep.equal(expectedCastMemberNigelHarman);
-			expect(castMemberJohnLight).to.deep.equal(expectedCastMemberJohnLight);
+			expect(cast).to.deep.equal(expectedCast);
 
 		});
 
@@ -431,54 +413,50 @@ describe('Roles with alternating cast', () => {
 
 		it('includes cast with Kit Harington as Austin and Lee, and Johnny Flynn as Lee and Austin', () => {
 
-			const expectedCastMemberKitHarington = {
-				model: 'person',
-				uuid: KIT_HARINGTON_PERSON_UUID,
-				name: 'Kit Harington',
-				roles: [
-					{
-						model: 'character',
-						uuid: AUSTIN_CHARACTER_UUID,
-						name: 'Austin',
-						qualifier: null
-					},
-					{
-						model: 'character',
-						uuid: LEE_CHARACTER_UUID,
-						name: 'Lee',
-						qualifier: null
-					}
-				]
-			};
-
-			const expectedCastMemberJohnnyFlynn = {
-				model: 'person',
-				uuid: JOHNNY_FLYNN_PERSON_UUID,
-				name: 'Johnny Flynn',
-				roles: [
-					{
-						model: 'character',
-						uuid: LEE_CHARACTER_UUID,
-						name: 'Lee',
-						qualifier: null
-					},
-					{
-						model: 'character',
-						uuid: AUSTIN_CHARACTER_UUID,
-						name: 'Austin',
-						qualifier: null
-					}
-				]
-			};
+			const expectedCast = [
+				{
+					model: 'person',
+					uuid: KIT_HARINGTON_PERSON_UUID,
+					name: 'Kit Harington',
+					roles: [
+						{
+							model: 'character',
+							uuid: AUSTIN_CHARACTER_UUID,
+							name: 'Austin',
+							qualifier: null
+						},
+						{
+							model: 'character',
+							uuid: LEE_CHARACTER_UUID,
+							name: 'Lee',
+							qualifier: null
+						}
+					]
+				},
+				{
+					model: 'person',
+					uuid: JOHNNY_FLYNN_PERSON_UUID,
+					name: 'Johnny Flynn',
+					roles: [
+						{
+							model: 'character',
+							uuid: LEE_CHARACTER_UUID,
+							name: 'Lee',
+							qualifier: null
+						},
+						{
+							model: 'character',
+							uuid: AUSTIN_CHARACTER_UUID,
+							name: 'Austin',
+							qualifier: null
+						}
+					]
+				}
+			];
 
 			const { cast } = trueWestVaudevilleProduction.body;
 
-			const castMemberKitHarington = cast.find(castMember => castMember.uuid === KIT_HARINGTON_PERSON_UUID);
-			const castMemberJohnnyFlynn = cast.find(castMember => castMember.uuid === JOHNNY_FLYNN_PERSON_UUID);
-
-			expect(cast.length).to.equal(2);
-			expect(castMemberKitHarington).to.deep.equal(expectedCastMemberKitHarington);
-			expect(castMemberJohnnyFlynn).to.deep.equal(expectedCastMemberJohnnyFlynn);
+			expect(cast).to.deep.equal(expectedCast);
 
 		});
 
@@ -488,37 +466,36 @@ describe('Roles with alternating cast', () => {
 
 		it('includes production with his portrayals of Austin and Lee', () => {
 
-			const expectedProduction = {
-				model: 'production',
-				uuid: TRUE_WEST_CRUCIBLE_PRODUCTION_UUID,
-				name: 'True West',
-				theatre: {
-					model: 'theatre',
-					uuid: CRUCIBLE_THEATRE_UUID,
-					name: 'Crucible Theatre'
-				},
-				roles: [
-					{
-						model: 'character',
-						uuid: AUSTIN_CHARACTER_UUID,
-						name: 'Austin',
-						qualifier: null
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: TRUE_WEST_CRUCIBLE_PRODUCTION_UUID,
+					name: 'True West',
+					theatre: {
+						model: 'theatre',
+						uuid: CRUCIBLE_THEATRE_UUID,
+						name: 'Crucible Theatre'
 					},
-					{
-						model: 'character',
-						uuid: LEE_CHARACTER_UUID,
-						name: 'Lee',
-						qualifier: null
-					}
-				]
-			};
+					roles: [
+						{
+							model: 'character',
+							uuid: AUSTIN_CHARACTER_UUID,
+							name: 'Austin',
+							qualifier: null
+						},
+						{
+							model: 'character',
+							uuid: LEE_CHARACTER_UUID,
+							name: 'Lee',
+							qualifier: null
+						}
+					]
+				}
+			];
 
 			const { productions } = nigelHarmanPerson.body;
 
-			const production = productions.find(production => production.uuid === TRUE_WEST_CRUCIBLE_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(production).to.deep.equal(expectedProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -528,37 +505,36 @@ describe('Roles with alternating cast', () => {
 
 		it('includes production with his portrayals of Lee and Austin', () => {
 
-			const expectedProduction = {
-				model: 'production',
-				uuid: TRUE_WEST_CRUCIBLE_PRODUCTION_UUID,
-				name: 'True West',
-				theatre: {
-					model: 'theatre',
-					uuid: CRUCIBLE_THEATRE_UUID,
-					name: 'Crucible Theatre'
-				},
-				roles: [
-					{
-						model: 'character',
-						uuid: LEE_CHARACTER_UUID,
-						name: 'Lee',
-						qualifier: null
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: TRUE_WEST_CRUCIBLE_PRODUCTION_UUID,
+					name: 'True West',
+					theatre: {
+						model: 'theatre',
+						uuid: CRUCIBLE_THEATRE_UUID,
+						name: 'Crucible Theatre'
 					},
-					{
-						model: 'character',
-						uuid: AUSTIN_CHARACTER_UUID,
-						name: 'Austin',
-						qualifier: null
-					}
-				]
-			};
+					roles: [
+						{
+							model: 'character',
+							uuid: LEE_CHARACTER_UUID,
+							name: 'Lee',
+							qualifier: null
+						},
+						{
+							model: 'character',
+							uuid: AUSTIN_CHARACTER_UUID,
+							name: 'Austin',
+							qualifier: null
+						}
+					]
+				}
+			];
 
 			const { productions } = johnLightPerson.body;
 
-			const production = productions.find(production => production.uuid === TRUE_WEST_CRUCIBLE_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(production).to.deep.equal(expectedProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -568,37 +544,36 @@ describe('Roles with alternating cast', () => {
 
 		it('includes production with his portrayals of Austin and Lee', () => {
 
-			const expectedProduction = {
-				model: 'production',
-				uuid: TRUE_WEST_VAUDEVILLE_PRODUCTION_UUID,
-				name: 'True West',
-				theatre: {
-					model: 'theatre',
-					uuid: VAUDEVILLE_THEATRE_UUID,
-					name: 'Vaudeville Theatre'
-				},
-				roles: [
-					{
-						model: 'character',
-						uuid: AUSTIN_CHARACTER_UUID,
-						name: 'Austin',
-						qualifier: null
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: TRUE_WEST_VAUDEVILLE_PRODUCTION_UUID,
+					name: 'True West',
+					theatre: {
+						model: 'theatre',
+						uuid: VAUDEVILLE_THEATRE_UUID,
+						name: 'Vaudeville Theatre'
 					},
-					{
-						model: 'character',
-						uuid: LEE_CHARACTER_UUID,
-						name: 'Lee',
-						qualifier: null
-					}
-				]
-			};
+					roles: [
+						{
+							model: 'character',
+							uuid: AUSTIN_CHARACTER_UUID,
+							name: 'Austin',
+							qualifier: null
+						},
+						{
+							model: 'character',
+							uuid: LEE_CHARACTER_UUID,
+							name: 'Lee',
+							qualifier: null
+						}
+					]
+				}
+			];
 
 			const { productions } = kitHaringtonPerson.body;
 
-			const production = productions.find(production => production.uuid === TRUE_WEST_VAUDEVILLE_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(production).to.deep.equal(expectedProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 
@@ -608,37 +583,36 @@ describe('Roles with alternating cast', () => {
 
 		it('includes production with his portrayals of Lee and Austin', () => {
 
-			const expectedProduction = {
-				model: 'production',
-				uuid: TRUE_WEST_VAUDEVILLE_PRODUCTION_UUID,
-				name: 'True West',
-				theatre: {
-					model: 'theatre',
-					uuid: VAUDEVILLE_THEATRE_UUID,
-					name: 'Vaudeville Theatre'
-				},
-				roles: [
-					{
-						model: 'character',
-						uuid: LEE_CHARACTER_UUID,
-						name: 'Lee',
-						qualifier: null
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: TRUE_WEST_VAUDEVILLE_PRODUCTION_UUID,
+					name: 'True West',
+					theatre: {
+						model: 'theatre',
+						uuid: VAUDEVILLE_THEATRE_UUID,
+						name: 'Vaudeville Theatre'
 					},
-					{
-						model: 'character',
-						uuid: AUSTIN_CHARACTER_UUID,
-						name: 'Austin',
-						qualifier: null
-					}
-				]
-			};
+					roles: [
+						{
+							model: 'character',
+							uuid: LEE_CHARACTER_UUID,
+							name: 'Lee',
+							qualifier: null
+						},
+						{
+							model: 'character',
+							uuid: AUSTIN_CHARACTER_UUID,
+							name: 'Austin',
+							qualifier: null
+						}
+					]
+				}
+			];
 
 			const { productions } = johnnyFlynnPerson.body;
 
-			const production = productions.find(production => production.uuid === TRUE_WEST_VAUDEVILLE_PRODUCTION_UUID);
-
-			expect(productions.length).to.equal(1);
-			expect(production).to.deep.equal(expectedProduction);
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 

--- a/test-e2e/model-interaction/theatre-with-multiple-productions.test.js
+++ b/test-e2e/model-interaction/theatre-with-multiple-productions.test.js
@@ -111,7 +111,7 @@ describe('Theatre with multiple productions', () => {
 
 		it('attributes theatre as Donmar Warehouse', () => {
 
-			const expectedTheatreDonmarWarehouse = {
+			const expectedTheatre = {
 				model: 'theatre',
 				uuid: DONMAR_WAREHOUSE_THEATRE_UUID,
 				name: 'Donmar Warehouse'
@@ -119,7 +119,7 @@ describe('Theatre with multiple productions', () => {
 
 			const { theatre } = streetcarNamedDesireDonmarProduction.body;
 
-			expect(theatre).to.deep.equal(expectedTheatreDonmarWarehouse);
+			expect(theatre).to.deep.equal(expectedTheatre);
 
 		});
 
@@ -129,7 +129,7 @@ describe('Theatre with multiple productions', () => {
 
 		it('attributes theatre as Donmar Warehouse', () => {
 
-			const expectedTheatreDonmarWarehouse = {
+			const expectedTheatre = {
 				model: 'theatre',
 				uuid: DONMAR_WAREHOUSE_THEATRE_UUID,
 				name: 'Donmar Warehouse'
@@ -137,7 +137,7 @@ describe('Theatre with multiple productions', () => {
 
 			const { theatre } = lifeIsADreamDonmarProduction.body;
 
-			expect(theatre).to.deep.equal(expectedTheatreDonmarWarehouse);
+			expect(theatre).to.deep.equal(expectedTheatre);
 
 		});
 
@@ -147,7 +147,7 @@ describe('Theatre with multiple productions', () => {
 
 		it('attributes theatre as Donmar Warehouse', () => {
 
-			const expectedTheatreDonmarWarehouse = {
+			const expectedTheatre = {
 				model: 'theatre',
 				uuid: DONMAR_WAREHOUSE_THEATRE_UUID,
 				name: 'Donmar Warehouse'
@@ -155,7 +155,7 @@ describe('Theatre with multiple productions', () => {
 
 			const { theatre } = redDonmarProduction.body;
 
-			expect(theatre).to.deep.equal(expectedTheatreDonmarWarehouse);
+			expect(theatre).to.deep.equal(expectedTheatre);
 
 		});
 


### PR DESCRIPTION
In the end-to-end tests there is currently a lot of work in finding specific items in arrays and testing individual expectations against those.

It is a lot simpler to do a deep comparison of the entire array, which at the same time also allows the order of the array to be tested.