### PR TITLE
Handle different characters with same name in same playtext

### DIFF
--- a/src/controllers/model-template-props/production.js
+++ b/src/controllers/model-template-props/production.js
@@ -14,6 +14,7 @@ export default {
 				{
 					name: '',
 					characterName: '',
+					characterDifferentiator: '',
 					qualifier: ''
 				}
 			]

--- a/src/lib/get-duplicate-indices.js
+++ b/src/lib/get-duplicate-indices.js
@@ -7,6 +7,7 @@ export const getDuplicateIndices = arrayOfObjects => {
 			arrayOfObjects.find((comparisonObject, comparisonIndex) =>
 				object.name === comparisonObject.name &&
 				object.differentiator === comparisonObject.differentiator &&
+				object.characterDifferentiator === comparisonObject.characterDifferentiator &&
 				object.qualifier === comparisonObject.qualifier &&
 				object.group === comparisonObject.group &&
 				index !== comparisonIndex

--- a/src/models/Base.js
+++ b/src/models/Base.js
@@ -25,6 +25,12 @@ export default class Base {
 
 	}
 
+	hasCharacterDifferentiatorProperty () {
+
+		return Object.prototype.hasOwnProperty.call(this, 'characterDifferentiator');
+
+	}
+
 	hasQualifierProperty () {
 
 		return Object.prototype.hasOwnProperty.call(this, 'qualifier');
@@ -80,6 +86,9 @@ export default class Base {
 			this.addPropertyError('name', uniquenessErrorMessage);
 
 			if (this.hasDifferentiatorProperty()) this.addPropertyError('differentiator', uniquenessErrorMessage);
+
+			if (this.hasCharacterDifferentiatorProperty())
+				this.addPropertyError('characterDifferentiator', uniquenessErrorMessage);
 
 			if (this.hasQualifierProperty()) this.addPropertyError('qualifier', uniquenessErrorMessage);
 

--- a/src/models/CastMember.js
+++ b/src/models/CastMember.js
@@ -34,6 +34,8 @@ export default class CastMember extends Person {
 
 			role.validateCharacterName();
 
+			role.validateCharacterDifferentiator();
+
 			role.validateQualifier();
 
 			role.validateCharacterNameHasRoleName();

--- a/src/models/Role.js
+++ b/src/models/Role.js
@@ -6,15 +6,24 @@ export default class Role extends Base {
 
 		super(props);
 
+		const { characterName, characterDifferentiator, qualifier } = props;
+
 		this.model = 'role';
-		this.characterName = props.characterName?.trim() || '';
-		this.qualifier = props.qualifier?.trim() || '';
+		this.characterName = characterName?.trim() || '';
+		this.characterDifferentiator = characterDifferentiator?.trim() || '';
+		this.qualifier = qualifier?.trim() || '';
 
 	}
 
 	validateCharacterName () {
 
 		this.validateStringForProperty('characterName', { isRequired: false });
+
+	}
+
+	validateCharacterDifferentiator () {
+
+		this.validateStringForProperty('characterDifferentiator', { isRequired: false });
 
 	}
 

--- a/src/neo4j/cypher-queries/character.js
+++ b/src/neo4j/cypher-queries/character.js
@@ -15,7 +15,9 @@ const getShowQuery = () => `
 		ORDER BY variantNamedRole.roleName
 
 	OPTIONAL MATCH (playtext)<-[productionRel:PRODUCTION_OF]-(production:Production)<-[role:PERFORMS_IN]-(person:Person)
-		WHERE character.name = role.roleName OR character.name = role.characterName
+		WHERE
+			(character.name = role.roleName OR character.name = role.characterName) AND
+			(role.characterDifferentiator IS NULL OR character.differentiator = role.characterDifferentiator)
 
 	OPTIONAL MATCH (production)<-[otherRole:PERFORMS_IN]-(person)
 		WHERE otherRole.roleName <> character.name
@@ -23,7 +25,9 @@ const getShowQuery = () => `
 
 	OPTIONAL MATCH (person)-[otherRole]->(production)-[productionRel]->
 		(playtext)-[:INCLUDES_CHARACTER]->(otherCharacter:Character)
-		WHERE otherRole.roleName = otherCharacter.name OR otherRole.characterName = otherCharacter.name
+		WHERE
+			(otherCharacter.name = otherRole.roleName OR otherCharacter.name = otherRole.characterName) AND
+			(otherRole.characterDifferentiator IS NULL OR otherCharacter.differentiator = otherRole.characterDifferentiator)
 
 	OPTIONAL MATCH (production)-[:PLAYS_AT]->(theatre:Theatre)
 

--- a/src/neo4j/cypher-queries/person.js
+++ b/src/neo4j/cypher-queries/person.js
@@ -6,7 +6,9 @@ const getShowQuery = () => `
 	OPTIONAL MATCH (production)-[:PLAYS_AT]->(theatre:Theatre)
 
 	OPTIONAL MATCH (production)-[:PRODUCTION_OF]->(:Playtext)-[characterRel:INCLUDES_CHARACTER]->(character:Character)
-		WHERE role.roleName = character.name OR role.characterName = character.name
+		WHERE
+			(role.roleName = character.name OR role.characterName = character.name) AND
+			(role.characterDifferentiator IS NULL OR role.characterDifferentiator = character.differentiator)
 
 	WITH DISTINCT person, production, theatre, role, character
 		ORDER BY role.rolePosition

--- a/src/neo4j/cypher-queries/production.js
+++ b/src/neo4j/cypher-queries/production.js
@@ -92,6 +92,7 @@ const getCreateUpdateQuery = action => {
 							rolePosition: role.position,
 							roleName: role.name,
 							characterName: role.characterName,
+							characterDifferentiator: role.characterDifferentiator,
 							qualifier: role.qualifier
 						}]-(person)
 				)
@@ -125,10 +126,11 @@ const getEditQuery = () => `
 				ELSE {
 					name: role.roleName,
 					characterName: CASE role.characterName WHEN NULL THEN '' ELSE role.characterName END,
+					characterDifferentiator: CASE role.characterDifferentiator WHEN NULL THEN '' ELSE role.characterDifferentiator END,
 					qualifier: CASE role.qualifier WHEN NULL THEN '' ELSE role.qualifier END
 				}
 			END
-		) + [{ name: '', characterName: '', qualifier: '' }] AS roles
+		) + [{ name: '', characterName: '', characterDifferentiator: '', qualifier: '' }] AS roles
 
 	RETURN
 		'production' AS model,
@@ -147,7 +149,7 @@ const getEditQuery = () => `
 				THEN null
 				ELSE { name: person.name, differentiator: person.differentiator, roles: roles }
 			END
-		) + [{ name: '', roles: [{ name: '', characterName: '', qualifier: '' }] }] AS cast
+		) + [{ name: '', roles: [{ name: '', characterName: '', characterDifferentiator: '', qualifier: '' }] }] AS cast
 `;
 
 const getUpdateQuery = () => getCreateUpdateQuery('update');
@@ -163,7 +165,9 @@ const getShowQuery = () => `
 
 	OPTIONAL MATCH (person)-[role]->(production)-[playtextRel]->
 		(playtext)-[characterRel:INCLUDES_CHARACTER]->(character:Character)
-		WHERE role.roleName = character.name OR role.characterName = character.name
+		WHERE
+			(role.roleName = character.name OR role.characterName = character.name) AND
+			(role.characterDifferentiator IS NULL OR role.characterDifferentiator = character.differentiator)
 
 	WITH DISTINCT production, theatre, playtext, person, role, character
 		ORDER BY role.castMemberPosition, role.rolePosition

--- a/test-e2e/crud/productions-api.test.js
+++ b/test-e2e/crud/productions-api.test.js
@@ -45,6 +45,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'role',
 								name: '',
 								characterName: '',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							}
@@ -120,6 +121,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'role',
 								name: '',
 								characterName: '',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							}
@@ -167,6 +169,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'role',
 								name: '',
 								characterName: '',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							}
@@ -218,6 +221,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'role',
 								name: '',
 								characterName: '',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							}
@@ -419,6 +423,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'role',
 								name: 'Hamlet',
 								characterName: '',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							},
@@ -426,6 +431,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'role',
 								name: '',
 								characterName: '',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							}
@@ -441,6 +447,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'role',
 								name: 'Ghost',
 								characterName: 'Ghost of King Hamlet',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							},
@@ -448,6 +455,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'role',
 								name: 'Player King',
 								characterName: 'First Player',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							},
@@ -455,6 +463,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'role',
 								name: '',
 								characterName: '',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							}
@@ -470,6 +479,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'role',
 								name: 'Lucianus',
 								characterName: '',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							},
@@ -478,12 +488,14 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								name: 'English Ambassador',
 								qualifier: '',
 								characterName: '',
+								characterDifferentiator: '',
 								errors: {}
 							},
 							{
 								model: 'role',
 								name: '',
 								characterName: '',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							}
@@ -499,6 +511,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'role',
 								name: '',
 								characterName: '',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							}
@@ -514,6 +527,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'role',
 								name: '',
 								characterName: '',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							}
@@ -650,6 +664,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'role',
 								name: 'Hamlet',
 								characterName: '',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							},
@@ -657,6 +672,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'role',
 								name: '',
 								characterName: '',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							}
@@ -672,6 +688,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'role',
 								name: 'Ghost',
 								characterName: 'Ghost of King Hamlet',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							},
@@ -679,6 +696,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'role',
 								name: 'Player King',
 								characterName: 'First Player',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							},
@@ -686,6 +704,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'role',
 								name: '',
 								characterName: '',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							}
@@ -701,6 +720,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'role',
 								name: 'Lucianus',
 								characterName: '',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							},
@@ -709,12 +729,14 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								name: 'English Ambassador',
 								qualifier: '',
 								characterName: '',
+								characterDifferentiator: '',
 								errors: {}
 							},
 							{
 								model: 'role',
 								name: '',
 								characterName: '',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							}
@@ -730,6 +752,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'role',
 								name: '',
 								characterName: '',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							}
@@ -745,6 +768,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'role',
 								name: '',
 								characterName: '',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							}
@@ -839,6 +863,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'role',
 								name: 'Richard, Duke of Gloucester',
 								characterName: '',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							},
@@ -846,6 +871,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'role',
 								name: '',
 								characterName: '',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							}
@@ -861,6 +887,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'role',
 								name: 'Brakenbury',
 								characterName: 'Sir Robert Brakenbury',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							},
@@ -868,6 +895,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'role',
 								name: 'Richmond',
 								characterName: 'Henry, Earl of Richmond',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							},
@@ -875,6 +903,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'role',
 								name: '',
 								characterName: '',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							}
@@ -890,6 +919,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'role',
 								name: 'Ratcliffe',
 								characterName: '',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							},
@@ -897,6 +927,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'role',
 								name: 'Lord Mayor',
 								characterName: '',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							},
@@ -904,6 +935,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'role',
 								name: '',
 								characterName: '',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							}
@@ -919,6 +951,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'role',
 								name: '',
 								characterName: '',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							}
@@ -934,6 +967,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'role',
 								name: '',
 								characterName: '',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							}
@@ -1099,6 +1133,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'role',
 								name: '',
 								characterName: '',
+								characterDifferentiator: '',
 								qualifier: '',
 								errors: {}
 							}

--- a/test-e2e/model-interaction/diff-characters-same-name-diff-playtexts.test.js
+++ b/test-e2e/model-interaction/diff-characters-same-name-diff-playtexts.test.js
@@ -6,7 +6,7 @@ import { v4 as uuid } from 'uuid';
 import app from '../../src/app';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
 
-describe('Different characters with the same name', () => {
+describe('Different characters with the same name from different playtexts', () => {
 
 	chai.use(chaiHttp);
 

--- a/test-e2e/model-interaction/diff-characters-same-name-same-playtext.test.js
+++ b/test-e2e/model-interaction/diff-characters-same-name-same-playtext.test.js
@@ -1,0 +1,394 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import { createSandbox } from 'sinon';
+import { v4 as uuid } from 'uuid';
+
+import app from '../../src/app';
+import purgeDatabase from '../test-helpers/neo4j/purge-database';
+
+describe('Different characters with the same name from the same playtext', () => {
+
+	chai.use(chaiHttp);
+
+	const JULIUS_CAESAR_PLAYTEXT_UUID = '4';
+	const CINNA_CHARACTER_1_UUID = '5';
+	const VOLUMNIUS_CHARACTER_UUID = '6';
+	const CINNA_CHARACTER_2_UUID = '7';
+	const JULIUS_CAESAR_BARBICAN_PRODUCTION_UUID = '8';
+	const BARBICAN_THEATRE_UUID = '9';
+	const PAUL_SHEARER_PERSON_UUID = '11';
+	const LEO_WRINGER_PERSON_UUID = '12';
+
+	let cinnaCharacter1;
+	let cinnaCharacter2;
+	let volumniusCharacter;
+	let juliusCaesarPlaytext;
+	let juliusCaesarBarbicanProduction;
+	let paulShearerPerson;
+	let leoWringerPerson;
+
+	const sandbox = createSandbox();
+
+	before(async () => {
+
+		let uuidCallCount = 0;
+
+		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+
+		await purgeDatabase();
+
+		await chai.request(app)
+			.post('/playtexts')
+			.send({
+				name: 'Julius Caesar',
+				characters: [
+					{
+						name: 'Cinna',
+						differentiator: '1'
+					},
+					{
+						name: 'Volumnius'
+					},
+					{
+						name: 'Cinna',
+						differentiator: '2'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Julius Caesar',
+				theatre: {
+					name: 'Barbican'
+				},
+				playtext: {
+					name: 'Julius Caesar'
+				},
+				cast: [
+					{
+						name: 'Paul Shearer',
+						roles: [
+							{
+								name: 'Cinna',
+								characterDifferentiator: '1'
+							},
+							{
+								name: 'Volumnius'
+							}
+						]
+					},
+					{
+						name: 'Leo Wringer',
+						roles: [
+							{
+								name: 'Cinna',
+								characterDifferentiator: '2'
+							}
+						]
+					}
+				]
+			});
+
+		cinnaCharacter1 = await chai.request(app)
+			.get(`/characters/${CINNA_CHARACTER_1_UUID}`);
+
+		cinnaCharacter2 = await chai.request(app)
+			.get(`/characters/${CINNA_CHARACTER_2_UUID}`);
+
+		volumniusCharacter = await chai.request(app)
+			.get(`/characters/${VOLUMNIUS_CHARACTER_UUID}`);
+
+		juliusCaesarPlaytext = await chai.request(app)
+			.get(`/playtexts/${JULIUS_CAESAR_PLAYTEXT_UUID}`);
+
+		juliusCaesarBarbicanProduction = await chai.request(app)
+			.get(`/productions/${JULIUS_CAESAR_BARBICAN_PRODUCTION_UUID}`);
+
+		paulShearerPerson = await chai.request(app)
+			.get(`/people/${PAUL_SHEARER_PERSON_UUID}`);
+
+		leoWringerPerson = await chai.request(app)
+			.get(`/people/${LEO_WRINGER_PERSON_UUID}`);
+
+	});
+
+	after(() => {
+
+		sandbox.restore();
+
+	});
+
+	describe('Cinna (character) (#1)', () => {
+
+		it('includes productions in which character was portrayed including performers who portrayed them (i.e. excludes portrayers of different character with same name)', () => {
+
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: JULIUS_CAESAR_BARBICAN_PRODUCTION_UUID,
+					name: 'Julius Caesar',
+					theatre: {
+						model: 'theatre',
+						uuid: BARBICAN_THEATRE_UUID,
+						name: 'Barbican'
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: PAUL_SHEARER_PERSON_UUID,
+							name: 'Paul Shearer',
+							roleName: 'Cinna',
+							qualifier: null,
+							otherRoles: [
+								{
+									model: 'character',
+									uuid: VOLUMNIUS_CHARACTER_UUID,
+									name: 'Volumnius',
+									qualifier: null
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { productions } = cinnaCharacter1.body;
+
+			expect(productions).to.deep.equal(expectedProductions);
+
+		});
+
+	});
+
+	describe('Cinna (character) (#2)', () => {
+
+		it('includes productions in which character was portrayed including performers who portrayed them (i.e. excludes portrayers of different character with same name)', () => {
+
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: JULIUS_CAESAR_BARBICAN_PRODUCTION_UUID,
+					name: 'Julius Caesar',
+					theatre: {
+						model: 'theatre',
+						uuid: BARBICAN_THEATRE_UUID,
+						name: 'Barbican'
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: LEO_WRINGER_PERSON_UUID,
+							name: 'Leo Wringer',
+							roleName: 'Cinna',
+							qualifier: null,
+							otherRoles: []
+						}
+					]
+				}
+			];
+
+			const { productions } = cinnaCharacter2.body;
+
+			expect(productions).to.deep.equal(expectedProductions);
+
+		});
+
+	});
+
+	describe('Volumnius (character)', () => {
+
+		it('includes productions in which character was portrayed including in portrayer\'s other roles the correct duplicate-named character', () => {
+
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: JULIUS_CAESAR_BARBICAN_PRODUCTION_UUID,
+					name: 'Julius Caesar',
+					theatre: {
+						model: 'theatre',
+						uuid: BARBICAN_THEATRE_UUID,
+						name: 'Barbican'
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: PAUL_SHEARER_PERSON_UUID,
+							name: 'Paul Shearer',
+							roleName: 'Volumnius',
+							qualifier: null,
+							otherRoles: [
+								{
+									model: 'character',
+									uuid: CINNA_CHARACTER_1_UUID,
+									name: 'Cinna',
+									qualifier: null
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { productions } = volumniusCharacter.body;
+
+			expect(productions).to.deep.equal(expectedProductions);
+
+		});
+
+	});
+
+	describe('Julius Caesar (playtext)', () => {
+
+		it('includes Cinna (#1) and Cinna (#2) in its characters', () => {
+
+			const expectedCharacters = [
+				{
+					model: 'character',
+					uuid: CINNA_CHARACTER_1_UUID,
+					name: 'Cinna',
+					qualifier: null
+				},
+				{
+					model: 'character',
+					uuid: VOLUMNIUS_CHARACTER_UUID,
+					name: 'Volumnius',
+					qualifier: null
+				},
+				{
+					model: 'character',
+					uuid: CINNA_CHARACTER_2_UUID,
+					name: 'Cinna',
+					qualifier: null
+				}
+			];
+
+			const { characterGroups: [{ characters }] } = juliusCaesarPlaytext.body;
+
+			expect(characters).to.deep.equal(expectedCharacters);
+
+		});
+
+	});
+
+	describe('Julius Caesar at Barbican (production)', () => {
+
+		it('includes cast with Paul Shearer as Cinna (#1) and Leo Wringer as Cinna (#2)', () => {
+
+			const expectedCast = [
+				{
+					model: 'person',
+					uuid: PAUL_SHEARER_PERSON_UUID,
+					name: 'Paul Shearer',
+					roles: [
+						{
+							model: 'character',
+							uuid: CINNA_CHARACTER_1_UUID,
+							name: 'Cinna',
+							qualifier: null
+						},
+						{
+							model: 'character',
+							uuid: VOLUMNIUS_CHARACTER_UUID,
+							name: 'Volumnius',
+							qualifier: null
+						}
+					]
+				},
+				{
+					model: 'person',
+					uuid: LEO_WRINGER_PERSON_UUID,
+					name: 'Leo Wringer',
+					roles: [
+						{
+							model: 'character',
+							uuid: CINNA_CHARACTER_2_UUID,
+							name: 'Cinna',
+							qualifier: null
+						}
+					]
+				}
+			];
+
+			const { cast } = juliusCaesarBarbicanProduction.body;
+
+			expect(cast).to.deep.equal(expectedCast);
+
+		});
+
+	});
+
+	describe('Paul Shearer (person)', () => {
+
+		it('includes in their production credits their portrayal of Cinna (#1) (i.e. and not Cinna (#2))', () => {
+
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: JULIUS_CAESAR_BARBICAN_PRODUCTION_UUID,
+					name: 'Julius Caesar',
+					theatre: {
+						model: 'theatre',
+						uuid: BARBICAN_THEATRE_UUID,
+						name: 'Barbican'
+					},
+					roles: [
+						{
+							model: 'character',
+							uuid: CINNA_CHARACTER_1_UUID,
+							name: 'Cinna',
+							qualifier: null
+						},
+						{
+							model: 'character',
+							uuid: VOLUMNIUS_CHARACTER_UUID,
+							name: 'Volumnius',
+							qualifier: null
+						}
+					]
+				}
+			];
+
+			const { productions } = paulShearerPerson.body;
+
+			expect(productions).to.deep.equal(expectedProductions);
+
+		});
+
+	});
+
+	describe('Leo Wringer (person)', () => {
+
+		it('includes in their production credits their portrayal of Cinna (#2) (i.e. and not Cinna (#1))', () => {
+
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: JULIUS_CAESAR_BARBICAN_PRODUCTION_UUID,
+					name: 'Julius Caesar',
+					theatre: {
+						model: 'theatre',
+						uuid: BARBICAN_THEATRE_UUID,
+						name: 'Barbican'
+					},
+					roles: [
+						{
+							model: 'character',
+							uuid: CINNA_CHARACTER_2_UUID,
+							name: 'Cinna',
+							qualifier: null
+						}
+					]
+				}
+			];
+
+			const { productions } = leoWringerPerson.body;
+
+			expect(productions).to.deep.equal(expectedProductions);
+
+		});
+
+	});
+
+});

--- a/test-e2e/uniqueness-in-db/productions-api.test.js
+++ b/test-e2e/uniqueness-in-db/productions-api.test.js
@@ -341,6 +341,7 @@ describe('Uniqueness in database: Productions API', () => {
 						model: 'role',
 						name: '',
 						characterName: '',
+						characterDifferentiator: '',
 						qualifier: '',
 						errors: {}
 					}
@@ -379,6 +380,7 @@ describe('Uniqueness in database: Productions API', () => {
 						model: 'role',
 						name: '',
 						characterName: '',
+						characterDifferentiator: '',
 						qualifier: '',
 						errors: {}
 					}
@@ -416,6 +418,7 @@ describe('Uniqueness in database: Productions API', () => {
 						model: 'role',
 						name: '',
 						characterName: '',
+						characterDifferentiator: '',
 						qualifier: '',
 						errors: {}
 					}
@@ -454,6 +457,7 @@ describe('Uniqueness in database: Productions API', () => {
 						model: 'role',
 						name: '',
 						characterName: '',
+						characterDifferentiator: '',
 						qualifier: '',
 						errors: {}
 					}

--- a/test-int/instance-validation-failures/production.test.js
+++ b/test-int/instance-validation-failures/production.test.js
@@ -677,6 +677,7 @@ describe('Production instance', () => {
 									model: 'role',
 									name: 'Hamlet',
 									characterName: '',
+									characterDifferentiator: '',
 									qualifier: '',
 									errors: {}
 								}
@@ -746,6 +747,7 @@ describe('Production instance', () => {
 									model: 'role',
 									name: ABOVE_MAX_LENGTH_STRING,
 									characterName: '',
+									characterDifferentiator: '',
 									qualifier: '',
 									errors: {
 										name: [
@@ -819,9 +821,85 @@ describe('Production instance', () => {
 									model: 'role',
 									name: 'Hamlet',
 									characterName: ABOVE_MAX_LENGTH_STRING,
+									characterDifferentiator: '',
 									qualifier: '',
 									errors: {
 										characterName: [
+											'Value is too long'
+										]
+									}
+								}
+							]
+						}
+					]
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+		context('cast member role characterDifferentiator value exceeds maximum limit', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instanceProps = {
+					name: 'Hamlet',
+					cast: [
+						{
+							name: 'Rory Kinnear',
+							roles: [
+								{
+									name: 'Hamlet',
+									characterName: '',
+									characterDifferentiator: ABOVE_MAX_LENGTH_STRING
+								}
+							]
+						}
+					]
+				};
+
+				const instance = new Production(instanceProps);
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					model: 'production',
+					uuid: undefined,
+					name: 'Hamlet',
+					hasErrors: true,
+					errors: {},
+					theatre: {
+						model: 'theatre',
+						uuid: undefined,
+						name: '',
+						differentiator: '',
+						errors: {}
+					},
+					playtext: {
+						model: 'playtext',
+						uuid: undefined,
+						name: '',
+						differentiator: '',
+						errors: {}
+					},
+					cast: [
+						{
+							model: 'person',
+							uuid: undefined,
+							name: 'Rory Kinnear',
+							differentiator: '',
+							errors: {},
+							roles: [
+								{
+									model: 'role',
+									name: 'Hamlet',
+									characterName: '',
+									characterDifferentiator: ABOVE_MAX_LENGTH_STRING,
+									qualifier: '',
+									errors: {
+										characterDifferentiator: [
 											'Value is too long'
 										]
 									}
@@ -892,6 +970,7 @@ describe('Production instance', () => {
 									model: 'role',
 									name: 'Hamlet',
 									characterName: '',
+									characterDifferentiator: '',
 									qualifier: ABOVE_MAX_LENGTH_STRING,
 									errors: {
 										qualifier: [
@@ -965,6 +1044,7 @@ describe('Production instance', () => {
 									model: 'role',
 									name: '',
 									characterName: 'Hamlet',
+									characterDifferentiator: '',
 									qualifier: '',
 									errors: {
 										name: [
@@ -1038,6 +1118,7 @@ describe('Production instance', () => {
 									model: 'role',
 									name: 'Hamlet',
 									characterName: 'Hamlet',
+									characterDifferentiator: '',
 									qualifier: '',
 									errors: {
 										characterName: [
@@ -1056,7 +1137,7 @@ describe('Production instance', () => {
 
 		});
 
-		context('duplicate combinations of cast member role name and qualifier values', () => {
+		context('duplicate combinations of cast member role name, qualifier, and characterDifferentiator values', () => {
 
 			it('assigns appropriate error', async () => {
 
@@ -1069,16 +1150,19 @@ describe('Production instance', () => {
 								{
 									name: 'Polonius',
 									characterName: '',
+									characterDifferentiator: '',
 									qualifier: ''
 								},
 								{
 									name: 'Gravedigger',
 									characterName: '',
+									characterDifferentiator: '',
 									qualifier: ''
 								},
 								{
 									name: 'Polonius',
 									characterName: '',
+									characterDifferentiator: '',
 									qualifier: ''
 								}
 							]
@@ -1122,9 +1206,13 @@ describe('Production instance', () => {
 									model: 'role',
 									name: 'Polonius',
 									characterName: '',
+									characterDifferentiator: '',
 									qualifier: '',
 									errors: {
 										name: [
+											'This item has been duplicated within the group'
+										],
+										characterDifferentiator: [
 											'This item has been duplicated within the group'
 										],
 										qualifier: [
@@ -1136,6 +1224,7 @@ describe('Production instance', () => {
 									model: 'role',
 									name: 'Gravedigger',
 									characterName: '',
+									characterDifferentiator: '',
 									qualifier: '',
 									errors: {}
 								},
@@ -1143,9 +1232,13 @@ describe('Production instance', () => {
 									model: 'role',
 									name: 'Polonius',
 									characterName: '',
+									characterDifferentiator: '',
 									qualifier: '',
 									errors: {
 										name: [
+											'This item has been duplicated within the group'
+										],
+										characterDifferentiator: [
 											'This item has been duplicated within the group'
 										],
 										qualifier: [

--- a/test-unit/src/lib/get-duplicate-indices.test.js
+++ b/test-unit/src/lib/get-duplicate-indices.test.js
@@ -46,6 +46,27 @@ describe('Get Duplicate Indices module', () => {
 
 		});
 
+		context('array items with characterDifferentiator', () => {
+
+			it('returns an empty array', () => {
+
+				const result = getDuplicateIndices(
+					[
+						{ name: 'Cinna', characterDifferentiator: '1' },
+						{ name: 'Citizen', characterDifferentiator: '' },
+						{ name: 'Volumnius', characterDifferentiator: '' },
+						{ name: 'Soothsayer', characterDifferentiator: '' },
+						{ name: 'Volumnius', characterDifferentiator: '1' },
+						{ name: 'Cinna', characterDifferentiator: '2' }
+					]
+				);
+
+				expect(result).to.deep.equal([]);
+
+			});
+
+		});
+
 		context('array items with qualifier', () => {
 
 			it('returns an empty array', () => {
@@ -91,7 +112,40 @@ describe('Get Duplicate Indices module', () => {
 
 		});
 
-		context('array items with differentiator, qualifier, and group', () => {
+		context('array items with characterDifferentiator and qualifier (e.g. production cast roles)', () => {
+
+			it('returns an empty array', () => {
+
+				const result = getDuplicateIndices(
+					[
+						{ name: 'Foo', characterDifferentiator: '', qualifier: '' },
+						{ name: 'Foo', characterDifferentiator: '1', qualifier: '' },
+						{ name: 'Foo', characterDifferentiator: '2', qualifier: '' },
+						{ name: 'Foo', characterDifferentiator: '', qualifier: 'younger' },
+						{ name: 'Foo', characterDifferentiator: '', qualifier: 'older' },
+						{ name: 'Foo', characterDifferentiator: '1', qualifier: 'younger' },
+						{ name: 'Foo', characterDifferentiator: '1', qualifier: 'older' },
+						{ name: 'Foo', characterDifferentiator: '2', qualifier: 'younger' },
+						{ name: 'Foo', characterDifferentiator: '2', qualifier: 'older' },
+						{ name: 'Bar', characterDifferentiator: '', qualifier: '' },
+						{ name: 'Bar', characterDifferentiator: '1', qualifier: '' },
+						{ name: 'Bar', characterDifferentiator: '2', qualifier: '' },
+						{ name: 'Bar', characterDifferentiator: '', qualifier: 'younger' },
+						{ name: 'Bar', characterDifferentiator: '', qualifier: 'older' },
+						{ name: 'Bar', characterDifferentiator: '1', qualifier: 'younger' },
+						{ name: 'Bar', characterDifferentiator: '1', qualifier: 'older' },
+						{ name: 'Bar', characterDifferentiator: '2', qualifier: 'younger' },
+						{ name: 'Bar', characterDifferentiator: '2', qualifier: 'older' }
+					]
+				);
+
+				expect(result).to.deep.equal([]);
+
+			});
+
+		});
+
+		context('array items with differentiator, qualifier, and group (e.g. playtext characters)', () => {
 
 			it('returns an empty array', () => {
 
@@ -299,6 +353,73 @@ describe('Get Duplicate Indices module', () => {
 
 		});
 
+		context('array items with characterDifferentiator', () => {
+
+			context('single pair of duplicate items', () => {
+
+				it('returns an array of indices of duplicate items', () => {
+
+					const result = getDuplicateIndices(
+						[
+							{ name: 'Cinna', characterDifferentiator: '1' },
+							{ name: 'Citizen', characterDifferentiator: '' },
+							{ name: 'Soothsayer', characterDifferentiator: '' },
+							{ name: 'Cinna', characterDifferentiator: '1' }
+						]
+					);
+
+					expect(result).to.deep.equal([0, 3]);
+
+				});
+
+			});
+
+			context('two pairs of duplicate items', () => {
+
+				it('returns an array of indices of duplicate items', () => {
+
+					const result = getDuplicateIndices(
+						[
+							{ name: 'Cinna', characterDifferentiator: '1' },
+							{ name: 'Citizen', characterDifferentiator: '' },
+							{ name: 'Volumnius', characterDifferentiator: '' },
+							{ name: 'Soothsayer', characterDifferentiator: '' },
+							{ name: 'Volumnius', characterDifferentiator: '' },
+							{ name: 'Cinna', characterDifferentiator: '1' }
+						]
+					);
+
+					expect(result).to.deep.equal([0, 2, 4, 5]);
+
+				});
+
+			});
+
+			context('two pairs of duplicate items, and a single pair of duplicate items with empty string name values', () => {
+
+				it('returns an array of indices of duplicate items, ignoring items with empty string name values', () => {
+
+					const result = getDuplicateIndices(
+						[
+							{ name: 'Cinna', characterDifferentiator: '1' },
+							{ name: '', characterDifferentiator: '' },
+							{ name: 'Citizen', characterDifferentiator: '' },
+							{ name: 'Volumnius', characterDifferentiator: '' },
+							{ name: '', characterDifferentiator: '' },
+							{ name: 'Soothsayer', characterDifferentiator: '' },
+							{ name: 'Volumnius', characterDifferentiator: '' },
+							{ name: 'Cinna', characterDifferentiator: '1' }
+						]
+					);
+
+					expect(result).to.deep.equal([0, 3, 6, 7]);
+
+				});
+
+			});
+
+		});
+
 		context('array items with qualifier', () => {
 
 			context('single pair of duplicate items', () => {
@@ -439,7 +560,74 @@ describe('Get Duplicate Indices module', () => {
 
 		});
 
-		context('array items with differentiator, qualifier, and group', () => {
+		context('array items with characterDifferentiator and qualifier (e.g. production cast roles)', () => {
+
+			context('single pair of duplicate items', () => {
+
+				it('returns an array of indices of duplicate items', () => {
+
+					const result = getDuplicateIndices(
+						[
+							{ name: 'Foo', characterDifferentiator: '1', qualifier: 'younger' },
+							{ name: 'Bar', characterDifferentiator: '1', qualifier: 'younger' },
+							{ name: 'Foo', characterDifferentiator: '1', qualifier: 'younger' },
+							{ name: 'Baz', characterDifferentiator: '1', qualifier: 'younger' }
+						]
+					);
+
+					expect(result).to.deep.equal([0, 2]);
+
+				});
+
+			});
+
+			context('two pairs of duplicate items', () => {
+
+				it('returns an array of indices of duplicate items', () => {
+
+					const result = getDuplicateIndices(
+						[
+							{ name: 'Foo', characterDifferentiator: '1', qualifier: 'younger' },
+							{ name: 'Bar', characterDifferentiator: '1', qualifier: 'younger' },
+							{ name: 'Baz', characterDifferentiator: '1', qualifier: 'younger' },
+							{ name: 'Foo', characterDifferentiator: '1', qualifier: 'younger' },
+							{ name: 'Bar', characterDifferentiator: '1', qualifier: 'younger' },
+							{ name: 'Qux', characterDifferentiator: '1', qualifier: 'younger' }
+						]
+					);
+
+					expect(result).to.deep.equal([0, 1, 3, 4]);
+
+				});
+
+			});
+
+			context('two pairs of duplicate items, and a single pair of duplicate items with empty string name values', () => {
+
+				it('returns an array of indices of duplicate items, ignoring items with empty string name values', () => {
+
+					const result = getDuplicateIndices(
+						[
+							{ name: 'Foo', characterDifferentiator: '1', qualifier: 'younger' },
+							{ name: 'Bar', characterDifferentiator: '1', qualifier: 'younger' },
+							{ name: '', characterDifferentiator: '1', qualifier: 'younger' },
+							{ name: 'Baz', characterDifferentiator: '1', qualifier: 'younger' },
+							{ name: 'Foo', characterDifferentiator: '1', qualifier: 'younger' },
+							{ name: 'Bar', characterDifferentiator: '1', qualifier: 'younger' },
+							{ name: '', characterDifferentiator: '1', qualifier: 'younger' },
+							{ name: 'Qux', characterDifferentiator: '1', qualifier: 'younger' }
+						]
+					);
+
+					expect(result).to.deep.equal([0, 1, 4, 5]);
+
+				});
+
+			});
+
+		});
+
+		context('array items with differentiator, qualifier, and group (e.g. playtext characters)', () => {
 
 			context('single pair of duplicate items', () => {
 

--- a/test-unit/src/models/Base.test.js
+++ b/test-unit/src/models/Base.test.js
@@ -147,6 +147,33 @@ describe('Base model', () => {
 
 	});
 
+	describe('hasCharacterDifferentiatorProperty method', () => {
+
+		context('instance has differentiator property', () => {
+
+			it('returns true', () => {
+
+				instance.characterDifferentiator = '';
+				const result = instance.hasCharacterDifferentiatorProperty();
+				expect(result).to.be.true;
+
+			});
+
+		});
+
+		context('instance does not have differentiator property', () => {
+
+			it('returns false', () => {
+
+				const result = instance.hasCharacterDifferentiatorProperty();
+				expect(result).to.be.false;
+
+			});
+
+		});
+
+	});
+
 	describe('hasQualifierProperty method', () => {
 
 		context('instance has qualifier property', () => {
@@ -303,12 +330,14 @@ describe('Base model', () => {
 			it('will not call addPropertyError method', () => {
 
 				spy(instance, 'hasDifferentiatorProperty');
+				spy(instance, 'hasCharacterDifferentiatorProperty');
 				spy(instance, 'hasQualifierProperty');
 				spy(instance, 'hasGroupProperty');
 				spy(instance, 'addPropertyError');
 				const opts = { isDuplicate: false };
 				instance.validateUniquenessInGroup(opts);
 				expect(instance.hasDifferentiatorProperty.notCalled).to.be.true;
+				expect(instance.hasCharacterDifferentiatorProperty.notCalled).to.be.true;
 				expect(instance.hasQualifierProperty.notCalled).to.be.true;
 				expect(instance.hasGroupProperty.notCalled).to.be.true;
 				expect(instance.addPropertyError.notCalled).to.be.true;
@@ -319,11 +348,12 @@ describe('Base model', () => {
 
 		context('invalid data', () => {
 
-			context('instance does not have differentiator, qualifier, or group property', () => {
+			context('instance does not have differentiator, characterDifferentiator, qualifier, or group property', () => {
 
 				it('will call addPropertyError method with group context error text for name property only', () => {
 
 					spy(instance, 'hasDifferentiatorProperty');
+					spy(instance, 'hasCharacterDifferentiatorProperty');
 					spy(instance, 'hasQualifierProperty');
 					spy(instance, 'hasGroupProperty');
 					spy(instance, 'addPropertyError');
@@ -331,6 +361,8 @@ describe('Base model', () => {
 					instance.validateUniquenessInGroup(opts);
 					expect(instance.hasDifferentiatorProperty.calledOnce).to.be.true;
 					expect(instance.hasDifferentiatorProperty.calledWithExactly()).to.be.true;
+					expect(instance.hasCharacterDifferentiatorProperty.calledOnce).to.be.true;
+					expect(instance.hasCharacterDifferentiatorProperty.calledWithExactly()).to.be.true;
 					expect(instance.hasQualifierProperty.calledOnce).to.be.true;
 					expect(instance.hasQualifierProperty.calledWithExactly()).to.be.true;
 					expect(instance.hasGroupProperty.calledOnce).to.be.true;
@@ -350,6 +382,7 @@ describe('Base model', () => {
 
 					instance.differentiator = '';
 					spy(instance, 'hasDifferentiatorProperty');
+					spy(instance, 'hasCharacterDifferentiatorProperty');
 					spy(instance, 'hasQualifierProperty');
 					spy(instance, 'hasGroupProperty');
 					spy(instance, 'addPropertyError');
@@ -357,6 +390,8 @@ describe('Base model', () => {
 					instance.validateUniquenessInGroup(opts);
 					expect(instance.hasDifferentiatorProperty.calledOnce).to.be.true;
 					expect(instance.hasDifferentiatorProperty.calledWithExactly()).to.be.true;
+					expect(instance.hasCharacterDifferentiatorProperty.calledOnce).to.be.true;
+					expect(instance.hasCharacterDifferentiatorProperty.calledWithExactly()).to.be.true;
 					expect(instance.hasQualifierProperty.calledOnce).to.be.true;
 					expect(instance.hasQualifierProperty.calledWithExactly()).to.be.true;
 					expect(instance.hasGroupProperty.calledOnce).to.be.true;
@@ -373,12 +408,13 @@ describe('Base model', () => {
 
 			});
 
-			context('instance has qualifier property', () => {
+			context('instance has characterDifferentiator property', () => {
 
-				it('will call addPropertyError method with group context error text for name and qualifier properties', () => {
+				it('will call addPropertyError method with group context error text for name and differentiator properties', () => {
 
-					instance.qualifier = '';
+					instance.characterDifferentiator = '';
 					spy(instance, 'hasDifferentiatorProperty');
+					spy(instance, 'hasCharacterDifferentiatorProperty');
 					spy(instance, 'hasQualifierProperty');
 					spy(instance, 'hasGroupProperty');
 					spy(instance, 'addPropertyError');
@@ -386,6 +422,40 @@ describe('Base model', () => {
 					instance.validateUniquenessInGroup(opts);
 					expect(instance.hasDifferentiatorProperty.calledOnce).to.be.true;
 					expect(instance.hasDifferentiatorProperty.calledWithExactly()).to.be.true;
+					expect(instance.hasCharacterDifferentiatorProperty.calledOnce).to.be.true;
+					expect(instance.hasCharacterDifferentiatorProperty.calledWithExactly()).to.be.true;
+					expect(instance.hasQualifierProperty.calledOnce).to.be.true;
+					expect(instance.hasQualifierProperty.calledWithExactly()).to.be.true;
+					expect(instance.hasGroupProperty.calledOnce).to.be.true;
+					expect(instance.hasGroupProperty.calledWithExactly()).to.be.true;
+					expect(instance.addPropertyError.calledTwice).to.be.true;
+					expect(instance.addPropertyError.firstCall.calledWithExactly(
+						'name', 'This item has been duplicated within the group'
+					)).to.be.true;
+					expect(instance.addPropertyError.secondCall.calledWithExactly(
+						'characterDifferentiator', 'This item has been duplicated within the group'
+					)).to.be.true;
+
+				});
+
+			});
+
+			context('instance has qualifier property', () => {
+
+				it('will call addPropertyError method with group context error text for name and qualifier properties', () => {
+
+					instance.qualifier = '';
+					spy(instance, 'hasDifferentiatorProperty');
+					spy(instance, 'hasCharacterDifferentiatorProperty');
+					spy(instance, 'hasQualifierProperty');
+					spy(instance, 'hasGroupProperty');
+					spy(instance, 'addPropertyError');
+					const opts = { isDuplicate: true };
+					instance.validateUniquenessInGroup(opts);
+					expect(instance.hasDifferentiatorProperty.calledOnce).to.be.true;
+					expect(instance.hasDifferentiatorProperty.calledWithExactly()).to.be.true;
+					expect(instance.hasCharacterDifferentiatorProperty.calledOnce).to.be.true;
+					expect(instance.hasCharacterDifferentiatorProperty.calledWithExactly()).to.be.true;
 					expect(instance.hasQualifierProperty.calledOnce).to.be.true;
 					expect(instance.hasQualifierProperty.calledWithExactly()).to.be.true;
 					expect(instance.hasGroupProperty.calledOnce).to.be.true;
@@ -408,6 +478,7 @@ describe('Base model', () => {
 
 					instance.group = '';
 					spy(instance, 'hasDifferentiatorProperty');
+					spy(instance, 'hasCharacterDifferentiatorProperty');
 					spy(instance, 'hasQualifierProperty');
 					spy(instance, 'hasGroupProperty');
 					spy(instance, 'addPropertyError');
@@ -415,6 +486,8 @@ describe('Base model', () => {
 					instance.validateUniquenessInGroup(opts);
 					expect(instance.hasDifferentiatorProperty.calledOnce).to.be.true;
 					expect(instance.hasDifferentiatorProperty.calledWithExactly()).to.be.true;
+					expect(instance.hasCharacterDifferentiatorProperty.calledOnce).to.be.true;
+					expect(instance.hasCharacterDifferentiatorProperty.calledWithExactly()).to.be.true;
 					expect(instance.hasQualifierProperty.calledOnce).to.be.true;
 					expect(instance.hasQualifierProperty.calledWithExactly()).to.be.true;
 					expect(instance.hasGroupProperty.calledOnce).to.be.true;
@@ -431,14 +504,16 @@ describe('Base model', () => {
 
 			});
 
-			context('instance has differentiator, qualifier, and group property', () => {
+			context('instance has differentiator, characterDifferentiator, qualifier, and group property', () => {
 
 				it('will call addPropertyError method with group context error text for name, differentiator, qualifier, and group properties', () => {
 
 					instance.differentiator = '';
+					instance.characterDifferentiator = '';
 					instance.qualifier = '';
 					instance.group = '';
 					spy(instance, 'hasDifferentiatorProperty');
+					spy(instance, 'hasCharacterDifferentiatorProperty');
 					spy(instance, 'hasQualifierProperty');
 					spy(instance, 'hasGroupProperty');
 					spy(instance, 'addPropertyError');
@@ -446,11 +521,13 @@ describe('Base model', () => {
 					instance.validateUniquenessInGroup(opts);
 					expect(instance.hasDifferentiatorProperty.calledOnce).to.be.true;
 					expect(instance.hasDifferentiatorProperty.calledWithExactly()).to.be.true;
+					expect(instance.hasCharacterDifferentiatorProperty.calledOnce).to.be.true;
+					expect(instance.hasCharacterDifferentiatorProperty.calledWithExactly()).to.be.true;
 					expect(instance.hasQualifierProperty.calledOnce).to.be.true;
 					expect(instance.hasQualifierProperty.calledWithExactly()).to.be.true;
 					expect(instance.hasGroupProperty.calledOnce).to.be.true;
 					expect(instance.hasGroupProperty.calledWithExactly()).to.be.true;
-					expect(instance.addPropertyError.callCount).to.equal(4);
+					expect(instance.addPropertyError.callCount).to.equal(5);
 					expect(instance.addPropertyError.firstCall.calledWithExactly(
 						'name', 'This item has been duplicated within the group'
 					)).to.be.true;
@@ -458,9 +535,12 @@ describe('Base model', () => {
 						'differentiator', 'This item has been duplicated within the group'
 					)).to.be.true;
 					expect(instance.addPropertyError.thirdCall.calledWithExactly(
-						'qualifier', 'This item has been duplicated within the group'
+						'characterDifferentiator', 'This item has been duplicated within the group'
 					)).to.be.true;
 					expect(instance.addPropertyError.getCall(3).calledWithExactly(
+						'qualifier', 'This item has been duplicated within the group'
+					)).to.be.true;
+					expect(instance.addPropertyError.getCall(4).calledWithExactly(
 						'group', 'This item has been duplicated within the group'
 					)).to.be.true;
 

--- a/test-unit/src/models/Role.test.js
+++ b/test-unit/src/models/Role.test.js
@@ -46,6 +46,45 @@ describe('Role model', () => {
 
 		});
 
+		describe('characterDifferentiator property', () => {
+
+			it('assigns empty string if absent from props', () => {
+
+				const instance = new Role({ name: 'Cinna' });
+				expect(instance.characterDifferentiator).to.equal('');
+
+			});
+
+			it('assigns empty string if included in props but value is empty string', () => {
+
+				const instance = new Role({ name: 'Cinna', characterDifferentiator: '' });
+				expect(instance.characterDifferentiator).to.equal('');
+
+			});
+
+			it('assigns empty string if included in props but value is whitespace-only string', () => {
+
+				const instance = new Role({ name: 'Cinna', characterDifferentiator: ' ' });
+				expect(instance.characterDifferentiator).to.equal('');
+
+			});
+
+			it('assigns value if included in props and value is string with length', () => {
+
+				const instance = new Role({ name: 'Cinna', characterDifferentiator: '1' });
+				expect(instance.characterDifferentiator).to.equal('1');
+
+			});
+
+			it('trims value before assigning', () => {
+
+				const instance = new Role({ name: 'Cinna', characterDifferentiator: ' 1 ' });
+				expect(instance.characterDifferentiator).to.equal('1');
+
+			});
+
+		});
+
 		describe('qualifier property', () => {
 
 			it('assigns empty string if absent from props', () => {
@@ -97,6 +136,22 @@ describe('Role model', () => {
 			expect(instance.validateStringForProperty.calledOnce).to.be.true;
 			expect(instance.validateStringForProperty.calledWithExactly(
 				'characterName', { isRequired: false })
+			).to.be.true;
+
+		});
+
+	});
+
+	describe('validateCharacterDifferentiator method', () => {
+
+		it('will call validateStringForProperty method', () => {
+
+			const instance = new Role({ name: 'Hamlet, Prince of Denmark', characterName: '' });
+			spy(instance, 'validateStringForProperty');
+			instance.validateCharacterDifferentiator();
+			expect(instance.validateStringForProperty.calledOnce).to.be.true;
+			expect(instance.validateStringForProperty.calledWithExactly(
+				'characterDifferentiator', { isRequired: false })
 			).to.be.true;
 
 		});

--- a/test-unit/src/neo4j/cypher-queries/production.test.js
+++ b/test-unit/src/neo4j/cypher-queries/production.test.js
@@ -87,6 +87,7 @@ describe('Cypher Queries Production module', () => {
 									rolePosition: role.position,
 									roleName: role.name,
 									characterName: role.characterName,
+									characterDifferentiator: role.characterDifferentiator,
 									qualifier: role.qualifier
 								}]-(person)
 						)
@@ -112,10 +113,11 @@ describe('Cypher Queries Production module', () => {
 							ELSE {
 								name: role.roleName,
 								characterName: CASE role.characterName WHEN NULL THEN '' ELSE role.characterName END,
+								characterDifferentiator: CASE role.characterDifferentiator WHEN NULL THEN '' ELSE role.characterDifferentiator END,
 								qualifier: CASE role.qualifier WHEN NULL THEN '' ELSE role.qualifier END
 							}
 						END
-					) + [{ name: '', characterName: '', qualifier: '' }] AS roles
+					) + [{ name: '', characterName: '', characterDifferentiator: '', qualifier: '' }] AS roles
 
 				RETURN
 					'production' AS model,
@@ -134,7 +136,7 @@ describe('Cypher Queries Production module', () => {
 							THEN null
 							ELSE { name: person.name, differentiator: person.differentiator, roles: roles }
 						END
-					) + [{ name: '', roles: [{ name: '', characterName: '', qualifier: '' }] }] AS cast
+					) + [{ name: '', roles: [{ name: '', characterName: '', characterDifferentiator: '', qualifier: '' }] }] AS cast
 			`));
 
 		});
@@ -231,6 +233,7 @@ describe('Cypher Queries Production module', () => {
 									rolePosition: role.position,
 									roleName: role.name,
 									characterName: role.characterName,
+									characterDifferentiator: role.characterDifferentiator,
 									qualifier: role.qualifier
 								}]-(person)
 						)
@@ -256,10 +259,11 @@ describe('Cypher Queries Production module', () => {
 							ELSE {
 								name: role.roleName,
 								characterName: CASE role.characterName WHEN NULL THEN '' ELSE role.characterName END,
+								characterDifferentiator: CASE role.characterDifferentiator WHEN NULL THEN '' ELSE role.characterDifferentiator END,
 								qualifier: CASE role.qualifier WHEN NULL THEN '' ELSE role.qualifier END
 							}
 						END
-					) + [{ name: '', characterName: '', qualifier: '' }] AS roles
+					) + [{ name: '', characterName: '', characterDifferentiator: '', qualifier: '' }] AS roles
 
 				RETURN
 					'production' AS model,
@@ -278,7 +282,7 @@ describe('Cypher Queries Production module', () => {
 							THEN null
 							ELSE { name: person.name, differentiator: person.differentiator, roles: roles }
 						END
-					) + [{ name: '', roles: [{ name: '', characterName: '', qualifier: '' }] }] AS cast
+					) + [{ name: '', roles: [{ name: '', characterName: '', characterDifferentiator: '', qualifier: '' }] }] AS cast
 			`));
 
 		});


### PR DESCRIPTION
There is an edge case of different characters with the same name appearing in the same playtext. This is obviously rare as it will result in confusion for the audience, but it can happen, and in the example used (Julius Caesar by William Shakespeare) is actually a plot point: Cinna the poet is killed by an angry mob after being mistaken for Cinna the conspirator.

Currently, the Cypher queries that match production cast roles with corresponding playtext characters does so on the basis of matching the names.

If the playtext includes two characters both called Cinna then the query will match both of them when a performer only has one role where the characters name is Cinna.

To remedy this, in this scenario the `differentiator` value used to differentiate the characters (e.g. `1` for Cinna # 1 and `2` for Cinna # 2) must be given in the production cast role information as the `characterDifferentiator` value.

This is only required when there are two characters with the same name in the same playtext as the query that is looking for a name match is scoped to the playtext, e.g. if the character of Demetrius in Titus Andronicus has a `differentiator` value of `2`, this need not be required as the `characterDifferentiator` in productions of that playtext as it contains only one character named Demetrius, even though there are other characters named Demetrius in other playtexts such as A Midsummer Night's Dream).

#### Julius Caesar (playtext) characters:
![julius-caesar-playtext-characters](https://user-images.githubusercontent.com/10484515/94281016-067efa80-ff46-11ea-9282-7a475e881877.png)

---

#### Julius Caesar at Barbican (production) cast:
![julius-caesar-production-cast](https://user-images.githubusercontent.com/10484515/94281038-0d0d7200-ff46-11ea-8fbe-51c4d1459e8b.png)

---

These scenarios are accommodated by the addition of a `qualifier` property, which distinguishes between different instances/aspects/facets of the character.

#### Julius Caesar (playtext):
![julius-caesar-playtext](https://user-images.githubusercontent.com/10484515/94284790-c5d5b000-ff4a-11ea-8ba1-3fcffa8c4796.png)

---

#### Julius Caesar at Barbican (production):
![julius-caesar-production](https://user-images.githubusercontent.com/10484515/94284895-ec93e680-ff4a-11ea-9c2e-6912ed22b4c0.png)

---

#### Cinna # 1 (character):
![cinna-1-character](https://user-images.githubusercontent.com/10484515/94284086-cfaae380-ff49-11ea-8bb4-654c59bdf292.png)

---

#### Cinna # 2 (character):
![cinna-2-character](https://user-images.githubusercontent.com/10484515/94284080-cde12000-ff49-11ea-9139-be7dd8bc737b.png)

---

#### Volumnius (character):
![volumnius-character](https://user-images.githubusercontent.com/10484515/94285070-27961a00-ff4b-11ea-8c43-51e285875ab6.png)

---

#### Paul Shearer (person):
![paul-shearer-person](https://user-images.githubusercontent.com/10484515/94285415-86f42a00-ff4b-11ea-864c-2065d1ea4d9a.png)

---

#### Leo Wringer (person):
![leo-wringer-person](https://user-images.githubusercontent.com/10484515/94285430-89ef1a80-ff4b-11ea-8ff0-b9010e4235e2.png)

---

#### Julius Caesar at Barbican (production) without `differentiator` value for one of the Cinna characters:
N.B. If there are two characters with the same name in the same playtext but one of them does not have a `differentiator` value then the query that maps characters to their portrayals in productions will match both characters.

A role having a null `characterDifferentiator` value (i.e. property is absent) and the corresponding character having a null `differentiator` value (i.e. property is absent) will not be considered a match: the match **must** be based on present values.
![julius-caesar-production-wrong](https://user-images.githubusercontent.com/10484515/94286721-485f6f00-ff4d-11ea-8fe7-b62866b14985.png)