### PR TITLE
Add database seeds to demonstrate different characters with same name in same playtext

### DIFF
--- a/db-seeding/seeds/playtexts/coriolanus.json
+++ b/db-seeding/seeds/playtexts/coriolanus.json
@@ -77,7 +77,8 @@
 			"name": "Lictors"
 		},
 		{
-			"name": "Soldiers"
+			"name": "Soldiers",
+			"differentiator": "Coriolanus"
 		},
 		{
 			"name": "Messengers"

--- a/db-seeding/seeds/playtexts/hamlet.json
+++ b/db-seeding/seeds/playtexts/hamlet.json
@@ -23,7 +23,8 @@
 			"name": "Player King"
 		},
 		{
-			"name": "Claudius"
+			"name": "Claudius",
+			"differentiator": "1"
 		},
 		{
 			"name": "Voltemand"

--- a/db-seeding/seeds/playtexts/julius-caesar.json
+++ b/db-seeding/seeds/playtexts/julius-caesar.json
@@ -1,0 +1,194 @@
+{
+	"name": "Julius Caesar",
+	"characters": [
+		{
+			"name": "Julius Caesar",
+			"group": ""
+		},
+		{
+			"name": "Octavius Caesar",
+			"group": "Triumvirs after Caesar's death"
+		},
+		{
+			"name": "Mark Antony",
+			"group": "Triumvirs after Caesar's death"
+		},
+		{
+			"name": "Lepidus",
+			"group": "Triumvirs after Caesar's death"
+		},
+		{
+			"name": "Marcus Brutus",
+			"group": "Conspirators against Caesar"
+		},
+		{
+			"name": "Caius Cassius",
+			"group": "Conspirators against Caesar"
+		},
+		{
+			"name": "Casca",
+			"group": "Conspirators against Caesar"
+		},
+		{
+			"name": "Decius Brutus",
+			"group": "Conspirators against Caesar"
+		},
+		{
+			"name": "Cinna",
+			"differentiator": "1",
+			"group": "Conspirators against Caesar"
+		},
+		{
+			"name": "Metellus Cimber",
+			"group": "Conspirators against Caesar"
+		},
+		{
+			"name": "Trebonius",
+			"group": "Conspirators against Caesar"
+		},
+		{
+			"name": "Caius Ligarius",
+			"group": "Conspirators against Caesar"
+		},
+		{
+			"name": "Flavius",
+			"group": "Tribunes"
+		},
+		{
+			"name": "Marullus",
+			"group": "Tribunes"
+		},
+		{
+			"name": "Cicero",
+			"group": "Roman Senate Senators"
+		},
+		{
+			"name": "Publius",
+			"differentiator": "2",
+			"group": "Roman Senate Senators"
+		},
+		{
+			"name": "Popilius Lena",
+			"group": "Roman Senate Senators"
+		},
+		{
+			"name": "Calphurnia",
+			"group": "Citizens"
+		},
+		{
+			"name": "Portia",
+			"group": "Citizens"
+		},
+		{
+			"name": "Soothsayer",
+			"group": "Citizens"
+		},
+		{
+			"name": "Artemidorus",
+			"group": "Citizens"
+		},
+		{
+			"name": "Cinna",
+			"differentiator": "2",
+			"group": "Citizens"
+		},
+		{
+			"name": "Cobbler",
+			"group": "Citizens"
+		},
+		{
+			"name": "Carpenter",
+			"group": "Citizens"
+		},
+		{
+			"name": "Poet",
+			"group": "Citizens"
+		},
+		{
+			"name": "Lucius",
+			"differentiator": "2",
+			"group": "Citizens"
+		},
+		{
+			"name": "Volumnius",
+			"group": "Loyal to Brutus and Cassius"
+		},
+		{
+			"name": "Titinius",
+			"group": "Loyal to Brutus and Cassius"
+		},
+		{
+			"name": "Young Cato",
+			"group": "Loyal to Brutus and Cassius"
+		},
+		{
+			"name": "Messala",
+			"group": "Loyal to Brutus and Cassius"
+		},
+		{
+			"name": "Varro",
+			"group": "Loyal to Brutus and Cassius"
+		},
+		{
+			"name": "Clitus",
+			"group": "Loyal to Brutus and Cassius"
+		},
+		{
+			"name": "Claudius",
+			"differentiator": "2",
+			"group": "Loyal to Brutus and Cassius"
+		},
+		{
+			"name": "Dardanius",
+			"group": "Loyal to Brutus and Cassius"
+		},
+		{
+			"name": "Strato",
+			"group": "Loyal to Brutus and Cassius"
+		},
+		{
+			"name": "Lucilius",
+			"group": "Loyal to Brutus and Cassius"
+		},
+		{
+			"name": "Pindarus",
+			"group": "Loyal to Brutus and Cassius"
+		},
+		{
+			"name": "Servant to Julius Caesar",
+			"group": "Other"
+		},
+		{
+			"name": "Servant to Mark Antony",
+			"group": "Other"
+		},
+		{
+			"name": "Servant to Octavius Caesar",
+			"group": "Other"
+		},
+		{
+			"name": "Messenger",
+			"differentiator": "Julius Caesar",
+			"group": "Other"
+		},
+		{
+			"name": "Senators",
+			"differentiator": "Julius Caesar",
+			"group": "Other"
+		},
+		{
+			"name": "Soldiers",
+			"differentiator": "Julius Caesar",
+			"group": "Other"
+		},
+		{
+			"name": "Plebeians",
+			"group": "Other"
+		},
+		{
+			"name": "Attendants",
+			"differentiator": "Julius Caesar",
+			"group": "Other"
+		}
+	]
+}

--- a/db-seeding/seeds/playtexts/titus-andronicus.json
+++ b/db-seeding/seeds/playtexts/titus-andronicus.json
@@ -14,10 +14,12 @@
 			"name": "Marcus Andronicus"
 		},
 		{
-			"name": "Publius"
+			"name": "Publius",
+			"differentiator": "1"
 		},
 		{
-			"name": "Lucius"
+			"name": "Lucius",
+			"differentiator": "1"
 		},
 		{
 			"name": "Quintus"
@@ -73,7 +75,8 @@
 			"differentiator": "Titus Andronicus"
 		},
 		{
-			"name": "Senators"
+			"name": "Senators",
+			"differentiator": "Titus Andronicus"
 		},
 		{
 			"name": "Tribunes"

--- a/db-seeding/seeds/productions/julius-caesar.json
+++ b/db-seeding/seeds/productions/julius-caesar.json
@@ -1,0 +1,290 @@
+{
+	"name": "Julius Caesar",
+	"theatre": {
+		"name": "Barbican"
+	},
+	"playtext": {
+		"name": "Julius Caesar"
+	},
+	"cast": [
+		{
+			"name": "David Collings",
+			"roles": [
+				{
+					"name": "Flavius"
+				},
+				{
+					"name": "Lepidus"
+				}
+			]
+		},
+		{
+			"name": "Anthony Mark Barrow",
+			"roles": [
+				{
+					"name": "Carpenter"
+				},
+				{
+					"name": "Strato"
+				}
+			]
+		},
+		{
+			"name": "Daniel Weyman",
+			"roles": [
+				{
+					"name": "Marullus"
+				},
+				{
+					"name": "Lucilius"
+				}
+			]
+		},
+		{
+			"name": "Jim Hooper",
+			"roles": [
+				{
+					"name": "Cobbler"
+				},
+				{
+					"name": "Clitus"
+				}
+			]
+		},
+		{
+			"name": "John Shrapnel",
+			"roles": [
+				{
+					"name": "Julius Caesar"
+				}
+			]
+		},
+		{
+			"name": "Struan Rodger",
+			"roles": [
+				{
+					"name": "Casca"
+				}
+			]
+		},
+		{
+			"name": "Ralph Fiennes",
+			"roles": [
+				{
+					"name": "Mark Antony"
+				}
+			]
+		},
+		{
+			"name": "Tim Potter",
+			"roles": [
+				{
+					"name": "Soothsayer"
+				},
+				{
+					"name": "Claudius"
+				}
+			]
+		},
+		{
+			"name": "Anton Lesser",
+			"roles": [
+				{
+					"name": "Marcus Brutus"
+				}
+			]
+		},
+		{
+			"name": "Simon Russell Beale",
+			"roles": [
+				{
+					"name": "Caius Cassius"
+				}
+			]
+		},
+		{
+			"name": "Clifford Rose",
+			"roles": [
+				{
+					"name": "Cicero"
+				}
+			]
+		},
+		{
+			"name": "Paul Shearer",
+			"roles": [
+				{
+					"name": "Cinna",
+					"characterDifferentiator": "1"
+				},
+				{
+					"name": "Second Poet",
+					"characterName": "Poet"
+				},
+				{
+					"name": "Volumnius"
+				}
+			]
+		},
+		{
+			"name": "James Anthony Pearson",
+			"roles": [
+				{
+					"name": "Lucius"
+				}
+			]
+		},
+		{
+			"name": "John Kane",
+			"roles": [
+				{
+					"name": "Decius Brutus"
+				}
+			]
+		},
+		{
+			"name": "Michael Gardiner",
+			"roles": [
+				{
+					"name": "Metellus Cimber"
+				},
+				{
+					"name": "Dardanius"
+				}
+			]
+		},
+		{
+			"name": "Chris Jarman",
+			"roles": [
+				{
+					"name": "Trebonius"
+				},
+				{
+					"name": "Titinius"
+				}
+			]
+		},
+		{
+			"name": "Fiona Shaw",
+			"roles": [
+				{
+					"name": "Portia"
+				}
+			]
+		},
+		{
+			"name": "Sean Baker",
+			"roles": [
+				{
+					"name": "Caius Ligarius"
+				}
+			]
+		},
+		{
+			"name": "Robert Demeger",
+			"roles": [
+				{
+					"name": "Servant to Julius Caesar"
+				},
+				{
+					"name": "Messala"
+				}
+			]
+		},
+		{
+			"name": "Ginny Holder",
+			"roles": [
+				{
+					"name": "Calphurnia"
+				}
+			]
+		},
+		{
+			"name": "Jimmy Gardner",
+			"roles": [
+				{
+					"name": "Publius"
+				}
+			]
+		},
+		{
+			"name": "John Rogan",
+			"roles": [
+				{
+					"name": "Artemidorus"
+				}
+			]
+		},
+		{
+			"name": "David Glover",
+			"roles": [
+				{
+					"name": "Popilius Lena"
+				}
+			]
+		},
+		{
+			"name": "Alex McIntosh",
+			"roles": [
+				{
+					"name": "Servant to Mark Antony"
+				},
+				{
+					"name": "Varro"
+				}
+			]
+		},
+		{
+			"name": "Rohan Siva",
+			"roles": [
+				{
+					"name": "Servant to Octavius Caesar"
+				},
+				{
+					"name": "Pindarus"
+				}
+			]
+		},
+		{
+			"name": "Joseph Kennedy",
+			"roles": [
+				{
+					"name": "Citizen",
+					"characterName": "Plebeians"
+				},
+				{
+					"name": "Young Cato"
+				}
+			]
+		},
+		{
+			"name": "Celia Meiras",
+			"roles": [
+				{
+					"name": "Citizen",
+					"characterName": "Plebeians"
+				},
+				{
+					"name": "Messenger"
+				}
+			]
+		},
+		{
+			"name": "Leo Wringer",
+			"roles": [
+				{
+					"name": "Cinna",
+					"characterDifferentiator": "2"
+				}
+			]
+		},
+		{
+			"name": "Oliver Kieran-Jones",
+			"roles": [
+				{
+					"name": "Octavius Caesar"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
Database seeds to demonstrate the production cast role `characterDifferentiator` property added in this PR: https://github.com/andygout/theatrebase-api/pull/235.