### PR TITLE
Handle characters in multiple playtexts with variant names

### DIFF
--- a/test-e2e/model-interaction/character-with-variant-names.test.js
+++ b/test-e2e/model-interaction/character-with-variant-names.test.js
@@ -205,8 +205,8 @@ describe('Character with variant names', () => {
 		it('includes variant names (i.e. portrayals in productions with names different to that in playtext)', () => {
 
 			const expectedVariantNames = [
-				'Ghost',
-				'King Hamlet'
+				'King Hamlet',
+				'Ghost'
 			];
 
 			const { variantNames } = ghostCharacter.body;


### PR DESCRIPTION
There was an issue with the character show Cypher query in that if a character appears in multiple playtexts *and* has variant names, then the COLLECTing applied in the query will produce results relating to one playtext only.

More modifications to this query are required so that ordering can be applied to the playtexts, variant names, and productions individually. This will be done in a separate PR.

#### Hamlet (character) (before):
![hamlet-before](https://user-images.githubusercontent.com/10484515/94339679-9d55c080-fff3-11ea-9fb8-28f03cec771a.png)

---

#### Hamlet (character) (after):
![hamlet-after](https://user-images.githubusercontent.com/10484515/94339683-a050b100-fff3-11ea-9ba6-cf097b68e8bd.png)