### PR TITLE
Revise character show query to collect depictions for each playtext

### DIFF
--- a/src/neo4j/cypher-queries/character.js
+++ b/src/neo4j/cypher-queries/character.js
@@ -9,9 +9,11 @@ const getShowQuery = () => `
 	WITH
 		character,
 		playtext,
-		playtextRel.displayName AS displayName,
-		COLLECT(playtextRel.qualifier) AS qualifiers,
-		COLLECT(playtextRel.group) AS groups
+		COLLECT({
+			displayName: playtextRel.displayName,
+			qualifier: playtextRel.qualifier,
+			group: playtextRel.group
+		}) AS depictions
 
 	OPTIONAL MATCH (character)<-[variantNamedDepiction:INCLUDES_CHARACTER]-(:Playtext)
 		WHERE variantNamedDepiction.displayName IS NOT NULL
@@ -56,9 +58,7 @@ const getShowQuery = () => `
 	WITH
 		character,
 		playtext,
-		displayName,
-		qualifiers,
-		groups,
+		depictions,
 		variantNamedDepiction,
 		production,
 		theatre,
@@ -72,9 +72,7 @@ const getShowQuery = () => `
 	WITH
 		character,
 		playtext,
-		displayName,
-		qualifiers,
-		groups,
+		depictions,
 		variantNamedDepiction,
 		variantNamedPortrayal,
 		production,
@@ -97,9 +95,7 @@ const getShowQuery = () => `
 	WITH
 		character,
 		playtext,
-		displayName,
-		qualifiers,
-		groups,
+		depictions,
 		variantNamedDepiction,
 		variantNamedPortrayal,
 		production,
@@ -114,7 +110,7 @@ const getShowQuery = () => `
 		}) AS performers
 		ORDER BY production.name, theatre.name
 
-	WITH character, playtext, displayName, qualifiers, groups, variantNamedDepiction, variantNamedPortrayal,
+	WITH character, playtext, depictions, variantNamedDepiction, variantNamedPortrayal,
 		COLLECT(
 			CASE production WHEN NULL
 				THEN null
@@ -133,11 +129,11 @@ const getShowQuery = () => `
 		) AS productions
 		ORDER BY variantNamedPortrayal.roleName
 
-	WITH character, playtext, displayName, qualifiers, groups, variantNamedDepiction, productions,
+	WITH character, playtext, depictions, variantNamedDepiction, productions,
 		COLLECT(DISTINCT(variantNamedPortrayal.roleName)) AS variantNamedPortrayals
 		ORDER BY variantNamedDepiction.displayName
 
-	WITH character, playtext, displayName, qualifiers, groups, variantNamedPortrayals, productions,
+	WITH character, playtext, depictions, variantNamedPortrayals, productions,
 		COLLECT(DISTINCT(variantNamedDepiction.displayName)) AS variantNamedDepictions
 		ORDER BY playtext.name
 
@@ -154,9 +150,7 @@ const getShowQuery = () => `
 					model: 'playtext',
 					uuid: playtext.uuid,
 					name: playtext.name,
-					characterDisplayName: displayName,
-					qualifiers: qualifiers,
-					groups: groups
+					depictions: depictions
 				}
 			END
 		) AS playtexts,

--- a/test-e2e/model-interaction/char-diff-groups-same-playtext.test.js
+++ b/test-e2e/model-interaction/char-diff-groups-same-playtext.test.js
@@ -202,11 +202,17 @@ describe('Character with multiple appearances in the same playtext in different 
 					model: 'playtext',
 					uuid: THREE_WINTERS_PLAYTEXT_UUID,
 					name: '3 Winters',
-					characterDisplayName: null,
-					qualifiers: [],
-					groups: [
-						'2011',
-						'1990'
+					depictions: [
+						{
+							displayName: null,
+							qualifier: null,
+							group: '2011'
+						},
+						{
+							displayName: null,
+							qualifier: null,
+							group: '1990'
+						}
 					]
 				}
 			];
@@ -267,11 +273,17 @@ describe('Character with multiple appearances in the same playtext in different 
 					model: 'playtext',
 					uuid: THREE_WINTERS_PLAYTEXT_UUID,
 					name: '3 Winters',
-					characterDisplayName: null,
-					qualifiers: [],
-					groups: [
-						'2011',
-						'1990'
+					depictions: [
+						{
+							displayName: null,
+							qualifier: null,
+							group: '2011'
+						},
+						{
+							displayName: null,
+							qualifier: null,
+							group: '1990'
+						}
 					]
 				}
 			];
@@ -324,11 +336,17 @@ describe('Character with multiple appearances in the same playtext in different 
 					model: 'playtext',
 					uuid: THREE_WINTERS_PLAYTEXT_UUID,
 					name: '3 Winters',
-					characterDisplayName: null,
-					qualifiers: [],
-					groups: [
-						'1990',
-						'1945'
+					depictions: [
+						{
+							displayName: null,
+							qualifier: null,
+							group: '1990'
+						},
+						{
+							displayName: null,
+							qualifier: null,
+							group: '1945'
+						}
 					]
 				}
 			];
@@ -389,10 +407,12 @@ describe('Character with multiple appearances in the same playtext in different 
 					model: 'playtext',
 					uuid: THREE_WINTERS_PLAYTEXT_UUID,
 					name: '3 Winters',
-					characterDisplayName: null,
-					qualifiers: [],
-					groups: [
-						'1945'
+					depictions: [
+						{
+							displayName: null,
+							qualifier: null,
+							group: '1945'
+						}
 					]
 				}
 			];

--- a/test-e2e/model-interaction/char-in-multi-prods-of-multi-playtexts.test.js
+++ b/test-e2e/model-interaction/char-in-multi-prods-of-multi-playtexts.test.js
@@ -305,25 +305,37 @@ describe('Character in multiple productions of multiple playtexts', () => {
 					model: 'playtext',
 					uuid: HENRY_IV_PART_1_PLAYTEXT_UUID,
 					name: 'Henry IV: Part 1',
-					characterDisplayName: null,
-					qualifiers: [],
-					groups: []
+					depictions: [
+						{
+							displayName: null,
+							qualifier: null,
+							group: null
+						}
+					]
 				},
 				{
 					model: 'playtext',
 					uuid: HENRY_IV_PART_2_PLAYTEXT_UUID,
 					name: 'Henry IV: Part 2',
-					characterDisplayName: null,
-					qualifiers: [],
-					groups: []
+					depictions: [
+						{
+							displayName: null,
+							qualifier: null,
+							group: null
+						}
+					]
 				},
 				{
 					model: 'playtext',
 					uuid: THE_MERRY_WIVES_OF_WINDSOR_PLAYTEXT_UUID,
 					name: 'The Merry Wives of Windsor',
-					characterDisplayName: null,
-					qualifiers: [],
-					groups: []
+					depictions: [
+						{
+							displayName: null,
+							qualifier: null,
+							group: null
+						}
+					]
 				}
 			];
 

--- a/test-e2e/model-interaction/char-multi-appearances-same-playtext.test.js
+++ b/test-e2e/model-interaction/char-multi-appearances-same-playtext.test.js
@@ -154,12 +154,18 @@ describe('Character with multiple appearances in the same playtext under differe
 					model: 'playtext',
 					uuid: ROCK_N_ROLL_PLAYTEXT_UUID,
 					name: 'Rock \'n\' Roll',
-					characterDisplayName: null,
-					qualifiers: [
-						'younger',
-						'older'
-					],
-					groups: []
+					depictions: [
+						{
+							displayName: null,
+							qualifier: 'younger',
+							group: null
+						},
+						{
+							displayName: null,
+							qualifier: 'older',
+							group: null
+						}
+					]
 				}
 			];
 

--- a/test-e2e/model-interaction/char-with-variant-depiction-portrayal-names.test.js
+++ b/test-e2e/model-interaction/char-with-variant-depiction-portrayal-names.test.js
@@ -384,25 +384,37 @@ describe('Character with variant depiction and portrayal names', () => {
 					model: 'playtext',
 					uuid: HENRY_IV_PART_1_PLAYTEXT_UUID,
 					name: 'Henry IV, Part 1',
-					characterDisplayName: 'Henry, Prince of Wales',
-					qualifiers: [],
-					groups: []
+					depictions: [
+						{
+							displayName: 'Henry, Prince of Wales',
+							qualifier: null,
+							group: null
+						}
+					]
 				},
 				{
 					model: 'playtext',
 					uuid: HENRY_IV_PART_2_PLAYTEXT_UUID,
 					name: 'Henry IV, Part 2',
-					characterDisplayName: 'Prince Hal',
-					qualifiers: [],
-					groups: []
+					depictions: [
+						{
+							displayName: 'Prince Hal',
+							qualifier: null,
+							group: null
+						}
+					]
 				},
 				{
 					model: 'playtext',
 					uuid: HENRY_V_PLAYTEXT_UUID,
 					name: 'Henry V',
-					characterDisplayName: null,
-					qualifiers: [],
-					groups: []
+					depictions: [
+						{
+							displayName: null,
+							qualifier: null,
+							group: null
+						}
+					]
 				}
 			];
 

--- a/test-e2e/model-interaction/char-with-variant-names-diff-playtexts.test.js
+++ b/test-e2e/model-interaction/char-with-variant-names-diff-playtexts.test.js
@@ -281,33 +281,49 @@ describe('Character with variant names from productions of different playtexts',
 					model: 'playtext',
 					uuid: FORTINBRAS_PLAYTEXT_UUID,
 					name: 'Fortinbras',
-					characterDisplayName: null,
-					qualifiers: [],
-					groups: []
+					depictions: [
+						{
+							displayName: null,
+							qualifier: null,
+							group: null
+						}
+					]
 				},
 				{
 					model: 'playtext',
 					uuid: HAMLET_PLAYTEXT_UUID,
 					name: 'Hamlet',
-					characterDisplayName: null,
-					qualifiers: [],
-					groups: []
+					depictions: [
+						{
+							displayName: null,
+							qualifier: null,
+							group: null
+						}
+					]
 				},
 				{
 					model: 'playtext',
 					uuid: HAMLETMACHINE_PLAYTEXT_UUID,
 					name: 'Hamletmachine',
-					characterDisplayName: null,
-					qualifiers: [],
-					groups: []
+					depictions: [
+						{
+							displayName: null,
+							qualifier: null,
+							group: null
+						}
+					]
 				},
 				{
 					model: 'playtext',
 					uuid: ROSENCRANTZ_AND_GUILDENSTERN_ARE_DEAD_PLAYTEXT_UUID,
 					name: 'Rosencrantz and Guildenstern Are Dead',
-					characterDisplayName: null,
-					qualifiers: [],
-					groups: []
+					depictions: [
+						{
+							displayName: null,
+							qualifier: null,
+							group: null
+						}
+					]
 				}
 			];
 


### PR DESCRIPTION
This PR revises the character show query so that depictions for each playtext are grouped together rather than the current logic that will group all qualifiers and group all, erm, groups.

Eventually more detail will be added to each depiction making it more important that it remain grouped appropriately, e.g.

### Alisa Kos (character):

#### Before:
3 Winters
- (*thirty-six years old*, *fifteen years old*), (2011, 1990)

---

#### After:
3 Winters
- *thirty-six years old*, 2011
- *fifteen years old*, 1990

This might not be the best example as it can be deduced that the younger instance of the character related to the earlier year, but there will likely be other examples where such deductions cannot be made.