### PR TITLE
Revise playtext character entry format

### DIFF
--- a/src/controllers/model-template-props/playtext.js
+++ b/src/controllers/model-template-props/playtext.js
@@ -3,7 +3,7 @@ export default {
 	characters: [
 		{
 			name: '',
-			displayName: '',
+			underlyingName: '',
 			differentiator: '',
 			qualifier: '',
 			group: ''

--- a/src/models/Character.js
+++ b/src/models/Character.js
@@ -6,7 +6,7 @@ export default class Character extends Base {
 
 		super(props);
 
-		const { uuid, differentiator, displayName, qualifier, group, isAssociation } = props;
+		const { uuid, differentiator, underlyingName, qualifier, group, isAssociation } = props;
 
 		this.model = 'character';
 		this.uuid = uuid;
@@ -14,7 +14,7 @@ export default class Character extends Base {
 
 		if (isAssociation) {
 
-			this.displayName = displayName?.trim() || '';
+			this.underlyingName = underlyingName?.trim() || '';
 			this.qualifier = qualifier?.trim() || '';
 			this.group = group?.trim() || '';
 
@@ -22,9 +22,9 @@ export default class Character extends Base {
 
 	}
 
-	validateDisplayName () {
+	validateUnderlyingName () {
 
-		this.validateStringForProperty('displayName', { isRequired: false });
+		this.validateStringForProperty('underlyingName', { isRequired: false });
 
 	}
 

--- a/src/models/Playtext.js
+++ b/src/models/Playtext.js
@@ -36,7 +36,7 @@ export default class Playtext extends Base {
 
 			character.validateName({ isRequired: false });
 
-			character.validateDisplayName();
+			character.validateUnderlyingName();
 
 			character.validateDifferentiator();
 

--- a/test-e2e/crud/playtexts-api.test.js
+++ b/test-e2e/crud/playtexts-api.test.js
@@ -27,7 +27,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 					{
 						model: 'character',
 						name: '',
-						displayName: '',
+						underlyingName: '',
 						differentiator: '',
 						qualifier: '',
 						group: '',
@@ -83,7 +83,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 					{
 						model: 'character',
 						name: '',
-						displayName: '',
+						underlyingName: '',
 						differentiator: '',
 						qualifier: '',
 						group: '',
@@ -113,7 +113,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 					{
 						model: 'character',
 						name: '',
-						displayName: '',
+						underlyingName: '',
 						differentiator: '',
 						qualifier: '',
 						group: '',
@@ -147,7 +147,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 					{
 						model: 'character',
 						name: '',
-						displayName: '',
+						underlyingName: '',
 						differentiator: '',
 						qualifier: '',
 						group: '',
@@ -288,7 +288,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 					{
 						model: 'character',
 						name: 'Irina Nikolayevna Arkadina',
-						displayName: '',
+						underlyingName: '',
 						differentiator: '',
 						qualifier: '',
 						group: '',
@@ -297,7 +297,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 					{
 						model: 'character',
 						name: 'Konstantin Gavrilovich Treplyov',
-						displayName: '',
+						underlyingName: '',
 						differentiator: '',
 						qualifier: '',
 						group: '',
@@ -306,7 +306,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 					{
 						model: 'character',
 						name: 'Boris Alexeyevich Trigorin',
-						displayName: '',
+						underlyingName: '',
 						differentiator: '',
 						qualifier: '',
 						group: '',
@@ -315,7 +315,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 					{
 						model: 'character',
 						name: '',
-						displayName: '',
+						underlyingName: '',
 						differentiator: '',
 						qualifier: '',
 						group: '',
@@ -389,7 +389,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 					{
 						model: 'character',
 						name: 'Irina Nikolayevna Arkadina',
-						displayName: '',
+						underlyingName: '',
 						differentiator: '',
 						qualifier: '',
 						group: '',
@@ -398,7 +398,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 					{
 						model: 'character',
 						name: 'Konstantin Gavrilovich Treplyov',
-						displayName: '',
+						underlyingName: '',
 						differentiator: '',
 						qualifier: '',
 						group: '',
@@ -407,7 +407,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 					{
 						model: 'character',
 						name: 'Boris Alexeyevich Trigorin',
-						displayName: '',
+						underlyingName: '',
 						differentiator: '',
 						qualifier: '',
 						group: '',
@@ -416,7 +416,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 					{
 						model: 'character',
 						name: '',
-						displayName: '',
+						underlyingName: '',
 						differentiator: '',
 						qualifier: '',
 						group: '',
@@ -464,7 +464,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 					{
 						model: 'character',
 						name: 'Olga Sergeyevna Prozorova',
-						displayName: '',
+						underlyingName: '',
 						differentiator: '',
 						qualifier: '',
 						group: 'The Prozorovs',
@@ -473,7 +473,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 					{
 						model: 'character',
 						name: 'Maria Sergeyevna Kulygina',
-						displayName: '',
+						underlyingName: '',
 						differentiator: '',
 						qualifier: '',
 						group: 'The Prozorovs',
@@ -482,7 +482,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 					{
 						model: 'character',
 						name: 'Irina Sergeyevna Prozorova',
-						displayName: '',
+						underlyingName: '',
 						differentiator: '',
 						qualifier: '',
 						group: 'The Prozorovs',
@@ -491,7 +491,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 					{
 						model: 'character',
 						name: '',
-						displayName: '',
+						underlyingName: '',
 						differentiator: '',
 						qualifier: '',
 						group: '',
@@ -589,7 +589,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 					{
 						model: 'character',
 						name: '',
-						displayName: '',
+						underlyingName: '',
 						differentiator: '',
 						qualifier: '',
 						group: '',

--- a/test-e2e/model-interaction/char-with-variant-depiction-portrayal-names.test.js
+++ b/test-e2e/model-interaction/char-with-variant-depiction-portrayal-names.test.js
@@ -68,8 +68,8 @@ describe('Character with variant depiction and portrayal names', () => {
 				name: 'Henry IV, Part 1',
 				characters: [
 					{
-						name: 'King Henry V',
-						displayName: 'Henry, Prince of Wales'
+						name: 'Henry, Prince of Wales',
+						underlyingName: 'King Henry V'
 					},
 					{
 						name: 'Sir John Falstaff'
@@ -86,8 +86,8 @@ describe('Character with variant depiction and portrayal names', () => {
 				name: 'Henry IV, Part 2',
 				characters: [
 					{
-						name: 'King Henry V',
-						displayName: 'Prince Hal'
+						name: 'Prince Hal',
+						underlyingName: 'King Henry V'
 					},
 					{
 						name: 'Sir John Falstaff'

--- a/test-e2e/uniqueness-in-db/playtexts-api.test.js
+++ b/test-e2e/uniqueness-in-db/playtexts-api.test.js
@@ -55,7 +55,7 @@ describe('Uniqueness in database: Playtexts API', () => {
 					{
 						model: 'character',
 						name: '',
-						displayName: '',
+						underlyingName: '',
 						differentiator: '',
 						qualifier: '',
 						group: '',
@@ -123,7 +123,7 @@ describe('Uniqueness in database: Playtexts API', () => {
 					{
 						model: 'character',
 						name: '',
-						displayName: '',
+						underlyingName: '',
 						differentiator: '',
 						qualifier: '',
 						group: '',
@@ -193,7 +193,7 @@ describe('Uniqueness in database: Playtexts API', () => {
 					{
 						model: 'character',
 						name: '',
-						displayName: '',
+						underlyingName: '',
 						differentiator: '',
 						qualifier: '',
 						group: '',
@@ -228,7 +228,7 @@ describe('Uniqueness in database: Playtexts API', () => {
 					{
 						model: 'character',
 						name: '',
-						displayName: '',
+						underlyingName: '',
 						differentiator: '',
 						qualifier: '',
 						group: '',
@@ -293,7 +293,7 @@ describe('Uniqueness in database: Playtexts API', () => {
 			const expectedCharacterDemetrius1 = {
 				model: 'character',
 				name: 'Demetrius',
-				displayName: '',
+				underlyingName: '',
 				differentiator: '',
 				qualifier: '',
 				group: '',
@@ -325,7 +325,7 @@ describe('Uniqueness in database: Playtexts API', () => {
 			const expectedCharacterDemetrius2 = {
 				model: 'character',
 				name: 'Demetrius',
-				displayName: '',
+				underlyingName: '',
 				differentiator: '1',
 				qualifier: '',
 				group: '',
@@ -356,7 +356,7 @@ describe('Uniqueness in database: Playtexts API', () => {
 			const expectedCharacterDemetrius1 = {
 				model: 'character',
 				name: 'Demetrius',
-				displayName: '',
+				underlyingName: '',
 				differentiator: '',
 				qualifier: '',
 				group: '',
@@ -388,7 +388,7 @@ describe('Uniqueness in database: Playtexts API', () => {
 			const expectedCharacterDemetrius2 = {
 				model: 'character',
 				name: 'Demetrius',
-				displayName: '',
+				underlyingName: '',
 				differentiator: '1',
 				qualifier: '',
 				group: '',

--- a/test-int/instance-validation-failures/playtext.test.js
+++ b/test-int/instance-validation-failures/playtext.test.js
@@ -138,7 +138,7 @@ describe('Playtext instance', () => {
 							model: 'character',
 							uuid: undefined,
 							name: ABOVE_MAX_LENGTH_STRING,
-							displayName: '',
+							underlyingName: '',
 							differentiator: '',
 							qualifier: '',
 							group: '',
@@ -157,7 +157,7 @@ describe('Playtext instance', () => {
 
 		});
 
-		context('character displayName value exceeds maximum limit', () => {
+		context('character underlyingName value exceeds maximum limit', () => {
 
 			it('assigns appropriate error', async () => {
 
@@ -166,7 +166,7 @@ describe('Playtext instance', () => {
 					characters: [
 						{
 							name: 'Johannes Rosmer',
-							displayName: ABOVE_MAX_LENGTH_STRING
+							underlyingName: ABOVE_MAX_LENGTH_STRING
 						}
 					]
 				};
@@ -187,12 +187,12 @@ describe('Playtext instance', () => {
 							model: 'character',
 							uuid: undefined,
 							name: 'Johannes Rosmer',
-							displayName: ABOVE_MAX_LENGTH_STRING,
+							underlyingName: ABOVE_MAX_LENGTH_STRING,
 							differentiator: '',
 							qualifier: '',
 							group: '',
 							errors: {
-								displayName: [
+								underlyingName: [
 									'Value is too long'
 								]
 							}
@@ -236,7 +236,7 @@ describe('Playtext instance', () => {
 							model: 'character',
 							uuid: undefined,
 							name: 'Johannes Rosmer',
-							displayName: '',
+							underlyingName: '',
 							differentiator: ABOVE_MAX_LENGTH_STRING,
 							qualifier: '',
 							group: '',
@@ -285,7 +285,7 @@ describe('Playtext instance', () => {
 							model: 'character',
 							uuid: undefined,
 							name: 'Johannes Rosmer',
-							displayName: '',
+							underlyingName: '',
 							differentiator: '',
 							qualifier: ABOVE_MAX_LENGTH_STRING,
 							group: '',
@@ -334,7 +334,7 @@ describe('Playtext instance', () => {
 							model: 'character',
 							uuid: undefined,
 							name: 'Johannes Rosmer',
-							displayName: '',
+							underlyingName: '',
 							differentiator: '',
 							qualifier: '',
 							group: ABOVE_MAX_LENGTH_STRING,
@@ -433,7 +433,7 @@ describe('Playtext instance', () => {
 							model: 'character',
 							uuid: undefined,
 							name: 'Johannes Rosmer',
-							displayName: '',
+							underlyingName: '',
 							differentiator: '',
 							qualifier: '',
 							group: '',
@@ -456,7 +456,7 @@ describe('Playtext instance', () => {
 							model: 'character',
 							uuid: undefined,
 							name: 'Rebecca West',
-							displayName: '',
+							underlyingName: '',
 							differentiator: '1',
 							qualifier: '',
 							group: '',
@@ -479,7 +479,7 @@ describe('Playtext instance', () => {
 							model: 'character',
 							uuid: undefined,
 							name: 'Professor Kroll',
-							displayName: '',
+							underlyingName: '',
 							differentiator: '',
 							qualifier: '',
 							group: '',
@@ -489,7 +489,7 @@ describe('Playtext instance', () => {
 							model: 'character',
 							uuid: undefined,
 							name: 'Ulrik Brendel',
-							displayName: '',
+							underlyingName: '',
 							differentiator: '1',
 							qualifier: '',
 							group: '',
@@ -499,7 +499,7 @@ describe('Playtext instance', () => {
 							model: 'character',
 							uuid: undefined,
 							name: 'Peder Mortensgaard',
-							displayName: '',
+							underlyingName: '',
 							differentiator: '',
 							qualifier: '',
 							group: '',
@@ -509,7 +509,7 @@ describe('Playtext instance', () => {
 							model: 'character',
 							uuid: undefined,
 							name: 'Johannes Rosmer',
-							displayName: '',
+							underlyingName: '',
 							differentiator: '',
 							qualifier: '',
 							group: '',
@@ -532,7 +532,7 @@ describe('Playtext instance', () => {
 							model: 'character',
 							uuid: undefined,
 							name: 'Rebecca West',
-							displayName: '',
+							underlyingName: '',
 							differentiator: '1',
 							qualifier: '',
 							group: '',
@@ -555,7 +555,7 @@ describe('Playtext instance', () => {
 							model: 'character',
 							uuid: undefined,
 							name: 'Professor Kroll',
-							displayName: '',
+							underlyingName: '',
 							differentiator: '1',
 							qualifier: '',
 							group: '',
@@ -565,7 +565,7 @@ describe('Playtext instance', () => {
 							model: 'character',
 							uuid: undefined,
 							name: 'Ulrik Brendel',
-							displayName: '',
+							underlyingName: '',
 							differentiator: '2',
 							qualifier: '',
 							group: '',
@@ -667,7 +667,7 @@ describe('Playtext instance', () => {
 							model: 'character',
 							uuid: undefined,
 							name: ABOVE_MAX_LENGTH_STRING,
-							displayName: '',
+							underlyingName: '',
 							differentiator: '',
 							qualifier: '',
 							group: '',

--- a/test-unit/src/models/Character.test.js
+++ b/test-unit/src/models/Character.test.js
@@ -46,21 +46,21 @@ describe('Character model', () => {
 
 		});
 
-		describe('displayName property', () => {
+		describe('underlyingName property', () => {
 
 			context('instance is subject', () => {
 
 				it('will not assign any value if absent from props', () => {
 
-					const instance = new Character({ name: 'King Henry V' });
-					expect(instance).not.to.have.property('displayName');
+					const instance = new Character({ name: 'Prince Hal' });
+					expect(instance).not.to.have.property('underlyingName');
 
 				});
 
 				it('will not assign any value if included in props', () => {
 
-					const instance = new Character({ name: 'King Henry V', displayName: 'Prince Hal' });
-					expect(instance).not.to.have.property('displayName');
+					const instance = new Character({ name: 'Prince Hal', underlyingName: 'King Henry V' });
+					expect(instance).not.to.have.property('underlyingName');
 
 				});
 
@@ -70,36 +70,36 @@ describe('Character model', () => {
 
 				it('assigns empty string if absent from props', () => {
 
-					const instance = new Character({ name: 'King Henry V', isAssociation: true });
-					expect(instance.displayName).to.equal('');
+					const instance = new Character({ name: 'Prince Hal', isAssociation: true });
+					expect(instance.underlyingName).to.equal('');
 
 				});
 
 				it('assigns empty string if included in props but value is empty string', () => {
 
-					const instance = new Character({ name: 'King Henry V', displayName: '', isAssociation: true });
-					expect(instance.displayName).to.equal('');
+					const instance = new Character({ name: 'Prince Hal', underlyingName: '', isAssociation: true });
+					expect(instance.underlyingName).to.equal('');
 
 				});
 
 				it('assigns empty string if included in props but value is whitespace-only string', () => {
 
-					const instance = new Character({ name: 'King Henry V', displayName: ' ', isAssociation: true });
-					expect(instance.displayName).to.equal('');
+					const instance = new Character({ name: 'Prince Hal', underlyingName: ' ', isAssociation: true });
+					expect(instance.underlyingName).to.equal('');
 
 				});
 
 				it('assigns value if included in props and value is string with length', () => {
 
-					const instance = new Character({ name: 'King Henry V', displayName: 'Prince Hal', isAssociation: true });
-					expect(instance.displayName).to.equal('Prince Hal');
+					const instance = new Character({ name: 'Prince Hal', underlyingName: 'King Henry V', isAssociation: true });
+					expect(instance.underlyingName).to.equal('King Henry V');
 
 				});
 
 				it('trims value before assigning', () => {
 
-					const instance = new Character({ name: 'King Henry V', displayName: ' Prince Hal ', isAssociation: true });
-					expect(instance.displayName).to.equal('Prince Hal');
+					const instance = new Character({ name: 'Prince Hal', underlyingName: ' King Henry V ', isAssociation: true });
+					expect(instance.underlyingName).to.equal('King Henry V');
 
 				});
 
@@ -231,16 +231,16 @@ describe('Character model', () => {
 
 	});
 
-	describe('validateDisplayName method', () => {
+	describe('validateUnderlyingName method', () => {
 
 		it('will call validateStringForProperty method', () => {
 
-			const instance = new Character({ name: 'King Henry V', displayName: 'Prince Hal', isAssociation: true });
+			const instance = new Character({ name: 'Prince Hal', underlyingName: 'King Henry V', isAssociation: true });
 			spy(instance, 'validateStringForProperty');
-			instance.validateDisplayName();
+			instance.validateUnderlyingName();
 			expect(instance.validateStringForProperty.calledOnce).to.be.true;
 			expect(instance.validateStringForProperty.calledWithExactly(
-				'displayName', { isRequired: false }
+				'underlyingName', { isRequired: false }
 			)).to.be.true;
 
 		});

--- a/test-unit/src/models/Playtext.test.js
+++ b/test-unit/src/models/Playtext.test.js
@@ -175,7 +175,7 @@ describe('Playtext model', () => {
 				instance.validateDifferentiator,
 				stubs.getDuplicateIndicesModule.getDuplicateIndices,
 				instance.characters[0].validateName,
-				instance.characters[0].validateDisplayName,
+				instance.characters[0].validateUnderlyingName,
 				instance.characters[0].validateDifferentiator,
 				instance.characters[0].validateQualifier,
 				instance.characters[0].validateGroup,
@@ -191,8 +191,8 @@ describe('Playtext model', () => {
 			)).to.be.true;
 			expect(instance.characters[0].validateName.calledOnce).to.be.true;
 			expect(instance.characters[0].validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.characters[0].validateDisplayName.calledOnce).to.be.true;
-			expect(instance.characters[0].validateDisplayName.calledWithExactly()).to.be.true;
+			expect(instance.characters[0].validateUnderlyingName.calledOnce).to.be.true;
+			expect(instance.characters[0].validateUnderlyingName.calledWithExactly()).to.be.true;
 			expect(instance.characters[0].validateDifferentiator.calledOnce).to.be.true;
 			expect(instance.characters[0].validateDifferentiator.calledWithExactly()).to.be.true;
 			expect(instance.characters[0].validateQualifier.calledOnce).to.be.true;

--- a/test-unit/src/neo4j/cypher-queries/playtext.test.js
+++ b/test-unit/src/neo4j/cypher-queries/playtext.test.js
@@ -17,7 +17,9 @@ describe('Cypher Queries Playtext module', () => {
 
 				UNWIND (CASE $characters WHEN [] THEN [null] ELSE $characters END) AS characterParam
 
-					OPTIONAL MATCH (existingCharacter:Character { name: characterParam.name })
+					OPTIONAL MATCH (existingCharacter:Character {
+						name: COALESCE(characterParam.underlyingName, characterParam.name)
+					})
 						WHERE
 							(characterParam.differentiator IS NULL AND existingCharacter.differentiator IS NULL) OR
 							(characterParam.differentiator = existingCharacter.differentiator)
@@ -28,7 +30,7 @@ describe('Cypher Queries Playtext module', () => {
 						CASE existingCharacter WHEN NULL
 							THEN {
 								uuid: characterParam.uuid,
-								name: characterParam.name,
+								name: COALESCE(characterParam.underlyingName, characterParam.name),
 								differentiator: characterParam.differentiator,
 								qualifier: characterParam.qualifier,
 								group: characterParam.group
@@ -43,7 +45,7 @@ describe('Cypher Queries Playtext module', () => {
 						CREATE (playtext)-
 							[:INCLUDES_CHARACTER {
 								position: characterParam.position,
-								displayName: characterParam.displayName,
+								displayName: CASE characterParam.underlyingName WHEN NULL THEN null ELSE characterParam.name END,
 								qualifier: characterParam.qualifier,
 								group: characterParam.group
 							}]->(character)
@@ -67,8 +69,8 @@ describe('Cypher Queries Playtext module', () => {
 						CASE character WHEN NULL
 							THEN null
 							ELSE {
-								name: character.name,
-								displayName: characterRel.displayName,
+								name: COALESCE(characterRel.displayName, character.name),
+								underlyingName: CASE characterRel.displayName WHEN NULL THEN null ELSE character.name END,
 								differentiator: character.differentiator,
 								qualifier: characterRel.qualifier,
 								group: characterRel.group
@@ -103,7 +105,9 @@ describe('Cypher Queries Playtext module', () => {
 
 				UNWIND (CASE $characters WHEN [] THEN [null] ELSE $characters END) AS characterParam
 
-					OPTIONAL MATCH (existingCharacter:Character { name: characterParam.name })
+					OPTIONAL MATCH (existingCharacter:Character {
+						name: COALESCE(characterParam.underlyingName, characterParam.name)
+					})
 						WHERE
 							(characterParam.differentiator IS NULL AND existingCharacter.differentiator IS NULL) OR
 							(characterParam.differentiator = existingCharacter.differentiator)
@@ -114,7 +118,7 @@ describe('Cypher Queries Playtext module', () => {
 						CASE existingCharacter WHEN NULL
 							THEN {
 								uuid: characterParam.uuid,
-								name: characterParam.name,
+								name: COALESCE(characterParam.underlyingName, characterParam.name),
 								differentiator: characterParam.differentiator,
 								qualifier: characterParam.qualifier,
 								group: characterParam.group
@@ -129,7 +133,7 @@ describe('Cypher Queries Playtext module', () => {
 						CREATE (playtext)-
 							[:INCLUDES_CHARACTER {
 								position: characterParam.position,
-								displayName: characterParam.displayName,
+								displayName: CASE characterParam.underlyingName WHEN NULL THEN null ELSE characterParam.name END,
 								qualifier: characterParam.qualifier,
 								group: characterParam.group
 							}]->(character)
@@ -153,8 +157,8 @@ describe('Cypher Queries Playtext module', () => {
 						CASE character WHEN NULL
 							THEN null
 							ELSE {
-								name: character.name,
-								displayName: characterRel.displayName,
+								name: COALESCE(characterRel.displayName, character.name),
+								underlyingName: CASE characterRel.displayName WHEN NULL THEN null ELSE character.name END,
 								differentiator: character.differentiator,
 								qualifier: characterRel.qualifier,
 								group: characterRel.group


### PR DESCRIPTION
This PR revises the playtext character entry format.

#### King Henry V (character) and playtexts in which it is depicted:

<img width="864" alt="king-henry-v-character" src="https://user-images.githubusercontent.com/10484515/95200802-e0bfe400-07d6-11eb-8ef4-30a2fe7b5fb1.png">

#### King Henry V (character) appears in Henry IV, Part 2 (playtext) as Prince Hal:

#### Before:
Data entered as:
**name:** King Henry V
**displayName:** Prince Hal

#### After:
Data entered as:
**name:** Prince Hal
**underlyingName:** King Henry V

Entering with these field names and in this order is a lot more intuitive as you will likely be entering them from a list of the characters with the names they use specifically for that playtext, with the underlying character name likely requiring an additional lookup and which will be added in a second pass.

It is also more aligned with how production cast member roles are entered, i.e. `name` is how the role is presented on the page, with the secondary `characterName` property used to serve the purpose of linking it up to a specific character node (or variant depiction name thereof).