### PR TITLE
Reorder character instance props when an association

### DIFF
--- a/src/models/Character.js
+++ b/src/models/Character.js
@@ -10,11 +10,15 @@ export default class Character extends Base {
 
 		this.model = 'character';
 		this.uuid = uuid;
+
+		// Property assignment order in contructor dictates order of fields in CMS form
+		// where `underlyingName` is desired directly after `name`.
+		if (isAssociation) this.underlyingName = underlyingName?.trim() || '';
+
 		this.differentiator = differentiator?.trim() || '';
 
 		if (isAssociation) {
 
-			this.underlyingName = underlyingName?.trim() || '';
 			this.qualifier = qualifier?.trim() || '';
 			this.group = group?.trim() || '';
 


### PR DESCRIPTION
Currently, the CMS form component blindly spits out objects in the order as given to them, which allows it to remain abstract enough to be able to handle all model types.

In the future the CMS form component might be in control of dictating which properties are output (likely when different data types are introduced, e.g. dates and numbers, and more variance is required for input field types), and so will be able to control the order of fields.

However, until then, the change in this PR does the trick by enforcing the desired order at source.