### PR TITLE
Fix casing in getDuplicateRoleIndices module

### DIFF
--- a/src/lib/get-duplicate-role-indices.js
+++ b/src/lib/get-duplicate-role-indices.js
@@ -1,16 +1,16 @@
 const isDuplicateName = (object, comparisonObject) => {
 
-	const objectcharacterName =
+	const objectCharacterName =
 		object.characterName.length
 			? object.characterName
 			: object.name;
 
-	const comparisonObjectcharacterName =
+	const comparisonObjectCharacterName =
 		comparisonObject.characterName.length
 			? comparisonObject.characterName
 			: comparisonObject.name;
 
-	return object.name === comparisonObject.name || objectcharacterName === comparisonObjectcharacterName;
+	return object.name === comparisonObject.name || objectCharacterName === comparisonObjectCharacterName;
 
 };
 


### PR DESCRIPTION
Fixes a botched multi-instance replacement from https://github.com/andygout/theatrebase-api/pull/259.