### PR TITLE
Remove unnecessary props from edit queries

### DIFF
--- a/src/neo4j/cypher-queries/playtext.js
+++ b/src/neo4j/cypher-queries/playtext.js
@@ -91,7 +91,7 @@ const getEditQuery = () => `
 					group: characterRel.group
 				}
 			END
-		) + [{ name: '' }] AS characters
+		) + [{}] AS characters
 `;
 
 const getUpdateQuery = () => getCreateUpdateQuery('update');

--- a/src/neo4j/cypher-queries/production.js
+++ b/src/neo4j/cypher-queries/production.js
@@ -149,7 +149,7 @@ const getEditQuery = () => `
 				THEN null
 				ELSE { name: person.name, differentiator: person.differentiator, roles: roles }
 			END
-		) + [{ name: '', roles: [{ name: '', characterName: '', characterDifferentiator: '', qualifier: '' }] }] AS cast
+		) + [{ roles: [{}] }] AS cast
 `;
 
 const getUpdateQuery = () => getCreateUpdateQuery('update');

--- a/src/neo4j/cypher-queries/theatre.js
+++ b/src/neo4j/cypher-queries/theatre.js
@@ -78,7 +78,7 @@ const getEditQuery = () => `
 					differentiator: subTheatre.differentiator
 				}
 			END
-		) + [{ name: '', differentiator: '' }] AS subTheatres
+		) + [{}] AS subTheatres
 `;
 
 const getUpdateQuery = () => getCreateUpdateQuery('update');

--- a/test-unit/src/neo4j/cypher-queries/playtext.test.js
+++ b/test-unit/src/neo4j/cypher-queries/playtext.test.js
@@ -76,7 +76,7 @@ describe('Cypher Queries Playtext module', () => {
 								group: characterRel.group
 							}
 						END
-					) + [{ name: '' }] AS characters
+					) + [{}] AS characters
 			`));
 
 		});
@@ -164,7 +164,7 @@ describe('Cypher Queries Playtext module', () => {
 								group: characterRel.group
 							}
 						END
-					) + [{ name: '' }] AS characters
+					) + [{}] AS characters
 			`));
 
 		});

--- a/test-unit/src/neo4j/cypher-queries/production.test.js
+++ b/test-unit/src/neo4j/cypher-queries/production.test.js
@@ -136,7 +136,7 @@ describe('Cypher Queries Production module', () => {
 							THEN null
 							ELSE { name: person.name, differentiator: person.differentiator, roles: roles }
 						END
-					) + [{ name: '', roles: [{ name: '', characterName: '', characterDifferentiator: '', qualifier: '' }] }] AS cast
+					) + [{ roles: [{}] }] AS cast
 			`));
 
 		});
@@ -282,7 +282,7 @@ describe('Cypher Queries Production module', () => {
 							THEN null
 							ELSE { name: person.name, differentiator: person.differentiator, roles: roles }
 						END
-					) + [{ name: '', roles: [{ name: '', characterName: '', characterDifferentiator: '', qualifier: '' }] }] AS cast
+					) + [{ roles: [{}] }] AS cast
 			`));
 
 		});


### PR DESCRIPTION
As with the previous PR https://github.com/andygout/theatrebase-api/pull/265, only placeholders for _nested_ properties are required as they are fed in as the props to instantiate a new instance, with the instantiation process doing the work of adding all the necessary props, meaning they need not be added as part of the Cypher query.