### PR TITLE
Test theatre Cypher queries

### DIFF
--- a/test-unit/src/neo4j/cypher-queries/theatre.test.js
+++ b/test-unit/src/neo4j/cypher-queries/theatre.test.js
@@ -1,0 +1,148 @@
+import { expect } from 'chai';
+
+import * as cypherQueriesTheatre from '../../../../src/neo4j/cypher-queries/theatre';
+import removeExcessWhitespace from '../../../test-helpers/remove-excess-whitespace';
+
+describe('Cypher Queries Theatre module', () => {
+
+	describe('getCreateQuery function', () => {
+
+		it('returns requisite query', () => {
+
+			const result = cypherQueriesTheatre.getCreateQuery();
+			expect(removeExcessWhitespace(result)).to.equal(removeExcessWhitespace(`
+				CREATE (theatre:Theatre { uuid: $uuid, name: $name, differentiator: $differentiator })
+
+				WITH theatre
+
+				UNWIND (CASE $subTheatres WHEN [] THEN [null] ELSE $subTheatres END) AS subTheatreParam
+
+					OPTIONAL MATCH (existingTheatre:Theatre { name: subTheatreParam.name })
+						WHERE
+							(subTheatreParam.differentiator IS NULL AND existingTheatre.differentiator IS NULL) OR
+							(subTheatreParam.differentiator = existingTheatre.differentiator)
+
+					WITH
+						theatre,
+						subTheatreParam,
+						CASE existingTheatre WHEN NULL
+							THEN {
+								uuid: subTheatreParam.uuid,
+								name: subTheatreParam.name,
+								differentiator: subTheatreParam.differentiator
+							}
+							ELSE existingTheatre
+						END AS subTheatreProps
+
+					FOREACH (item IN CASE subTheatreParam WHEN NULL THEN [] ELSE [1] END |
+						MERGE (subTheatre:Theatre { uuid: subTheatreProps.uuid, name: subTheatreProps.name })
+							ON CREATE SET subTheatre.differentiator = subTheatreProps.differentiator
+
+						CREATE (theatre)-[:INCLUDES_SUB_THEATRE { position: subTheatreParam.position }]->(subTheatre)
+					)
+
+				WITH DISTINCT theatre
+
+				MATCH (theatre:Theatre { uuid: $uuid })
+
+				OPTIONAL MATCH (theatre)-[subTheatreRel:INCLUDES_SUB_THEATRE]->(subTheatre:Theatre)
+
+				WITH theatre, subTheatreRel, subTheatre
+					ORDER BY subTheatreRel.position
+
+				RETURN
+					'theatre' AS model,
+					theatre.uuid AS uuid,
+					theatre.name AS name,
+					theatre.differentiator AS differentiator,
+					COLLECT(
+						CASE subTheatre WHEN NULL
+							THEN null
+							ELSE {
+								name: subTheatre.name,
+								differentiator: subTheatre.differentiator
+							}
+						END
+					) + [{}] AS subTheatres
+			`));
+
+		});
+
+	});
+
+	describe('getUpdateQuery function', () => {
+
+		it('returns requisite query', () => {
+
+			const result = cypherQueriesTheatre.getUpdateQuery();
+			expect(removeExcessWhitespace(result)).to.equal(removeExcessWhitespace(`
+				MATCH (theatre:Theatre { uuid: $uuid })
+
+				OPTIONAL MATCH (theatre)-[relationship:INCLUDES_SUB_THEATRE]-(:Theatre)
+
+				DELETE relationship
+
+				WITH DISTINCT theatre
+
+				SET
+					theatre.name = $name,
+					theatre.differentiator = $differentiator
+
+				WITH theatre
+
+				UNWIND (CASE $subTheatres WHEN [] THEN [null] ELSE $subTheatres END) AS subTheatreParam
+
+					OPTIONAL MATCH (existingTheatre:Theatre { name: subTheatreParam.name })
+						WHERE
+							(subTheatreParam.differentiator IS NULL AND existingTheatre.differentiator IS NULL) OR
+							(subTheatreParam.differentiator = existingTheatre.differentiator)
+
+					WITH
+						theatre,
+						subTheatreParam,
+						CASE existingTheatre WHEN NULL
+							THEN {
+								uuid: subTheatreParam.uuid,
+								name: subTheatreParam.name,
+								differentiator: subTheatreParam.differentiator
+							}
+							ELSE existingTheatre
+						END AS subTheatreProps
+
+					FOREACH (item IN CASE subTheatreParam WHEN NULL THEN [] ELSE [1] END |
+						MERGE (subTheatre:Theatre { uuid: subTheatreProps.uuid, name: subTheatreProps.name })
+							ON CREATE SET subTheatre.differentiator = subTheatreProps.differentiator
+
+						CREATE (theatre)-[:INCLUDES_SUB_THEATRE { position: subTheatreParam.position }]->(subTheatre)
+					)
+
+				WITH DISTINCT theatre
+
+				MATCH (theatre:Theatre { uuid: $uuid })
+
+				OPTIONAL MATCH (theatre)-[subTheatreRel:INCLUDES_SUB_THEATRE]->(subTheatre:Theatre)
+
+				WITH theatre, subTheatreRel, subTheatre
+					ORDER BY subTheatreRel.position
+
+				RETURN
+					'theatre' AS model,
+					theatre.uuid AS uuid,
+					theatre.name AS name,
+					theatre.differentiator AS differentiator,
+					COLLECT(
+						CASE subTheatre WHEN NULL
+							THEN null
+							ELSE {
+								name: subTheatre.name,
+								differentiator: subTheatre.differentiator
+							}
+						END
+					) + [{}] AS subTheatres
+			`));
+
+		});
+
+	});
+
+});


### PR DESCRIPTION
This PR https://github.com/andygout/theatrebase-api/pull/263 switched from theatre instances using the shared Cypher queries to its own bespoke queries, which - for the create and update queries - are comprised of component parts and therefore require testing.

This PR adds those tests.