### PR TITLE
Switch order of theatre + playtext production props

### DIFF
--- a/test-e2e/crud/productions-api.test.js
+++ b/test-e2e/crud/productions-api.test.js
@@ -22,14 +22,14 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 				model: 'production',
 				name: '',
 				errors: {},
-				theatre: {
-					model: 'theatre',
+				playtext: {
+					model: 'playtext',
 					name: '',
 					differentiator: '',
 					errors: {}
 				},
-				playtext: {
-					model: 'playtext',
+				theatre: {
+					model: 'theatre',
 					name: '',
 					differentiator: '',
 					errors: {}
@@ -98,14 +98,14 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 				uuid: PRODUCTION_UUID,
 				name: 'As You Like It',
 				errors: {},
-				theatre: {
-					model: 'theatre',
+				playtext: {
+					model: 'playtext',
 					name: '',
 					differentiator: '',
 					errors: {}
 				},
-				playtext: {
-					model: 'playtext',
+				theatre: {
+					model: 'theatre',
 					name: '',
 					differentiator: '',
 					errors: {}
@@ -146,14 +146,14 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 				uuid: PRODUCTION_UUID,
 				name: 'As You Like It',
 				errors: {},
-				theatre: {
-					model: 'theatre',
+				playtext: {
+					model: 'playtext',
 					name: '',
 					differentiator: '',
 					errors: {}
 				},
-				playtext: {
-					model: 'playtext',
+				theatre: {
+					model: 'theatre',
 					name: '',
 					differentiator: '',
 					errors: {}
@@ -198,14 +198,14 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 				uuid: PRODUCTION_UUID,
 				name: 'The Tempest',
 				errors: {},
-				theatre: {
-					model: 'theatre',
+				playtext: {
+					model: 'playtext',
 					name: '',
 					differentiator: '',
 					errors: {}
 				},
-				playtext: {
-					model: 'playtext',
+				theatre: {
+					model: 'theatre',
 					name: '',
 					differentiator: '',
 					errors: {}
@@ -245,8 +245,8 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 				model: 'production',
 				uuid: PRODUCTION_UUID,
 				name: 'The Tempest',
-				theatre: null,
 				playtext: null,
+				theatre: null,
 				cast: []
 			};
 
@@ -285,16 +285,16 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 				model: 'production',
 				name: 'The Tempest',
 				errors: {},
-				theatre: {
-					differentiator: '',
-					errors: {},
-					model: 'theatre',
-					name: ''
-				},
 				playtext: {
 					differentiator: '',
 					errors: {},
 					model: 'playtext',
+					name: ''
+				},
+				theatre: {
+					differentiator: '',
+					errors: {},
+					model: 'theatre',
 					name: ''
 				},
 				cast: []
@@ -350,11 +350,11 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 				.post('/productions')
 				.send({
 					name: 'Hamlet',
-					theatre: {
-						name: 'National Theatre'
-					},
 					playtext: {
 						name: 'The Tragedy of Hamlet, Prince of Denmark'
+					},
+					theatre: {
+						name: 'National Theatre'
 					},
 					cast: [
 						{
@@ -400,15 +400,15 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 				uuid: PRODUCTION_UUID,
 				name: 'Hamlet',
 				errors: {},
-				theatre: {
-					model: 'theatre',
-					name: 'National Theatre',
-					differentiator: '',
-					errors: {}
-				},
 				playtext: {
 					model: 'playtext',
 					name: 'The Tragedy of Hamlet, Prince of Denmark',
+					differentiator: '',
+					errors: {}
+				},
+				theatre: {
+					model: 'theatre',
+					name: 'National Theatre',
 					differentiator: '',
 					errors: {}
 				},
@@ -551,16 +551,16 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 				model: 'production',
 				uuid: PRODUCTION_UUID,
 				name: 'Hamlet',
+				playtext: {
+					model: 'playtext',
+					uuid: THE_TRAGEDY_OF_HAMLET_PRINCE_OF_DENMARK_UUID,
+					name: 'The Tragedy of Hamlet, Prince of Denmark'
+				},
 				theatre: {
 					model: 'theatre',
 					uuid: NATIONAL_THEATRE_UUID,
 					name: 'National Theatre',
 					surTheatre: null
-				},
-				playtext: {
-					model: 'playtext',
-					uuid: THE_TRAGEDY_OF_HAMLET_PRINCE_OF_DENMARK_UUID,
-					name: 'The Tragedy of Hamlet, Prince of Denmark'
 				},
 				cast: [
 					{
@@ -642,15 +642,15 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 				uuid: PRODUCTION_UUID,
 				name: 'Hamlet',
 				errors: {},
-				theatre: {
-					model: 'theatre',
-					name: 'National Theatre',
-					differentiator: '',
-					errors: {}
-				},
 				playtext: {
 					model: 'playtext',
 					name: 'The Tragedy of Hamlet, Prince of Denmark',
+					differentiator: '',
+					errors: {}
+				},
+				theatre: {
+					model: 'theatre',
+					name: 'National Theatre',
 					differentiator: '',
 					errors: {}
 				},
@@ -791,11 +791,11 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 				.put(`/productions/${PRODUCTION_UUID}`)
 				.send({
 					name: 'Richard III',
-					theatre: {
-						name: 'Almeida Theatre'
-					},
 					playtext: {
 						name: 'The Tragedy of King Richard III'
+					},
+					theatre: {
+						name: 'Almeida Theatre'
 					},
 					cast: [
 						{
@@ -841,15 +841,15 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 				uuid: PRODUCTION_UUID,
 				name: 'Richard III',
 				errors: {},
-				theatre: {
-					model: 'theatre',
-					name: 'Almeida Theatre',
-					differentiator: '',
-					errors: {}
-				},
 				playtext: {
 					model: 'playtext',
 					name: 'The Tragedy of King Richard III',
+					differentiator: '',
+					errors: {}
+				},
+				theatre: {
+					model: 'theatre',
+					name: 'Almeida Theatre',
 					differentiator: '',
 					errors: {}
 				},
@@ -992,16 +992,16 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 				model: 'production',
 				uuid: PRODUCTION_UUID,
 				name: 'Richard III',
+				playtext: {
+					model: 'playtext',
+					uuid: THE_TRAGEDY_OF_KING_RICHARD_III_UUID,
+					name: 'The Tragedy of King Richard III'
+				},
 				theatre: {
 					model: 'theatre',
 					uuid: ALMEIDA_THEATRE_UUID,
 					name: 'Almeida Theatre',
 					surTheatre: null
-				},
-				playtext: {
-					model: 'playtext',
-					uuid: THE_TRAGEDY_OF_KING_RICHARD_III_UUID,
-					name: 'The Tragedy of King Richard III'
 				},
 				cast: [
 					{
@@ -1112,14 +1112,14 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 				uuid: PRODUCTION_UUID,
 				name: 'Richard III',
 				errors: {},
-				theatre: {
-					model: 'theatre',
+				playtext: {
+					model: 'playtext',
 					name: '',
 					differentiator: '',
 					errors: {}
 				},
-				playtext: {
-					model: 'playtext',
+				theatre: {
+					model: 'theatre',
 					name: '',
 					differentiator: '',
 					errors: {}
@@ -1161,16 +1161,16 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 				model: 'production',
 				name: 'Richard III',
 				errors: {},
-				theatre: {
-					differentiator: '',
-					errors: {},
-					model: 'theatre',
-					name: ''
-				},
 				playtext: {
 					differentiator: '',
 					errors: {},
 					model: 'playtext',
+					name: ''
+				},
+				theatre: {
+					differentiator: '',
+					errors: {},
+					model: 'theatre',
 					name: ''
 				},
 				cast: []

--- a/test-e2e/instance-validation-failures/productions-api.test.js
+++ b/test-e2e/instance-validation-failures/productions-api.test.js
@@ -41,14 +41,14 @@ describe('Instance validation failures: Productions API', () => {
 							'Value is too short'
 						]
 					},
-					theatre: {
-						model: 'theatre',
+					playtext: {
+						model: 'playtext',
 						name: '',
 						differentiator: '',
 						errors: {}
 					},
-					playtext: {
-						model: 'playtext',
+					theatre: {
+						model: 'theatre',
 						name: '',
 						differentiator: '',
 						errors: {}
@@ -104,14 +104,14 @@ describe('Instance validation failures: Productions API', () => {
 							'Value is too short'
 						]
 					},
-					theatre: {
-						model: 'theatre',
+					playtext: {
+						model: 'playtext',
 						name: '',
 						differentiator: '',
 						errors: {}
 					},
-					playtext: {
-						model: 'playtext',
+					theatre: {
+						model: 'theatre',
 						name: '',
 						differentiator: '',
 						errors: {}
@@ -200,14 +200,14 @@ describe('Instance validation failures: Productions API', () => {
 							'Theatre'
 						]
 					},
-					theatre: {
-						model: 'theatre',
+					playtext: {
+						model: 'playtext',
 						name: '',
 						differentiator: '',
 						errors: {}
 					},
-					playtext: {
-						model: 'playtext',
+					theatre: {
+						model: 'theatre',
 						name: '',
 						differentiator: '',
 						errors: {}

--- a/test-e2e/model-interaction/cast-member-diff-roles-of-playtext.test.js
+++ b/test-e2e/model-interaction/cast-member-diff-roles-of-playtext.test.js
@@ -56,11 +56,11 @@ describe('Cast member performing different roles in different productions of sam
 			.post('/productions')
 			.send({
 				name: 'King Lear',
-				theatre: {
-					name: 'Royal Shakespeare Theatre'
-				},
 				playtext: {
 					name: 'The Tragedy of King Lear'
+				},
+				theatre: {
+					name: 'Royal Shakespeare Theatre'
 				},
 				cast: [
 					{
@@ -86,11 +86,11 @@ describe('Cast member performing different roles in different productions of sam
 			.post('/productions')
 			.send({
 				name: 'King Lear',
-				theatre: {
-					name: 'Barbican'
-				},
 				playtext: {
 					name: 'The Tragedy of King Lear'
+				},
+				theatre: {
+					name: 'Barbican'
 				},
 				cast: [
 					{

--- a/test-e2e/model-interaction/cast-member-same-role-of-playtext.test.js
+++ b/test-e2e/model-interaction/cast-member-same-role-of-playtext.test.js
@@ -47,11 +47,11 @@ describe('Cast member performing same role in different productions of same play
 			.post('/productions')
 			.send({
 				name: 'A Midsummer Night\'s Dream',
-				theatre: {
-					name: 'Royal Shakespeare Theatre'
-				},
 				playtext: {
 					name: 'A Midsummer Night\'s Dream'
+				},
+				theatre: {
+					name: 'Royal Shakespeare Theatre'
 				},
 				cast: [
 					{
@@ -70,11 +70,11 @@ describe('Cast member performing same role in different productions of same play
 			.post('/productions')
 			.send({
 				name: 'A Midsummer Night\'s Dream',
-				theatre: {
-					name: 'Rose Theatre'
-				},
 				playtext: {
 					name: 'A Midsummer Night\'s Dream'
+				},
+				theatre: {
+					name: 'Rose Theatre'
 				},
 				cast: [
 					{

--- a/test-e2e/model-interaction/char-diff-groups-same-playtext.test.js
+++ b/test-e2e/model-interaction/char-diff-groups-same-playtext.test.js
@@ -87,11 +87,11 @@ describe('Character with multiple appearances in the same playtext in different 
 			.post('/productions')
 			.send({
 				name: '3 Winters',
-				theatre: {
-					name: 'National Theatre'
-				},
 				playtext: {
 					name: '3 Winters'
+				},
+				theatre: {
+					name: 'National Theatre'
 				},
 				cast: [
 					{

--- a/test-e2e/model-interaction/char-in-multi-prods-of-multi-playtexts.test.js
+++ b/test-e2e/model-interaction/char-in-multi-prods-of-multi-playtexts.test.js
@@ -82,11 +82,11 @@ describe('Character in multiple productions of multiple playtexts', () => {
 			.post('/productions')
 			.send({
 				name: 'Henry IV: Part 1',
-				theatre: {
-					name: 'National Theatre'
-				},
 				playtext: {
 					name: 'Henry IV: Part 1'
+				},
+				theatre: {
+					name: 'National Theatre'
 				},
 				cast: [
 					{
@@ -104,11 +104,11 @@ describe('Character in multiple productions of multiple playtexts', () => {
 			.post('/productions')
 			.send({
 				name: 'Henry IV: Part 2',
-				theatre: {
-					name: 'National Theatre'
-				},
 				playtext: {
 					name: 'Henry IV: Part 2'
+				},
+				theatre: {
+					name: 'National Theatre'
 				},
 				cast: [
 					{
@@ -126,11 +126,11 @@ describe('Character in multiple productions of multiple playtexts', () => {
 			.post('/productions')
 			.send({
 				name: 'The Merry Wives of Windsor',
-				theatre: {
-					name: 'National Theatre'
-				},
 				playtext: {
 					name: 'The Merry Wives of Windsor'
+				},
+				theatre: {
+					name: 'National Theatre'
 				},
 				cast: [
 					{
@@ -148,11 +148,11 @@ describe('Character in multiple productions of multiple playtexts', () => {
 			.post('/productions')
 			.send({
 				name: 'Henry IV: Part 1',
-				theatre: {
-					name: 'Shakespeare\'s Globe'
-				},
 				playtext: {
 					name: 'Henry IV: Part 1'
+				},
+				theatre: {
+					name: 'Shakespeare\'s Globe'
 				},
 				cast: [
 					{
@@ -170,11 +170,11 @@ describe('Character in multiple productions of multiple playtexts', () => {
 			.post('/productions')
 			.send({
 				name: 'Henry IV: Part 2',
-				theatre: {
-					name: 'Shakespeare\'s Globe'
-				},
 				playtext: {
 					name: 'Henry IV: Part 2'
+				},
+				theatre: {
+					name: 'Shakespeare\'s Globe'
 				},
 				cast: [
 					{
@@ -192,11 +192,11 @@ describe('Character in multiple productions of multiple playtexts', () => {
 			.post('/productions')
 			.send({
 				name: 'The Merry Wives of Windsor',
-				theatre: {
-					name: 'Shakespeare\'s Globe'
-				},
 				playtext: {
 					name: 'The Merry Wives of Windsor'
+				},
+				theatre: {
+					name: 'Shakespeare\'s Globe'
 				},
 				cast: [
 					{
@@ -236,11 +236,11 @@ describe('Character in multiple productions of multiple playtexts', () => {
 			.post('/productions')
 			.send({
 				name: 'Henry IV: Part 2',
-				theatre: {
-					name: 'Swan Theatre'
-				},
 				playtext: {
 					name: 'Henry IV: Part 2'
+				},
+				theatre: {
+					name: 'Swan Theatre'
 				},
 				cast: [
 					{
@@ -258,11 +258,11 @@ describe('Character in multiple productions of multiple playtexts', () => {
 			.post('/productions')
 			.send({
 				name: 'The Merry Wives of Windsor',
-				theatre: {
-					name: 'Swan Theatre'
-				},
 				playtext: {
 					name: 'The Merry Wives of Windsor'
+				},
+				theatre: {
+					name: 'Swan Theatre'
 				},
 				cast: [
 					{

--- a/test-e2e/model-interaction/char-multi-appearances-same-playtext.test.js
+++ b/test-e2e/model-interaction/char-multi-appearances-same-playtext.test.js
@@ -71,11 +71,11 @@ describe('Character with multiple appearances in the same playtext under differe
 			.post('/productions')
 			.send({
 				name: 'Rock \'n\' Roll',
-				theatre: {
-					name: 'Royal Court Theatre'
-				},
 				playtext: {
 					name: 'Rock \'n\' Roll'
+				},
+				theatre: {
+					name: 'Royal Court Theatre'
 				},
 				cast: [
 					{

--- a/test-e2e/model-interaction/char-portrayed-with-other-roles.test.js
+++ b/test-e2e/model-interaction/char-portrayed-with-other-roles.test.js
@@ -60,11 +60,11 @@ describe('Character portrayed with other roles', () => {
 			.post('/productions')
 			.send({
 				name: 'War Horse',
-				theatre: {
-					name: 'National Theatre'
-				},
 				playtext: {
 					name: 'War Horse'
+				},
+				theatre: {
+					name: 'National Theatre'
 				},
 				cast: [
 					{

--- a/test-e2e/model-interaction/char-with-variant-depiction-portrayal-names.test.js
+++ b/test-e2e/model-interaction/char-with-variant-depiction-portrayal-names.test.js
@@ -119,11 +119,11 @@ describe('Character with variant depiction and portrayal names', () => {
 			.post('/productions')
 			.send({
 				name: 'Henry IV, Part 1',
-				theatre: {
-					name: 'Royal Shakespeare Theatre'
-				},
 				playtext: {
 					name: 'Henry IV, Part 1'
+				},
+				theatre: {
+					name: 'Royal Shakespeare Theatre'
 				},
 				cast: [
 					{
@@ -153,11 +153,11 @@ describe('Character with variant depiction and portrayal names', () => {
 			.post('/productions')
 			.send({
 				name: 'Henry IV, Part 2',
-				theatre: {
-					name: 'Royal Shakespeare Theatre'
-				},
 				playtext: {
 					name: 'Henry IV, Part 2'
+				},
+				theatre: {
+					name: 'Royal Shakespeare Theatre'
 				},
 				cast: [
 					{
@@ -187,11 +187,11 @@ describe('Character with variant depiction and portrayal names', () => {
 			.post('/productions')
 			.send({
 				name: 'Henry V',
-				theatre: {
-					name: 'Royal Shakespeare Theatre'
-				},
 				playtext: {
 					name: 'Henry V'
+				},
+				theatre: {
+					name: 'Royal Shakespeare Theatre'
 				},
 				cast: [
 					{
@@ -221,11 +221,11 @@ describe('Character with variant depiction and portrayal names', () => {
 			.post('/productions')
 			.send({
 				name: 'Henry IV, Part 1',
-				theatre: {
-					name: 'National Theatre'
-				},
 				playtext: {
 					name: 'Henry IV, Part 1'
+				},
+				theatre: {
+					name: 'National Theatre'
 				},
 				cast: [
 					{
@@ -255,11 +255,11 @@ describe('Character with variant depiction and portrayal names', () => {
 			.post('/productions')
 			.send({
 				name: 'Henry IV, Part 2',
-				theatre: {
-					name: 'National Theatre'
-				},
 				playtext: {
 					name: 'Henry IV, Part 2'
+				},
+				theatre: {
+					name: 'National Theatre'
 				},
 				cast: [
 					{
@@ -289,11 +289,11 @@ describe('Character with variant depiction and portrayal names', () => {
 			.post('/productions')
 			.send({
 				name: 'Henry V',
-				theatre: {
-					name: 'National Theatre'
-				},
 				playtext: {
 					name: 'Henry V'
+				},
+				theatre: {
+					name: 'National Theatre'
 				},
 				cast: [
 					{

--- a/test-e2e/model-interaction/char-with-variant-names-diff-playtexts.test.js
+++ b/test-e2e/model-interaction/char-with-variant-names-diff-playtexts.test.js
@@ -113,11 +113,11 @@ describe('Character with variant names from productions of different playtexts',
 			.post('/productions')
 			.send({
 				name: 'Hamlet',
-				theatre: {
-					name: 'National Theatre'
-				},
 				playtext: {
 					name: 'Hamlet'
+				},
+				theatre: {
+					name: 'National Theatre'
 				},
 				cast: [
 					{
@@ -145,11 +145,11 @@ describe('Character with variant names from productions of different playtexts',
 			.post('/productions')
 			.send({
 				name: 'Rosencrantz and Guildenstern Are Dead',
-				theatre: {
-					name: 'Theatre Royal Haymarket'
-				},
 				playtext: {
 					name: 'Rosencrantz and Guildenstern Are Dead'
+				},
+				theatre: {
+					name: 'Theatre Royal Haymarket'
 				},
 				cast: [
 					{
@@ -177,11 +177,11 @@ describe('Character with variant names from productions of different playtexts',
 			.post('/productions')
 			.send({
 				name: 'Fortinbras',
-				theatre: {
-					name: 'La Jolla Playhouse'
-				},
 				playtext: {
 					name: 'Fortinbras'
+				},
+				theatre: {
+					name: 'La Jolla Playhouse'
 				},
 				cast: [
 					{
@@ -209,11 +209,11 @@ describe('Character with variant names from productions of different playtexts',
 			.post('/productions')
 			.send({
 				name: 'Hamletmachine',
-				theatre: {
-					name: 'Teatro San Nicolò'
-				},
 				playtext: {
 					name: 'Hamletmachine'
+				},
+				theatre: {
+					name: 'Teatro San Nicolò'
 				},
 				cast: [
 					{

--- a/test-e2e/model-interaction/char-with-variant-names-same-playtext.test.js
+++ b/test-e2e/model-interaction/char-with-variant-names-same-playtext.test.js
@@ -69,11 +69,11 @@ describe('Character with variant names from productions of the same playtext', (
 			.post('/productions')
 			.send({
 				name: 'Hamlet',
-				theatre: {
-					name: 'Almeida Theatre'
-				},
 				playtext: {
 					name: 'Hamlet'
+				},
+				theatre: {
+					name: 'Almeida Theatre'
 				},
 				cast: [
 					{
@@ -105,11 +105,11 @@ describe('Character with variant names from productions of the same playtext', (
 			.post('/productions')
 			.send({
 				name: 'Hamlet',
-				theatre: {
-					name: 'Novello Theatre'
-				},
 				playtext: {
 					name: 'Hamlet'
+				},
+				theatre: {
+					name: 'Novello Theatre'
 				},
 				cast: [
 					{
@@ -140,11 +140,11 @@ describe('Character with variant names from productions of the same playtext', (
 			.post('/productions')
 			.send({
 				name: 'Hamlet',
-				theatre: {
-					name: 'Wyndham\'s Theatre'
-				},
 				playtext: {
 					name: 'Hamlet'
+				},
+				theatre: {
+					name: 'Wyndham\'s Theatre'
 				},
 				cast: [
 					{

--- a/test-e2e/model-interaction/diff-chars-same-name-diff-playtexts.test.js
+++ b/test-e2e/model-interaction/diff-chars-same-name-diff-playtexts.test.js
@@ -78,11 +78,11 @@ describe('Different characters with the same name from different playtexts', () 
 			.post('/productions')
 			.send({
 				name: 'A Midsummer Night\'s Dream',
-				theatre: {
-					name: 'Novello Theatre'
-				},
 				playtext: {
 					name: 'A Midsummer Night\'s Dream'
+				},
+				theatre: {
+					name: 'Novello Theatre'
 				},
 				cast: [
 					{
@@ -108,11 +108,11 @@ describe('Different characters with the same name from different playtexts', () 
 			.post('/productions')
 			.send({
 				name: 'Titus Andronicus',
-				theatre: {
-					name: 'Shakespeare\'s Globe'
-				},
 				playtext: {
 					name: 'Titus Andronicus'
+				},
+				theatre: {
+					name: 'Shakespeare\'s Globe'
 				},
 				cast: [
 					{

--- a/test-e2e/model-interaction/diff-chars-same-name-same-playtext.test.js
+++ b/test-e2e/model-interaction/diff-chars-same-name-same-playtext.test.js
@@ -60,11 +60,11 @@ describe('Different characters with the same name from the same playtext', () =>
 			.post('/productions')
 			.send({
 				name: 'Julius Caesar',
-				theatre: {
-					name: 'Barbican'
-				},
 				playtext: {
 					name: 'Julius Caesar'
+				},
+				theatre: {
+					name: 'Barbican'
 				},
 				cast: [
 					{

--- a/test-e2e/model-interaction/playtext-with-multi-prods.test.js
+++ b/test-e2e/model-interaction/playtext-with-multi-prods.test.js
@@ -37,11 +37,11 @@ describe('Playtext with multiple productions', () => {
 			.post('/productions')
 			.send({
 				name: 'Measure for Measure',
+				playtext: {
+					name: 'Measure for Measure'
+				},
 				theatre: {
 					name: 'National Theatre'
-				},
-				playtext: {
-					name: 'Measure for Measure'
 				}
 			});
 
@@ -49,11 +49,11 @@ describe('Playtext with multiple productions', () => {
 			.post('/productions')
 			.send({
 				name: 'Measure for Measure',
+				playtext: {
+					name: 'Measure for Measure'
+				},
 				theatre: {
 					name: 'Almeida Theatre'
-				},
-				playtext: {
-					name: 'Measure for Measure'
 				}
 			});
 
@@ -61,11 +61,11 @@ describe('Playtext with multiple productions', () => {
 			.post('/productions')
 			.send({
 				name: 'Measure for Measure',
-				theatre: {
-					name: 'Donmar Warehouse'
-				},
 				playtext: {
 					name: 'Measure for Measure'
+				},
+				theatre: {
+					name: 'Donmar Warehouse'
 				}
 			});
 

--- a/test-e2e/model-interaction/roles-with-alternating-cast.test.js
+++ b/test-e2e/model-interaction/roles-with-alternating-cast.test.js
@@ -58,11 +58,11 @@ describe('Roles with alternating cast', () => {
 			.post('/productions')
 			.send({
 				name: 'True West',
-				theatre: {
-					name: 'Crucible Theatre'
-				},
 				playtext: {
 					name: 'True West'
+				},
+				theatre: {
+					name: 'Crucible Theatre'
 				},
 				cast: [
 					{
@@ -94,11 +94,11 @@ describe('Roles with alternating cast', () => {
 			.post('/productions')
 			.send({
 				name: 'True West',
-				theatre: {
-					name: 'Vaudeville Theatre'
-				},
 				playtext: {
 					name: 'True West'
+				},
+				theatre: {
+					name: 'Vaudeville Theatre'
 				},
 				cast: [
 					{

--- a/test-e2e/model-interaction/theatre-with-sub-theatres.test.js
+++ b/test-e2e/model-interaction/theatre-with-sub-theatres.test.js
@@ -77,11 +77,11 @@ describe('Theatre with sub-theatres', () => {
 			.post('/productions')
 			.send({
 				name: 'Mother Courage and Her Children',
-				theatre: {
-					name: 'Olivier Theatre'
-				},
 				playtext: {
 					name: 'Mother Courage and Her Children'
+				},
+				theatre: {
+					name: 'Olivier Theatre'
 				},
 				cast: [
 					{
@@ -99,11 +99,11 @@ describe('Theatre with sub-theatres', () => {
 			.post('/productions')
 			.send({
 				name: 'Richard II',
-				theatre: {
-					name: 'National Theatre'
-				},
 				playtext: {
 					name: 'Richard II'
+				},
+				theatre: {
+					name: 'National Theatre'
 				},
 				cast: [
 					{


### PR DESCRIPTION
Makes order of production's theatre + playtext props consistent with changes introduced in PR https://github.com/andygout/theatrebase-api/pull/258.