### PR TITLE
Revise model unit tests

### DIFF
--- a/test-unit/src/models/CastMember.test.js
+++ b/test-unit/src/models/CastMember.test.js
@@ -7,7 +7,6 @@ import { Role } from '../../../src/models';
 describe('Cast Member model', () => {
 
 	let stubs;
-	let instance;
 
 	const RoleStub = function () {
 
@@ -26,8 +25,6 @@ describe('Cast Member model', () => {
 			}
 		};
 
-		instance = createInstance();
-
 	});
 
 	const createSubject = () =>
@@ -36,7 +33,7 @@ describe('Cast Member model', () => {
 			'.': stubs.models
 		}).default;
 
-	const createInstance = (props = { name: 'Ian McKellen', roles: [{ name: 'King Lear' }] }) => {
+	const createInstance = props => {
 
 		const CastMember = createSubject();
 
@@ -58,7 +55,7 @@ describe('Cast Member model', () => {
 						{ name: ' ' }
 					]
 				};
-				instance = createInstance(props);
+				const instance = createInstance(props);
 				expect(instance.roles.length).to.equal(3);
 				expect(instance.roles[0] instanceof Role).to.be.true;
 				expect(instance.roles[1] instanceof Role).to.be.true;
@@ -74,6 +71,15 @@ describe('Cast Member model', () => {
 
 		it('calls instance validate method and associated models\' validate methods', () => {
 
+			const props = {
+				name: 'Ian McKellen',
+				roles: [
+					{
+						name: 'King Lear'
+					}
+				]
+			};
+			const instance = createInstance(props);
 			spy(instance, 'validateName');
 			spy(instance, 'validateDifferentiator');
 			spy(instance, 'validateUniquenessInGroup');
@@ -136,7 +142,7 @@ describe('Cast Member model', () => {
 
 				it('will not add properties to errors property', () => {
 
-					instance = createInstance({ name: '', roles: [{ name: '' }] });
+					const instance = createInstance({ name: '', roles: [{ name: '' }] });
 					spy(instance, 'addPropertyError');
 					instance.validateNamePresenceIfRoles();
 					expect(instance.addPropertyError.notCalled).to.be.true;
@@ -149,7 +155,7 @@ describe('Cast Member model', () => {
 
 				it('will not add properties to errors property', () => {
 
-					instance = createInstance({ name: 'Ian McKellen', roles: [{ name: '' }] });
+					const instance = createInstance({ name: 'Ian McKellen', roles: [{ name: '' }] });
 					spy(instance, 'addPropertyError');
 					instance.validateNamePresenceIfRoles();
 					expect(instance.addPropertyError.notCalled).to.be.true;
@@ -161,7 +167,7 @@ describe('Cast Member model', () => {
 
 				it('will not add properties to errors property', () => {
 
-					instance = createInstance({ name: 'Ian McKellen', roles: [{ name: 'King Lear' }] });
+					const instance = createInstance({ name: 'Ian McKellen', roles: [{ name: 'King Lear' }] });
 					spy(instance, 'addPropertyError');
 					instance.validateNamePresenceIfRoles();
 					expect(instance.addPropertyError.notCalled).to.be.true;
@@ -176,7 +182,7 @@ describe('Cast Member model', () => {
 
 			it('adds properties whose values are arrays to errors property', () => {
 
-				instance = createInstance({ name: '', roles: [{ name: 'King Lear' }] });
+				const instance = createInstance({ name: '', roles: [{ name: 'King Lear' }] });
 				spy(instance, 'addPropertyError');
 				instance.validateNamePresenceIfRoles();
 				expect(instance.addPropertyError.calledOnce).to.be.true;

--- a/test-unit/src/models/Playtext.test.js
+++ b/test-unit/src/models/Playtext.test.js
@@ -7,12 +7,6 @@ import { Character } from '../../../src/models';
 describe('Playtext model', () => {
 
 	let stubs;
-	let instance;
-
-	const DEFAULT_INSTANCE_PROPS = {
-		name: 'The Tragedy of Hamlet, Prince of Denmark',
-		characters: [{ name: 'Hamlet' }]
-	};
 
 	const CharacterStub = function () {
 
@@ -26,30 +20,20 @@ describe('Playtext model', () => {
 			getDuplicateCharacterIndicesModule: {
 				getDuplicateCharacterIndices: stub().returns([])
 			},
-			Base: {
-				validateStringModule: {
-					validateString: stub()
-				}
-			},
 			models: {
 				Character: CharacterStub
 			}
 		};
-
-		instance = createInstance();
 
 	});
 
 	const createSubject = () =>
 		proxyquire('../../../src/models/Playtext', {
 			'../lib/get-duplicate-character-indices': stubs.getDuplicateCharacterIndicesModule,
-			'./Base': proxyquire('../../../src/models/Base', {
-				'../lib/validate-string': stubs.Base.validateStringModule
-			}),
 			'.': stubs.models
 		}).default;
 
-	const createInstance = (props = DEFAULT_INSTANCE_PROPS) => {
+	const createInstance = props => {
 
 		const Playtext = createSubject();
 
@@ -63,40 +47,35 @@ describe('Playtext model', () => {
 
 			it('assigns empty string if absent from props', () => {
 
-				const props = { name: 'Home' };
-				const instance = createInstance(props);
+				const instance = createInstance({ name: 'Home' });
 				expect(instance.differentiator).to.equal('');
 
 			});
 
 			it('assigns empty string if included in props but value is empty string', () => {
 
-				const props = { name: 'Home', differentiator: '' };
-				const instance = createInstance(props);
+				const instance = createInstance({ name: 'Home', differentiator: '' });
 				expect(instance.differentiator).to.equal('');
 
 			});
 
 			it('assigns empty string if included in props but value is whitespace-only string', () => {
 
-				const props = { name: 'Home', differentiator: ' ' };
-				const instance = createInstance(props);
+				const instance = createInstance({ name: 'Home', differentiator: ' ' });
 				expect(instance.differentiator).to.equal('');
 
 			});
 
 			it('assigns value if included in props and value is string with length', () => {
 
-				const props = { name: 'Home', differentiator: '1' };
-				const instance = createInstance(props);
+				const instance = createInstance({ name: 'Home', differentiator: '1' });
 				expect(instance.differentiator).to.equal('1');
 
 			});
 
 			it('trims value before assigning', () => {
 
-				const props = { name: 'Home', differentiator: ' 1 ' };
-				const instance = createInstance(props);
+				const instance = createInstance({ name: 'Home', differentiator: ' 1 ' });
 				expect(instance.differentiator).to.equal('1');
 
 			});
@@ -109,8 +88,7 @@ describe('Playtext model', () => {
 
 				it('assigns empty array if absent from props', () => {
 
-					const props = { name: 'The Tragedy of Hamlet, Prince of Denmark' };
-					const instance = createInstance(props);
+					const instance = createInstance({ name: 'The Tragedy of Hamlet, Prince of Denmark' });
 					expect(instance.characters).to.deep.equal([]);
 
 				});
@@ -120,9 +98,15 @@ describe('Playtext model', () => {
 					const props = {
 						name: 'The Tragedy of Hamlet, Prince of Denmark',
 						characters: [
-							{ name: 'Hamlet' },
-							{ name: '' },
-							{ name: ' ' }
+							{
+								name: 'Hamlet'
+							},
+							{
+								name: ''
+							},
+							{
+								name: ' '
+							}
 						]
 					};
 					const instance = createInstance(props);
@@ -139,7 +123,10 @@ describe('Playtext model', () => {
 
 				it('will not assign any value if absent from props', () => {
 
-					const props = { name: 'The Tragedy of Hamlet, Prince of Denmark', isAssociation: true };
+					const props = {
+						name: 'The Tragedy of Hamlet, Prince of Denmark',
+						isAssociation: true
+					};
 					const instance = createInstance(props);
 					expect(instance).not.to.have.property('characters');
 
@@ -149,7 +136,11 @@ describe('Playtext model', () => {
 
 					const props = {
 						name: 'The Tragedy of Hamlet, Prince of Denmark',
-						characters: [{ name: 'Hamlet' }],
+						characters: [
+							{
+								name: 'Hamlet'
+							}
+						],
 						isAssociation: true
 					};
 					const instance = createInstance(props);
@@ -167,6 +158,15 @@ describe('Playtext model', () => {
 
 		it('calls instance validate method and associated models\' validate methods', () => {
 
+			const props = {
+				name: 'The Tragedy of Hamlet, Prince of Denmark',
+				characters: [
+					{
+						name: 'Hamlet'
+					}
+				]
+			};
+			const instance = createInstance(props);
 			spy(instance, 'validateName');
 			spy(instance, 'validateDifferentiator');
 			instance.runInputValidations();

--- a/test-unit/src/models/Production.test.js
+++ b/test-unit/src/models/Production.test.js
@@ -7,7 +7,6 @@ import { CastMember, Playtext, Theatre } from '../../../src/models';
 describe('Production model', () => {
 
 	let stubs;
-	let instance;
 
 	const CastMemberStub = function () {
 
@@ -34,9 +33,6 @@ describe('Production model', () => {
 				getDuplicateBaseInstanceIndices: stub().returns([])
 			},
 			Base: {
-				validateStringModule: {
-					validateString: stub()
-				},
 				neo4jQueryModule: {
 					neo4jQuery: stub()
 				}
@@ -48,21 +44,18 @@ describe('Production model', () => {
 			}
 		};
 
-		instance = createInstance();
-
 	});
 
 	const createSubject = () =>
 		proxyquire('../../../src/models/Production', {
 			'../lib/get-duplicate-base-instance-indices': stubs.getDuplicateBaseInstanceIndicesModule,
 			'./Base': proxyquire('../../../src/models/Base', {
-				'../lib/validate-string': stubs.Base.validateStringModule,
 				'../neo4j/query': stubs.Base.neo4jQueryModule
 			}),
 			'.': stubs.models
 		}).default;
 
-	const createInstance = (props = { name: 'Hamlet', cast: [{ name: 'Patrick Stewart' }] }) => {
+	const createInstance = props => {
 
 		const Production = createSubject();
 
@@ -76,8 +69,7 @@ describe('Production model', () => {
 
 			it('assigns empty array if absent from props', () => {
 
-				const props = { name: 'Hamlet' };
-				const instance = createInstance(props);
+				const instance = createInstance({ name: 'Hamlet' });
 				expect(instance.cast).to.deep.equal([]);
 
 			});
@@ -108,6 +100,15 @@ describe('Production model', () => {
 
 		it('calls instance validate method and associated models\' validate methods', () => {
 
+			const props = {
+				name: 'Hamlet',
+				cast: [
+					{
+						name: 'Patrick Stewart'
+					}
+				]
+			};
+			const instance = createInstance(props);
 			spy(instance, 'validateName');
 			instance.runInputValidations();
 			assert.callOrder(
@@ -144,6 +145,7 @@ describe('Production model', () => {
 
 		it('does nothing, i.e. it overrides the Base model runDatabaseValidations() method with an empty function', () => {
 
+			const instance = createInstance({ name: 'Hamlet' });
 			instance.runDatabaseValidations();
 			expect(stubs.Base.neo4jQueryModule.neo4jQuery.notCalled).to.be.true;
 


### PR DESCRIPTION
Some tidying up of the unit tests for model classes:

- Repeat usage of `let instance` which is then overridden as it is barely used; the majority of the tests each contain their own `const instance`.
- If it fits on a single line, apply the `props` value directly as the argument required for instantiation of instance rather than assigning to a variable which then gets assigned.
- Remove `DEFAULT_INSTANCE_PROPS` given they are barely used; just apply props for each individual test.
- Don't bother stubbing `validateStringModule` as it's return value in the context of the tests stubbing it is meaningless, i.e. we only care if the method which would go on to call the module is called at all, not its return value.
- Remove proxyquire from the Theatre model tests given it does not need to stub out any other models (which is the reason for using proxyquire as the Sinon sandbox is good at stubbing modules and their functions but not classes).