### PR TITLE
Revise production + theatre Cypher query ORDER BY clauses

### DIFF
--- a/src/neo4j/cypher-queries/production.js
+++ b/src/neo4j/cypher-queries/production.js
@@ -254,7 +254,7 @@ const getListQuery = () => `
 			}
 		END AS theatre
 
-	ORDER BY production.name
+	ORDER BY production.name, theatre.name
 
 	LIMIT 100
 `;

--- a/src/neo4j/cypher-queries/theatre.js
+++ b/src/neo4j/cypher-queries/theatre.js
@@ -111,7 +111,7 @@ const getShowQuery = () => `
 		subTheatreForProduction,
 		LENGTH(path) AS theatreToProductionPathLength,
 		production
-		ORDER BY production.name
+		ORDER BY production.name, theatre.name
 
 	RETURN
 		'theatre' AS model,


### PR DESCRIPTION
When productions are ordered they order by the production name then by the theatre name.

This PR ensures that all queries use this ordering for productions (a couple of queries were not applying secondary sorting by the theatre name).