### PR TITLE
Add database seeds to demo playtexts with multiple writers

### DIFF
--- a/db-seeding/seeds/playtexts/greenland.json
+++ b/db-seeding/seeds/playtexts/greenland.json
@@ -1,0 +1,118 @@
+{
+	"name": "Greenland",
+	"writers": [
+		{
+			"name": "Moira Buffini"
+		},
+		{
+			"name": "Matt Charman"
+		},
+		{
+			"name": "Penelope Skinner"
+		},
+		{
+			"name": "Jack Thorne"
+		}
+	],
+	"characters": [
+		{
+			"name": "Adeel"
+		},
+		{
+			"name": "Paula"
+		},
+		{
+			"name": "Lisa"
+		},
+		{
+			"name": "Shopper"
+		},
+		{
+			"name": "Ray"
+		},
+		{
+			"name": "Robert"
+		},
+		{
+			"name": "Harold"
+		},
+		{
+			"name": "Harry"
+		},
+		{
+			"name": "Sarah"
+		},
+		{
+			"name": "Freya"
+		},
+		{
+			"name": "Al"
+		},
+		{
+			"name": "Naval Cadet"
+		},
+		{
+			"name": "Phoebe"
+		},
+		{
+			"name": "Damien"
+		},
+		{
+			"name": "Bernice"
+		},
+		{
+			"name": "Natasha"
+		},
+		{
+			"name": "Dav"
+		},
+		{
+			"name": "Susie"
+		},
+		{
+			"name": "Peta"
+		},
+		{
+			"name": "Sam"
+		},
+		{
+			"name": "Claude"
+		},
+		{
+			"name": "Adam"
+		},
+		{
+			"name": "Pam"
+		},
+		{
+			"name": "Serena"
+		},
+		{
+			"name": "Celia"
+		},
+		{
+			"name": "Nigel"
+		},
+		{
+			"name": "Alamir"
+		},
+		{
+			"name": "Seydou"
+		},
+		{
+			"name": "Depledge"
+		},
+		{
+			"name": "Oppenheim"
+		},
+		{
+			"name": "Jacobs"
+		},
+		{
+			"name": "Waiter"
+		},
+		{
+			"name": "Mac"
+		}
+	]
+}

--- a/db-seeding/seeds/productions/greenland.json
+++ b/db-seeding/seeds/productions/greenland.json
@@ -1,0 +1,56 @@
+{
+	"name": "Greenland",
+	"theatre": {
+		"name": "Lyttelton Theatre"
+	},
+	"playtext": {
+		"name": "Greenland"
+	},
+	"cast": [
+		{
+			"name": "James Alper"
+		},
+		{
+			"name": "Tobi Bakare"
+		},
+		{
+			"name": "Natasha Broomfield"
+		},
+		{
+			"name": "Elizabeth Chan"
+		},
+		{
+			"name": "Michael Gould"
+		},
+		{
+			"name": "Tamzin Griffin"
+		},
+		{
+			"name": "Isabella Laughland"
+		},
+		{
+			"name": "Amanda Lawrence"
+		},
+		{
+			"name": "Tunji Lucas"
+		},
+		{
+			"name": "Paul McCleary"
+		},
+		{
+			"name": "Peter McDonald"
+		},
+		{
+			"name": "Simon Manyonda"
+		},
+		{
+			"name": "Lyndsey Marshal"
+		},
+		{
+			"name": "Rhys Rusbatch"
+		},
+		{
+			"name": "Sam Swann"
+		}
+	]
+}


### PR DESCRIPTION
Database seeds to demonstrate playtexts with multiple writers functionality added in this PR: https://github.com/andygout/theatrebase-api/pull/273.