### PR TITLE
Return empty character depictions array if all values null

### DIFF
--- a/src/neo4j/cypher-queries/character.js
+++ b/src/neo4j/cypher-queries/character.js
@@ -21,11 +21,16 @@ const getShowQuery = () => `
 		character,
 		playtext,
 		writers,
-		COLLECT({
-			displayName: playtextRel.displayName,
-			qualifier: playtextRel.qualifier,
-			group: playtextRel.group
-		}) AS depictions
+		COLLECT(
+			CASE WHEN playtextRel.displayName IS NULL AND playtextRel.qualifier IS NULL AND playtextRel.group IS NULL
+				THEN null
+				ELSE {
+					displayName: playtextRel.displayName,
+					qualifier: playtextRel.qualifier,
+					group: playtextRel.group
+				}
+			END
+		) AS depictions
 		ORDER BY playtext.name
 
 	WITH character,

--- a/test-e2e/model-interaction/char-in-multi-prods-of-multi-playtexts.test.js
+++ b/test-e2e/model-interaction/char-in-multi-prods-of-multi-playtexts.test.js
@@ -306,39 +306,21 @@ describe('Character in multiple productions of multiple playtexts', () => {
 					uuid: HENRY_IV_PART_1_PLAYTEXT_UUID,
 					name: 'Henry IV: Part 1',
 					writers: [],
-					depictions: [
-						{
-							displayName: null,
-							qualifier: null,
-							group: null
-						}
-					]
+					depictions: []
 				},
 				{
 					model: 'playtext',
 					uuid: HENRY_IV_PART_2_PLAYTEXT_UUID,
 					name: 'Henry IV: Part 2',
 					writers: [],
-					depictions: [
-						{
-							displayName: null,
-							qualifier: null,
-							group: null
-						}
-					]
+					depictions: []
 				},
 				{
 					model: 'playtext',
 					uuid: THE_MERRY_WIVES_OF_WINDSOR_PLAYTEXT_UUID,
 					name: 'The Merry Wives of Windsor',
 					writers: [],
-					depictions: [
-						{
-							displayName: null,
-							qualifier: null,
-							group: null
-						}
-					]
+					depictions: []
 				}
 			];
 

--- a/test-e2e/model-interaction/char-with-variant-depiction-portrayal-names.test.js
+++ b/test-e2e/model-interaction/char-with-variant-depiction-portrayal-names.test.js
@@ -426,13 +426,7 @@ describe('Character with variant depiction and portrayal names', () => {
 					uuid: HENRY_V_PLAYTEXT_UUID,
 					name: 'Henry V',
 					writers: [],
-					depictions: [
-						{
-							displayName: null,
-							qualifier: null,
-							group: null
-						}
-					]
+					depictions: []
 				},
 				{
 					model: 'playtext',

--- a/test-e2e/model-interaction/char-with-variant-names-diff-playtexts.test.js
+++ b/test-e2e/model-interaction/char-with-variant-names-diff-playtexts.test.js
@@ -282,52 +282,28 @@ describe('Character with variant names from productions of different playtexts',
 					uuid: FORTINBRAS_PLAYTEXT_UUID,
 					name: 'Fortinbras',
 					writers: [],
-					depictions: [
-						{
-							displayName: null,
-							qualifier: null,
-							group: null
-						}
-					]
+					depictions: []
 				},
 				{
 					model: 'playtext',
 					uuid: HAMLET_PLAYTEXT_UUID,
 					name: 'Hamlet',
 					writers: [],
-					depictions: [
-						{
-							displayName: null,
-							qualifier: null,
-							group: null
-						}
-					]
+					depictions: []
 				},
 				{
 					model: 'playtext',
 					uuid: HAMLETMACHINE_PLAYTEXT_UUID,
 					name: 'Hamletmachine',
 					writers: [],
-					depictions: [
-						{
-							displayName: null,
-							qualifier: null,
-							group: null
-						}
-					]
+					depictions: []
 				},
 				{
 					model: 'playtext',
 					uuid: ROSENCRANTZ_AND_GUILDENSTERN_ARE_DEAD_PLAYTEXT_UUID,
 					name: 'Rosencrantz and Guildenstern Are Dead',
 					writers: [],
-					depictions: [
-						{
-							displayName: null,
-							qualifier: null,
-							group: null
-						}
-					]
+					depictions: []
 				}
 			];
 

--- a/test-e2e/model-interaction/writer-of-multiple-playtexts.test.js
+++ b/test-e2e/model-interaction/writer-of-multiple-playtexts.test.js
@@ -312,13 +312,7 @@ describe('Writer of multiple playtexts', () => {
 							name: 'Moira Buffini'
 						}
 					],
-					depictions: [
-						{
-							displayName: null,
-							qualifier: null,
-							group: null
-						}
-					]
+					depictions: []
 				}
 			];
 
@@ -361,13 +355,7 @@ describe('Writer of multiple playtexts', () => {
 							name: 'Jack Thorne'
 						}
 					],
-					depictions: [
-						{
-							displayName: null,
-							qualifier: null,
-							group: null
-						}
-					]
+					depictions: []
 				}
 			];
 


### PR DESCRIPTION
If character `depictions` is an array containing a single object whose values are all null, then it should simply be an empty array.

This PR applies those changes.