### PR TITLE
Return empty playtext characterGroups array if characters arrays are empty

### DIFF
--- a/src/neo4j/cypher-queries/playtext.js
+++ b/src/neo4j/cypher-queries/playtext.js
@@ -187,11 +187,14 @@ const getShowQuery = () => `
 
 	WITH playtext, writers,
 		COLLECT(
-			{
-				model: 'characterGroup',
-				name: characterGroup,
-				characters: characters
-			}
+			CASE SIZE(characters) WHEN 0
+				THEN null
+				ELSE {
+					model: 'characterGroup',
+					name: characterGroup,
+					characters: characters
+				}
+			END
 		) AS characterGroups
 
 	OPTIONAL MATCH (playtext)<-[:PRODUCTION_OF]-(production:Production)

--- a/test-e2e/crud/playtexts-api.test.js
+++ b/test-e2e/crud/playtexts-api.test.js
@@ -204,13 +204,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 				uuid: PLAYTEXT_UUID,
 				name: 'The Cherry Orchard',
 				differentiator: null,
-				characterGroups: [
-					{
-						model: 'characterGroup',
-						name: null,
-						characters: []
-					}
-				],
+				characterGroups: [],
 				writers: [],
 				productions: []
 			};


### PR DESCRIPTION
For playtexts that have no characters, the front-end is unnecessarily displaying the **Characters** header with no content underneath.

This PR fixes the playtext show query to ensure that the returned `characterGroups` array is empty if all of the objects it contains have empty `characters` arrays.

### Before

#### Neo4j console (`characterGroups` array is populated):
<img width="1302" alt="before-neo4j-console" src="https://user-images.githubusercontent.com/10484515/98109326-4b774480-1e95-11eb-8d0f-cc252ddaf1cf.png">

#### Front-end (Characters header is present but with no content):
![before-front-end](https://user-images.githubusercontent.com/10484515/98109341-50d48f00-1e95-11eb-9761-e08542f38269.png)

---

### After

#### Neo4j console (`characterGroups` array is not populated):
<img width="1301" alt="after-neo4j-console" src="https://user-images.githubusercontent.com/10484515/98109350-53cf7f80-1e95-11eb-9d83-d1c7d652bca6.png">

#### Front-end (Characters header is no longer present):
![after-front-end](https://user-images.githubusercontent.com/10484515/98109358-5631d980-1e95-11eb-82a7-cca91567a5fd.png)