### PR TITLE
Revise E2E tests to ensure ORDER BY clauses are applied correctly

### DIFF
--- a/src/neo4j/cypher-queries/theatre.js
+++ b/src/neo4j/cypher-queries/theatre.js
@@ -111,7 +111,7 @@ const getShowQuery = () => `
 		subTheatreForProduction,
 		LENGTH(path) AS theatreToProductionPathLength,
 		production
-		ORDER BY production.name, theatre.name
+		ORDER BY production.name
 
 	RETURN
 		'theatre' AS model,

--- a/test-e2e/crud/characters-api.test.js
+++ b/test-e2e/crud/characters-api.test.js
@@ -139,24 +139,6 @@ describe('CRUD (Create, Read, Update, Delete): Characters API', () => {
 
 		});
 
-		it('lists all characters', async () => {
-
-			const response = await chai.request(app)
-				.get('/characters');
-
-			const expectedResponseBody = [
-				{
-					model: 'character',
-					uuid: CHARACTER_UUID,
-					name: 'Juliet'
-				}
-			];
-
-			expect(response).to.have.status(200);
-			expect(response.body).to.deep.equal(expectedResponseBody);
-
-		});
-
 		it('deletes character', async () => {
 
 			expect(await countNodesWithLabel('Character')).to.equal(1);
@@ -174,6 +156,78 @@ describe('CRUD (Create, Read, Update, Delete): Characters API', () => {
 			expect(response).to.have.status(200);
 			expect(response.body).to.deep.equal(expectedResponseBody);
 			expect(await countNodesWithLabel('Character')).to.equal(0);
+
+		});
+
+	});
+
+	describe('GET list endpoint', () => {
+
+		const ROMEO_CHARACTER_UUID = '1';
+		const JULIET_CHARACTER_UUID = '3';
+		const NURSE_CHARACTER_UUID = '5';
+
+		const sandbox = createSandbox();
+
+		before(async () => {
+
+			let uuidCallCount = 0;
+
+			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+
+			await purgeDatabase();
+
+			await chai.request(app)
+				.post('/characters')
+				.send({
+					name: 'Romeo'
+				});
+
+			await chai.request(app)
+				.post('/characters')
+				.send({
+					name: 'Juliet'
+				});
+
+			await chai.request(app)
+				.post('/characters')
+				.send({
+					name: 'Nurse'
+				});
+
+		});
+
+		after(() => {
+
+			sandbox.restore();
+
+		});
+
+		it('lists all characters ordered by name', async () => {
+
+			const response = await chai.request(app)
+				.get('/characters');
+
+			const expectedResponseBody = [
+				{
+					model: 'character',
+					uuid: JULIET_CHARACTER_UUID,
+					name: 'Juliet'
+				},
+				{
+					model: 'character',
+					uuid: NURSE_CHARACTER_UUID,
+					name: 'Nurse'
+				},
+				{
+					model: 'character',
+					uuid: ROMEO_CHARACTER_UUID,
+					name: 'Romeo'
+				}
+			];
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
 
 		});
 

--- a/test-e2e/crud/people-api.test.js
+++ b/test-e2e/crud/people-api.test.js
@@ -137,24 +137,6 @@ describe('CRUD (Create, Read, Update, Delete): People API', () => {
 
 		});
 
-		it('lists all people', async () => {
-
-			const response = await chai.request(app)
-				.get('/people');
-
-			const expectedResponseBody = [
-				{
-					model: 'person',
-					uuid: PERSON_UUID,
-					name: 'Patrick Stewart'
-				}
-			];
-
-			expect(response).to.have.status(200);
-			expect(response.body).to.deep.equal(expectedResponseBody);
-
-		});
-
 		it('deletes person', async () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(1);
@@ -172,6 +154,78 @@ describe('CRUD (Create, Read, Update, Delete): People API', () => {
 			expect(response).to.have.status(200);
 			expect(response.body).to.deep.equal(expectedResponseBody);
 			expect(await countNodesWithLabel('Person')).to.equal(0);
+
+		});
+
+	});
+
+	describe('GET list endpoint', () => {
+
+		const IAN_MCKELLEN_PERSON_UUID = '1';
+		const PATRICK_STEWART_PERSON_UUID = '3';
+		const MATTHEW_KELLY_PERSON_UUID = '5';
+
+		const sandbox = createSandbox();
+
+		before(async () => {
+
+			let uuidCallCount = 0;
+
+			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+
+			await purgeDatabase();
+
+			await chai.request(app)
+				.post('/people')
+				.send({
+					name: 'Ian McKellen'
+				});
+
+			await chai.request(app)
+				.post('/people')
+				.send({
+					name: 'Patrick Stewart'
+				});
+
+			await chai.request(app)
+				.post('/people')
+				.send({
+					name: 'Matthew Kelly'
+				});
+
+		});
+
+		after(() => {
+
+			sandbox.restore();
+
+		});
+
+		it('lists all people ordered by name', async () => {
+
+			const response = await chai.request(app)
+				.get('/people');
+
+			const expectedResponseBody = [
+				{
+					model: 'person',
+					uuid: IAN_MCKELLEN_PERSON_UUID,
+					name: 'Ian McKellen'
+				},
+				{
+					model: 'person',
+					uuid: MATTHEW_KELLY_PERSON_UUID,
+					name: 'Matthew Kelly'
+				},
+				{
+					model: 'person',
+					uuid: PATRICK_STEWART_PERSON_UUID,
+					name: 'Patrick Stewart'
+				}
+			];
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
 
 		});
 

--- a/test-e2e/crud/playtexts-api.test.js
+++ b/test-e2e/crud/playtexts-api.test.js
@@ -214,25 +214,6 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 
 		});
 
-		it('lists all playtexts', async () => {
-
-			const response = await chai.request(app)
-				.get('/playtexts');
-
-			const expectedResponseBody = [
-				{
-					model: 'playtext',
-					uuid: PLAYTEXT_UUID,
-					name: 'The Cherry Orchard',
-					writers: []
-				}
-			];
-
-			expect(response).to.have.status(200);
-			expect(response.body).to.deep.equal(expectedResponseBody);
-
-		});
-
 		it('deletes playtext', async () => {
 
 			expect(await countNodesWithLabel('Playtext')).to.equal(1);
@@ -709,36 +690,6 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 
 		});
 
-		it('lists all playtexts', async () => {
-
-			const response = await chai.request(app)
-				.get('/playtexts');
-
-			const expectedResponseBody = [
-				{
-					model: 'playtext',
-					uuid: PLAYTEXT_UUID,
-					name: 'Three Sisters',
-					writers: [
-						{
-							model: 'person',
-							uuid: ANTON_CHEKHOV_PERSON_UUID,
-							name: 'Anton Chekhov'
-						},
-						{
-							model: 'person',
-							uuid: MAXIM_GORKY_PERSON_UUID,
-							name: 'Maxim Gorky'
-						}
-					]
-				}
-			];
-
-			expect(response).to.have.status(200);
-			expect(response.body).to.deep.equal(expectedResponseBody);
-
-		});
-
 		it('updates playtext to remove all associations prior to deletion', async () => {
 
 			expect(await countNodesWithLabel('Playtext')).to.equal(1);
@@ -802,6 +753,81 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 			expect(response).to.have.status(200);
 			expect(response.body).to.deep.equal(expectedResponseBody);
 			expect(await countNodesWithLabel('Playtext')).to.equal(0);
+
+		});
+
+	});
+
+	describe('GET list endpoint', () => {
+
+		const UNCLE_VANYA_PLAYTEXT_UUID = '1';
+		const THE_CHERRY_ORCHARD_PLAYTEXT_UUID = '3';
+		const THREE_SISTERS_PLAYTEXT_UUID = '5';
+
+		const sandbox = createSandbox();
+
+		before(async () => {
+
+			let uuidCallCount = 0;
+
+			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+
+			await purgeDatabase();
+
+			await chai.request(app)
+				.post('/playtexts')
+				.send({
+					name: 'Uncle Vanya'
+				});
+
+			await chai.request(app)
+				.post('/playtexts')
+				.send({
+					name: 'The Cherry Orchard'
+				});
+
+			await chai.request(app)
+				.post('/playtexts')
+				.send({
+					name: 'Three Sisters'
+				});
+
+		});
+
+		after(() => {
+
+			sandbox.restore();
+
+		});
+
+		it('lists all playtexts ordered by name', async () => {
+
+			const response = await chai.request(app)
+				.get('/playtexts');
+
+			const expectedResponseBody = [
+				{
+					model: 'playtext',
+					uuid: THE_CHERRY_ORCHARD_PLAYTEXT_UUID,
+					name: 'The Cherry Orchard',
+					writers: []
+				},
+				{
+					model: 'playtext',
+					uuid: THREE_SISTERS_PLAYTEXT_UUID,
+					name: 'Three Sisters',
+					writers: []
+				},
+				{
+					model: 'playtext',
+					uuid: UNCLE_VANYA_PLAYTEXT_UUID,
+					name: 'Uncle Vanya',
+					writers: []
+				}
+			];
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
 
 		});
 

--- a/test-e2e/crud/productions-api.test.js
+++ b/test-e2e/crud/productions-api.test.js
@@ -255,25 +255,6 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 
 		});
 
-		it('lists all productions', async () => {
-
-			const response = await chai.request(app)
-				.get('/productions');
-
-			const expectedResponseBody = [
-				{
-					model: 'production',
-					uuid: PRODUCTION_UUID,
-					name: 'The Tempest',
-					theatre: null
-				}
-			];
-
-			expect(response).to.have.status(200);
-			expect(response.body).to.deep.equal(expectedResponseBody);
-
-		});
-
 		it('deletes production', async () => {
 
 			expect(await countNodesWithLabel('Production')).to.equal(1);
@@ -1114,30 +1095,6 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 
 		});
 
-		it('lists all productions', async () => {
-
-			const response = await chai.request(app)
-				.get('/productions');
-
-			const expectedResponseBody = [
-				{
-					model: 'production',
-					uuid: PRODUCTION_UUID,
-					name: 'Richard III',
-					theatre: {
-						model: 'theatre',
-						uuid: ALMEIDA_THEATRE_UUID,
-						name: 'Almeida Theatre',
-						surTheatre: null
-					}
-				}
-			];
-
-			expect(response).to.have.status(200);
-			expect(response.body).to.deep.equal(expectedResponseBody);
-
-		});
-
 		it('updates production to remove all associations prior to deletion', async () => {
 
 			expect(await countNodesWithLabel('Production')).to.equal(1);
@@ -1220,6 +1177,128 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 			expect(response).to.have.status(200);
 			expect(response.body).to.deep.equal(expectedResponseBody);
 			expect(await countNodesWithLabel('Production')).to.equal(0);
+
+		});
+
+	});
+
+	describe('GET list endpoint', () => {
+
+		const MEASURE_FOR_MEASURE_NATIONAL_PRODUCTION_UUID = '0';
+		const NATIONAL_THEATRE_UUID = '2';
+		const HAMLET_NATIONAL_PRODUCTION_UUID = '3';
+		const MEASURE_FOR_MEASURE_ALMEIDA_PRODUCTION_UUID = '6';
+		const ALMEIDA_THEATRE_UUID = '8';
+		const HAMLET_ALMEIDA_PRODUCTION_UUID = '9';
+
+		const sandbox = createSandbox();
+
+		before(async () => {
+
+			let uuidCallCount = 0;
+
+			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+
+			await purgeDatabase();
+
+			await chai.request(app)
+				.post('/productions')
+				.send({
+					name: 'Measure for Measure',
+					theatre: {
+						name: 'National Theatre'
+					}
+				});
+
+			await chai.request(app)
+				.post('/productions')
+				.send({
+					name: 'Hamlet',
+					theatre: {
+						name: 'National Theatre'
+					}
+				});
+
+			await chai.request(app)
+				.post('/productions')
+				.send({
+					name: 'Measure for Measure',
+					theatre: {
+						name: 'Almeida Theatre'
+					}
+				});
+
+			await chai.request(app)
+				.post('/productions')
+				.send({
+					name: 'Hamlet',
+					theatre: {
+						name: 'Almeida Theatre'
+					}
+				});
+
+		});
+
+		after(() => {
+
+			sandbox.restore();
+
+		});
+
+		it('lists all productions ordered by name then theatre name', async () => {
+
+			const response = await chai.request(app)
+				.get('/productions');
+
+			const expectedResponseBody = [
+				{
+					model: 'production',
+					uuid: HAMLET_ALMEIDA_PRODUCTION_UUID,
+					name: 'Hamlet',
+					theatre: {
+						model: 'theatre',
+						uuid: ALMEIDA_THEATRE_UUID,
+						name: 'Almeida Theatre',
+						surTheatre: null
+					}
+				},
+				{
+					model: 'production',
+					uuid: HAMLET_NATIONAL_PRODUCTION_UUID,
+					name: 'Hamlet',
+					theatre: {
+						model: 'theatre',
+						uuid: NATIONAL_THEATRE_UUID,
+						name: 'National Theatre',
+						surTheatre: null
+					}
+				},
+				{
+					model: 'production',
+					uuid: MEASURE_FOR_MEASURE_ALMEIDA_PRODUCTION_UUID,
+					name: 'Measure for Measure',
+					theatre: {
+						model: 'theatre',
+						uuid: ALMEIDA_THEATRE_UUID,
+						name: 'Almeida Theatre',
+						surTheatre: null
+					}
+				},
+				{
+					model: 'production',
+					uuid: MEASURE_FOR_MEASURE_NATIONAL_PRODUCTION_UUID,
+					name: 'Measure for Measure',
+					theatre: {
+						model: 'theatre',
+						uuid: NATIONAL_THEATRE_UUID,
+						name: 'National Theatre',
+						surTheatre: null
+					}
+				}
+			];
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
 
 		});
 

--- a/test-e2e/crud/theatres-api.test.js
+++ b/test-e2e/crud/theatres-api.test.js
@@ -170,25 +170,6 @@ describe('CRUD (Create, Read, Update, Delete): Theatres API', () => {
 
 		});
 
-		it('lists all theatres', async () => {
-
-			const response = await chai.request(app)
-				.get('/theatres');
-
-			const expectedResponseBody = [
-				{
-					model: 'theatre',
-					uuid: THEATRE_UUID,
-					name: 'Almeida Theatre',
-					subTheatres: []
-				}
-			];
-
-			expect(response).to.have.status(200);
-			expect(response.body).to.deep.equal(expectedResponseBody);
-
-		});
-
 		it('deletes theatre', async () => {
 
 			expect(await countNodesWithLabel('Theatre')).to.equal(1);
@@ -470,54 +451,6 @@ describe('CRUD (Create, Read, Update, Delete): Theatres API', () => {
 
 		});
 
-		it('lists all theatres', async () => {
-
-			const response = await chai.request(app)
-				.get('/theatres');
-
-			const expectedResponseBody = [
-				{
-					model: 'theatre',
-					uuid: DORFMAN_THEATRE_UUID,
-					name: 'Dorfman Theatre',
-					subTheatres: []
-				},
-				{
-					model: 'theatre',
-					uuid: LYTTELTON_THEATRE_UUID,
-					name: 'Lyttelton Theatre',
-					subTheatres: []
-				},
-				{
-					model: 'theatre',
-					uuid: OLIVIER_THEATRE_UUID,
-					name: 'Olivier Theatre',
-					subTheatres: []
-				},
-				{
-					model: 'theatre',
-					uuid: THEATRE_UUID,
-					name: 'Royal Court Theatre',
-					subTheatres: [
-						{
-							model: 'theatre',
-							uuid: JERWOOD_THEATRE_DOWNSTAIRS_UUID,
-							name: 'Jerwood Theatre Downstairs'
-						},
-						{
-							model: 'theatre',
-							uuid: JERWOOD_THEATRE_UPSTAIRS_UUID,
-							name: 'Jerwood Theatre Upstairs'
-						}
-					]
-				}
-			];
-
-			expect(response).to.have.status(200);
-			expect(response.body).to.deep.equal(expectedResponseBody);
-
-		});
-
 		it('updates theatre to remove all associations prior to deletion', async () => {
 
 			expect(await countNodesWithLabel('Theatre')).to.equal(6);
@@ -569,6 +502,81 @@ describe('CRUD (Create, Read, Update, Delete): Theatres API', () => {
 			expect(response).to.have.status(200);
 			expect(response.body).to.deep.equal(expectedResponseBody);
 			expect(await countNodesWithLabel('Theatre')).to.equal(5);
+
+		});
+
+	});
+
+	describe('GET list endpoint', () => {
+
+		const DONMAR_WAREHOUSE_THEATRE_UUID = '1';
+		const NATIONAL_THEATRE_UUID = '3';
+		const ALMEIDA_THEATRE_UUID = '5';
+
+		const sandbox = createSandbox();
+
+		before(async () => {
+
+			let uuidCallCount = 0;
+
+			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+
+			await purgeDatabase();
+
+			await chai.request(app)
+				.post('/theatres')
+				.send({
+					name: 'Donmar Warehouse'
+				});
+
+			await chai.request(app)
+				.post('/theatres')
+				.send({
+					name: 'National Theatre'
+				});
+
+			await chai.request(app)
+				.post('/theatres')
+				.send({
+					name: 'Almeida Theatre'
+				});
+
+		});
+
+		after(() => {
+
+			sandbox.restore();
+
+		});
+
+		it('lists all theatres ordered by name', async () => {
+
+			const response = await chai.request(app)
+				.get('/theatres');
+
+			const expectedResponseBody = [
+				{
+					model: 'theatre',
+					uuid: ALMEIDA_THEATRE_UUID,
+					name: 'Almeida Theatre',
+					subTheatres: []
+				},
+				{
+					model: 'theatre',
+					uuid: DONMAR_WAREHOUSE_THEATRE_UUID,
+					name: 'Donmar Warehouse',
+					subTheatres: []
+				},
+				{
+					model: 'theatre',
+					uuid: NATIONAL_THEATRE_UUID,
+					name: 'National Theatre',
+					subTheatres: []
+				}
+			];
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
 
 		});
 

--- a/test-e2e/model-interaction/playtext-with-multi-prods.test.js
+++ b/test-e2e/model-interaction/playtext-with-multi-prods.test.js
@@ -10,18 +10,18 @@ describe('Playtext with multiple productions', () => {
 
 	chai.use(chaiHttp);
 
-	const MEASURE_FOR_MEASURE_NATIONAL_PRODUCTION_UUID = '0';
-	const MEASURE_FOR_MEASURE_PLAYTEXT_UUID = '1';
-	const NATIONAL_THEATRE_UUID = '2';
-	const MEASURE_FOR_MEASURE_ALMEIDA_PRODUCTION_UUID = '3';
-	const ALMEIDA_THEATRE_UUID = '5';
-	const MEASURE_FOR_MEASURE_DONMAR_PRODUCTION_UUID = '6';
-	const DONMAR_WAREHOUSE_THEATRE_UUID = '8';
+	const TWELFTH_NIGHT_GLOBE_PRODUCTION_UUID = '0';
+	const TWELFTH_NIGHT_PLAYTEXT_UUID = '1';
+	const SHAKESPEARES_GLOBE_THEATRE_UUID = '2';
+	const TWELFTH_NIGHT_OR_WHAT_YOU_WILL_DONMAR_PRODUCTION_UUID = '3';
+	const DONMAR_WAREHOUSE_THEATRE_UUID = '5';
+	const TWELFTH_NIGHT_NATIONAL_PRODUCTION_UUID = '6';
+	const NATIONAL_THEATRE_UUID = '8';
 
-	let measureForMeasurePlaytext;
-	let measureForMeasureNationalProduction;
-	let measureForMeasureAlmeidaProduction;
-	let measureForMeasureDonmarProduction;
+	let twelfthNightPlaytext;
+	let twelfthNightGlobeProduction;
+	let twelfthNightDonmarProduction;
+	let twelfthNightNationalProduction;
 
 	const sandbox = createSandbox();
 
@@ -36,50 +36,50 @@ describe('Playtext with multiple productions', () => {
 		await chai.request(app)
 			.post('/productions')
 			.send({
-				name: 'Measure for Measure',
+				name: 'Twelfth Night',
 				playtext: {
-					name: 'Measure for Measure'
+					name: 'Twelfth Night'
 				},
 				theatre: {
-					name: 'National Theatre'
+					name: 'Shakespeare\'s Globe'
 				}
 			});
 
 		await chai.request(app)
 			.post('/productions')
 			.send({
-				name: 'Measure for Measure',
+				name: 'Twelfth Night, or What You Will',
 				playtext: {
-					name: 'Measure for Measure'
-				},
-				theatre: {
-					name: 'Almeida Theatre'
-				}
-			});
-
-		await chai.request(app)
-			.post('/productions')
-			.send({
-				name: 'Measure for Measure',
-				playtext: {
-					name: 'Measure for Measure'
+					name: 'Twelfth Night'
 				},
 				theatre: {
 					name: 'Donmar Warehouse'
 				}
 			});
 
-		measureForMeasurePlaytext = await chai.request(app)
-			.get(`/playtexts/${MEASURE_FOR_MEASURE_PLAYTEXT_UUID}`);
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Twelfth Night',
+				playtext: {
+					name: 'Twelfth Night'
+				},
+				theatre: {
+					name: 'National Theatre'
+				}
+			});
 
-		measureForMeasureNationalProduction = await chai.request(app)
-			.get(`/productions/${MEASURE_FOR_MEASURE_NATIONAL_PRODUCTION_UUID}`);
+		twelfthNightPlaytext = await chai.request(app)
+			.get(`/playtexts/${TWELFTH_NIGHT_PLAYTEXT_UUID}`);
 
-		measureForMeasureAlmeidaProduction = await chai.request(app)
-			.get(`/productions/${MEASURE_FOR_MEASURE_ALMEIDA_PRODUCTION_UUID}`);
+		twelfthNightGlobeProduction = await chai.request(app)
+			.get(`/productions/${TWELFTH_NIGHT_GLOBE_PRODUCTION_UUID}`);
 
-		measureForMeasureDonmarProduction = await chai.request(app)
-			.get(`/productions/${MEASURE_FOR_MEASURE_DONMAR_PRODUCTION_UUID}`);
+		twelfthNightDonmarProduction = await chai.request(app)
+			.get(`/productions/${TWELFTH_NIGHT_OR_WHAT_YOU_WILL_DONMAR_PRODUCTION_UUID}`);
+
+		twelfthNightNationalProduction = await chai.request(app)
+			.get(`/productions/${TWELFTH_NIGHT_NATIONAL_PRODUCTION_UUID}`);
 
 	});
 
@@ -89,47 +89,47 @@ describe('Playtext with multiple productions', () => {
 
 	});
 
-	describe('Measure for Measure (playtext)', () => {
+	describe('Twelfth Night (playtext)', () => {
 
-		it('includes productions of playtext', () => {
+		it('includes productions of playtext ordered by production name then theatre name', () => {
 
 			const expectedProductions = [
 				{
 					model: 'production',
-					uuid: MEASURE_FOR_MEASURE_ALMEIDA_PRODUCTION_UUID,
-					name: 'Measure for Measure',
-					theatre: {
-						model: 'theatre',
-						uuid: ALMEIDA_THEATRE_UUID,
-						name: 'Almeida Theatre',
-						surTheatre: null
-					}
-				},
-				{
-					model: 'production',
-					uuid: MEASURE_FOR_MEASURE_DONMAR_PRODUCTION_UUID,
-					name: 'Measure for Measure',
-					theatre: {
-						model: 'theatre',
-						uuid: DONMAR_WAREHOUSE_THEATRE_UUID,
-						name: 'Donmar Warehouse',
-						surTheatre: null
-					}
-				},
-				{
-					model: 'production',
-					uuid: MEASURE_FOR_MEASURE_NATIONAL_PRODUCTION_UUID,
-					name: 'Measure for Measure',
+					uuid: TWELFTH_NIGHT_NATIONAL_PRODUCTION_UUID,
+					name: 'Twelfth Night',
 					theatre: {
 						model: 'theatre',
 						uuid: NATIONAL_THEATRE_UUID,
 						name: 'National Theatre',
 						surTheatre: null
 					}
+				},
+				{
+					model: 'production',
+					uuid: TWELFTH_NIGHT_GLOBE_PRODUCTION_UUID,
+					name: 'Twelfth Night',
+					theatre: {
+						model: 'theatre',
+						uuid: SHAKESPEARES_GLOBE_THEATRE_UUID,
+						name: 'Shakespeare\'s Globe',
+						surTheatre: null
+					}
+				},
+				{
+					model: 'production',
+					uuid: TWELFTH_NIGHT_OR_WHAT_YOU_WILL_DONMAR_PRODUCTION_UUID,
+					name: 'Twelfth Night, or What You Will',
+					theatre: {
+						model: 'theatre',
+						uuid: DONMAR_WAREHOUSE_THEATRE_UUID,
+						name: 'Donmar Warehouse',
+						surTheatre: null
+					}
 				}
 			];
 
-			const { productions } = measureForMeasurePlaytext.body;
+			const { productions } = twelfthNightPlaytext.body;
 
 			expect(productions).to.deep.equal(expectedProductions);
 
@@ -137,18 +137,18 @@ describe('Playtext with multiple productions', () => {
 
 	});
 
-	describe('Measure for Measure at National Theatre (production)', () => {
+	describe('Twelfth Night at Shakespeare\'s Globe (production)', () => {
 
-		it('attributes playtext as Measure for Measure', () => {
+		it('attributes playtext as Twelfth Night', () => {
 
 			const expectedPlaytext = {
 				model: 'playtext',
-				uuid: MEASURE_FOR_MEASURE_PLAYTEXT_UUID,
-				name: 'Measure for Measure',
+				uuid: TWELFTH_NIGHT_PLAYTEXT_UUID,
+				name: 'Twelfth Night',
 				writers: []
 			};
 
-			const { playtext } = measureForMeasureNationalProduction.body;
+			const { playtext } = twelfthNightGlobeProduction.body;
 
 			expect(playtext).to.deep.equal(expectedPlaytext);
 
@@ -156,18 +156,18 @@ describe('Playtext with multiple productions', () => {
 
 	});
 
-	describe('Measure for Measure at Almeida Theatre (production)', () => {
+	describe('Twelfth Night at Donmar Warehouse (production)', () => {
 
-		it('attributes playtext as Measure for Measure', () => {
+		it('attributes playtext as Twelfth Night', () => {
 
 			const expectedPlaytext = {
 				model: 'playtext',
-				uuid: MEASURE_FOR_MEASURE_PLAYTEXT_UUID,
-				name: 'Measure for Measure',
+				uuid: TWELFTH_NIGHT_PLAYTEXT_UUID,
+				name: 'Twelfth Night',
 				writers: []
 			};
 
-			const { playtext } = measureForMeasureAlmeidaProduction.body;
+			const { playtext } = twelfthNightDonmarProduction.body;
 
 			expect(playtext).to.deep.equal(expectedPlaytext);
 
@@ -175,18 +175,18 @@ describe('Playtext with multiple productions', () => {
 
 	});
 
-	describe('Measure for Measure at Donmar Warehouse (production)', () => {
+	describe('Twelfth Night at National Theatre (production)', () => {
 
-		it('attributes playtext as Measure for Measure', () => {
+		it('attributes playtext as Twelfth Night', () => {
 
 			const expectedPlaytext = {
 				model: 'playtext',
-				uuid: MEASURE_FOR_MEASURE_PLAYTEXT_UUID,
-				name: 'Measure for Measure',
+				uuid: TWELFTH_NIGHT_PLAYTEXT_UUID,
+				name: 'Twelfth Night',
 				writers: []
 			};
 
-			const { playtext } = measureForMeasureDonmarProduction.body;
+			const { playtext } = twelfthNightNationalProduction.body;
 
 			expect(playtext).to.deep.equal(expectedPlaytext);
 

--- a/test-e2e/model-interaction/theatre-with-sub-theatres.test.js
+++ b/test-e2e/model-interaction/theatre-with-sub-theatres.test.js
@@ -10,15 +10,17 @@ describe('Theatre with sub-theatres', () => {
 
 	chai.use(chaiHttp);
 
-	const NATIONAL_THEATRE_UUID = '2';
-	const OLIVIER_THEATRE_UUID = '3';
-	const MOTHER_COURAGE_AND_HER_CHILDREN_PLAYTEXT_UUID = '6';
-	const MOTHER_COURAGE_CHARACTER_UUID = '7';
-	const RICHARD_II_PLAYTEXT_UUID = '10';
-	const KING_RICHARD_II_CHARACTER_UUID = '11';
-	const MOTHER_COURAGE_AND_HER_CHILDREN_OLIVIER_PRODUCTION_UUID = '12';
-	const FIONA_SHAW_PERSON_UUID = '15';
-	const RICHARD_II_NATIONAL_PRODUCTION_UUID = '16';
+	const NATIONAL_THEATRE_UUID = '4';
+	const OLIVIER_THEATRE_UUID = '5';
+	const LYTTELTON_THEATRE_UUID = '6';
+	const DORFMAN_THEATRE_UUID = '7';
+	const MOTHER_COURAGE_AND_HER_CHILDREN_PLAYTEXT_UUID = '10';
+	const MOTHER_COURAGE_CHARACTER_UUID = '11';
+	const RICHARD_II_PLAYTEXT_UUID = '14';
+	const KING_RICHARD_II_CHARACTER_UUID = '15';
+	const MOTHER_COURAGE_AND_HER_CHILDREN_OLIVIER_PRODUCTION_UUID = '16';
+	const FIONA_SHAW_PERSON_UUID = '19';
+	const RICHARD_II_NATIONAL_PRODUCTION_UUID = '20';
 
 	let nationalTheatre;
 	let olivierTheatre;
@@ -47,6 +49,12 @@ describe('Theatre with sub-theatres', () => {
 				subTheatres: [
 					{
 						name: 'Olivier Theatre'
+					},
+					{
+						name: 'Lyttelton Theatre'
+					},
+					{
+						name: 'Dorfman Theatre'
 					}
 				]
 			});
@@ -154,13 +162,23 @@ describe('Theatre with sub-theatres', () => {
 
 	describe('National Theatre (theatre)', () => {
 
-		it('includes Olivier Theatre in its sub-theatres', () => {
+		it('includes its sub-theatres', () => {
 
 			const expectedSubTheatres = [
 				{
 					model: 'theatre',
 					uuid: OLIVIER_THEATRE_UUID,
 					name: 'Olivier Theatre'
+				},
+				{
+					model: 'theatre',
+					uuid: LYTTELTON_THEATRE_UUID,
+					name: 'Lyttelton Theatre'
+				},
+				{
+					model: 'theatre',
+					uuid: DORFMAN_THEATRE_UUID,
+					name: 'Dorfman Theatre'
 				}
 			];
 
@@ -460,6 +478,45 @@ describe('Theatre with sub-theatres', () => {
 			const { productions } = fionaShawPerson.body;
 
 			expect(productions).to.deep.equal(expectedProductions);
+
+		});
+
+	});
+
+	describe('theatres list', () => {
+
+		it('includes theatre and corresponding sub-theatres', async () => {
+
+			const response = await chai.request(app)
+				.get('/theatres');
+
+			const expectedResponseBody = [
+				{
+					model: 'theatre',
+					uuid: NATIONAL_THEATRE_UUID,
+					name: 'National Theatre',
+					subTheatres: [
+						{
+							model: 'theatre',
+							uuid: OLIVIER_THEATRE_UUID,
+							name: 'Olivier Theatre'
+						},
+						{
+							model: 'theatre',
+							uuid: LYTTELTON_THEATRE_UUID,
+							name: 'Lyttelton Theatre'
+						},
+						{
+							model: 'theatre',
+							uuid: DORFMAN_THEATRE_UUID,
+							name: 'Dorfman Theatre'
+						}
+					]
+				}
+			];
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
 
 		});
 


### PR DESCRIPTION
Revises end-to-end tests to ensure that if any of the existing `ORDER BY` clauses have their ordering reversed (i.e. by appending `DESC`, e.g. `ORDER BY production.name DESC`) then one of the tests will catch it.

This means:
- Having a committed `describe` block in the API CRUD tests for the list endpoint that ensure the ordering is applied.
- Applying some changes to other end-to-end tests (playtexts with multiple productions, theatres with sub-theatres).

Another small related change has also been made:
- The theatre show query no longer has secondary ordering by theatre name because the theatre is the subject and therefore will be the same for every result and is therefore unnecessary.