### PR TITLE
Fix playtext create/update Cypher query

### DIFF
--- a/src/neo4j/cypher-queries/playtext.js
+++ b/src/neo4j/cypher-queries/playtext.js
@@ -30,9 +30,7 @@ const getCreateUpdateQuery = action => {
 
 		UNWIND (CASE $writers WHEN [] THEN [null] ELSE $writers END) AS writerParam
 
-			OPTIONAL MATCH (existingWriter:Person {
-				name: COALESCE(writerParam.underlyingName, writerParam.name)
-			})
+			OPTIONAL MATCH (existingWriter:Person { name: writerParam.name })
 				WHERE
 					(writerParam.differentiator IS NULL AND existingWriter.differentiator IS NULL) OR
 					(writerParam.differentiator = existingWriter.differentiator)
@@ -43,10 +41,8 @@ const getCreateUpdateQuery = action => {
 				CASE existingWriter WHEN NULL
 					THEN {
 						uuid: writerParam.uuid,
-						name: COALESCE(writerParam.underlyingName, writerParam.name),
-						differentiator: writerParam.differentiator,
-						qualifier: writerParam.qualifier,
-						group: writerParam.group
+						name: writerParam.name,
+						differentiator: writerParam.differentiator
 					}
 					ELSE existingWriter
 				END AS writerProps

--- a/test-unit/src/neo4j/cypher-queries/playtext.test.js
+++ b/test-unit/src/neo4j/cypher-queries/playtext.test.js
@@ -17,9 +17,7 @@ describe('Cypher Queries Playtext module', () => {
 
 				UNWIND (CASE $writers WHEN [] THEN [null] ELSE $writers END) AS writerParam
 
-					OPTIONAL MATCH (existingWriter:Person {
-						name: COALESCE(writerParam.underlyingName, writerParam.name)
-					})
+					OPTIONAL MATCH (existingWriter:Person { name: writerParam.name })
 						WHERE
 							(writerParam.differentiator IS NULL AND existingWriter.differentiator IS NULL) OR
 							(writerParam.differentiator = existingWriter.differentiator)
@@ -30,10 +28,8 @@ describe('Cypher Queries Playtext module', () => {
 						CASE existingWriter WHEN NULL
 							THEN {
 								uuid: writerParam.uuid,
-								name: COALESCE(writerParam.underlyingName, writerParam.name),
-								differentiator: writerParam.differentiator,
-								qualifier: writerParam.qualifier,
-								group: writerParam.group
+								name: writerParam.name,
+								differentiator: writerParam.differentiator
 							}
 							ELSE existingWriter
 						END AS writerProps
@@ -160,9 +156,7 @@ describe('Cypher Queries Playtext module', () => {
 
 				UNWIND (CASE $writers WHEN [] THEN [null] ELSE $writers END) AS writerParam
 
-					OPTIONAL MATCH (existingWriter:Person {
-						name: COALESCE(writerParam.underlyingName, writerParam.name)
-					})
+					OPTIONAL MATCH (existingWriter:Person { name: writerParam.name })
 						WHERE
 							(writerParam.differentiator IS NULL AND existingWriter.differentiator IS NULL) OR
 							(writerParam.differentiator = existingWriter.differentiator)
@@ -173,10 +167,8 @@ describe('Cypher Queries Playtext module', () => {
 						CASE existingWriter WHEN NULL
 							THEN {
 								uuid: writerParam.uuid,
-								name: COALESCE(writerParam.underlyingName, writerParam.name),
-								differentiator: writerParam.differentiator,
-								qualifier: writerParam.qualifier,
-								group: writerParam.group
+								name: writerParam.name,
+								differentiator: writerParam.differentiator
 							}
 							ELSE existingWriter
 						END AS writerProps


### PR DESCRIPTION
When adding playtext writers (https://github.com/andygout/theatrebase-api/pull/273), some copy-pasted sections of the playtext create/update Cypher query for playtext characters were used for playtext writers, resulting in acquiring the writer name via an unnecessary `COALESCE` function, and adding attributes to `writerProps` that will never be used.

This PR fixes the Cypher query to remove these unnecessary aspects.