### PR TITLE
Restructure playtext characters input object

### DIFF
--- a/db-seeding/seeds/playtexts/3-winters.json
+++ b/db-seeding/seeds/playtexts/3-winters.json
@@ -9,90 +9,84 @@
 			]
 		}
 	],
-	"characters": [
+	"characterGroups": [
 		{
-			"name": "Alisa Kos",
-			"group": "2011"
+			"name": "2011",
+			"characters": [
+				{
+					"name": "Alisa Kos"
+				},
+				{
+					"name": "Lucija Kos"
+				},
+				{
+					"name": "Maša Kos"
+				},
+				{
+					"name": "Vlado Kos"
+				},
+				{
+					"name": "Dunja King"
+				},
+				{
+					"name": "Marko Horvat"
+				}
+			]
 		},
 		{
-			"name": "Lucija Kos",
-			"group": "2011"
+			"name": "1990",
+			"characters": [
+				{
+					"name": "Maša Kos"
+				},
+				{
+					"name": "Vlado Kos"
+				},
+				{
+					"name": "Dunja King"
+				},
+				{
+					"name": "Karl Dolinar"
+				},
+				{
+					"name": "Karolina Amruš"
+				},
+				{
+					"name": "Igor Maljević"
+				},
+				{
+					"name": "Aleksander King"
+				},
+				{
+					"name": "Alisa Kos"
+				},
+				{
+					"name": "Lucija Kos"
+				},
+				{
+					"name": "Marko Horvat"
+				}
+			]
 		},
 		{
-			"name": "Maša Kos",
-			"group": "2011"
-		},
-		{
-			"name": "Vlado Kos",
-			"group": "2011"
-		},
-		{
-			"name": "Dunja King",
-			"group": "2011"
-		},
-		{
-			"name": "Marko Horvat",
-			"group": "2011"
-		},
-		{
-			"name": "Maša Kos",
-			"group": "1990"
-		},
-		{
-			"name": "Vlado Kos",
-			"group": "1990"
-		},
-		{
-			"name": "Dunja King",
-			"group": "1990"
-		},
-		{
-			"name": "Karl Dolinar",
-			"group": "1990"
-		},
-		{
-			"name": "Karolina Amruš",
-			"group": "1990"
-		},
-		{
-			"name": "Igor Maljević",
-			"group": "1990"
-		},
-		{
-			"name": "Aleksander King",
-			"group": "1990"
-		},
-		{
-			"name": "Alisa Kos",
-			"group": "1990"
-		},
-		{
-			"name": "Lucija Kos",
-			"group": "1990"
-		},
-		{
-			"name": "Marko Horvat",
-			"group": "1990"
-		},
-		{
-			"name": "Rose King",
-			"group": "1945"
-		},
-		{
-			"name": "Aleksander King",
-			"group": "1945"
-		},
-		{
-			"name": "Monika Zima",
-			"group": "1945"
-		},
-		{
-			"name": "Karolina Amruš",
-			"group": "1945"
-		},
-		{
-			"name": "Marinko",
-			"group": "1945"
+			"name": "1945",
+			"characters": [
+				{
+					"name": "Rose King"
+				},
+				{
+					"name": "Aleksander King"
+				},
+				{
+					"name": "Monika Zima"
+				},
+				{
+					"name": "Karolina Amruš"
+				},
+				{
+					"name": "Marinko"
+				}
+			]
 		}
 	]
 }

--- a/db-seeding/seeds/playtexts/a-midsummer-nights-dream.json
+++ b/db-seeding/seeds/playtexts/a-midsummer-nights-dream.json
@@ -9,105 +9,101 @@
 			]
 		}
 	],
-	"characters": [
+	"characterGroups": [
 		{
-			"name": "Theseus",
-			"group": "The Athenians"
+			"name": "The Athenians",
+			"characters": [
+				{
+					"name": "Theseus"
+				},
+				{
+					"name": "Hippolyta"
+				},
+				{
+					"name": "Egeus"
+				},
+				{
+					"name": "Philostrate"
+				},
+				{
+					"name": "Lords",
+					"differentiator": "A Midsummer Night's Dream"
+				},
+				{
+					"name": "Attendants",
+					"differentiator": "A Midsummer Night's Dream"
+				}
+			]
 		},
 		{
-			"name": "Hippolyta",
-			"group": "The Athenians"
+			"name": "The Lovers",
+			"characters": [
+				{
+					"name": "Hermia"
+				},
+				{
+					"name": "Lysander"
+				},
+				{
+					"name": "Demetrius",
+					"differentiator": "1"
+				},
+				{
+					"name": "Helena"
+				}
+			]
 		},
 		{
-			"name": "Egeus",
-			"group": "The Athenians"
+			"name": "The Fairies",
+			"characters": [
+				{
+					"name": "Oberon"
+				},
+				{
+					"name": "Titania"
+				},
+				{
+					"name": "Puck"
+				},
+				{
+					"name": "Peaseblossom"
+				},
+				{
+					"name": "Cobweb"
+				},
+				{
+					"name": "Moth"
+				},
+				{
+					"name": "Mustardseed"
+				},
+				{
+					"name": "Fairies"
+				}
+			]
 		},
 		{
-			"name": "Philostrate",
-			"group": "The Athenians"
-		},
-		{
-			"name": "Hermia",
-			"group": "The Lovers"
-		},
-		{
-			"name": "Lysander",
-			"group": "The Lovers"
-		},
-		{
-			"name": "Demetrius",
-			"differentiator": "1",
-			"group": "The Lovers"
-		},
-		{
-			"name": "Helena",
-			"group": "The Lovers"
-		},
-		{
-			"name": "Oberon",
-			"group": "The Fairies"
-		},
-		{
-			"name": "Titania",
-			"group": "The Fairies"
-		},
-		{
-			"name": "Puck",
-			"group": "The Fairies"
-		},
-		{
-			"name": "Peaseblossom",
-			"group": "The Fairies"
-		},
-		{
-			"name": "Cobweb",
-			"group": "The Fairies"
-		},
-		{
-			"name": "Moth",
-			"group": "The Fairies"
-		},
-		{
-			"name": "Mustardseed",
-			"group": "The Fairies"
-		},
-		{
-			"name": "Fairies",
-			"group": "The Fairies"
-		},
-		{
-			"name": "Peter Quince",
-			"group": "The Mechanicals"
-		},
-		{
-			"name": "Nick Bottom",
-			"group": "The Mechanicals"
-		},
-		{
-			"name": "Francis Flute",
-			"group": "The Mechanicals"
-		},
-		{
-			"name": "Tom Snout",
-			"group": "The Mechanicals"
-		},
-		{
-			"name": "Snug",
-			"group": "The Mechanicals"
-		},
-		{
-			"name": "Robin Starveling",
-			"group": "The Mechanicals"
-		},
-		{
-			"name": "Lords",
-			"differentiator": "A Midsummer Night's Dream",
-			"group": "The Athenians"
-		},
-		{
-			"name": "Attendants",
-			"differentiator": "A Midsummer Night's Dream",
-			"group": "The Athenians"
+			"name": "The Mechanicals",
+			"characters": [
+				{
+					"name": "Peter Quince"
+				},
+				{
+					"name": "Nick Bottom"
+				},
+				{
+					"name": "Francis Flute"
+				},
+				{
+					"name": "Tom Snout"
+				},
+				{
+					"name": "Snug"
+				},
+				{
+					"name": "Robin Starveling"
+				}
+			]
 		}
 	]
 }

--- a/db-seeding/seeds/playtexts/coriolanus.json
+++ b/db-seeding/seeds/playtexts/coriolanus.json
@@ -9,122 +9,114 @@
 			]
 		}
 	],
-	"characters": [
+	"characterGroups": [
 		{
-			"name": "Caius Martius Coriolanus",
-			"group": "Romans"
+			"name": "Romans",
+			"characters": [
+				{
+					"name": "Caius Martius Coriolanus"
+				},
+				{
+					"name": "Titus Lartius"
+				},
+				{
+					"name": "Cominius"
+				},
+				{
+					"name": "Menenius Agrippa"
+				},
+				{
+					"name": "Sicinius Velutus"
+				},
+				{
+					"name": "Junius Brutus"
+				},
+				{
+					"name": "Roman Citizens"
+				},
+				{
+					"name": "Roman Herald"
+				},
+				{
+					"name": "Volumnia"
+				},
+				{
+					"name": "Virgilia"
+				},
+				{
+					"name": "Young Martius"
+				},
+				{
+					"name": "Valeria"
+				},
+				{
+					"name": "Roman Senators"
+				}
+			]
 		},
 		{
-			"name": "Titus Lartius",
-			"group": "Romans"
+			"name": "Volscians",
+			"characters": [
+				{
+					"name": "Nicanor"
+				},
+				{
+					"name": "Tullus Aufidius"
+				},
+				{
+					"name": "Lieutenant"
+				},
+				{
+					"name": "Conspirators"
+				},
+				{
+					"name": "Adrian"
+				},
+				{
+					"name": "A Citizen of Antium"
+				},
+				{
+					"name": "Volscian Guards"
+				},
+				{
+					"name": "Volscian Senators"
+				},
+
+				{
+					"name": "Volscian Citizens"
+				},
+				{
+					"name": "Servants of Aufidius"
+				}
+			]
 		},
 		{
-			"name": "Cominius",
-			"group": "Romans"
-		},
-		{
-			"name": "Menenius Agrippa",
-			"group": "Romans"
-		},
-		{
-			"name": "Sicinius Velutus",
-			"group": "Romans"
-		},
-		{
-			"name": "Junius Brutus",
-			"group": "Romans"
-		},
-		{
-			"name": "Roman Citizens",
-			"group": "Romans"
-		},
-		{
-			"name": "Roman Herald",
-			"group": "Romans"
-		},
-		{
-			"name": "Nicanor",
-			"group": "Volscians"
-		},
-		{
-			"name": "Volumnia",
-			"group": "Romans"
-		},
-		{
-			"name": "Virgilia",
-			"group": "Romans"
-		},
-		{
-			"name": "Young Martius",
-			"group": "Romans"
-		},
-		{
-			"name": "Valeria",
-			"group": "Romans"
-		},
-		{
-			"name": "Gentlewoman"
-		},
-		{
-			"name": "Tullus Aufidius",
-			"group": "Volscians"
-		},
-		{
-			"name": "Lieutenant",
-			"group": "Volscians"
-		},
-		{
-			"name": "Conspirators",
-			"group": "Volscians"
-		},
-		{
-			"name": "Adrian",
-			"group": "Volscians"
-		},
-		{
-			"name": "A Citizen of Antium",
-			"group": "Volscians"
-		},
-		{
-			"name": "Volscian Guards",
-			"group": "Volscians"
-		},
-		{
-			"name": "Roman Senators",
-			"group": "Romans"
-		},
-		{
-			"name": "Volscian Senators",
-			"group": "Volscians"
-		},
-		{
-			"name": "Patricians"
-		},
-		{
-			"name": "Aediles"
-		},
-		{
-			"name": "Lictors"
-		},
-		{
-			"name": "Soldiers",
-			"differentiator": "Coriolanus"
-		},
-		{
-			"name": "Messengers",
-			"differentiator": "Coriolanus"
-		},
-		{
-			"name": "Volscian Citizens",
-			"group": "Volscians"
-		},
-		{
-			"name": "Servants of Aufidius",
-			"group": "Volscians"
-		},
-		{
-			"name": "Attendants",
-			"differentiator": "Coriolanus"
+			"characters": [
+				{
+					"name": "Gentlewoman"
+				},
+				{
+					"name": "Patricians"
+				},
+				{
+					"name": "Aediles"
+				},
+				{
+					"name": "Lictors"
+				},
+				{
+					"name": "Soldiers",
+					"differentiator": "Coriolanus"
+				},
+				{
+					"name": "Messengers",
+					"differentiator": "Coriolanus"
+				},
+				{
+					"name": "Attendants",
+					"differentiator": "Coriolanus"
+				}
+			]
 		}
 	]
 }

--- a/db-seeding/seeds/playtexts/hamlet.json
+++ b/db-seeding/seeds/playtexts/hamlet.json
@@ -9,89 +9,93 @@
 			]
 		}
 	],
-	"characters": [
+	"characterGroups": [
 		{
-			"name": "Barnardo"
-		},
-		{
-			"name": "Francisco"
-		},
-		{
-			"name": "Captain in Fortinbras' Army"
-		},
-		{
-			"name": "Horatio"
-		},
-		{
-			"name": "Marcellus"
-		},
-		{
-			"name": "King Hamlet"
-		},
-		{
-			"name": "Player King"
-		},
-		{
-			"name": "Claudius",
-			"differentiator": "1"
-		},
-		{
-			"name": "Voltemand"
-		},
-		{
-			"name": "Cornelius"
-		},
-		{
-			"name": "Laertes"
-		},
-		{
-			"name": "Polonius"
-		},
-		{
-			"name": "Gravedigger"
-		},
-		{
-			"name": "Hamlet"
-		},
-		{
-			"name": "Gertrude"
-		},
-		{
-			"name": "Ophelia"
-		},
-		{
-			"name": "Reynaldo"
-		},
-		{
-			"name": "Rosencrantz"
-		},
-		{
-			"name": "Guildenstern"
-		},
-		{
-			"name": "Player Queen"
-		},
-		{
-			"name": "Lucianus"
-		},
-		{
-			"name": "English Ambassador"
-		},
-		{
-			"name": "Musician"
-		},
-		{
-			"name": "Fortinbras"
-		},
-		{
-			"name": "Osrick"
-		},
-		{
-			"name": "Messenger",
-			"differentiator": "Hamlet"
-		},
-		{
-			"name": "Priest"
+			"characters": [
+				{
+					"name": "Barnardo"
+				},
+				{
+					"name": "Francisco"
+				},
+				{
+					"name": "Captain in Fortinbras' Army"
+				},
+				{
+					"name": "Horatio"
+				},
+				{
+					"name": "Marcellus"
+				},
+				{
+					"name": "King Hamlet"
+				},
+				{
+					"name": "Player King"
+				},
+				{
+					"name": "Claudius",
+					"differentiator": "1"
+				},
+				{
+					"name": "Voltemand"
+				},
+				{
+					"name": "Cornelius"
+				},
+				{
+					"name": "Laertes"
+				},
+				{
+					"name": "Polonius"
+				},
+				{
+					"name": "Gravedigger"
+				},
+				{
+					"name": "Hamlet"
+				},
+				{
+					"name": "Gertrude"
+				},
+				{
+					"name": "Ophelia"
+				},
+				{
+					"name": "Reynaldo"
+				},
+				{
+					"name": "Rosencrantz"
+				},
+				{
+					"name": "Guildenstern"
+				},
+				{
+					"name": "Player Queen"
+				},
+				{
+					"name": "Lucianus"
+				},
+				{
+					"name": "English Ambassador"
+				},
+				{
+					"name": "Musician"
+				},
+				{
+					"name": "Fortinbras"
+				},
+				{
+					"name": "Osrick"
+				},
+				{
+					"name": "Messenger",
+					"differentiator": "Hamlet"
+				},
+				{
+					"name": "Priest"
+				}
+			]
 		}
 	]
 }

--- a/db-seeding/seeds/playtexts/happy-days.json
+++ b/db-seeding/seeds/playtexts/happy-days.json
@@ -9,12 +9,16 @@
 			]
 		}
 	],
-	"characters": [
+	"characterGroups": [
 		{
-			"name": "Winnie"
-		},
-		{
-			"name": "Willie"
+			"characters": [
+				{
+					"name": "Winnie"
+				},
+				{
+					"name": "Willie"
+				}
+			]
 		}
 	]
 }

--- a/db-seeding/seeds/playtexts/henry-iv-part-1.json
+++ b/db-seeding/seeds/playtexts/henry-iv-part-1.json
@@ -9,141 +9,134 @@
 			]
 		}
 	],
-	"characters": [
+	"characterGroups": [
 		{
-			"name": "King Henry IV",
-			"group": "Of the King's party"
+			"name": "Of the King's party",
+			"characters": [
+				{
+					"name": "King Henry IV"
+				},
+				{
+					"name": "Henry, Prince of Wales",
+					"underlyingName": "King Henry V"
+				},
+				{
+					"name": "Lord John of Lancaster"
+				},
+				{
+					"name": "Ralph Neville, Earl of Westmorland"
+				},
+				{
+					"name": "Sir Walter Blunt"
+				}
+			]
 		},
 		{
-			"name": "Henry, Prince of Wales",
-			"underlyingName": "King Henry V",
-			"group": "Of the King's party"
+			"name": "Eastcheap",
+			"characters": [
+				{
+					"name": "Sir John Falstaff"
+				},
+				{
+					"name": "Ned Poins"
+				},
+				{
+					"name": "Bardolph"
+				},
+				{
+					"name": "Peto"
+				},
+				{
+					"name": "Mistress Quickly"
+				},
+				{
+					"name": "Francis"
+				},
+				{
+					"name": "Vintner"
+				},
+				{
+					"name": "Gadshill"
+				},
+				{
+					"name": "Carriers"
+				},
+				{
+					"name": "Ostler"
+				}
+			]
 		},
 		{
-			"name": "Lord John of Lancaster",
-			"group": "Of the King's party"
+			"name": "Rebels",
+			"characters": [
+				{
+					"name": "Henry Percy, Earl of Northumberland"
+				},
+				{
+					"name": "Thomas Percy, Earl of Worcester"
+				},
+				{
+					"name": "Harry Percy"
+				},
+				{
+					"name": "Edmund, Lord Mortimer"
+				},
+				{
+					"name": "Owen Glendower"
+				},
+				{
+					"name": "Archibald, Earl of Douglas"
+				},
+				{
+					"name": "Sir Richard Vernon, 8th Baron of Shipbrook"
+				},
+				{
+					"name": "Richard Scroop, Archbishop of York"
+				},
+				{
+					"name": "Sir Michael"
+				},
+				{
+					"name": "Lady Percy"
+				},
+				{
+					"name": "Lady Mortimer"
+				}
+			]
 		},
 		{
-			"name": "Ralph Neville, Earl of Westmorland",
-			"group": "Of the King's party"
-		},
-		{
-			"name": "Sir Walter Blunt",
-			"group": "Of the King's party"
-		},
-		{
-			"name": "Sir John Falstaff",
-			"group": "Eastcheap"
-		},
-		{
-			"name": "Ned Poins",
-			"group": "Eastcheap"
-		},
-		{
-			"name": "Bardolph",
-			"group": "Eastcheap"
-		},
-		{
-			"name": "Peto",
-			"group": "Eastcheap"
-		},
-		{
-			"name": "Mistress Quickly",
-			"group": "Eastcheap"
-		},
-		{
-			"name": "Francis",
-			"group": "Eastcheap"
-		},
-		{
-			"name": "Vintner",
-			"group": "Eastcheap"
-		},
-		{
-			"name": "Gadshill",
-			"group": "Eastcheap"
-		},
-		{
-			"name": "Carriers",
-			"group": "Eastcheap"
-		},
-		{
-			"name": "Ostler",
-			"group": "Eastcheap"
-		},
-		{
-			"name": "Henry Percy, Earl of Northumberland",
-			"group": "Rebels"
-		},
-		{
-			"name": "Thomas Percy, Earl of Worcester",
-			"group": "Rebels"
-		},
-		{
-			"name": "Harry Percy",
-			"group": "Rebels"
-		},
-		{
-			"name": "Edmund, Lord Mortimer",
-			"group": "Rebels"
-		},
-		{
-			"name": "Owen Glendower",
-			"group": "Rebels"
-		},
-		{
-			"name": "Archibald, Earl of Douglas",
-			"group": "Rebels"
-		},
-		{
-			"name": "Sir Richard Vernon, 8th Baron of Shipbrook",
-			"group": "Rebels"
-		},
-		{
-			"name": "Richard Scroop, Archbishop of York",
-			"group": "Rebels"
-		},
-		{
-			"name": "Sir Michael",
-			"group": "Rebels"
-		},
-		{
-			"name": "Lady Percy",
-			"group": "Rebels"
-		},
-		{
-			"name": "Lady Mortimer",
-			"group": "Rebels"
-		},
-		{
-			"name": "Chamberlain"
-		},
-		{
-			"name": "Sheriff"
-		},
-		{
-			"name": "Travellers"
-		},
-		{
-			"name": "Servant to Hotspur"
-		},
-		{
-			"name": "Lords",
-			"differentiator": "Henry IV, Part 1"
-		},
-		{
-			"name": "Officers"
-		},
-		{
-			"name": "Drawers"
-		},
-		{
-			"name": "Messengers",
-			"differentiator": "Henry IV, Part 1"
-		},
-		{
-			"name": "Attendants",
-			"differentiator": "Henry IV, Part 1"
+			"characters": [
+				{
+					"name": "Chamberlain"
+				},
+				{
+					"name": "Sheriff"
+				},
+				{
+					"name": "Travellers"
+				},
+				{
+					"name": "Servant to Hotspur"
+				},
+				{
+					"name": "Lords",
+					"differentiator": "Henry IV, Part 1"
+				},
+				{
+					"name": "Officers"
+				},
+				{
+					"name": "Drawers"
+				},
+				{
+					"name": "Messengers",
+					"differentiator": "Henry IV, Part 1"
+				},
+				{
+					"name": "Attendants",
+					"differentiator": "Henry IV, Part 1"
+				}
+			]
 		}
 	]
 }

--- a/db-seeding/seeds/playtexts/henry-iv-part-2.json
+++ b/db-seeding/seeds/playtexts/henry-iv-part-2.json
@@ -9,206 +9,195 @@
 			]
 		}
 	],
-	"characters": [
+	"characterGroups": [
 		{
-			"name": "King Henry IV",
-			"group": "Of the King's party"
+			"name": "Of the King's party",
+			"characters": [
+				{
+					"name": "King Henry IV"
+				},
+				{
+					"name": "Prince Henry",
+					"underlyingName": "King Henry V"
+				},
+				{
+					"name": "Prince John of Lancaster"
+				},
+				{
+					"name": "Humphrey, Duke of Gloucester"
+				},
+				{
+					"name": "Thomas, Duke of Clarence"
+				},
+				{
+					"name": "Earl of Warwick"
+				},
+				{
+					"name": "Earl of Surrey"
+				},
+				{
+					"name": "Earl of Westmorland",
+					"underlyingName": "Ralph Neville, Earl of Westmorland"
+				},
+				{
+					"name": "Harcourt"
+				},
+				{
+					"name": "Sir John Blunt"
+				}
+			]
 		},
 		{
-			"name": "Prince Henry",
-			"underlyingName": "King Henry V",
-			"group": "Of the King's party"
+			"name": "Rebels",
+			"characters": [
+				{
+					"name": "Archbishop of York",
+					"underlyingName": "Richard Scroop, Archbishop of York"
+				},
+				{
+					"name": "Lord Bardolph"
+				},
+				{
+					"name": "Lord Mowbray"
+				},
+				{
+					"name": "Lord Hastings"
+				},
+				{
+					"name": "Sir John Coleville"
+				},
+				{
+					"name": "Earl of Northumberland",
+					"underlyingName": "Henry Percy, Earl of Northumberland"
+				},
+				{
+					"name": "Lady Northumberland"
+				},
+				{
+					"name": "Lady Percy"
+				},
+				{
+					"name": "Travers"
+				},
+				{
+					"name": "Morton"
+				}
+			]
 		},
 		{
-			"name": "Prince John of Lancaster",
-			"group": "Of the King's party"
+			"name": "Court",
+			"characters": [
+				{
+					"name": "Lord Chief Justice"
+				},
+				{
+					"name": "Servant"
+				},
+				{
+					"name": "Gower"
+				},
+				{
+					"name": "Beadle"
+				},
+				{
+					"name": "Two Grooms"
+				}
+			]
 		},
 		{
-			"name": "Humphrey, Duke of Gloucester",
-			"group": "Of the King's party"
+			"name": "Eastcheap",
+			"characters": [
+				{
+					"name": "Sir John Falstaff"
+				},
+				{
+					"name": "Falstaff's Page"
+				},
+				{
+					"name": "Bardolph"
+				},
+				{
+					"name": "Pistol"
+				},
+				{
+					"name": "Ned Poins"
+				},
+				{
+					"name": "Peto"
+				},
+				{
+					"name": "Mistress Quickly"
+				},
+				{
+					"name": "Doll Tearsheet"
+				},
+				{
+					"name": "Francis"
+				},
+				{
+					"name": "William"
+				}
+			]
 		},
 		{
-			"name": "Thomas, Duke of Clarence",
-			"group": "Of the King's party"
+			"name": "Recruits",
+			"characters": [
+				{
+					"name": "Ralph Mouldy"
+				},
+				{
+					"name": "Simon Shadow"
+				},
+				{
+					"name": "Thomas Wart"
+				},
+				{
+					"name": "Francis Feeble"
+				},
+				{
+					"name": "Peter Bullcalf"
+				}
+			]
 		},
 		{
-			"name": "Earl of Warwick",
-			"group": "Of the King's party"
-		},
-		{
-			"name": "Earl of Surrey",
-			"group": "Of the King's party"
-		},
-		{
-			"name": "Earl of Westmorland",
-			"underlyingName": "Ralph Neville, Earl of Westmorland",
-			"group": "Of the King's party"
-		},
-		{
-			"name": "Harcourt",
-			"group": "Of the King's party"
-		},
-		{
-			"name": "Sir John Blunt",
-			"group": "Of the King's party"
-		},
-		{
-			"name": "Archbishop of York",
-			"underlyingName": "Richard Scroop, Archbishop of York",
-			"group": "Rebels"
-		},
-		{
-			"name": "Lord Bardolph",
-			"group": "Rebels"
-		},
-		{
-			"name": "Lord Mowbray",
-			"group": "Rebels"
-		},
-		{
-			"name": "Lord Hastings",
-			"group": "Rebels"
-		},
-		{
-			"name": "Sir John Coleville",
-			"group": "Rebels"
-		},
-		{
-			"name": "Earl of Northumberland",
-			"underlyingName": "Henry Percy, Earl of Northumberland",
-			"group": "Rebels"
-		},
-		{
-			"name": "Lady Northumberland",
-			"group": "Rebels"
-		},
-		{
-			"name": "Lady Percy",
-			"group": "Rebels"
-		},
-		{
-			"name": "Travers",
-			"group": "Rebels"
-		},
-		{
-			"name": "Morton",
-			"group": "Rebels"
-		},
-		{
-			"name": "Lord Chief Justice",
-			"group": "Court"
-		},
-		{
-			"name": "Servant",
-			"group": "Court"
-		},
-		{
-			"name": "Gower",
-			"group": "Court"
-		},
-		{
-			"name": "Beadle",
-			"group": "Court"
-		},
-		{
-			"name": "Two Grooms",
-			"group": "Court"
-		},
-		{
-			"name": "Sir John Falstaff",
-			"group": "Eastcheap"
-		},
-		{
-			"name": "Falstaff's Page",
-			"group": "Eastcheap"
-		},
-		{
-			"name": "Bardolph",
-			"group": "Eastcheap"
-		},
-		{
-			"name": "Pistol",
-			"group": "Eastcheap"
-		},
-		{
-			"name": "Ned Poins",
-			"group": "Eastcheap"
-		},
-		{
-			"name": "Peto",
-			"group": "Eastcheap"
-		},
-		{
-			"name": "Mistress Quickly",
-			"group": "Eastcheap"
-		},
-		{
-			"name": "Doll Tearsheet",
-			"group": "Eastcheap"
-		},
-		{
-			"name": "Francis",
-			"group": "Eastcheap"
-		},
-		{
-			"name": "William",
-			"group": "Eastcheap"
-		},
-		{
-			"name": "Ralph Mouldy",
-			"group": "Recruits"
-		},
-		{
-			"name": "Simon Shadow",
-			"group": "Recruits"
-		},
-		{
-			"name": "Thomas Wart",
-			"group": "Recruits"
-		},
-		{
-			"name": "Francis Feeble",
-			"group": "Recruits"
-		},
-		{
-			"name": "Peter Bullcalf",
-			"group": "Recruits"
-		},
-		{
-			"name": "Rumour"
-		},
-		{
-			"name": "Epilogue"
-		},
-		{
-			"name": "Justice Shallow"
-		},
-		{
-			"name": "Justice Silence"
-		},
-		{
-			"name": "Davy"
-		},
-		{
-			"name": "Snare"
-		},
-		{
-			"name": "Fang"
-		},
-		{
-			"name": "Messengers",
-			"differentiator": "Henry IV, Part 2"
-		},
-		{
-			"name": "Musicians"
-		},
-		{
-			"name": "Soldiers",
-			"differentiator": "Henry IV, Part 2"
-		},
-		{
-			"name": "Attendants",
-			"differentiator": "Henry IV, Part 2"
+			"characters": [
+				{
+					"name": "Rumour"
+				},
+				{
+					"name": "Epilogue"
+				},
+				{
+					"name": "Justice Shallow"
+				},
+				{
+					"name": "Justice Silence"
+				},
+				{
+					"name": "Davy"
+				},
+				{
+					"name": "Snare"
+				},
+				{
+					"name": "Fang"
+				},
+				{
+					"name": "Messengers",
+					"differentiator": "Henry IV, Part 2"
+				},
+				{
+					"name": "Musicians"
+				},
+				{
+					"name": "Soldiers",
+					"differentiator": "Henry IV, Part 2"
+				},
+				{
+					"name": "Attendants",
+					"differentiator": "Henry IV, Part 2"
+				}
+			]
 		}
 	]
 }

--- a/db-seeding/seeds/playtexts/henry-v.json
+++ b/db-seeding/seeds/playtexts/henry-v.json
@@ -9,207 +9,177 @@
 			]
 		}
 	],
-	"characters": [
+	"characterGroups": [
 		{
-			"name": "Chorus",
-			"group": "The English"
+			"name": "The English",
+			"characters": [
+				{
+					"name": "Chorus"
+				},
+				{
+					"name": "King Henry V"
+				},
+				{
+					"name": "Duke of Gloucester"
+				},
+				{
+					"name": "Duke of Bedford"
+				},
+				{
+					"name": "Duke of Clarence"
+				},
+				{
+					"name": "Duke of Exeter"
+				},
+				{
+					"name": "Duke of York"
+				},
+				{
+					"name": "Earl of Salisbury"
+				},
+				{
+					"name": "Earl of Westmorland",
+					"underlyingName": "Ralph Neville, Earl of Westmorland"
+				},
+				{
+					"name": "Earl of Warwick"
+				},
+				{
+					"name": "Sir Thomas Erpingham"
+				},
+				{
+					"name": "Captain Gower"
+				},
+				{
+					"name": "Captain Fluellen"
+				},
+				{
+					"name": "Captain Macmorris"
+				},
+				{
+					"name": "Captain Jamy"
+				},
+				{
+					"name": "John Bates"
+				},
+				{
+					"name": "Alexander Court"
+				},
+				{
+					"name": "Michael Williams"
+				},
+				{
+					"name": "Herald"
+				},
+				{
+					"name": "Pistol"
+				},
+				{
+					"name": "Nym"
+				},
+				{
+					"name": "Bardolph"
+				},
+				{
+					"name": "Boy"
+				},
+				{
+					"name": "Hostess",
+					"underlyingName": "Mistress Quickly"
+				},
+				{
+					"name": "Archbishop of Canterbury"
+				},
+				{
+					"name": "Bishop of Ely"
+				}
+			]
 		},
 		{
-			"name": "King Henry V",
-			"group": "The English"
+			"name": "The English (traitors)",
+			"characters": [
+				{
+					"name": "Richard, Earl of Cambridge"
+				},
+				{
+					"name": "Lord Henry Scroop"
+				},
+				{
+					"name": "Sir Thomas Grey"
+				}
+			]
 		},
 		{
-			"name": "Duke of Gloucester",
-			"group": "The English"
+			"name": "The French",
+			"characters": [
+				{
+					"name": "King of France"
+				},
+				{
+					"name": "Queen Isabel"
+				},
+				{
+					"name": "Louis, Duke of Guyenne and Dauphin of France"
+				},
+				{
+					"name": "Katherine"
+				},
+				{
+					"name": "Alice"
+				},
+				{
+					"name": "Charles Delabreth, Constable of France"
+				},
+				{
+					"name": "Duke of Bourbon"
+				},
+				{
+					"name": "Duke of Orléans"
+				},
+				{
+					"name": "Duke of Berry"
+				},
+				{
+					"name": "Duke of Burgundy"
+				},
+				{
+					"name": "Lord Rambures"
+				},
+				{
+					"name": "Lord Grandpré"
+				},
+				{
+					"name": "Monsieur le Fer"
+				},
+				{
+					"name": "Montjoy"
+				},
+				{
+					"name": "Governor of Harfleur"
+				},
+				{
+					"name": "French Ambassadors"
+				}
+			]
 		},
 		{
-			"name": "Duke of Bedford",
-			"group": "The English"
-		},
-		{
-			"name": "Duke of Clarence",
-			"group": "The English"
-		},
-		{
-			"name": "Duke of Exeter",
-			"group": "The English"
-		},
-		{
-			"name": "Duke of York",
-			"group": "The English"
-		},
-		{
-			"name": "Earl of Salisbury",
-			"group": "The English"
-		},
-		{
-			"name": "Earl of Westmorland",
-			"underlyingName": "Ralph Neville, Earl of Westmorland",
-			"group": "The English"
-		},
-		{
-			"name": "Earl of Warwick",
-			"group": "The English"
-		},
-		{
-			"name": "Sir Thomas Erpingham",
-			"group": "The English"
-		},
-		{
-			"name": "Captain Gower",
-			"group": "The English"
-		},
-		{
-			"name": "Captain Fluellen",
-			"group": "The English"
-		},
-		{
-			"name": "Captain Macmorris",
-			"group": "The English"
-		},
-		{
-			"name": "Captain Jamy",
-			"group": "The English"
-		},
-		{
-			"name": "John Bates",
-			"group": "The English"
-		},
-		{
-			"name": "Alexander Court",
-			"group": "The English"
-		},
-		{
-			"name": "Michael Williams",
-			"group": "The English"
-		},
-		{
-			"name": "Herald",
-			"group": "The English"
-		},
-		{
-			"name": "Pistol",
-			"group": "The English"
-		},
-		{
-			"name": "Nym",
-			"group": "The English"
-		},
-		{
-			"name": "Bardolph",
-			"group": "The English"
-		},
-		{
-			"name": "Boy",
-			"group": "The English"
-		},
-		{
-			"name": "Hostess",
-			"underlyingName": "Mistress Quickly",
-			"group": "The English"
-		},
-		{
-			"name": "Archbishop of Canterbury",
-			"group": "The English"
-		},
-		{
-			"name": "Bishop of Ely",
-			"group": "The English"
-		},
-		{
-			"name": "Richard, Earl of Cambridge",
-			"group": "The English (traitors)"
-		},
-		{
-			"name": "Lord Henry Scroop",
-			"group": "The English (traitors)"
-		},
-		{
-			"name": "Sir Thomas Grey",
-			"group": "The English (traitors)"
-		},
-		{
-			"name": "King of France",
-			"group": "The French"
-		},
-		{
-			"name": "Queen Isabel",
-			"group": "The French"
-		},
-		{
-			"name": "Louis, Duke of Guyenne and Dauphin of France",
-			"group": "The French"
-		},
-		{
-			"name": "Katherine",
-			"group": "The French"
-		},
-		{
-			"name": "Alice",
-			"group": "The French"
-		},
-		{
-			"name": "Charles Delabreth, Constable of France",
-			"group": "The French"
-		},
-		{
-			"name": "Duke of Bourbon",
-			"group": "The French"
-		},
-		{
-			"name": "Duke of Orléans",
-			"group": "The French"
-		},
-		{
-			"name": "Duke of Berry",
-			"group": "The French"
-		},
-		{
-			"name": "Duke of Burgundy",
-			"group": "The French"
-		},
-		{
-			"name": "Lord Rambures",
-			"group": "The French"
-		},
-		{
-			"name": "Lord Grandpré",
-			"group": "The French"
-		},
-		{
-			"name": "Monsieur le Fer",
-			"group": "The French"
-		},
-		{
-			"name": "Montjoy",
-			"group": "The French"
-		},
-		{
-			"name": "Governor of Harfleur",
-			"group": "The French"
-		},
-		{
-			"name": "French Ambassadors",
-			"group": "The French"
-		},
-		{
-			"name": "Soldiers",
-			"differentiator": "Henry V",
-			"group": "Other"
-		},
-		{
-			"name": "Servants",
-			"group": "Other"
-		},
-		{
-			"name": "Attendants",
-			"differentiator": "Henry V",
-			"group": "Other"
-		},
-		{
-			"name": "Lords",
-			"differentiator": "Henry V",
-			"group": "Other"
+			"characters": [
+				{
+					"name": "Soldiers",
+					"differentiator": "Henry V"
+				},
+				{
+					"name": "Servants"
+				},
+				{
+					"name": "Attendants",
+					"differentiator": "Henry V"
+				},
+				{
+					"name": "Lords",
+					"differentiator": "Henry V"
+				}
+			]
 		}
 	]
 }

--- a/db-seeding/seeds/playtexts/julius-caesar.json
+++ b/db-seeding/seeds/playtexts/julius-caesar.json
@@ -9,195 +9,189 @@
 			]
 		}
 	],
-	"characters": [
+	"characterGroups": [
 		{
-			"name": "Julius Caesar",
-			"group": ""
+			"characters": [
+				{
+					"name": "Julius Caesar"
+				}
+			]
 		},
 		{
-			"name": "Octavius Caesar",
-			"group": "Triumvirs after Caesar's death"
+			"name": "Triumvirs after Caesar's death",
+			"characters": [
+				{
+					"name": "Octavius Caesar"
+				},
+				{
+					"name": "Mark Antony"
+				},
+				{
+					"name": "Lepidus"
+				}
+			]
 		},
 		{
-			"name": "Mark Antony",
-			"group": "Triumvirs after Caesar's death"
+			"name": "Conspirators against Caesar",
+			"characters": [
+				{
+					"name": "Marcus Brutus"
+				},
+				{
+					"name": "Caius Cassius"
+				},
+				{
+					"name": "Casca"
+				},
+				{
+					"name": "Decius Brutus"
+				},
+				{
+					"name": "Cinna",
+					"differentiator": "1"
+				},
+				{
+					"name": "Metellus Cimber"
+				},
+				{
+					"name": "Trebonius"
+				},
+				{
+					"name": "Caius Ligarius"
+				}
+			]
 		},
 		{
-			"name": "Lepidus",
-			"group": "Triumvirs after Caesar's death"
+			"name": "Tribunes",
+			"characters": [
+				{
+					"name": "Flavius"
+				},
+				{
+					"name": "Marullus"
+				}
+			]
 		},
 		{
-			"name": "Marcus Brutus",
-			"group": "Conspirators against Caesar"
+			"name": "Roman Senate Senators",
+			"characters": [
+				{
+					"name": "Cicero"
+				},
+				{
+					"name": "Publius",
+					"differentiator": "2"
+				},
+				{
+					"name": "Popilius Lena"
+				}
+			]
 		},
 		{
-			"name": "Caius Cassius",
-			"group": "Conspirators against Caesar"
+			"name": "Citizens",
+			"characters": [
+				{
+					"name": "Calphurnia"
+				},
+				{
+					"name": "Portia"
+				},
+				{
+					"name": "Soothsayer"
+				},
+				{
+					"name": "Artemidorus"
+				},
+				{
+					"name": "Cinna",
+					"differentiator": "2"
+				},
+				{
+					"name": "Cobbler"
+				},
+				{
+					"name": "Carpenter"
+				},
+				{
+					"name": "Poet"
+				},
+				{
+					"name": "Lucius",
+					"differentiator": "2"
+				}
+			]
 		},
 		{
-			"name": "Casca",
-			"group": "Conspirators against Caesar"
+			"name": "Loyal to Brutus and Cassius",
+			"characters": [
+				{
+					"name": "Volumnius"
+				},
+				{
+					"name": "Titinius"
+				},
+				{
+					"name": "Young Cato"
+				},
+				{
+					"name": "Messala"
+				},
+				{
+					"name": "Varro"
+				},
+				{
+					"name": "Clitus"
+				},
+				{
+					"name": "Claudius",
+					"differentiator": "2"
+				},
+				{
+					"name": "Dardanius"
+				},
+				{
+					"name": "Strato"
+				},
+				{
+					"name": "Lucilius"
+				},
+				{
+					"name": "Pindarus"
+				}
+			]
 		},
 		{
-			"name": "Decius Brutus",
-			"group": "Conspirators against Caesar"
-		},
-		{
-			"name": "Cinna",
-			"differentiator": "1",
-			"group": "Conspirators against Caesar"
-		},
-		{
-			"name": "Metellus Cimber",
-			"group": "Conspirators against Caesar"
-		},
-		{
-			"name": "Trebonius",
-			"group": "Conspirators against Caesar"
-		},
-		{
-			"name": "Caius Ligarius",
-			"group": "Conspirators against Caesar"
-		},
-		{
-			"name": "Flavius",
-			"group": "Tribunes"
-		},
-		{
-			"name": "Marullus",
-			"group": "Tribunes"
-		},
-		{
-			"name": "Cicero",
-			"group": "Roman Senate Senators"
-		},
-		{
-			"name": "Publius",
-			"differentiator": "2",
-			"group": "Roman Senate Senators"
-		},
-		{
-			"name": "Popilius Lena",
-			"group": "Roman Senate Senators"
-		},
-		{
-			"name": "Calphurnia",
-			"group": "Citizens"
-		},
-		{
-			"name": "Portia",
-			"group": "Citizens"
-		},
-		{
-			"name": "Soothsayer",
-			"group": "Citizens"
-		},
-		{
-			"name": "Artemidorus",
-			"group": "Citizens"
-		},
-		{
-			"name": "Cinna",
-			"differentiator": "2",
-			"group": "Citizens"
-		},
-		{
-			"name": "Cobbler",
-			"group": "Citizens"
-		},
-		{
-			"name": "Carpenter",
-			"group": "Citizens"
-		},
-		{
-			"name": "Poet",
-			"group": "Citizens"
-		},
-		{
-			"name": "Lucius",
-			"differentiator": "2",
-			"group": "Citizens"
-		},
-		{
-			"name": "Volumnius",
-			"group": "Loyal to Brutus and Cassius"
-		},
-		{
-			"name": "Titinius",
-			"group": "Loyal to Brutus and Cassius"
-		},
-		{
-			"name": "Young Cato",
-			"group": "Loyal to Brutus and Cassius"
-		},
-		{
-			"name": "Messala",
-			"group": "Loyal to Brutus and Cassius"
-		},
-		{
-			"name": "Varro",
-			"group": "Loyal to Brutus and Cassius"
-		},
-		{
-			"name": "Clitus",
-			"group": "Loyal to Brutus and Cassius"
-		},
-		{
-			"name": "Claudius",
-			"differentiator": "2",
-			"group": "Loyal to Brutus and Cassius"
-		},
-		{
-			"name": "Dardanius",
-			"group": "Loyal to Brutus and Cassius"
-		},
-		{
-			"name": "Strato",
-			"group": "Loyal to Brutus and Cassius"
-		},
-		{
-			"name": "Lucilius",
-			"group": "Loyal to Brutus and Cassius"
-		},
-		{
-			"name": "Pindarus",
-			"group": "Loyal to Brutus and Cassius"
-		},
-		{
-			"name": "Servant to Julius Caesar",
-			"group": "Other"
-		},
-		{
-			"name": "Servant to Mark Antony",
-			"group": "Other"
-		},
-		{
-			"name": "Servant to Octavius Caesar",
-			"group": "Other"
-		},
-		{
-			"name": "Messenger",
-			"differentiator": "Julius Caesar",
-			"group": "Other"
-		},
-		{
-			"name": "Senators",
-			"differentiator": "Julius Caesar",
-			"group": "Other"
-		},
-		{
-			"name": "Soldiers",
-			"differentiator": "Julius Caesar",
-			"group": "Other"
-		},
-		{
-			"name": "Plebeians",
-			"group": "Other"
-		},
-		{
-			"name": "Attendants",
-			"differentiator": "Julius Caesar",
-			"group": "Other"
+			"name": "Other",
+			"characters": [
+				{
+					"name": "Servant to Julius Caesar"
+				},
+				{
+					"name": "Servant to Mark Antony"
+				},
+				{
+					"name": "Servant to Octavius Caesar"
+				},
+				{
+					"name": "Messenger",
+					"differentiator": "Julius Caesar"
+				},
+				{
+					"name": "Senators",
+					"differentiator": "Julius Caesar"
+				},
+				{
+					"name": "Soldiers",
+					"differentiator": "Julius Caesar"
+				},
+				{
+					"name": "Plebeians"
+				},
+				{
+					"name": "Attendants",
+					"differentiator": "Julius Caesar"
+				}
+			]
 		}
 	]
 }

--- a/db-seeding/seeds/playtexts/peer-gynt.json
+++ b/db-seeding/seeds/playtexts/peer-gynt.json
@@ -28,63 +28,67 @@
 			]
 		}
 	],
-	"characters": [
+	"characterGroups": [
 		{
-			"name": "Peer Gynt"
-		},
-		{
-			"name": "Solveig"
-		},
-		{
-			"name": "Kari"
-		},
-		{
-			"name": "Herd Girls"
-		},
-		{
-			"name": "Trumpeterstraale"
-		},
-		{
-			"name": "Woman in Green"
-		},
-		{
-			"name": "Professor Begriffenfeldt"
-		},
-		{
-			"name": "Button Moulder"
-		},
-		{
-			"name": "Great Between (Baygen)"
-		},
-		{
-			"name": "Child"
-		},
-		{
-			"name": "Monsieur Ballon"
-		},
-		{
-			"name": "Aase"
-		},
-		{
-			"name": "Groom"
-		},
-		{
-			"name": "Von Eberkopf"
-		},
-		{
-			"name": "Pen"
-		},
-		{
-			"name": "Scrawny Person"
-		},
-		{
-			"name": "Solveig's Father"
-		},
-		{
-			"name": "Old Man of Dovre"
-		},
-		{
-			"name": "Master Cotton"
+			"characters": [
+				{
+					"name": "Peer Gynt"
+				},
+				{
+					"name": "Solveig"
+				},
+				{
+					"name": "Kari"
+				},
+				{
+					"name": "Herd Girls"
+				},
+				{
+					"name": "Trumpeterstraale"
+				},
+				{
+					"name": "Woman in Green"
+				},
+				{
+					"name": "Professor Begriffenfeldt"
+				},
+				{
+					"name": "Button Moulder"
+				},
+				{
+					"name": "Great Between (Baygen)"
+				},
+				{
+					"name": "Child"
+				},
+				{
+					"name": "Monsieur Ballon"
+				},
+				{
+					"name": "Aase"
+				},
+				{
+					"name": "Groom"
+				},
+				{
+					"name": "Von Eberkopf"
+				},
+				{
+					"name": "Pen"
+				},
+				{
+					"name": "Scrawny Person"
+				},
+				{
+					"name": "Solveig's Father"
+				},
+				{
+					"name": "Old Man of Dovre"
+				},
+				{
+					"name": "Master Cotton"
+				}
+			]
 		}
 	]
 }

--- a/db-seeding/seeds/playtexts/rock-n-roll.json
+++ b/db-seeding/seeds/playtexts/rock-n-roll.json
@@ -9,68 +9,72 @@
 			]
 		}
 	],
-	"characters": [
+	"characterGroups": [
 		{
-			"name": "The Piper"
-		},
-		{
-			"name": "Esme",
-			"qualifier": "younger"
-		},
-		{
-			"name": "Jan"
-		},
-		{
-			"name": "Max"
-		},
-		{
-			"name": "Eleanor"
-		},
-		{
-			"name": "Gillian"
-		},
-		{
-			"name": "Interrogator"
-		},
-		{
-			"name": "Ferdinand"
-		},
-		{
-			"name": "Milan"
-		},
-		{
-			"name": "Magda"
-		},
-		{
-			"name": "Policeman 1"
-		},
-		{
-			"name": "Policeman 2"
-		},
-		{
-			"name": "Lenka"
-		},
-		{
-			"name": "Nigel"
-		},
-		{
-			"name": "Esme",
-			"qualifier": "older"
-		},
-		{
-			"name": "Alice"
-		},
-		{
-			"name": "Stephen"
-		},
-		{
-			"name": "Candida"
-		},
-		{
-			"name": "Deirdre"
-		},
-		{
-			"name": "Waiter"
+			"characters": [
+				{
+					"name": "The Piper"
+				},
+				{
+					"name": "Esme",
+					"qualifier": "younger"
+				},
+				{
+					"name": "Jan"
+				},
+				{
+					"name": "Max"
+				},
+				{
+					"name": "Eleanor"
+				},
+				{
+					"name": "Gillian"
+				},
+				{
+					"name": "Interrogator"
+				},
+				{
+					"name": "Ferdinand"
+				},
+				{
+					"name": "Milan"
+				},
+				{
+					"name": "Magda"
+				},
+				{
+					"name": "Policeman 1"
+				},
+				{
+					"name": "Policeman 2"
+				},
+				{
+					"name": "Lenka"
+				},
+				{
+					"name": "Nigel"
+				},
+				{
+					"name": "Esme",
+					"qualifier": "older"
+				},
+				{
+					"name": "Alice"
+				},
+				{
+					"name": "Stephen"
+				},
+				{
+					"name": "Candida"
+				},
+				{
+					"name": "Deirdre"
+				},
+				{
+					"name": "Waiter"
+				}
+			]
 		}
 	]
 }

--- a/db-seeding/seeds/playtexts/rope.json
+++ b/db-seeding/seeds/playtexts/rope.json
@@ -9,30 +9,34 @@
 			]
 		}
 	],
-	"characters": [
+	"characterGroups": [
 		{
-			"name": "Sabot"
-		},
-		{
-			"name": "Rupert Cadell"
-		},
-		{
-			"name": "Mrs Debenham"
-		},
-		{
-			"name": "Sir Johnstone Kentley"
-		},
-		{
-			"name": "Kenneth Raglan"
-		},
-		{
-			"name": "Wyndham Brandon"
-		},
-		{
-			"name": "Charles Granillo"
-		},
-		{
-			"name": "Leila Arden"
+			"characters": [
+				{
+					"name": "Sabot"
+				},
+				{
+					"name": "Rupert Cadell"
+				},
+				{
+					"name": "Mrs Debenham"
+				},
+				{
+					"name": "Sir Johnstone Kentley"
+				},
+				{
+					"name": "Kenneth Raglan"
+				},
+				{
+					"name": "Wyndham Brandon"
+				},
+				{
+					"name": "Charles Granillo"
+				},
+				{
+					"name": "Leila Arden"
+				}
+			]
 		}
 	]
 }

--- a/db-seeding/seeds/playtexts/the-b-file.json
+++ b/db-seeding/seeds/playtexts/the-b-file.json
@@ -9,26 +9,30 @@
 			]
 		}
 	],
-	"characters": [
+	"characterGroups": [
 		{
-			"name": "Beatrice",
-			"qualifier": "#1"
-		},
-		{
-			"name": "Beatrice",
-			"qualifier": "#2"
-		},
-		{
-			"name": "Beatrice",
-			"qualifier": "#3"
-		},
-		{
-			"name": "Beatrice",
-			"qualifier": "#4"
-		},
-		{
-			"name": "Beatrice",
-			"qualifier": "#5"
+			"characters": [
+				{
+					"name": "Beatrice",
+					"qualifier": "#1"
+				},
+				{
+					"name": "Beatrice",
+					"qualifier": "#2"
+				},
+				{
+					"name": "Beatrice",
+					"qualifier": "#3"
+				},
+				{
+					"name": "Beatrice",
+					"qualifier": "#4"
+				},
+				{
+					"name": "Beatrice",
+					"qualifier": "#5"
+				}
+			]
 		}
 	]
 }

--- a/db-seeding/seeds/playtexts/the-dumb-waiter.json
+++ b/db-seeding/seeds/playtexts/the-dumb-waiter.json
@@ -9,12 +9,16 @@
 			]
 		}
 	],
-	"characters": [
+	"characterGroups": [
 		{
-			"name": "Ben"
-		},
-		{
-			"name": "Gus"
+			"characters": [
+				{
+					"name": "Ben"
+				},
+				{
+					"name": "Gus"
+				}
+			]
 		}
 	]
 }

--- a/db-seeding/seeds/playtexts/titus-andronicus.json
+++ b/db-seeding/seeds/playtexts/titus-andronicus.json
@@ -9,124 +9,106 @@
 			]
 		}
 	],
-	"characters": [
+	"characterGroups": [
 		{
-			"name": "Saturninus",
-			"group": "Romans"
-		},
-		{
-			"name": "Bassianus",
-			"group": "Romans"
-		},
-		{
-			"name": "Titus Andronicus",
-			"group": "Romans"
-		},
-		{
-			"name": "Marcus Andronicus",
-			"group": "Romans"
-		},
-		{
-			"name": "Publius",
-			"differentiator": "1",
-			"group": "Romans"
-		},
-		{
-			"name": "Lucius",
-			"differentiator": "1",
-			"group": "Romans"
-		},
-		{
-			"name": "Quintus",
-			"group": "Romans"
-		},
-		{
-			"name": "Martius",
-			"group": "Romans"
-		},
-		{
-			"name": "Mutius",
-			"group": "Romans"
-		},
-		{
-			"name": "Lavinia",
-			"group": "Romans"
-		},
-		{
-			"name": "Young Lucius",
-			"group": "Romans"
-		},
-		{
-			"name": "Sempronius",
-			"group": "Romans"
-		},
-		{
-			"name": "Caius",
-			"group": "Romans"
-		},
-		{
-			"name": "Valentine",
-			"group": "Romans"
-		},
-		{
-			"name": "Æmilius",
-			"group": "Romans"
-		},
-		{
-			"name": "Tamora",
-			"group": "Goths"
-		},
-		{
-			"name": "Alarbus",
-			"group": "Goths"
-		},
-		{
-			"name": "Demetrius",
-			"differentiator": "2",
-			"group": "Goths"
-		},
-		{
-			"name": "Chiron",
-			"group": "Goths"
-		},
-		{
-			"name": "Aaron",
-			"group": "Goths"
-		},
-		{
-			"name": "Nurse",
-			"group": "Romans"
-		},
-		{
-			"name": "Clown",
-			"group": "Romans"
-		},
-		{
-			"name": "Messenger",
-			"differentiator": "Titus Andronicus",
-			"group": "Romans"
-		},
-		{
-			"name": "Senators",
-			"differentiator": "Titus Andronicus",
-			"group": "Romans"
-		},
-		{
-			"name": "Tribunes",
-			"group": "Romans"
-		},
-		{
-			"name": "Roman Soldiers",
-			"group": "Romans"
-		},
-		{
-			"name": "Attendants",
-			"differentiator": "Titus Andronicus",
-			"group": "Romans"
+			"name": "Romans",
+			"characters": [
+				{
+					"name": "Saturninus"
+				},
+				{
+					"name": "Bassianus"
+				},
+				{
+					"name": "Titus Andronicus"
+				},
+				{
+					"name": "Marcus Andronicus"
+				},
+				{
+					"name": "Publius",
+					"differentiator": "1"
+				},
+				{
+					"name": "Lucius",
+					"differentiator": "1"
+				},
+				{
+					"name": "Quintus"
+				},
+				{
+					"name": "Martius"
+				},
+				{
+					"name": "Mutius"
+				},
+				{
+					"name": "Lavinia"
+				},
+				{
+					"name": "Young Lucius"
+				},
+				{
+					"name": "Sempronius"
+				},
+				{
+					"name": "Caius"
+				},
+				{
+					"name": "Valentine"
+				},
+				{
+					"name": "Æmilius"
+				},
+				{
+					"name": "Nurse"
+				},
+				{
+					"name": "Clown"
+				},
+				{
+					"name": "Messenger",
+					"differentiator": "Titus Andronicus"
+				},
+				{
+					"name": "Senators",
+					"differentiator": "Titus Andronicus"
+				},
+				{
+					"name": "Tribunes"
+				},
+				{
+					"name": "Roman Soldiers"
+				},
+				{
+					"name": "Attendants",
+					"differentiator": "Titus Andronicus"
+				}
+			]
 		},
 		{
 			"name": "Goths",
-			"group": "Goths"
+			"characters": [
+				{
+					"name": "Tamora"
+				},
+				{
+					"name": "Alarbus"
+				},
+				{
+					"name": "Demetrius",
+					"differentiator": "2"
+				},
+				{
+					"name": "Chiron"
+				},
+				{
+					"name": "Aaron"
+				},
+				{
+					"name": "Goths"
+				}
+			]
 		}
 	]
 }

--- a/db-seeding/seeds/playtexts/true-west.json
+++ b/db-seeding/seeds/playtexts/true-west.json
@@ -9,12 +9,16 @@
 			]
 		}
 	],
-	"characters": [
+	"characterGroups": [
 		{
-			"name": "Austin"
-		},
-		{
-			"name": "Lee"
+			"characters": [
+				{
+					"name": "Austin"
+				},
+				{
+					"name": "Lee"
+				}
+			]
 		}
 	]
 }

--- a/src/controllers/model-seed-props/playtext.js
+++ b/src/controllers/model-seed-props/playtext.js
@@ -6,7 +6,11 @@ export default {
 			]
 		}
 	],
-	characters: [
-		{}
-	]
+	characterGroups: [
+		{
+			characters: [
+				{}
+			]
+		}
+	],
 };

--- a/src/lib/get-duplicate-character-indices.js
+++ b/src/lib/get-duplicate-character-indices.js
@@ -24,7 +24,6 @@ export const getDuplicateCharacterIndices = arrayOfObjects => {
 				isDuplicateName(object, comparisonObject) &&
 				object.differentiator === comparisonObject.differentiator &&
 				object.qualifier === comparisonObject.qualifier &&
-				object.group === comparisonObject.group &&
 				index !== comparisonIndex
 			);
 

--- a/src/models/Character.js
+++ b/src/models/Character.js
@@ -6,7 +6,7 @@ export default class Character extends Base {
 
 		super(props);
 
-		const { uuid, differentiator, underlyingName, qualifier, group, isAssociation } = props;
+		const { uuid, differentiator, underlyingName, qualifier, isAssociation } = props;
 
 		this.model = 'character';
 		this.uuid = uuid;
@@ -17,24 +17,13 @@ export default class Character extends Base {
 
 		this.differentiator = differentiator?.trim() || '';
 
-		if (isAssociation) {
-
-			this.qualifier = qualifier?.trim() || '';
-			this.group = group?.trim() || '';
-
-		}
+		if (isAssociation) this.qualifier = qualifier?.trim() || '';
 
 	}
 
 	validateUnderlyingName () {
 
 		this.validateStringForProperty('underlyingName', { isRequired: false });
-
-	}
-
-	validateGroup () {
-
-		this.validateStringForProperty('group', { isRequired: false });
 
 	}
 

--- a/src/models/CharacterGroup.js
+++ b/src/models/CharacterGroup.js
@@ -1,0 +1,46 @@
+import { getDuplicateCharacterIndices } from '../lib/get-duplicate-character-indices';
+import Base from './Base';
+import { Character } from '.';
+
+export default class CharacterGroup extends Base {
+
+	constructor (props = {}) {
+
+		super(props);
+
+		const { characters } = props;
+
+		this.model = 'characterGroup';
+		this.characters = characters
+			? characters.map(character => new Character({ ...character, isAssociation: true }))
+			: [];
+
+	}
+
+	runInputValidations (opts) {
+
+		this.validateName({ isRequired: false });
+
+		this.validateUniquenessInGroup({ isDuplicate: opts.isDuplicate });
+
+		const duplicateCharacterIndices = getDuplicateCharacterIndices(this.characters);
+
+		this.characters.forEach((character, index) => {
+
+			character.validateName({ isRequired: false });
+
+			character.validateUnderlyingName();
+
+			character.validateDifferentiator();
+
+			character.validateQualifier();
+
+			character.validateCharacterNameUnderlyingNameDisparity();
+
+			character.validateUniquenessInGroup({ isDuplicate: duplicateCharacterIndices.includes(index) });
+
+		});
+
+	}
+
+}

--- a/src/models/Playtext.js
+++ b/src/models/Playtext.js
@@ -1,7 +1,6 @@
 import { getDuplicateBaseInstanceIndices } from '../lib/get-duplicate-base-instance-indices';
-import { getDuplicateCharacterIndices } from '../lib/get-duplicate-character-indices';
 import Base from './Base';
-import { Character, WriterGroup } from '.';
+import { CharacterGroup, WriterGroup } from '.';
 
 export default class Playtext extends Base {
 
@@ -9,7 +8,7 @@ export default class Playtext extends Base {
 
 		super(props);
 
-		const { uuid, differentiator, writerGroups, characters, isAssociation } = props;
+		const { uuid, differentiator, writerGroups, characterGroups, isAssociation } = props;
 
 		this.model = 'playtext';
 		this.uuid = uuid;
@@ -21,8 +20,8 @@ export default class Playtext extends Base {
 				? writerGroups.map(writerGroup => new WriterGroup(writerGroup))
 				: [];
 
-			this.characters = characters
-				? characters.map(character => new Character({ ...character, isAssociation: true }))
+			this.characterGroups = characterGroups
+				? characterGroups.map(characterGroup => new CharacterGroup(characterGroup))
 				: [];
 
 		}
@@ -41,25 +40,11 @@ export default class Playtext extends Base {
 			writerGroup.runInputValidations({ isDuplicate: duplicateWriterGroupIndices.includes(index) })
 		);
 
-		const duplicateCharacterIndices = getDuplicateCharacterIndices(this.characters);
+		const duplicateCharacterGroupIndices = getDuplicateBaseInstanceIndices(this.characterGroups);
 
-		this.characters.forEach((character, index) => {
-
-			character.validateName({ isRequired: false });
-
-			character.validateUnderlyingName();
-
-			character.validateDifferentiator();
-
-			character.validateQualifier();
-
-			character.validateGroup();
-
-			character.validateCharacterNameUnderlyingNameDisparity();
-
-			character.validateUniquenessInGroup({ isDuplicate: duplicateCharacterIndices.includes(index) });
-
-		});
+		this.characterGroups.forEach((characterGroup, index) =>
+			characterGroup.runInputValidations({ isDuplicate: duplicateCharacterGroupIndices.includes(index) })
+		);
 
 	}
 

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,5 +1,6 @@
 import CastMember from './CastMember';
 import Character from './Character';
+import CharacterGroup from './CharacterGroup';
 import Person from './Person';
 import Playtext from './Playtext';
 import Production from './Production';
@@ -10,6 +11,7 @@ import WriterGroup from './WriterGroup';
 export {
 	CastMember,
 	Character,
+	CharacterGroup,
 	Person,
 	Playtext,
 	Production,

--- a/src/neo4j/cypher-queries/character.js
+++ b/src/neo4j/cypher-queries/character.js
@@ -23,7 +23,7 @@ const getShowQuery = () => `
 				ELSE { model: 'writerGroup', name: COALESCE(writerGroup, 'by'), writers: writers }
 			END
 		) AS writerGroups
-		ORDER BY playtextRel.position
+		ORDER BY playtextRel.groupPosition, playtextRel.characterPosition
 
 	WITH
 		character,

--- a/src/neo4j/cypher-queries/playtext.js
+++ b/src/neo4j/cypher-queries/playtext.js
@@ -65,41 +65,45 @@ const getCreateUpdateQuery = action => {
 
 		WITH DISTINCT playtext
 
-		UNWIND (CASE $characters WHEN [] THEN [null] ELSE $characters END) AS characterParam
+		UNWIND (CASE $characterGroups WHEN [] THEN [{ characters: [] }] ELSE $characterGroups END) AS characterGroupParam
 
-			OPTIONAL MATCH (existingCharacter:Character {
-				name: COALESCE(characterParam.underlyingName, characterParam.name)
-			})
-				WHERE
-					(characterParam.differentiator IS NULL AND existingCharacter.differentiator IS NULL) OR
-					(characterParam.differentiator = existingCharacter.differentiator)
+			UNWIND (CASE characterGroupParam.characters WHEN [] THEN [null] ELSE characterGroupParam.characters END) AS characterParam
 
-			WITH
-				playtext,
-				characterParam,
-				CASE existingCharacter WHEN NULL
-					THEN {
-						uuid: characterParam.uuid,
-						name: COALESCE(characterParam.underlyingName, characterParam.name),
-						differentiator: characterParam.differentiator,
-						qualifier: characterParam.qualifier,
-						group: characterParam.group
-					}
-					ELSE existingCharacter
-				END AS characterProps
+				OPTIONAL MATCH (existingCharacter:Character {
+					name: COALESCE(characterParam.underlyingName, characterParam.name)
+				})
+					WHERE
+						(characterParam.differentiator IS NULL AND existingCharacter.differentiator IS NULL) OR
+						(characterParam.differentiator = existingCharacter.differentiator)
 
-			FOREACH (item IN CASE characterParam WHEN NULL THEN [] ELSE [1] END |
-				MERGE (character:Character { uuid: characterProps.uuid, name: characterProps.name })
-					ON CREATE SET character.differentiator = characterProps.differentiator
+				WITH
+					playtext,
+					characterGroupParam,
+					characterParam,
+					CASE existingCharacter WHEN NULL
+						THEN {
+							uuid: characterParam.uuid,
+							name: COALESCE(characterParam.underlyingName, characterParam.name),
+							differentiator: characterParam.differentiator,
+							qualifier: characterParam.qualifier,
+							group: characterGroupParam.name
+						}
+						ELSE existingCharacter
+					END AS characterProps
 
-				CREATE (playtext)-
-					[:INCLUDES_CHARACTER {
-						position: characterParam.position,
-						displayName: CASE characterParam.underlyingName WHEN NULL THEN null ELSE characterParam.name END,
-						qualifier: characterParam.qualifier,
-						group: characterParam.group
-					}]->(character)
-			)
+				FOREACH (item IN CASE characterParam WHEN NULL THEN [] ELSE [1] END |
+					MERGE (character:Character { uuid: characterProps.uuid, name: characterProps.name })
+						ON CREATE SET character.differentiator = characterProps.differentiator
+
+					CREATE (playtext)-
+						[:INCLUDES_CHARACTER {
+							groupPosition: characterGroupParam.position,
+							characterPosition: characterParam.position,
+							displayName: CASE characterParam.underlyingName WHEN NULL THEN null ELSE characterParam.name END,
+							qualifier: characterParam.qualifier,
+							group: characterGroupParam.name
+						}]->(character)
+				)
 
 		WITH DISTINCT playtext
 
@@ -137,14 +141,9 @@ const getEditQuery = () => `
 	OPTIONAL MATCH (playtext)-[characterRel:INCLUDES_CHARACTER]->(character:Character)
 
 	WITH playtext, writerGroups, characterRel, character
-		ORDER BY characterRel.position
+		ORDER BY characterRel.groupPosition, characterRel.characterPosition
 
-	RETURN
-		'playtext' AS model,
-		playtext.uuid AS uuid,
-		playtext.name AS name,
-		playtext.differentiator AS differentiator,
-		writerGroups,
+	WITH playtext, writerGroups, characterRel.group AS characterGroup,
 		COLLECT(
 			CASE character WHEN NULL
 				THEN null
@@ -157,6 +156,19 @@ const getEditQuery = () => `
 				}
 			END
 		) + [{}] AS characters
+
+	RETURN
+		'playtext' AS model,
+		playtext.uuid AS uuid,
+		playtext.name AS name,
+		playtext.differentiator AS differentiator,
+		writerGroups,
+		COLLECT(
+			CASE WHEN characterGroup IS NULL AND SIZE(characters) = 1
+				THEN null
+				ELSE { model: 'characterGroup', name: characterGroup, characters: characters }
+			END
+		) + [{ characters: [{}] }] AS characterGroups
 `;
 
 const getUpdateQuery = () => getCreateUpdateQuery('update');
@@ -188,7 +200,7 @@ const getShowQuery = () => `
 	OPTIONAL MATCH (playtext)-[characterRel:INCLUDES_CHARACTER]->(character:Character)
 
 	WITH playtext, writerGroups, characterRel, character
-		ORDER BY characterRel.position
+		ORDER BY characterRel.groupPosition, characterRel.characterPosition
 
 	WITH playtext, writerGroups, characterRel.group AS characterGroup,
 		COLLECT(

--- a/test-e2e/crud/playtexts-api.test.js
+++ b/test-e2e/crud/playtexts-api.test.js
@@ -38,15 +38,21 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 						]
 					}
 				],
-				characters: [
+				characterGroups: [
 					{
-						model: 'character',
+						model: 'characterGroup',
 						name: '',
-						underlyingName: '',
-						differentiator: '',
-						qualifier: '',
-						group: '',
-						errors: {}
+						errors: {},
+						characters: [
+							{
+								model: 'character',
+								name: '',
+								underlyingName: '',
+								differentiator: '',
+								qualifier: '',
+								errors: {}
+							}
+						]
 					}
 				]
 			};
@@ -109,15 +115,21 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 						]
 					}
 				],
-				characters: [
+				characterGroups: [
 					{
-						model: 'character',
+						model: 'characterGroup',
 						name: '',
-						underlyingName: '',
-						differentiator: '',
-						qualifier: '',
-						group: '',
-						errors: {}
+						errors: {},
+						characters: [
+							{
+								model: 'character',
+								name: '',
+								underlyingName: '',
+								differentiator: '',
+								qualifier: '',
+								errors: {}
+							}
+						]
 					}
 				]
 			};
@@ -154,15 +166,21 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 						]
 					}
 				],
-				characters: [
+				characterGroups: [
 					{
-						model: 'character',
+						model: 'characterGroup',
 						name: '',
-						underlyingName: '',
-						differentiator: '',
-						qualifier: '',
-						group: '',
-						errors: {}
+						errors: {},
+						characters: [
+							{
+								model: 'character',
+								name: '',
+								underlyingName: '',
+								differentiator: '',
+								qualifier: '',
+								errors: {}
+							}
+						]
 					}
 				]
 			};
@@ -203,15 +221,21 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 						]
 					}
 				],
-				characters: [
+				characterGroups: [
 					{
-						model: 'character',
+						model: 'characterGroup',
 						name: '',
-						underlyingName: '',
-						differentiator: '',
-						qualifier: '',
-						group: '',
-						errors: {}
+						errors: {},
+						characters: [
+							{
+								model: 'character',
+								name: '',
+								underlyingName: '',
+								differentiator: '',
+								qualifier: '',
+								errors: {}
+							}
+						]
 					}
 				]
 			};
@@ -255,7 +279,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 				differentiator: '',
 				errors: {},
 				writerGroups: [],
-				characters: []
+				characterGroups: []
 			};
 
 			expect(response).to.have.status(200);
@@ -331,27 +355,29 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 							]
 						}
 					],
-					characters: [
+					characterGroups: [
 						{
-							name: 'John Gabriel Borkman',
-							underlyingName: 'Mr John Gabriel Borkman',
-							differentiator: '1',
-							qualifier: 'foo',
-							group: 'The Borkmans'
-						},
-						{
-							name: 'Gunhild Borkman',
-							underlyingName: 'Mrs Gunhild Borkman',
-							differentiator: '1',
-							qualifier: 'bar',
-							group: 'The Borkmans'
-						},
-						{
-							name: 'Erhart Borkman',
-							underlyingName: 'Mr Erhart Borkman',
-							differentiator: '1',
-							qualifier: 'baz',
-							group: 'The Borkmans'
+							name: 'The Borkmans',
+							characters: [
+								{
+									name: 'John Gabriel Borkman',
+									underlyingName: 'Mr John Gabriel Borkman',
+									differentiator: '1',
+									qualifier: 'foo'
+								},
+								{
+									name: 'Gunhild Borkman',
+									underlyingName: 'Mrs Gunhild Borkman',
+									differentiator: '1',
+									qualifier: 'bar'
+								},
+								{
+									name: 'Erhart Borkman',
+									underlyingName: 'Mr Erhart Borkman',
+									differentiator: '1',
+									qualifier: 'baz'
+								}
+							]
 						}
 					]
 				});
@@ -415,42 +441,60 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 						]
 					}
 				],
-				characters: [
+				characterGroups: [
 					{
-						model: 'character',
-						name: 'John Gabriel Borkman',
-						underlyingName: 'Mr John Gabriel Borkman',
-						differentiator: '1',
-						qualifier: 'foo',
-						group: 'The Borkmans',
-						errors: {}
+						model: 'characterGroup',
+						name: 'The Borkmans',
+						errors: {},
+						characters: [
+							{
+								model: 'character',
+								name: 'John Gabriel Borkman',
+								underlyingName: 'Mr John Gabriel Borkman',
+								differentiator: '1',
+								qualifier: 'foo',
+								errors: {}
+							},
+							{
+								model: 'character',
+								name: 'Gunhild Borkman',
+								underlyingName: 'Mrs Gunhild Borkman',
+								differentiator: '1',
+								qualifier: 'bar',
+								errors: {}
+							},
+							{
+								model: 'character',
+								name: 'Erhart Borkman',
+								underlyingName: 'Mr Erhart Borkman',
+								differentiator: '1',
+								qualifier: 'baz',
+								errors: {}
+							},
+							{
+								model: 'character',
+								name: '',
+								underlyingName: '',
+								differentiator: '',
+								qualifier: '',
+								errors: {}
+							}
+						]
 					},
 					{
-						model: 'character',
-						name: 'Gunhild Borkman',
-						underlyingName: 'Mrs Gunhild Borkman',
-						differentiator: '1',
-						qualifier: 'bar',
-						group: 'The Borkmans',
-						errors: {}
-					},
-					{
-						model: 'character',
-						name: 'Erhart Borkman',
-						underlyingName: 'Mr Erhart Borkman',
-						differentiator: '1',
-						qualifier: 'baz',
-						group: 'The Borkmans',
-						errors: {}
-					},
-					{
-						model: 'character',
+						model: 'characterGroup',
 						name: '',
-						underlyingName: '',
-						differentiator: '',
-						qualifier: '',
-						group: '',
-						errors: {}
+						errors: {},
+						characters: [
+							{
+								model: 'character',
+								name: '',
+								underlyingName: '',
+								differentiator: '',
+								qualifier: '',
+								errors: {}
+							}
+						]
 					}
 				]
 			};
@@ -593,42 +637,60 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 						]
 					}
 				],
-				characters: [
+				characterGroups: [
 					{
-						model: 'character',
-						name: 'John Gabriel Borkman',
-						underlyingName: 'Mr John Gabriel Borkman',
-						differentiator: '1',
-						qualifier: 'foo',
-						group: 'The Borkmans',
-						errors: {}
+						model: 'characterGroup',
+						name: 'The Borkmans',
+						errors: {},
+						characters: [
+							{
+								model: 'character',
+								name: 'John Gabriel Borkman',
+								underlyingName: 'Mr John Gabriel Borkman',
+								differentiator: '1',
+								qualifier: 'foo',
+								errors: {}
+							},
+							{
+								model: 'character',
+								name: 'Gunhild Borkman',
+								underlyingName: 'Mrs Gunhild Borkman',
+								differentiator: '1',
+								qualifier: 'bar',
+								errors: {}
+							},
+							{
+								model: 'character',
+								name: 'Erhart Borkman',
+								underlyingName: 'Mr Erhart Borkman',
+								differentiator: '1',
+								qualifier: 'baz',
+								errors: {}
+							},
+							{
+								model: 'character',
+								name: '',
+								underlyingName: '',
+								differentiator: '',
+								qualifier: '',
+								errors: {}
+							}
+						]
 					},
 					{
-						model: 'character',
-						name: 'Gunhild Borkman',
-						underlyingName: 'Mrs Gunhild Borkman',
-						differentiator: '1',
-						qualifier: 'bar',
-						group: 'The Borkmans',
-						errors: {}
-					},
-					{
-						model: 'character',
-						name: 'Erhart Borkman',
-						underlyingName: 'Mr Erhart Borkman',
-						differentiator: '1',
-						qualifier: 'baz',
-						group: 'The Borkmans',
-						errors: {}
-					},
-					{
-						model: 'character',
+						model: 'characterGroup',
 						name: '',
-						underlyingName: '',
-						differentiator: '',
-						qualifier: '',
-						group: '',
-						errors: {}
+						errors: {},
+						characters: [
+							{
+								model: 'character',
+								name: '',
+								underlyingName: '',
+								differentiator: '',
+								qualifier: '',
+								errors: {}
+							}
+						]
 					}
 				]
 			};
@@ -671,27 +733,29 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 							]
 						}
 					],
-					characters: [
+					characterGroups: [
 						{
-							name: 'Olga',
-							underlyingName: 'Olga Sergeyevna Prozorova',
-							differentiator: '1',
-							qualifier: 'foo',
-							group: 'The Prozorovs'
-						},
-						{
-							name: 'Maria',
-							underlyingName: 'Maria Sergeyevna Kulygina',
-							differentiator: '1',
-							qualifier: 'bar',
-							group: 'The Prozorovs'
-						},
-						{
-							name: 'Irina',
-							underlyingName: 'Irina Sergeyevna Prozorova',
-							differentiator: '1',
-							qualifier: 'baz',
-							group: 'The Prozorovs'
+							name: 'The Prozorovs',
+							characters: [
+								{
+									name: 'Olga',
+									underlyingName: 'Olga Sergeyevna Prozorova',
+									differentiator: '1',
+									qualifier: 'foo'
+								},
+								{
+									name: 'Maria',
+									underlyingName: 'Maria Sergeyevna Kulygina',
+									differentiator: '1',
+									qualifier: 'bar'
+								},
+								{
+									name: 'Irina',
+									underlyingName: 'Irina Sergeyevna Prozorova',
+									differentiator: '1',
+									qualifier: 'baz'
+								}
+							]
 						}
 					]
 				});
@@ -755,42 +819,60 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 						]
 					}
 				],
-				characters: [
+				characterGroups: [
 					{
-						model: 'character',
-						name: 'Olga',
-						underlyingName: 'Olga Sergeyevna Prozorova',
-						differentiator: '1',
-						qualifier: 'foo',
-						group: 'The Prozorovs',
-						errors: {}
+						model: 'characterGroup',
+						name: 'The Prozorovs',
+						errors: {},
+						characters: [
+							{
+								model: 'character',
+								name: 'Olga',
+								underlyingName: 'Olga Sergeyevna Prozorova',
+								differentiator: '1',
+								qualifier: 'foo',
+								errors: {}
+							},
+							{
+								model: 'character',
+								name: 'Maria',
+								underlyingName: 'Maria Sergeyevna Kulygina',
+								differentiator: '1',
+								qualifier: 'bar',
+								errors: {}
+							},
+							{
+								model: 'character',
+								name: 'Irina',
+								underlyingName: 'Irina Sergeyevna Prozorova',
+								differentiator: '1',
+								qualifier: 'baz',
+								errors: {}
+							},
+							{
+								model: 'character',
+								name: '',
+								underlyingName: '',
+								differentiator: '',
+								qualifier: '',
+								errors: {}
+							}
+						]
 					},
 					{
-						model: 'character',
-						name: 'Maria',
-						underlyingName: 'Maria Sergeyevna Kulygina',
-						differentiator: '1',
-						qualifier: 'bar',
-						group: 'The Prozorovs',
-						errors: {}
-					},
-					{
-						model: 'character',
-						name: 'Irina',
-						underlyingName: 'Irina Sergeyevna Prozorova',
-						differentiator: '1',
-						qualifier: 'baz',
-						group: 'The Prozorovs',
-						errors: {}
-					},
-					{
-						model: 'character',
+						model: 'characterGroup',
 						name: '',
-						underlyingName: '',
-						differentiator: '',
-						qualifier: '',
-						group: '',
-						errors: {}
+						errors: {},
+						characters: [
+							{
+								model: 'character',
+								name: '',
+								underlyingName: '',
+								differentiator: '',
+								qualifier: '',
+								errors: {}
+							}
+						]
 					}
 				]
 			};
@@ -901,15 +983,21 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 						]
 					}
 				],
-				characters: [
+				characterGroups: [
 					{
-						model: 'character',
+						model: 'characterGroup',
 						name: '',
-						underlyingName: '',
-						differentiator: '',
-						qualifier: '',
-						group: '',
-						errors: {}
+						errors: {},
+						characters: [
+							{
+								model: 'character',
+								name: '',
+								underlyingName: '',
+								differentiator: '',
+								qualifier: '',
+								errors: {}
+							}
+						]
 					}
 				]
 			};
@@ -933,7 +1021,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 				differentiator: '1',
 				errors: {},
 				writerGroups: [],
-				characters: []
+				characterGroups: []
 			};
 
 			expect(response).to.have.status(200);

--- a/test-e2e/instance-validation-failures/playtexts-api.test.js
+++ b/test-e2e/instance-validation-failures/playtexts-api.test.js
@@ -51,7 +51,7 @@ describe('Instance validation failures: Playtexts API', () => {
 						]
 					},
 					writerGroups: [],
-					characters: []
+					characterGroups: []
 				};
 
 				expect(response).to.have.status(200);
@@ -88,7 +88,7 @@ describe('Instance validation failures: Playtexts API', () => {
 						]
 					},
 					writerGroups: [],
-					characters: []
+					characterGroups: []
 				};
 
 				expect(response).to.have.status(200);
@@ -148,7 +148,7 @@ describe('Instance validation failures: Playtexts API', () => {
 						]
 					},
 					writerGroups: [],
-					characters: []
+					characterGroups: []
 				};
 
 				expect(response).to.have.status(200);
@@ -191,7 +191,7 @@ describe('Instance validation failures: Playtexts API', () => {
 						]
 					},
 					writerGroups: [],
-					characters: []
+					characterGroups: []
 				};
 
 				expect(response).to.have.status(200);
@@ -261,7 +261,7 @@ describe('Instance validation failures: Playtexts API', () => {
 						]
 					},
 					writerGroups: [],
-					characters: []
+					characterGroups: []
 				};
 
 				expect(response).to.have.status(200);

--- a/test-e2e/model-interaction/cast-member-diff-roles-of-playtext.test.js
+++ b/test-e2e/model-interaction/cast-member-diff-roles-of-playtext.test.js
@@ -42,12 +42,16 @@ describe('Cast member performing different roles in different productions of sam
 			.post('/playtexts')
 			.send({
 				name: 'The Tragedy of King Lear',
-				characters: [
+				characterGroups: [
 					{
-						name: 'King Lear'
-					},
-					{
-						name: 'Fool'
+						characters: [
+							{
+								name: 'King Lear'
+							},
+							{
+								name: 'Fool'
+							}
+						]
 					}
 				]
 			});

--- a/test-e2e/model-interaction/cast-member-same-role-of-playtext.test.js
+++ b/test-e2e/model-interaction/cast-member-same-role-of-playtext.test.js
@@ -36,9 +36,13 @@ describe('Cast member performing same role in different productions of same play
 			.post('/playtexts')
 			.send({
 				name: 'A Midsummer Night\'s Dream',
-				characters: [
+				characterGroups: [
 					{
-						name: 'Titania, Queen of the Fairies'
+						characters: [
+							{
+								name: 'Titania, Queen of the Fairies'
+							}
+						]
 					}
 				]
 			});

--- a/test-e2e/model-interaction/char-diff-groups-same-playtext.test.js
+++ b/test-e2e/model-interaction/char-diff-groups-same-playtext.test.js
@@ -10,19 +10,19 @@ describe('Character with multiple appearances in the same playtext in different 
 
 	chai.use(chaiHttp);
 
-	const THREE_WINTERS_PLAYTEXT_UUID = '8';
-	const ALISA_KOS_CHARACTER_UUID = '9';
-	const MAŠA_KOS_CHARACTER_UUID = '10';
-	const ALEKSANDER_KING_CHARACTER_UUID = '12';
-	const ROSE_KING_CHARACTER_UUID = '14';
-	const THREE_WINTERS_NATIONAL_PRODUCTION_UUID = '16';
-	const NATIONAL_THEATRE_UUID = '18';
-	const SIOBHAN_FINNERAN_PERSON_UUID = '19';
-	const JO_HERBERT_PERSON_UUID = '20';
-	const JAMES_LAURENSON_PERSON_UUID = '21';
-	const JODIE_MCNEE_PERSON_UUID = '22';
-	const ALEX_PRICE_PERSON_UUID = '23';
-	const BEBE_SANDERS_PERSON_UUID = '24';
+	const THREE_WINTERS_PLAYTEXT_UUID = '5';
+	const ALISA_KOS_CHARACTER_UUID = '6';
+	const MAŠA_KOS_CHARACTER_UUID = '7';
+	const ALEKSANDER_KING_CHARACTER_UUID = '8';
+	const ROSE_KING_CHARACTER_UUID = '9';
+	const THREE_WINTERS_NATIONAL_PRODUCTION_UUID = '10';
+	const NATIONAL_THEATRE_UUID = '12';
+	const SIOBHAN_FINNERAN_PERSON_UUID = '13';
+	const JO_HERBERT_PERSON_UUID = '14';
+	const JAMES_LAURENSON_PERSON_UUID = '15';
+	const JODIE_MCNEE_PERSON_UUID = '16';
+	const ALEX_PRICE_PERSON_UUID = '17';
+	const BEBE_SANDERS_PERSON_UUID = '18';
 
 	let alisaKosCharacter;
 	let mašaKosCharacter;
@@ -51,34 +51,42 @@ describe('Character with multiple appearances in the same playtext in different 
 			.post('/playtexts')
 			.send({
 				name: '3 Winters',
-				characters: [
+				characterGroups: [
 					{
-						name: 'Alisa Kos',
-						group: '2011'
+						name: '2011',
+						characters: [
+							{
+								name: 'Alisa Kos'
+							},
+							{
+								name: 'Maša Kos'
+							}
+						]
 					},
 					{
-						name: 'Maša Kos',
-						group: '2011'
+						name: '1990',
+						characters: [
+							{
+								name: 'Maša Kos'
+							},
+							{
+								name: 'Aleksander King'
+							},
+							{
+								name: 'Alisa Kos'
+							}
+						]
 					},
 					{
-						name: 'Maša Kos',
-						group: '1990'
-					},
-					{
-						name: 'Aleksander King',
-						group: '1990'
-					},
-					{
-						name: 'Alisa Kos',
-						group: '1990'
-					},
-					{
-						name: 'Rose King',
-						group: '1945'
-					},
-					{
-						name: 'Aleksander King',
-						group: '1945'
+						name: '1945',
+						characters: [
+							{
+								name: 'Rose King'
+							},
+							{
+								name: 'Aleksander King'
+							}
+						]
 					}
 				]
 			});

--- a/test-e2e/model-interaction/char-in-multi-prods-of-multi-playtexts.test.js
+++ b/test-e2e/model-interaction/char-in-multi-prods-of-multi-playtexts.test.js
@@ -49,9 +49,13 @@ describe('Character in multiple productions of multiple playtexts', () => {
 			.post('/playtexts')
 			.send({
 				name: 'Henry IV: Part 1',
-				characters: [
+				characterGroups: [
 					{
-						name: 'Sir John Falstaff'
+						characters: [
+							{
+								name: 'Sir John Falstaff'
+							}
+						]
 					}
 				]
 			});
@@ -60,9 +64,13 @@ describe('Character in multiple productions of multiple playtexts', () => {
 			.post('/playtexts')
 			.send({
 				name: 'Henry IV: Part 2',
-				characters: [
+				characterGroups: [
 					{
-						name: 'Sir John Falstaff'
+						characters: [
+							{
+								name: 'Sir John Falstaff'
+							}
+						]
 					}
 				]
 			});
@@ -71,9 +79,13 @@ describe('Character in multiple productions of multiple playtexts', () => {
 			.post('/playtexts')
 			.send({
 				name: 'The Merry Wives of Windsor',
-				characters: [
+				characterGroups: [
 					{
-						name: 'Sir John Falstaff'
+						characters: [
+							{
+								name: 'Sir John Falstaff'
+							}
+						]
 					}
 				]
 			});

--- a/test-e2e/model-interaction/char-multi-appearances-same-playtext.test.js
+++ b/test-e2e/model-interaction/char-multi-appearances-same-playtext.test.js
@@ -10,16 +10,16 @@ describe('Character with multiple appearances in the same playtext under differe
 
 	chai.use(chaiHttp);
 
-	const ROCK_N_ROLL_PLAYTEXT_UUID = '6';
-	const ESME_CHARACTER_UUID = '7';
-	const MAX_CHARACTER_UUID = '8';
-	const ELEANOR_CHARACTER_UUID = '9';
-	const ALICE_CHARACTER_UUID = '11';
-	const ROCK_N_ROLL_ROYAL_COURT_PRODUCTION_UUID = '12';
-	const ROYAL_COURT_THEATRE_UUID = '14';
-	const ALICE_EVE_PERSON_UUID = '15';
-	const BRIAN_COX_PERSON_UUID = '16';
-	const SINEAD_CUSACK_PERSON_UUID = '17';
+	const ROCK_N_ROLL_PLAYTEXT_UUID = '5';
+	const ESME_CHARACTER_UUID = '6';
+	const MAX_CHARACTER_UUID = '7';
+	const ELEANOR_CHARACTER_UUID = '8';
+	const ALICE_CHARACTER_UUID = '9';
+	const ROCK_N_ROLL_ROYAL_COURT_PRODUCTION_UUID = '10';
+	const ROYAL_COURT_THEATRE_UUID = '12';
+	const ALICE_EVE_PERSON_UUID = '13';
+	const BRIAN_COX_PERSON_UUID = '14';
+	const SINEAD_CUSACK_PERSON_UUID = '15';
 
 	let esmeCharacter;
 	let aliceCharacter;
@@ -43,26 +43,30 @@ describe('Character with multiple appearances in the same playtext under differe
 			.post('/playtexts')
 			.send({
 				name: 'Rock \'n\' Roll',
-				characters: [
+				characterGroups: [
 					{
-						name: 'Esme',
-						qualifier: 'younger'
-					},
-					{
-						name: 'Max',
-						qualifier: ''
-					},
-					{
-						name: 'Eleanor',
-						qualifier: ''
-					},
-					{
-						name: 'Esme',
-						qualifier: 'older'
-					},
-					{
-						name: 'Alice',
-						qualifier: ''
+						characters: [
+							{
+								name: 'Esme',
+								qualifier: 'younger'
+							},
+							{
+								name: 'Max',
+								qualifier: ''
+							},
+							{
+								name: 'Eleanor',
+								qualifier: ''
+							},
+							{
+								name: 'Esme',
+								qualifier: 'older'
+							},
+							{
+								name: 'Alice',
+								qualifier: ''
+							}
+						]
 					}
 				]
 			});

--- a/test-e2e/model-interaction/char-portrayed-with-other-roles.test.js
+++ b/test-e2e/model-interaction/char-portrayed-with-other-roles.test.js
@@ -37,21 +37,25 @@ describe('Character portrayed with other roles', () => {
 			.post('/playtexts')
 			.send({
 				name: 'War Horse',
-				characters: [
+				characterGroups: [
 					{
-						name: 'Major Nicholls'
-					},
-					{
-						name: 'Joey\'s mother'
-					},
-					{
-						name: 'Dr Schweyk'
-					},
-					{
-						name: 'Coco'
-					},
-					{
-						name: 'Geordie'
+						characters: [
+							{
+								name: 'Major Nicholls'
+							},
+							{
+								name: 'Joey\'s mother'
+							},
+							{
+								name: 'Dr Schweyk'
+							},
+							{
+								name: 'Coco'
+							},
+							{
+								name: 'Geordie'
+							}
+						]
 					}
 				]
 			});

--- a/test-e2e/model-interaction/char-with-variant-depiction-portrayal-names.test.js
+++ b/test-e2e/model-interaction/char-with-variant-depiction-portrayal-names.test.js
@@ -67,16 +67,20 @@ describe('Character with variant depiction and portrayal names', () => {
 			.post('/playtexts')
 			.send({
 				name: 'Henry IV, Part 1',
-				characters: [
+				characterGroups: [
 					{
-						name: 'Henry, Prince of Wales',
-						underlyingName: 'King Henry V'
-					},
-					{
-						name: 'Sir John Falstaff'
-					},
-					{
-						name: 'Messenger'
+						characters: [
+							{
+								name: 'Henry, Prince of Wales',
+								underlyingName: 'King Henry V'
+							},
+							{
+								name: 'Sir John Falstaff'
+							},
+							{
+								name: 'Messenger'
+							}
+						]
 					}
 				]
 			});
@@ -85,16 +89,20 @@ describe('Character with variant depiction and portrayal names', () => {
 			.post('/playtexts')
 			.send({
 				name: 'Henry IV, Part 2',
-				characters: [
+				characterGroups: [
 					{
-						name: 'Prince Hal',
-						underlyingName: 'King Henry V'
-					},
-					{
-						name: 'Sir John Falstaff'
-					},
-					{
-						name: 'Attendant'
+						characters: [
+							{
+								name: 'Prince Hal',
+								underlyingName: 'King Henry V'
+							},
+							{
+								name: 'Sir John Falstaff'
+							},
+							{
+								name: 'Attendant'
+							}
+						]
 					}
 				]
 			});
@@ -103,15 +111,19 @@ describe('Character with variant depiction and portrayal names', () => {
 			.post('/playtexts')
 			.send({
 				name: 'Henry V',
-				characters: [
+				characterGroups: [
 					{
-						name: 'King Henry V'
-					},
-					{
-						name: 'King of France'
-					},
-					{
-						name: 'Soldier'
+						characters: [
+							{
+								name: 'King Henry V'
+							},
+							{
+								name: 'King of France'
+							},
+							{
+								name: 'Soldier'
+							}
+						]
 					}
 				]
 			});
@@ -122,10 +134,14 @@ describe('Character with variant depiction and portrayal names', () => {
 			.post('/playtexts')
 			.send({
 				name: 'The Merry Wives of Windsor',
-				characters: [
+				characterGroups: [
 					{
-						name: 'Prince Hal',
-						underlyingName: 'King Henry V'
+						characters: [
+							{
+								name: 'Prince Hal',
+								underlyingName: 'King Henry V'
+							}
+						]
 					}
 				]
 			});

--- a/test-e2e/model-interaction/char-with-variant-names-diff-playtexts.test.js
+++ b/test-e2e/model-interaction/char-with-variant-names-diff-playtexts.test.js
@@ -57,12 +57,16 @@ describe('Character with variant names from productions of different playtexts',
 			.post('/playtexts')
 			.send({
 				name: 'Hamlet',
-				characters: [
+				characterGroups: [
 					{
-						name: 'Hamlet'
-					},
-					{
-						name: 'Claudius'
+						characters: [
+							{
+								name: 'Hamlet'
+							},
+							{
+								name: 'Claudius'
+							}
+						]
 					}
 				]
 			});
@@ -71,12 +75,16 @@ describe('Character with variant names from productions of different playtexts',
 			.post('/playtexts')
 			.send({
 				name: 'Rosencrantz and Guildenstern Are Dead',
-				characters: [
+				characterGroups: [
 					{
-						name: 'Hamlet'
-					},
-					{
-						name: 'Claudius'
+						characters: [
+							{
+								name: 'Hamlet'
+							},
+							{
+								name: 'Claudius'
+							}
+						]
 					}
 				]
 			});
@@ -85,12 +93,16 @@ describe('Character with variant names from productions of different playtexts',
 			.post('/playtexts')
 			.send({
 				name: 'Fortinbras',
-				characters: [
+				characterGroups: [
 					{
-						name: 'Hamlet'
-					},
-					{
-						name: 'Claudius'
+						characters: [
+							{
+								name: 'Hamlet'
+							},
+							{
+								name: 'Claudius'
+							}
+						]
 					}
 				]
 			});
@@ -99,12 +111,16 @@ describe('Character with variant names from productions of different playtexts',
 			.post('/playtexts')
 			.send({
 				name: 'Hamletmachine',
-				characters: [
+				characterGroups: [
 					{
-						name: 'Hamlet'
-					},
-					{
-						name: 'Claudius'
+						characters: [
+							{
+								name: 'Hamlet'
+							},
+							{
+								name: 'Claudius'
+							}
+						]
 					}
 				]
 			});

--- a/test-e2e/model-interaction/char-with-variant-names-same-playtext.test.js
+++ b/test-e2e/model-interaction/char-with-variant-names-same-playtext.test.js
@@ -49,18 +49,22 @@ describe('Character with variant names from productions of the same playtext', (
 			.post('/playtexts')
 			.send({
 				name: 'Hamlet',
-				characters: [
+				characterGroups: [
 					{
-						name: 'Hamlet'
-					},
-					{
-						name: 'Claudius'
-					},
-					{
-						name: 'Ghost'
-					},
-					{
-						name: 'First Player'
+						characters: [
+							{
+								name: 'Hamlet'
+							},
+							{
+								name: 'Claudius'
+							},
+							{
+								name: 'Ghost'
+							},
+							{
+								name: 'First Player'
+							}
+						]
 					}
 				]
 			});

--- a/test-e2e/model-interaction/diff-chars-same-name-diff-playtexts.test.js
+++ b/test-e2e/model-interaction/diff-chars-same-name-diff-playtexts.test.js
@@ -48,13 +48,17 @@ describe('Different characters with the same name from different playtexts', () 
 			.post('/playtexts')
 			.send({
 				name: 'A Midsummer Night\'s Dream',
-				characters: [
+				characterGroups: [
 					{
-						name: 'Lysander'
-					},
-					{
-						name: 'Demetrius',
-						differentiator: '1'
+						characters: [
+							{
+								name: 'Lysander'
+							},
+							{
+								name: 'Demetrius',
+								differentiator: '1'
+							}
+						]
 					}
 				]
 			});
@@ -63,13 +67,17 @@ describe('Different characters with the same name from different playtexts', () 
 			.post('/playtexts')
 			.send({
 				name: 'Titus Andronicus',
-				characters: [
+				characterGroups: [
 					{
-						name: 'Demetrius',
-						differentiator: '2'
-					},
-					{
-						name: 'Chiron'
+						characters: [
+							{
+								name: 'Demetrius',
+								differentiator: '2'
+							},
+							{
+								name: 'Chiron'
+							}
+						]
 					}
 				]
 			});

--- a/test-e2e/model-interaction/diff-chars-same-name-same-playtext.test.js
+++ b/test-e2e/model-interaction/diff-chars-same-name-same-playtext.test.js
@@ -41,17 +41,21 @@ describe('Different characters with the same name from the same playtext', () =>
 			.post('/playtexts')
 			.send({
 				name: 'Julius Caesar',
-				characters: [
+				characterGroups: [
 					{
-						name: 'Cinna',
-						differentiator: '1'
-					},
-					{
-						name: 'Volumnius'
-					},
-					{
-						name: 'Cinna',
-						differentiator: '2'
+						characters: [
+							{
+								name: 'Cinna',
+								differentiator: '1'
+							},
+							{
+								name: 'Volumnius'
+							},
+							{
+								name: 'Cinna',
+								differentiator: '2'
+							}
+						]
 					}
 				]
 			});

--- a/test-e2e/model-interaction/playtext-with-multi-writer-groups.test.js
+++ b/test-e2e/model-interaction/playtext-with-multi-writer-groups.test.js
@@ -67,9 +67,13 @@ describe('Playtext with multiple writer groups', () => {
 						]
 					}
 				],
-				characters: [
+				characterGroups: [
 					{
-						name: 'Peer Gynt'
+						characters: [
+							{
+								name: 'Peer Gynt'
+							}
+						]
 					}
 				]
 			});

--- a/test-e2e/model-interaction/roles-with-alternating-cast.test.js
+++ b/test-e2e/model-interaction/roles-with-alternating-cast.test.js
@@ -44,12 +44,16 @@ describe('Roles with alternating cast', () => {
 			.post('/playtexts')
 			.send({
 				name: 'True West',
-				characters: [
+				characterGroups: [
 					{
-						name: 'Austin'
-					},
-					{
-						name: 'Lee'
+						characters: [
+							{
+								name: 'Austin'
+							},
+							{
+								name: 'Lee'
+							}
+						]
 					}
 				]
 			});

--- a/test-e2e/model-interaction/theatre-with-sub-theatres.test.js
+++ b/test-e2e/model-interaction/theatre-with-sub-theatres.test.js
@@ -63,9 +63,13 @@ describe('Theatre with sub-theatres', () => {
 			.post('/playtexts')
 			.send({
 				name: 'Mother Courage and Her Children',
-				characters: [
+				characterGroups: [
 					{
-						name: 'Mother Courage'
+						characters: [
+							{
+								name: 'Mother Courage'
+							}
+						]
 					}
 				]
 			});
@@ -74,9 +78,13 @@ describe('Theatre with sub-theatres', () => {
 			.post('/playtexts')
 			.send({
 				name: 'Richard II',
-				characters: [
+				characterGroups: [
 					{
-						name: 'King Richard II'
+						characters: [
+							{
+								name: 'King Richard II'
+							}
+						]
 					}
 				]
 			});

--- a/test-e2e/uniqueness-in-db/playtexts-api.test.js
+++ b/test-e2e/uniqueness-in-db/playtexts-api.test.js
@@ -66,15 +66,21 @@ describe('Uniqueness in database: Playtexts API', () => {
 						]
 					}
 				],
-				characters: [
+				characterGroups: [
 					{
-						model: 'character',
+						model: 'characterGroup',
 						name: '',
-						underlyingName: '',
-						differentiator: '',
-						qualifier: '',
-						group: '',
-						errors: {}
+						errors: {},
+						characters: [
+							{
+								model: 'character',
+								name: '',
+								underlyingName: '',
+								differentiator: '',
+								qualifier: '',
+								errors: {}
+							}
+						]
 					}
 				]
 			};
@@ -109,7 +115,7 @@ describe('Uniqueness in database: Playtexts API', () => {
 					]
 				},
 				writerGroups: [],
-				characters: []
+				characterGroups: []
 			};
 
 			expect(response).to.have.status(200);
@@ -150,15 +156,21 @@ describe('Uniqueness in database: Playtexts API', () => {
 						]
 					}
 				],
-				characters: [
+				characterGroups: [
 					{
-						model: 'character',
+						model: 'characterGroup',
 						name: '',
-						underlyingName: '',
-						differentiator: '',
-						qualifier: '',
-						group: '',
-						errors: {}
+						errors: {},
+						characters: [
+							{
+								model: 'character',
+								name: '',
+								underlyingName: '',
+								differentiator: '',
+								qualifier: '',
+								errors: {}
+							}
+						]
 					}
 				]
 			};
@@ -195,7 +207,7 @@ describe('Uniqueness in database: Playtexts API', () => {
 					]
 				},
 				writerGroups: [],
-				characters: []
+				characterGroups: []
 			};
 
 			expect(response).to.have.status(200);
@@ -236,15 +248,21 @@ describe('Uniqueness in database: Playtexts API', () => {
 						]
 					}
 				],
-				characters: [
+				characterGroups: [
 					{
-						model: 'character',
+						model: 'characterGroup',
 						name: '',
-						underlyingName: '',
-						differentiator: '',
-						qualifier: '',
-						group: '',
-						errors: {}
+						errors: {},
+						characters: [
+							{
+								model: 'character',
+								name: '',
+								underlyingName: '',
+								differentiator: '',
+								qualifier: '',
+								errors: {}
+							}
+						]
 					}
 				]
 			};
@@ -286,15 +304,21 @@ describe('Uniqueness in database: Playtexts API', () => {
 						]
 					}
 				],
-				characters: [
+				characterGroups: [
 					{
-						model: 'character',
+						model: 'characterGroup',
 						name: '',
-						underlyingName: '',
-						differentiator: '',
-						qualifier: '',
-						group: '',
-						errors: {}
+						errors: {},
+						characters: [
+							{
+								model: 'character',
+								name: '',
+								underlyingName: '',
+								differentiator: '',
+								qualifier: '',
+								errors: {}
+							}
+						]
 					}
 				]
 			};
@@ -507,9 +531,13 @@ describe('Uniqueness in database: Playtexts API', () => {
 				.put(`/playtexts/${TITUS_ANDRONICUS_PLAYTEXT_UUID}`)
 				.send({
 					name: 'Titus Andronicus',
-					characters: [
+					characterGroups: [
 						{
-							name: 'Demetrius'
+							characters: [
+								{
+									name: 'Demetrius'
+								}
+							]
 						}
 					]
 				});
@@ -520,12 +548,11 @@ describe('Uniqueness in database: Playtexts API', () => {
 				underlyingName: '',
 				differentiator: '',
 				qualifier: '',
-				group: '',
 				errors: {}
 			};
 
 			expect(response).to.have.status(200);
-			expect(response.body.characters[0]).to.deep.equal(expectedCharacterDemetrius1);
+			expect(response.body.characterGroups[0].characters[0]).to.deep.equal(expectedCharacterDemetrius1);
 			expect(await countNodesWithLabel('Character')).to.equal(1);
 
 		});
@@ -538,10 +565,14 @@ describe('Uniqueness in database: Playtexts API', () => {
 				.put(`/playtexts/${TITUS_ANDRONICUS_PLAYTEXT_UUID}`)
 				.send({
 					name: 'Titus Andronicus',
-					characters: [
+					characterGroups: [
 						{
-							name: 'Demetrius',
-							differentiator: '1'
+							characters: [
+								{
+									name: 'Demetrius',
+									differentiator: '1'
+								}
+							]
 						}
 					]
 				});
@@ -552,12 +583,11 @@ describe('Uniqueness in database: Playtexts API', () => {
 				underlyingName: '',
 				differentiator: '1',
 				qualifier: '',
-				group: '',
 				errors: {}
 			};
 
 			expect(response).to.have.status(200);
-			expect(response.body.characters[0]).to.deep.equal(expectedCharacterDemetrius2);
+			expect(response.body.characterGroups[0].characters[0]).to.deep.equal(expectedCharacterDemetrius2);
 			expect(await countNodesWithLabel('Character')).to.equal(2);
 
 		});
@@ -570,9 +600,13 @@ describe('Uniqueness in database: Playtexts API', () => {
 				.put(`/playtexts/${TITUS_ANDRONICUS_PLAYTEXT_UUID}`)
 				.send({
 					name: 'Titus Andronicus',
-					characters: [
+					characterGroups: [
 						{
-							name: 'Demetrius'
+							characters: [
+								{
+									name: 'Demetrius'
+								}
+							]
 						}
 					]
 				});
@@ -583,12 +617,11 @@ describe('Uniqueness in database: Playtexts API', () => {
 				underlyingName: '',
 				differentiator: '',
 				qualifier: '',
-				group: '',
 				errors: {}
 			};
 
 			expect(response).to.have.status(200);
-			expect(response.body.characters[0]).to.deep.equal(expectedCharacterDemetrius1);
+			expect(response.body.characterGroups[0].characters[0]).to.deep.equal(expectedCharacterDemetrius1);
 			expect(await countNodesWithLabel('Character')).to.equal(2);
 
 		});
@@ -601,10 +634,14 @@ describe('Uniqueness in database: Playtexts API', () => {
 				.put(`/playtexts/${TITUS_ANDRONICUS_PLAYTEXT_UUID}`)
 				.send({
 					name: 'Titus Andronicus',
-					characters: [
+					characterGroups: [
 						{
-							name: 'Demetrius',
-							differentiator: '1'
+							characters: [
+								{
+									name: 'Demetrius',
+									differentiator: '1'
+								}
+							]
 						}
 					]
 				});
@@ -615,12 +652,11 @@ describe('Uniqueness in database: Playtexts API', () => {
 				underlyingName: '',
 				differentiator: '1',
 				qualifier: '',
-				group: '',
 				errors: {}
 			};
 
 			expect(response).to.have.status(200);
-			expect(response.body.characters[0]).to.deep.equal(expectedCharacterDemetrius2);
+			expect(response.body.characterGroups[0].characters[0]).to.deep.equal(expectedCharacterDemetrius2);
 			expect(await countNodesWithLabel('Character')).to.equal(2);
 
 		});

--- a/test-int/instance-validation-failures/playtext.test.js
+++ b/test-int/instance-validation-failures/playtext.test.js
@@ -45,7 +45,7 @@ describe('Playtext instance', () => {
 						]
 					},
 					writerGroups: [],
-					characters: []
+					characterGroups: []
 				};
 
 				expect(result).to.deep.equal(expectedResponseBody);
@@ -74,7 +74,7 @@ describe('Playtext instance', () => {
 						]
 					},
 					writerGroups: [],
-					characters: []
+					characterGroups: []
 				};
 
 				expect(result).to.deep.equal(expectedResponseBody);
@@ -103,7 +103,7 @@ describe('Playtext instance', () => {
 						]
 					},
 					writerGroups: [],
-					characters: []
+					characterGroups: []
 				};
 
 				expect(result).to.deep.equal(expectedResponseBody);
@@ -148,7 +148,7 @@ describe('Playtext instance', () => {
 							writers: []
 						}
 					],
-					characters: []
+					characterGroups: []
 				};
 
 				expect(result).to.deep.equal(expectedResponseBody);
@@ -206,7 +206,7 @@ describe('Playtext instance', () => {
 							writers: []
 						}
 					],
-					characters: []
+					characterGroups: []
 				};
 
 				expect(result).to.deep.equal(expectedResponseBody);
@@ -263,7 +263,7 @@ describe('Playtext instance', () => {
 							]
 						}
 					],
-					characters: []
+					characterGroups: []
 				};
 
 				expect(result).to.deep.equal(expectedResponseBody);
@@ -321,7 +321,7 @@ describe('Playtext instance', () => {
 							]
 						}
 					],
-					characters: []
+					characterGroups: []
 				};
 
 				expect(result).to.deep.equal(expectedResponseBody);
@@ -398,7 +398,7 @@ describe('Playtext instance', () => {
 							]
 						}
 					],
-					characters: []
+					characterGroups: []
 				};
 
 				expect(result).to.deep.equal(expectedResponseBody);
@@ -407,13 +407,13 @@ describe('Playtext instance', () => {
 
 		});
 
-		context('character name value exceeds maximum limit', () => {
+		context('characterGroup name value exceeds maximum limit', () => {
 
 			it('assigns appropriate error', async () => {
 
 				const instanceProps = {
 					name: 'Rosmersholm',
-					characters: [
+					characterGroups: [
 						{
 							name: ABOVE_MAX_LENGTH_STRING
 						}
@@ -432,20 +432,133 @@ describe('Playtext instance', () => {
 					hasErrors: true,
 					errors: {},
 					writerGroups: [],
-					characters: [
+					characterGroups: [
 						{
-							model: 'character',
-							uuid: undefined,
+							model: 'characterGroup',
 							name: ABOVE_MAX_LENGTH_STRING,
-							underlyingName: '',
-							differentiator: '',
-							qualifier: '',
-							group: '',
 							errors: {
 								name: [
 									'Value is too long'
 								]
-							}
+							},
+							characters: []
+						}
+					]
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+		context('duplicate characterGroups', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instanceProps = {
+					name: 'Rosmersholm',
+					characterGroups: [
+						{
+							name: 'Rosmersholm residents'
+						},
+						{
+							name: 'Rosmersholm residents'
+						}
+					]
+				};
+
+				const instance = new Playtext(instanceProps);
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					model: 'playtext',
+					uuid: undefined,
+					name: 'Rosmersholm',
+					differentiator: '',
+					hasErrors: true,
+					errors: {},
+					writerGroups: [],
+					characterGroups: [
+						{
+							model: 'characterGroup',
+							name: 'Rosmersholm residents',
+							errors: {
+								name: [
+									'This item has been duplicated within the group'
+								]
+							},
+							characters: []
+						},
+						{
+							model: 'characterGroup',
+							name: 'Rosmersholm residents',
+							errors: {
+								name: [
+									'This item has been duplicated within the group'
+								]
+							},
+							characters: []
+						}
+					]
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+		context('character name value exceeds maximum limit', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instanceProps = {
+					name: 'Rosmersholm',
+					characterGroups: [
+						{
+							characters: [
+								{
+									name: ABOVE_MAX_LENGTH_STRING
+								}
+							]
+						}
+					]
+				};
+
+				const instance = new Playtext(instanceProps);
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					model: 'playtext',
+					uuid: undefined,
+					name: 'Rosmersholm',
+					differentiator: '',
+					hasErrors: true,
+					errors: {},
+					writerGroups: [],
+					characterGroups: [
+						{
+							model: 'characterGroup',
+							name: '',
+							errors: {},
+							characters: [
+								{
+									model: 'character',
+									uuid: undefined,
+									name: ABOVE_MAX_LENGTH_STRING,
+									underlyingName: '',
+									differentiator: '',
+									qualifier: '',
+									errors: {
+										name: [
+											'Value is too long'
+										]
+									}
+								}
+							]
 						}
 					]
 				};
@@ -462,10 +575,14 @@ describe('Playtext instance', () => {
 
 				const instanceProps = {
 					name: 'Rosmersholm',
-					characters: [
+					characterGroups: [
 						{
-							name: 'Johannes Rosmer',
-							underlyingName: ABOVE_MAX_LENGTH_STRING
+							characters: [
+								{
+									name: 'Johannes Rosmer',
+									underlyingName: ABOVE_MAX_LENGTH_STRING
+								}
+							]
 						}
 					]
 				};
@@ -482,20 +599,26 @@ describe('Playtext instance', () => {
 					hasErrors: true,
 					errors: {},
 					writerGroups: [],
-					characters: [
+					characterGroups: [
 						{
-							model: 'character',
-							uuid: undefined,
-							name: 'Johannes Rosmer',
-							underlyingName: ABOVE_MAX_LENGTH_STRING,
-							differentiator: '',
-							qualifier: '',
-							group: '',
-							errors: {
-								underlyingName: [
-									'Value is too long'
-								]
-							}
+							model: 'characterGroup',
+							name: '',
+							errors: {},
+							characters: [
+								{
+									model: 'character',
+									uuid: undefined,
+									name: 'Johannes Rosmer',
+									underlyingName: ABOVE_MAX_LENGTH_STRING,
+									differentiator: '',
+									qualifier: '',
+									errors: {
+										underlyingName: [
+											'Value is too long'
+										]
+									}
+								}
+							]
 						}
 					]
 				};
@@ -512,10 +635,14 @@ describe('Playtext instance', () => {
 
 				const instanceProps = {
 					name: 'Rosmersholm',
-					characters: [
+					characterGroups: [
 						{
-							name: 'Johannes Rosmer',
-							differentiator: ABOVE_MAX_LENGTH_STRING
+							characters: [
+								{
+									name: 'Johannes Rosmer',
+									differentiator: ABOVE_MAX_LENGTH_STRING
+								}
+							]
 						}
 					]
 				};
@@ -532,20 +659,26 @@ describe('Playtext instance', () => {
 					hasErrors: true,
 					errors: {},
 					writerGroups: [],
-					characters: [
+					characterGroups: [
 						{
-							model: 'character',
-							uuid: undefined,
-							name: 'Johannes Rosmer',
-							underlyingName: '',
-							differentiator: ABOVE_MAX_LENGTH_STRING,
-							qualifier: '',
-							group: '',
-							errors: {
-								differentiator: [
-									'Value is too long'
-								]
-							}
+							model: 'characterGroup',
+							name: '',
+							errors: {},
+							characters: [
+								{
+									model: 'character',
+									uuid: undefined,
+									name: 'Johannes Rosmer',
+									underlyingName: '',
+									differentiator: ABOVE_MAX_LENGTH_STRING,
+									qualifier: '',
+									errors: {
+										differentiator: [
+											'Value is too long'
+										]
+									}
+								}
+							]
 						}
 					]
 				};
@@ -562,10 +695,14 @@ describe('Playtext instance', () => {
 
 				const instanceProps = {
 					name: 'Rosmersholm',
-					characters: [
+					characterGroups: [
 						{
-							name: 'Johannes Rosmer',
-							qualifier: ABOVE_MAX_LENGTH_STRING
+							characters: [
+								{
+									name: 'Johannes Rosmer',
+									qualifier: ABOVE_MAX_LENGTH_STRING
+								}
+							]
 						}
 					]
 				};
@@ -582,70 +719,26 @@ describe('Playtext instance', () => {
 					hasErrors: true,
 					errors: {},
 					writerGroups: [],
-					characters: [
+					characterGroups: [
 						{
-							model: 'character',
-							uuid: undefined,
-							name: 'Johannes Rosmer',
-							underlyingName: '',
-							differentiator: '',
-							qualifier: ABOVE_MAX_LENGTH_STRING,
-							group: '',
-							errors: {
-								qualifier: [
-									'Value is too long'
-								]
-							}
-						}
-					]
-				};
-
-				expect(result).to.deep.equal(expectedResponseBody);
-
-			});
-
-		});
-
-		context('character group value exceeds maximum limit', () => {
-
-			it('assigns appropriate error', async () => {
-
-				const instanceProps = {
-					name: 'Rosmersholm',
-					characters: [
-						{
-							name: 'Johannes Rosmer',
-							group: ABOVE_MAX_LENGTH_STRING
-						}
-					]
-				};
-
-				const instance = new Playtext(instanceProps);
-
-				const result = await instance.create();
-
-				const expectedResponseBody = {
-					model: 'playtext',
-					uuid: undefined,
-					name: 'Rosmersholm',
-					differentiator: '',
-					hasErrors: true,
-					errors: {},
-					writerGroups: [],
-					characters: [
-						{
-							model: 'character',
-							uuid: undefined,
-							name: 'Johannes Rosmer',
-							underlyingName: '',
-							differentiator: '',
-							qualifier: '',
-							group: ABOVE_MAX_LENGTH_STRING,
-							errors: {
-								group: [
-									'Value is too long'
-								]
-							}
+							model: 'characterGroup',
+							name: '',
+							errors: {},
+							characters: [
+								{
+									model: 'character',
+									uuid: undefined,
+									name: 'Johannes Rosmer',
+									underlyingName: '',
+									differentiator: '',
+									qualifier: ABOVE_MAX_LENGTH_STRING,
+									errors: {
+										qualifier: [
+											'Value is too long'
+										]
+									}
+								}
+							]
 						}
 					]
 				};
@@ -662,10 +755,14 @@ describe('Playtext instance', () => {
 
 				const instanceProps = {
 					name: 'Rosmersholm',
-					characters: [
+					characterGroups: [
 						{
-							name: 'Johannes Rosmer',
-							underlyingName: 'Johannes Rosmer'
+							characters: [
+								{
+									name: 'Johannes Rosmer',
+									underlyingName: 'Johannes Rosmer'
+								}
+							]
 						}
 					]
 				};
@@ -682,20 +779,26 @@ describe('Playtext instance', () => {
 					hasErrors: true,
 					errors: {},
 					writerGroups: [],
-					characters: [
+					characterGroups: [
 						{
-							model: 'character',
-							uuid: undefined,
-							name: 'Johannes Rosmer',
-							underlyingName: 'Johannes Rosmer',
-							differentiator: '',
-							qualifier: '',
-							group: '',
-							errors: {
-								underlyingName: [
-									'Underlying name is only required if different from character name'
-								]
-							}
+							model: 'characterGroup',
+							name: '',
+							errors: {},
+							characters: [
+								{
+									model: 'character',
+									uuid: undefined,
+									name: 'Johannes Rosmer',
+									underlyingName: 'Johannes Rosmer',
+									differentiator: '',
+									qualifier: '',
+									errors: {
+										underlyingName: [
+											'Underlying name is only required if different from character name'
+										]
+									}
+								}
+							]
 						}
 					]
 				};
@@ -712,15 +815,19 @@ describe('Playtext instance', () => {
 
 				const instanceProps = {
 					name: 'Rosmersholm',
-					characters: [
+					characterGroups: [
 						{
-							name: 'Johannes Rosmer'
-						},
-						{
-							name: 'Rebecca West'
-						},
-						{
-							name: 'Johannes Rosmer'
+							characters: [
+								{
+									name: 'Johannes Rosmer'
+								},
+								{
+									name: 'Rebecca West'
+								},
+								{
+									name: 'Johannes Rosmer'
+								}
+							]
 						}
 					]
 				};
@@ -737,68 +844,66 @@ describe('Playtext instance', () => {
 					hasErrors: true,
 					errors: {},
 					writerGroups: [],
-					characters: [
+					characterGroups: [
 						{
-							model: 'character',
-							uuid: undefined,
-							name: 'Johannes Rosmer',
-							underlyingName: '',
-							differentiator: '',
-							qualifier: '',
-							group: '',
-							errors: {
-								name: [
-									'This item has been duplicated within the group'
-								],
-								underlyingName: [
-									'This item has been duplicated within the group'
-								],
-								differentiator: [
-									'This item has been duplicated within the group'
-								],
-								qualifier: [
-									'This item has been duplicated within the group'
-								],
-								group: [
-									'This item has been duplicated within the group'
-								]
-							}
-						},
-						{
-							model: 'character',
-							uuid: undefined,
-							name: 'Rebecca West',
-							underlyingName: '',
-							differentiator: '',
-							qualifier: '',
-							group: '',
-							errors: {}
-						},
-						{
-							model: 'character',
-							uuid: undefined,
-							name: 'Johannes Rosmer',
-							underlyingName: '',
-							differentiator: '',
-							qualifier: '',
-							group: '',
-							errors: {
-								name: [
-									'This item has been duplicated within the group'
-								],
-								underlyingName: [
-									'This item has been duplicated within the group'
-								],
-								differentiator: [
-									'This item has been duplicated within the group'
-								],
-								qualifier: [
-									'This item has been duplicated within the group'
-								],
-								group: [
-									'This item has been duplicated within the group'
-								]
-							}
+							model: 'characterGroup',
+							name: '',
+							errors: {},
+							characters: [
+								{
+									model: 'character',
+									uuid: undefined,
+									name: 'Johannes Rosmer',
+									underlyingName: '',
+									differentiator: '',
+									qualifier: '',
+									errors: {
+										name: [
+											'This item has been duplicated within the group'
+										],
+										underlyingName: [
+											'This item has been duplicated within the group'
+										],
+										differentiator: [
+											'This item has been duplicated within the group'
+										],
+										qualifier: [
+											'This item has been duplicated within the group'
+										]
+									}
+								},
+								{
+									model: 'character',
+									uuid: undefined,
+									name: 'Rebecca West',
+									underlyingName: '',
+									differentiator: '',
+									qualifier: '',
+									errors: {}
+								},
+								{
+									model: 'character',
+									uuid: undefined,
+									name: 'Johannes Rosmer',
+									underlyingName: '',
+									differentiator: '',
+									qualifier: '',
+									errors: {
+										name: [
+											'This item has been duplicated within the group'
+										],
+										underlyingName: [
+											'This item has been duplicated within the group'
+										],
+										differentiator: [
+											'This item has been duplicated within the group'
+										],
+										qualifier: [
+											'This item has been duplicated within the group'
+										]
+									}
+								}
+							]
 						}
 					]
 				};
@@ -842,7 +947,7 @@ describe('Playtext instance', () => {
 						]
 					},
 					writerGroups: [],
-					characters: []
+					characterGroups: []
 				};
 
 				expect(result).to.deep.equal(expectedResponseBody);
@@ -867,9 +972,13 @@ describe('Playtext instance', () => {
 
 				const instanceProps = {
 					name: 'Rosmersholm',
-					characters: [
+					characterGroups: [
 						{
-							name: ABOVE_MAX_LENGTH_STRING
+							characters: [
+								{
+									name: ABOVE_MAX_LENGTH_STRING
+								}
+							]
 						}
 					]
 				};
@@ -893,20 +1002,26 @@ describe('Playtext instance', () => {
 						]
 					},
 					writerGroups: [],
-					characters: [
+					characterGroups: [
 						{
-							model: 'character',
-							uuid: undefined,
-							name: ABOVE_MAX_LENGTH_STRING,
-							underlyingName: '',
-							differentiator: '',
-							qualifier: '',
-							group: '',
-							errors: {
-								name: [
-									'Value is too long'
-								]
-							}
+							model: 'characterGroup',
+							name: '',
+							errors: {},
+							characters: [
+								{
+									model: 'character',
+									uuid: undefined,
+									name: ABOVE_MAX_LENGTH_STRING,
+									underlyingName: '',
+									differentiator: '',
+									qualifier: '',
+									errors: {
+										name: [
+											'Value is too long'
+										]
+									}
+								}
+							]
 						}
 					]
 				};

--- a/test-unit/src/lib/get-duplicate-character-indices.test.js
+++ b/test-unit/src/lib/get-duplicate-character-indices.test.js
@@ -10,60 +10,24 @@ describe('Get Duplicate Character Indices module', () => {
 
 			const result = getDuplicateCharacterIndices(
 				[
-					{ name: 'Foo', underlyingName: '', differentiator: '', qualifier: '', group: '' },
-					{ name: 'Foo', underlyingName: '', differentiator: '1', qualifier: '', group: '' },
-					{ name: 'Foo', underlyingName: '', differentiator: '2', qualifier: '', group: '' },
-					{ name: 'Foo', underlyingName: '', differentiator: '', qualifier: 'younger', group: '' },
-					{ name: 'Foo', underlyingName: '', differentiator: '', qualifier: 'older', group: '' },
-					{ name: 'Foo', underlyingName: '', differentiator: '', qualifier: '', group: 'Romans' },
-					{ name: 'Foo', underlyingName: '', differentiator: '', qualifier: '', group: 'Goths' },
-					{ name: 'Foo', underlyingName: '', differentiator: '', qualifier: 'younger', group: 'Romans' },
-					{ name: 'Foo', underlyingName: '', differentiator: '', qualifier: 'younger', group: 'Goths' },
-					{ name: 'Foo', underlyingName: '', differentiator: '', qualifier: 'older', group: 'Romans' },
-					{ name: 'Foo', underlyingName: '', differentiator: '', qualifier: 'older', group: 'Goths' },
-					{ name: 'Foo', underlyingName: '', differentiator: '1', qualifier: 'younger', group: '' },
-					{ name: 'Foo', underlyingName: '', differentiator: '1', qualifier: 'older', group: '' },
-					{ name: 'Foo', underlyingName: '', differentiator: '1', qualifier: '', group: 'Romans' },
-					{ name: 'Foo', underlyingName: '', differentiator: '1', qualifier: '', group: 'Goths' },
-					{ name: 'Foo', underlyingName: '', differentiator: '1', qualifier: 'younger', group: 'Romans' },
-					{ name: 'Foo', underlyingName: '', differentiator: '1', qualifier: 'younger', group: 'Goths' },
-					{ name: 'Foo', underlyingName: '', differentiator: '1', qualifier: 'older', group: 'Romans' },
-					{ name: 'Foo', underlyingName: '', differentiator: '1', qualifier: 'older', group: 'Goths' },
-					{ name: 'Foo', underlyingName: '', differentiator: '2', qualifier: 'younger', group: '' },
-					{ name: 'Foo', underlyingName: '', differentiator: '2', qualifier: 'older', group: '' },
-					{ name: 'Foo', underlyingName: '', differentiator: '2', qualifier: '', group: 'Romans' },
-					{ name: 'Foo', underlyingName: '', differentiator: '2', qualifier: '', group: 'Goths' },
-					{ name: 'Foo', underlyingName: '', differentiator: '2', qualifier: 'younger', group: 'Romans' },
-					{ name: 'Foo', underlyingName: '', differentiator: '2', qualifier: 'younger', group: 'Goths' },
-					{ name: 'Foo', underlyingName: '', differentiator: '2', qualifier: 'older', group: 'Romans' },
-					{ name: 'Foo', underlyingName: '', differentiator: '2', qualifier: 'older', group: 'Goths' },
-					{ name: 'Bar', underlyingName: '', differentiator: '', qualifier: '', group: '' },
-					{ name: 'Bar', underlyingName: '', differentiator: '1', qualifier: '', group: '' },
-					{ name: 'Bar', underlyingName: '', differentiator: '2', qualifier: '', group: '' },
-					{ name: 'Bar', underlyingName: '', differentiator: '', qualifier: 'younger', group: '' },
-					{ name: 'Bar', underlyingName: '', differentiator: '', qualifier: 'older', group: '' },
-					{ name: 'Bar', underlyingName: '', differentiator: '', qualifier: '', group: 'Romans' },
-					{ name: 'Bar', underlyingName: '', differentiator: '', qualifier: '', group: 'Goths' },
-					{ name: 'Bar', underlyingName: '', differentiator: '', qualifier: 'younger', group: 'Romans' },
-					{ name: 'Bar', underlyingName: '', differentiator: '', qualifier: 'younger', group: 'Goths' },
-					{ name: 'Bar', underlyingName: '', differentiator: '', qualifier: 'older', group: 'Romans' },
-					{ name: 'Bar', underlyingName: '', differentiator: '', qualifier: 'older', group: 'Goths' },
-					{ name: 'Bar', underlyingName: '', differentiator: '1', qualifier: 'younger', group: '' },
-					{ name: 'Bar', underlyingName: '', differentiator: '1', qualifier: 'older', group: '' },
-					{ name: 'Bar', underlyingName: '', differentiator: '1', qualifier: '', group: 'Romans' },
-					{ name: 'Bar', underlyingName: '', differentiator: '1', qualifier: '', group: 'Goths' },
-					{ name: 'Bar', underlyingName: '', differentiator: '1', qualifier: 'younger', group: 'Romans' },
-					{ name: 'Bar', underlyingName: '', differentiator: '1', qualifier: 'younger', group: 'Goths' },
-					{ name: 'Bar', underlyingName: '', differentiator: '1', qualifier: 'older', group: 'Romans' },
-					{ name: 'Bar', underlyingName: '', differentiator: '1', qualifier: 'older', group: 'Goths' },
-					{ name: 'Bar', underlyingName: '', differentiator: '2', qualifier: 'younger', group: '' },
-					{ name: 'Bar', underlyingName: '', differentiator: '2', qualifier: 'older', group: '' },
-					{ name: 'Bar', underlyingName: '', differentiator: '2', qualifier: '', group: 'Romans' },
-					{ name: 'Bar', underlyingName: '', differentiator: '2', qualifier: '', group: 'Goths' },
-					{ name: 'Bar', underlyingName: '', differentiator: '2', qualifier: 'younger', group: 'Romans' },
-					{ name: 'Bar', underlyingName: '', differentiator: '2', qualifier: 'younger', group: 'Goths' },
-					{ name: 'Bar', underlyingName: '', differentiator: '2', qualifier: 'older', group: 'Romans' },
-					{ name: 'Bar', underlyingName: '', differentiator: '2', qualifier: 'older', group: 'Goths' }
+					{ name: 'Foo', underlyingName: '', differentiator: '', qualifier: '' },
+					{ name: 'Foo', underlyingName: '', differentiator: '1', qualifier: '' },
+					{ name: 'Foo', underlyingName: '', differentiator: '2', qualifier: '' },
+					{ name: 'Foo', underlyingName: '', differentiator: '', qualifier: 'younger' },
+					{ name: 'Foo', underlyingName: '', differentiator: '', qualifier: 'older' },
+					{ name: 'Foo', underlyingName: '', differentiator: '1', qualifier: 'younger' },
+					{ name: 'Foo', underlyingName: '', differentiator: '1', qualifier: 'older' },
+					{ name: 'Foo', underlyingName: '', differentiator: '2', qualifier: 'younger' },
+					{ name: 'Foo', underlyingName: '', differentiator: '2', qualifier: 'older' },
+					{ name: 'Bar', underlyingName: '', differentiator: '', qualifier: '' },
+					{ name: 'Bar', underlyingName: '', differentiator: '1', qualifier: '' },
+					{ name: 'Bar', underlyingName: '', differentiator: '2', qualifier: '' },
+					{ name: 'Bar', underlyingName: '', differentiator: '', qualifier: 'younger' },
+					{ name: 'Bar', underlyingName: '', differentiator: '', qualifier: 'older' },
+					{ name: 'Bar', underlyingName: '', differentiator: '1', qualifier: 'younger' },
+					{ name: 'Bar', underlyingName: '', differentiator: '1', qualifier: 'older' },
+					{ name: 'Bar', underlyingName: '', differentiator: '2', qualifier: 'younger' },
+					{ name: 'Bar', underlyingName: '', differentiator: '2', qualifier: 'older' }
 				]
 			);
 
@@ -79,14 +43,14 @@ describe('Get Duplicate Character Indices module', () => {
 
 			const result = getDuplicateCharacterIndices(
 				[
-					{ name: 'Foo', underlyingName: '', differentiator: '1', qualifier: 'younger', group: 'Romans' },
-					{ name: 'Bar', underlyingName: '', differentiator: '1', qualifier: 'younger', group: 'Romans' },
-					{ name: '', underlyingName: '', differentiator: '1', qualifier: 'younger', group: 'Romans' },
-					{ name: 'Baz', underlyingName: '', differentiator: '1', qualifier: 'younger', group: 'Romans' },
-					{ name: 'Foo', underlyingName: '', differentiator: '1', qualifier: 'younger', group: 'Romans' },
-					{ name: 'Bar', underlyingName: '', differentiator: '1', qualifier: 'younger', group: 'Romans' },
-					{ name: '', underlyingName: '', differentiator: '1', qualifier: 'younger', group: 'Romans' },
-					{ name: 'Qux', underlyingName: '', differentiator: '1', qualifier: 'younger', group: 'Romans' }
+					{ name: 'Foo', underlyingName: '', differentiator: '1', qualifier: 'younger' },
+					{ name: 'Bar', underlyingName: '', differentiator: '1', qualifier: 'younger' },
+					{ name: '', underlyingName: '', differentiator: '1', qualifier: 'younger' },
+					{ name: 'Baz', underlyingName: '', differentiator: '1', qualifier: 'younger' },
+					{ name: 'Foo', underlyingName: '', differentiator: '1', qualifier: 'younger' },
+					{ name: 'Bar', underlyingName: '', differentiator: '1', qualifier: 'younger' },
+					{ name: '', underlyingName: '', differentiator: '1', qualifier: 'younger' },
+					{ name: 'Qux', underlyingName: '', differentiator: '1', qualifier: 'younger' }
 				]
 			);
 
@@ -98,8 +62,8 @@ describe('Get Duplicate Character Indices module', () => {
 
 			const result = getDuplicateCharacterIndices(
 				[
-					{ name: 'Foo', underlyingName: 'Bar', differentiator: '', qualifier: '', group: '' },
-					{ name: 'Foo', underlyingName: 'Baz', differentiator: '', qualifier: '', group: '' }
+					{ name: 'Foo', underlyingName: 'Bar', differentiator: '', qualifier: '' },
+					{ name: 'Foo', underlyingName: 'Baz', differentiator: '', qualifier: '' }
 				]
 			);
 
@@ -111,11 +75,11 @@ describe('Get Duplicate Character Indices module', () => {
 
 			const result = getDuplicateCharacterIndices(
 				[
-					{ name: 'Foo', underlyingName: '', differentiator: '', qualifier: '', group: '' },
-					{ name: 'Bar', underlyingName: 'Foo', differentiator: '', qualifier: '', group: '' },
-					{ name: 'Baz', underlyingName: '', differentiator: '', qualifier: '', group: '' },
-					{ name: 'Qux', underlyingName: 'Quux', differentiator: '', qualifier: '', group: '' },
-					{ name: 'Quuz', underlyingName: 'Quux', differentiator: '', qualifier: '', group: '' }
+					{ name: 'Foo', underlyingName: '', differentiator: '', qualifier: '' },
+					{ name: 'Bar', underlyingName: 'Foo', differentiator: '', qualifier: '' },
+					{ name: 'Baz', underlyingName: '', differentiator: '', qualifier: '' },
+					{ name: 'Qux', underlyingName: 'Quux', differentiator: '', qualifier: '' },
+					{ name: 'Quuz', underlyingName: 'Quux', differentiator: '', qualifier: '' }
 				]
 			);
 

--- a/test-unit/src/lib/prepare-as-params.test.js
+++ b/test-unit/src/lib/prepare-as-params.test.js
@@ -273,7 +273,7 @@ describe('Prepare As Params module', () => {
 
 				const instance = { cast: [{ uuid: '' }, { uuid: '' }] };
 				const result = prepareAsParams(instance);
-				expect(stubs.uuid.calledTwice).to.be.true;
+				expect(stubs.uuid.calledOnce).to.be.true;
 				expect(stubs.neo4jInt.calledTwice).to.be.true;
 				expect((stubs.neo4jInt.getCall(0)).calledWithExactly(0)).to.be.true;
 				expect((stubs.neo4jInt.getCall(1)).calledWithExactly(1)).to.be.true;
@@ -302,7 +302,7 @@ describe('Prepare As Params module', () => {
 
 		});
 
-		context('object is in writerGroups array where items are permitted an empty string name value', () => {
+		context('object is in array (e.g. writerGroups, characterGroups) where items are permitted an empty string name value', () => {
 
 			it('does not filter out objects that have a name attribute which is an empty string', () => {
 
@@ -310,11 +310,15 @@ describe('Prepare As Params module', () => {
 					writerGroups: [
 						{ name: '', writers: [{ name: 'Henrik Ibsen' }] },
 						{ name: 'version by', writers: [{ name: 'David Eldridge' }] }
+					],
+					characterGroups: [
+						{ name: 'The Borkmans', characters: [{ name: 'John Gabriel Borkman' }] },
+						{ name: '', characters: [{ name: 'Malene' }] }
 					]
 				};
 				const result = prepareAsParams(instance);
 				expect(stubs.uuid.notCalled).to.be.true;
-				expect(stubs.neo4jInt.calledTwice).to.be.true;
+				expect(stubs.neo4jInt.callCount).to.equal(4);
 				expect(result.writerGroups.length).to.equal(2);
 				expect(result.writerGroups[0].name).to.be.null;
 				expect(result.writerGroups[0]).to.have.property('position');
@@ -322,16 +326,28 @@ describe('Prepare As Params module', () => {
 				expect(result.writerGroups[1].name).to.equal('version by');
 				expect(result.writerGroups[1]).to.have.property('position');
 				expect(result.writerGroups[1].position).to.equal(1);
+				expect(result.characterGroups.length).to.equal(2);
+				expect(result.characterGroups[0].name).to.equal('The Borkmans');
+				expect(result.characterGroups[0]).to.have.property('position');
+				expect(result.characterGroups[0].position).to.equal(0);
+				expect(result.characterGroups[1].name).to.be.null;
+				expect(result.characterGroups[1]).to.have.property('position');
+				expect(result.characterGroups[1].position).to.equal(1);
 
 			});
 
-			it('filters out objects that do not have any non-empty string name writers', () => {
+			it('filters out objects that do not have any non-empty string name writers/characters', () => {
 
 				const instance = {
 					writerGroups: [
 						{ name: '', writers: [{ name: '' }] },
 						{ name: 'version by', writers: [{ name: 'David Eldridge' }] },
 						{ name: 'translation by', writers: [{ name: '' }] }
+					],
+					characterGroups: [
+						{ name: '', characters: [{ name: '' }] },
+						{ name: 'The Borkmans', characters: [{ name: 'John Gabriel Borkman' }] },
+						{ name: 'The Foldals', characters: [{ name: '' }] }
 					]
 				};
 				const result = prepareAsParams(instance);
@@ -340,6 +356,9 @@ describe('Prepare As Params module', () => {
 				expect(result.writerGroups.length).to.equal(1);
 				expect(result.writerGroups[0].name).to.equal('version by');
 				expect(result.writerGroups[0]).to.not.have.property('position');
+				expect(result.characterGroups.length).to.equal(1);
+				expect(result.characterGroups[0].name).to.equal('The Borkmans');
+				expect(result.characterGroups[0]).to.not.have.property('position');
 
 			});
 
@@ -351,9 +370,7 @@ describe('Prepare As Params module', () => {
 				.onFirstCall().returns('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
 				.onSecondCall().returns('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb')
 				.onThirdCall().returns('cccccccc-cccc-cccc-cccc-cccccccccccc')
-				.onCall(3).returns('dddddddd-dddd-dddd-dddd-dddddddddddd')
-				.onCall(4).returns('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee')
-				.onCall(5).returns('ffffffff-ffff-ffff-ffff-ffffffffffff');
+				.onCall(3).returns('dddddddd-dddd-dddd-dddd-dddddddddddd');
 			const instance = {
 				cast: [
 					{ uuid: '', name: 'Foo', differentiator: '', qualifier: 'younger' },
@@ -365,7 +382,7 @@ describe('Prepare As Params module', () => {
 				]
 			};
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.callCount).to.equal(6);
+			expect(stubs.uuid.callCount).to.equal(4);
 			expect(stubs.neo4jInt.callCount).to.equal(6);
 			expect(result.cast[0].uuid).to.equal(result.cast[3].uuid);
 			expect(result.cast[1].uuid).to.equal(result.cast[4].uuid);
@@ -447,7 +464,7 @@ describe('Prepare As Params module', () => {
 
 				const instance = { playtext: { characters: [{ uuid: '' }, { uuid: '' }] } };
 				const result = prepareAsParams(instance);
-				expect(stubs.uuid.calledTwice).to.be.true;
+				expect(stubs.uuid.calledOnce).to.be.true;
 				expect(stubs.neo4jInt.calledTwice).to.be.true;
 				expect((stubs.neo4jInt.getCall(0)).calledWithExactly(0)).to.be.true;
 				expect((stubs.neo4jInt.getCall(1)).calledWithExactly(1)).to.be.true;
@@ -476,7 +493,7 @@ describe('Prepare As Params module', () => {
 
 		});
 
-		context('object is in writerGroups array where items are permitted an empty string name value', () => {
+		context('object is in array (e.g. writerGroups, characterGroups) where items are permitted an empty string name value', () => {
 
 			it('does not filter out objects that have a name attribute which is an empty string', () => {
 
@@ -485,12 +502,16 @@ describe('Prepare As Params module', () => {
 						writerGroups: [
 							{ name: '', writers: [{ name: 'Henrik Ibsen' }] },
 							{ name: 'version by', writers: [{ name: 'David Eldridge' }] }
+						],
+						characterGroups: [
+							{ name: 'The Borkmans', characters: [{ name: 'John Gabriel Borkman' }] },
+							{ name: '', characters: [{ name: 'Malene' }] }
 						]
 					}
 				};
 				const result = prepareAsParams(instance);
 				expect(stubs.uuid.notCalled).to.be.true;
-				expect(stubs.neo4jInt.calledTwice).to.be.true;
+				expect(stubs.neo4jInt.callCount).to.equal(4);
 				expect(result.playtext.writerGroups.length).to.equal(2);
 				expect(result.playtext.writerGroups[0].name).to.be.null;
 				expect(result.playtext.writerGroups[0]).to.have.property('position');
@@ -498,10 +519,17 @@ describe('Prepare As Params module', () => {
 				expect(result.playtext.writerGroups[1].name).to.equal('version by');
 				expect(result.playtext.writerGroups[1]).to.have.property('position');
 				expect(result.playtext.writerGroups[1].position).to.equal(1);
+				expect(result.playtext.characterGroups.length).to.equal(2);
+				expect(result.playtext.characterGroups[0].name).to.equal('The Borkmans');
+				expect(result.playtext.characterGroups[0]).to.have.property('position');
+				expect(result.playtext.characterGroups[0].position).to.equal(0);
+				expect(result.playtext.characterGroups[1].name).to.be.null;
+				expect(result.playtext.characterGroups[1]).to.have.property('position');
+				expect(result.playtext.characterGroups[1].position).to.equal(1);
 
 			});
 
-			it('filters out objects that do not have any non-empty string name writers', () => {
+			it('filters out objects that do not have any non-empty string name writers/characters', () => {
 
 				const instance = {
 					playtext: {
@@ -509,6 +537,11 @@ describe('Prepare As Params module', () => {
 							{ name: '', writers: [{ name: '' }] },
 							{ name: 'version by', writers: [{ name: 'David Eldridge' }] },
 							{ name: 'translation by', writers: [{ name: '' }] }
+						],
+						characterGroups: [
+							{ name: '', characters: [{ name: '' }] },
+							{ name: 'The Borkmans', characters: [{ name: 'John Gabriel Borkman' }] },
+							{ name: 'The Foldals', characters: [{ name: '' }] }
 						]
 					}
 				};
@@ -529,9 +562,7 @@ describe('Prepare As Params module', () => {
 				.onFirstCall().returns('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
 				.onSecondCall().returns('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb')
 				.onThirdCall().returns('cccccccc-cccc-cccc-cccc-cccccccccccc')
-				.onCall(3).returns('dddddddd-dddd-dddd-dddd-dddddddddddd')
-				.onCall(4).returns('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee')
-				.onCall(5).returns('ffffffff-ffff-ffff-ffff-ffffffffffff');
+				.onCall(3).returns('dddddddd-dddd-dddd-dddd-dddddddddddd');
 			const instance = {
 				playtext: {
 					characters: [
@@ -545,7 +576,7 @@ describe('Prepare As Params module', () => {
 				}
 			};
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.callCount).to.equal(6);
+			expect(stubs.uuid.callCount).to.equal(4);
 			expect(stubs.neo4jInt.callCount).to.equal(6);
 			expect(result.playtext.characters[0].uuid).to.equal(result.playtext.characters[3].uuid);
 			expect(result.playtext.characters[1].uuid).to.equal(result.playtext.characters[4].uuid);
@@ -628,7 +659,7 @@ describe('Prepare As Params module', () => {
 
 				const instance = { cast: [{ roles: [{ uuid: '' }, { uuid: '' }] }] };
 				const result = prepareAsParams(instance);
-				expect(stubs.uuid.calledTwice).to.be.true;
+				expect(stubs.uuid.calledOnce).to.be.true;
 				expect(stubs.neo4jInt.calledTwice).to.be.true;
 				expect((stubs.neo4jInt.getCall(0)).calledWithExactly(0)).to.be.true;
 				expect((stubs.neo4jInt.getCall(1)).calledWithExactly(1)).to.be.true;
@@ -658,7 +689,7 @@ describe('Prepare As Params module', () => {
 
 		});
 
-		context('object is in writerGroups array where items are permitted an empty string name value', () => {
+		context('object is in array (e.g. writerGroups, characterGroups) where items are permitted an empty string name value', () => {
 
 			it('does not filter out objects that have a name attribute which is an empty string', () => {
 
@@ -668,13 +699,17 @@ describe('Prepare As Params module', () => {
 							writerGroups: [
 								{ name: '', writers: [{ name: 'Henrik Ibsen' }] },
 								{ name: 'version by', writers: [{ name: 'David Eldridge' }] }
+							],
+							characterGroups: [
+								{ name: 'The Borkmans', characters: [{ name: 'John Gabriel Borkman' }] },
+								{ name: '', characters: [{ name: 'Malene' }] }
 							]
 						}
 					]
 				};
 				const result = prepareAsParams(instance);
 				expect(stubs.uuid.notCalled).to.be.true;
-				expect(stubs.neo4jInt.calledTwice).to.be.true;
+				expect(stubs.neo4jInt.callCount).to.equal(4);
 				expect(result.playtexts[0].writerGroups.length).to.equal(2);
 				expect(result.playtexts[0].writerGroups[0].name).to.be.null;
 				expect(result.playtexts[0].writerGroups[0]).to.have.property('position');
@@ -682,10 +717,17 @@ describe('Prepare As Params module', () => {
 				expect(result.playtexts[0].writerGroups[1].name).to.equal('version by');
 				expect(result.playtexts[0].writerGroups[1]).to.have.property('position');
 				expect(result.playtexts[0].writerGroups[1].position).to.equal(1);
+				expect(result.playtexts[0].characterGroups.length).to.equal(2);
+				expect(result.playtexts[0].characterGroups[0].name).to.equal('The Borkmans');
+				expect(result.playtexts[0].characterGroups[0]).to.have.property('position');
+				expect(result.playtexts[0].characterGroups[0].position).to.equal(0);
+				expect(result.playtexts[0].characterGroups[1].name).to.be.null;
+				expect(result.playtexts[0].characterGroups[1]).to.have.property('position');
+				expect(result.playtexts[0].characterGroups[1].position).to.equal(1);
 
 			});
 
-			it('filters out objects that do not have any non-empty string name writers', () => {
+			it('filters out objects that do not have any non-empty string name writers/characters', () => {
 
 				const instance = {
 					playtexts: [
@@ -694,6 +736,11 @@ describe('Prepare As Params module', () => {
 								{ name: '', writers: [{ name: '' }] },
 								{ name: 'version by', writers: [{ name: 'David Eldridge' }] },
 								{ name: 'translation by', writers: [{ name: '' }] }
+							],
+							characterGroups: [
+								{ name: '', characters: [{ name: '' }] },
+								{ name: 'The Borkmans', characters: [{ name: 'John Gabriel Borkman' }] },
+								{ name: 'The Foldals', characters: [{ name: '' }] }
 							]
 						}
 					]
@@ -704,20 +751,21 @@ describe('Prepare As Params module', () => {
 				expect(result.playtexts[0].writerGroups.length).to.equal(1);
 				expect(result.playtexts[0].writerGroups[0].name).to.equal('version by');
 				expect(result.playtexts[0].writerGroups[0]).to.not.have.property('position');
+				expect(result.playtexts[0].characterGroups.length).to.equal(1);
+				expect(result.playtexts[0].characterGroups[0].name).to.equal('The Borkmans');
+				expect(result.playtexts[0].characterGroups[0]).to.not.have.property('position');
 
 			});
 
 		});
 
-		it('applies the same uuid value to items that will need to share the same database entry', () => {
+		it('applies the same uuid value to items in the same array that will need to share the same database entry', () => {
 
 			stubs.uuid
 				.onFirstCall().returns('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
 				.onSecondCall().returns('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb')
 				.onThirdCall().returns('cccccccc-cccc-cccc-cccc-cccccccccccc')
-				.onCall(3).returns('dddddddd-dddd-dddd-dddd-dddddddddddd')
-				.onCall(4).returns('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee')
-				.onCall(5).returns('ffffffff-ffff-ffff-ffff-ffffffffffff');
+				.onCall(3).returns('dddddddd-dddd-dddd-dddd-dddddddddddd');
 			const instance = {
 				cast: [
 					{
@@ -733,11 +781,49 @@ describe('Prepare As Params module', () => {
 				]
 			};
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.callCount).to.equal(6);
+			expect(stubs.uuid.callCount).to.equal(4);
 			expect(stubs.neo4jInt.callCount).to.equal(6);
 			expect(result.cast[0].roles[0].uuid).to.equal(result.cast[0].roles[3].uuid);
 			expect(result.cast[0].roles[1].uuid).to.equal(result.cast[0].roles[4].uuid);
 			expect(result.cast[0].roles[2].uuid).not.to.equal(result.cast[0].roles[5].uuid);
+
+		});
+
+		it('applies the same uuid value to items in different arrays that will need to share the same database entry', () => {
+
+			stubs.uuid
+				.onFirstCall().returns('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+				.onSecondCall().returns('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb')
+				.onThirdCall().returns('cccccccc-cccc-cccc-cccc-cccccccccccc')
+				.onCall(3).returns('dddddddd-dddd-dddd-dddd-dddddddddddd');
+			const instance = {
+				characterGroups: [
+					{
+						model: 'characterGroup',
+						name: 'Montagues',
+						characters: [
+							{ model: 'character', uuid: '', name: 'Foo', underlyingName: '', differentiator: '', qualifier: '' },
+							{ model: 'character', uuid: '', name: 'Bar', underlyingName: '', differentiator: '', qualifier: '' },
+							{ model: 'character', uuid: '', name: 'Baz', underlyingName: '', differentiator: '', qualifier: '' }
+						]
+					},
+					{
+						model: 'characterGroup',
+						name: 'Capulets',
+						characters: [
+							{ model: 'character', uuid: '', name: 'Foo', underlyingName: '', differentiator: '', qualifier: '' },
+							{ model: 'character', uuid: '', name: 'Bar', underlyingName: '', differentiator: '', qualifier: '' },
+							{ model: 'character', uuid: '', name: 'Baz', underlyingName: '', differentiator: '1', qualifier: '' }
+						]
+					}
+				]
+			};
+			const result = prepareAsParams(instance);
+			expect(stubs.uuid.callCount).to.equal(4);
+			expect(stubs.neo4jInt.callCount).to.equal(8);
+			expect(result.characterGroups[0].characters[0].uuid).to.equal(result.characterGroups[1].characters[0].uuid);
+			expect(result.characterGroups[0].characters[1].uuid).to.equal(result.characterGroups[1].characters[1].uuid);
+			expect(result.characterGroups[0].characters[2].uuid).not.to.equal(result.characterGroups[1].characters[2].uuid);
 
 		});
 

--- a/test-unit/src/models/Character.test.js
+++ b/test-unit/src/models/Character.test.js
@@ -168,67 +168,6 @@ describe('Character model', () => {
 
 		});
 
-		describe('group property', () => {
-
-			context('instance is subject', () => {
-
-				it('will not assign any value if absent from props', () => {
-
-					const instance = new Character({ name: 'Tamora' });
-					expect(instance).not.to.have.property('group');
-
-				});
-
-				it('will not assign any value if included in props', () => {
-
-					const instance = new Character({ name: 'Tamora', group: 'Goths' });
-					expect(instance).not.to.have.property('group');
-
-				});
-
-			});
-
-			context('instance is not subject, i.e. it is an association of another instance', () => {
-
-				it('assigns empty string if absent from props', () => {
-
-					const instance = new Character({ name: 'Tamora', isAssociation: true });
-					expect(instance.group).to.equal('');
-
-				});
-
-				it('assigns empty string if included in props but value is empty string', () => {
-
-					const instance = new Character({ name: 'Tamora', group: '', isAssociation: true });
-					expect(instance.group).to.equal('');
-
-				});
-
-				it('assigns empty string if included in props but value is whitespace-only string', () => {
-
-					const instance = new Character({ name: 'Tamora', group: ' ', isAssociation: true });
-					expect(instance.group).to.equal('');
-
-				});
-
-				it('assigns value if included in props and value is string with length', () => {
-
-					const instance = new Character({ name: 'Tamora', group: 'Goths', isAssociation: true });
-					expect(instance.group).to.equal('Goths');
-
-				});
-
-				it('trims value before assigning', () => {
-
-					const instance = new Character({ name: 'Tamora', group: ' Goths ', isAssociation: true });
-					expect(instance.group).to.equal('Goths');
-
-				});
-
-			});
-
-		});
-
 	});
 
 	describe('validateUnderlyingName method', () => {
@@ -242,20 +181,6 @@ describe('Character model', () => {
 			expect(instance.validateStringForProperty.calledWithExactly(
 				'underlyingName', { isRequired: false }
 			)).to.be.true;
-
-		});
-
-	});
-
-	describe('validateGroup method', () => {
-
-		it('will call validateStringForProperty method', () => {
-
-			const instance = new Character({ name: 'Bottom', group: 'The Mechanicals', isAssociation: true });
-			spy(instance, 'validateStringForProperty');
-			instance.validateGroup();
-			expect(instance.validateStringForProperty.calledOnce).to.be.true;
-			expect(instance.validateStringForProperty.calledWithExactly('group', { isRequired: false })).to.be.true;
 
 		});
 

--- a/test-unit/src/models/CharacterGroup.test.js
+++ b/test-unit/src/models/CharacterGroup.test.js
@@ -1,0 +1,135 @@
+import { expect } from 'chai';
+import proxyquire from 'proxyquire';
+import { assert, createStubInstance, spy, stub } from 'sinon';
+
+import { Character } from '../../../src/models';
+
+describe('CharacterGroup model', () => {
+
+	let stubs;
+
+	const CharacterStub = function () {
+
+		return createStubInstance(Character);
+
+	};
+
+	beforeEach(() => {
+
+		stubs = {
+			getDuplicateCharacterIndicesModule: {
+				getDuplicateCharacterIndices: stub().returns([])
+			},
+			models: {
+				Character: CharacterStub
+			}
+		};
+
+	});
+
+	const createSubject = () =>
+		proxyquire('../../../src/models/CharacterGroup', {
+			'../lib/get-duplicate-character-indices': stubs.getDuplicateCharacterIndicesModule,
+			'.': stubs.models
+		}).default;
+
+	const createInstance = props => {
+
+		const CharacterGroup = createSubject();
+
+		return new CharacterGroup(props);
+
+	};
+
+	describe('constructor method', () => {
+
+		describe('character property', () => {
+
+			it('assigns empty array if absent from props', () => {
+
+				const instance = createInstance({ name: 'Montagues' });
+				expect(instance.characters).to.deep.equal([]);
+
+			});
+
+			it('assigns array of characters if included in props, retaining those with empty or whitespace-only string names', () => {
+
+				const props = {
+					name: 'Montagues',
+					characters: [
+						{
+							name: 'Romeo'
+						},
+						{
+							name: ''
+						},
+						{
+							name: ' '
+						}
+					]
+				};
+				const instance = createInstance(props);
+				expect(instance.characters.length).to.equal(3);
+				expect(instance.characters[0] instanceof Character).to.be.true;
+				expect(instance.characters[1] instanceof Character).to.be.true;
+				expect(instance.characters[2] instanceof Character).to.be.true;
+
+			});
+
+		});
+
+	});
+
+	describe('runInputValidations method', () => {
+
+		it('calls instance validate method and associated models\' validate methods', () => {
+
+			const props = {
+				name: 'Montagues',
+				characters: [
+					{
+						name: 'Romeo'
+					}
+				]
+			};
+			const instance = createInstance(props);
+			spy(instance, 'validateName');
+			spy(instance, 'validateUniquenessInGroup');
+			instance.runInputValidations({ isDuplicate: false });
+			assert.callOrder(
+				instance.validateName,
+				instance.validateUniquenessInGroup,
+				stubs.getDuplicateCharacterIndicesModule.getDuplicateCharacterIndices,
+				instance.characters[0].validateName,
+				instance.characters[0].validateUnderlyingName,
+				instance.characters[0].validateDifferentiator,
+				instance.characters[0].validateQualifier,
+				instance.characters[0].validateCharacterNameUnderlyingNameDisparity,
+				instance.characters[0].validateUniquenessInGroup
+			);
+			expect(instance.validateName.calledOnce).to.be.true;
+			expect(instance.validateName.calledWithExactly({ isRequired: false })).to.be.true;
+			expect(stubs.getDuplicateCharacterIndicesModule.getDuplicateCharacterIndices.calledOnce).to.be.true;
+			expect(stubs.getDuplicateCharacterIndicesModule.getDuplicateCharacterIndices.calledWithExactly(
+				instance.characters
+			)).to.be.true;
+			expect(instance.characters[0].validateName.calledOnce).to.be.true;
+			expect(instance.characters[0].validateName.calledWithExactly({ isRequired: false })).to.be.true;
+			expect(instance.characters[0].validateUnderlyingName.calledOnce).to.be.true;
+			expect(instance.characters[0].validateUnderlyingName.calledWithExactly()).to.be.true;
+			expect(instance.characters[0].validateDifferentiator.calledOnce).to.be.true;
+			expect(instance.characters[0].validateDifferentiator.calledWithExactly()).to.be.true;
+			expect(instance.characters[0].validateQualifier.calledOnce).to.be.true;
+			expect(instance.characters[0].validateQualifier.calledWithExactly()).to.be.true;
+			expect(instance.characters[0].validateCharacterNameUnderlyingNameDisparity.calledOnce).to.be.true;
+			expect(instance.characters[0].validateCharacterNameUnderlyingNameDisparity.calledWithExactly()).to.be.true;
+			expect(instance.characters[0].validateUniquenessInGroup.calledOnce).to.be.true;
+			expect(instance.characters[0].validateUniquenessInGroup.calledWithExactly(
+				{ isDuplicate: false }
+			)).to.be.true;
+
+		});
+
+	});
+
+});

--- a/test-unit/src/models/Playtext.test.js
+++ b/test-unit/src/models/Playtext.test.js
@@ -2,15 +2,15 @@ import { expect } from 'chai';
 import proxyquire from 'proxyquire';
 import { assert, createStubInstance, spy, stub } from 'sinon';
 
-import { Character, WriterGroup } from '../../../src/models';
+import { CharacterGroup, WriterGroup } from '../../../src/models';
 
 describe('Playtext model', () => {
 
 	let stubs;
 
-	const CharacterStub = function () {
+	const CharacterGroupStub = function () {
 
-		return createStubInstance(Character);
+		return createStubInstance(CharacterGroup);
 
 	};
 
@@ -26,11 +26,8 @@ describe('Playtext model', () => {
 			getDuplicateBaseInstanceIndicesModule: {
 				getDuplicateBaseInstanceIndices: stub().returns([])
 			},
-			getDuplicateCharacterIndicesModule: {
-				getDuplicateCharacterIndices: stub().returns([])
-			},
 			models: {
-				Character: CharacterStub,
+				CharacterGroup: CharacterGroupStub,
 				WriterGroup: WriterGroupStub
 			}
 		};
@@ -40,7 +37,6 @@ describe('Playtext model', () => {
 	const createSubject = () =>
 		proxyquire('../../../src/models/Playtext', {
 			'../lib/get-duplicate-base-instance-indices': stubs.getDuplicateBaseInstanceIndicesModule,
-			'../lib/get-duplicate-character-indices': stubs.getDuplicateCharacterIndicesModule,
 			'.': stubs.models
 		}).default;
 
@@ -163,24 +159,24 @@ describe('Playtext model', () => {
 
 		});
 
-		describe('characters property', () => {
+		describe('characterGroups property', () => {
 
 			context('instance is subject', () => {
 
 				it('assigns empty array if absent from props', () => {
 
 					const instance = createInstance({ name: 'The Tragedy of Hamlet, Prince of Denmark' });
-					expect(instance.characters).to.deep.equal([]);
+					expect(instance.characterGroups).to.deep.equal([]);
 
 				});
 
-				it('assigns array of characters if included in props, retaining those with empty or whitespace-only string names', () => {
+				it('assigns array of characterGroups if included in props, retaining those with empty or whitespace-only string names', () => {
 
 					const props = {
 						name: 'The Tragedy of Hamlet, Prince of Denmark',
-						characters: [
+						characterGroups: [
 							{
-								name: 'Hamlet'
+								name: 'Court of Elsinore'
 							},
 							{
 								name: ''
@@ -191,10 +187,10 @@ describe('Playtext model', () => {
 						]
 					};
 					const instance = createInstance(props);
-					expect(instance.characters.length).to.equal(3);
-					expect(instance.characters[0] instanceof Character).to.be.true;
-					expect(instance.characters[1] instanceof Character).to.be.true;
-					expect(instance.characters[2] instanceof Character).to.be.true;
+					expect(instance.characterGroups.length).to.equal(3);
+					expect(instance.characterGroups[0] instanceof CharacterGroup).to.be.true;
+					expect(instance.characterGroups[1] instanceof CharacterGroup).to.be.true;
+					expect(instance.characterGroups[2] instanceof CharacterGroup).to.be.true;
 
 				});
 
@@ -209,7 +205,7 @@ describe('Playtext model', () => {
 						isAssociation: true
 					};
 					const instance = createInstance(props);
-					expect(instance).not.to.have.property('characters');
+					expect(instance).not.to.have.property('characterGroups');
 
 				});
 
@@ -217,15 +213,15 @@ describe('Playtext model', () => {
 
 					const props = {
 						name: 'The Tragedy of Hamlet, Prince of Denmark',
-						characters: [
+						characterGroups: [
 							{
-								name: 'Hamlet'
+								name: 'Court of Elsinore'
 							}
 						],
 						isAssociation: true
 					};
 					const instance = createInstance(props);
-					expect(instance).not.to.have.property('characters');
+					expect(instance).not.to.have.property('characterGroups');
 
 				});
 
@@ -246,9 +242,9 @@ describe('Playtext model', () => {
 						name: 'version by'
 					}
 				],
-				characters: [
+				characterGroups: [
 					{
-						name: 'Hamlet'
+						name: 'Court of Elsinore'
 					}
 				]
 			};
@@ -261,43 +257,24 @@ describe('Playtext model', () => {
 				instance.validateDifferentiator,
 				stubs.getDuplicateBaseInstanceIndicesModule.getDuplicateBaseInstanceIndices,
 				instance.writerGroups[0].runInputValidations,
-				stubs.getDuplicateCharacterIndicesModule.getDuplicateCharacterIndices,
-				instance.characters[0].validateName,
-				instance.characters[0].validateUnderlyingName,
-				instance.characters[0].validateDifferentiator,
-				instance.characters[0].validateQualifier,
-				instance.characters[0].validateGroup,
-				instance.characters[0].validateCharacterNameUnderlyingNameDisparity,
-				instance.characters[0].validateUniquenessInGroup
+				stubs.getDuplicateBaseInstanceIndicesModule.getDuplicateBaseInstanceIndices,
+				instance.characterGroups[0].runInputValidations
 			);
 			expect(instance.validateName.calledOnce).to.be.true;
 			expect(instance.validateName.calledWithExactly({ isRequired: true })).to.be.true;
 			expect(instance.validateDifferentiator.calledOnce).to.be.true;
 			expect(instance.validateDifferentiator.calledWithExactly()).to.be.true;
-			expect(stubs.getDuplicateBaseInstanceIndicesModule.getDuplicateBaseInstanceIndices.calledOnce).to.be.true;
-			expect(stubs.getDuplicateBaseInstanceIndicesModule.getDuplicateBaseInstanceIndices.calledWithExactly(
-				instance.writerGroups
-			)).to.be.true;
+			expect(stubs.getDuplicateBaseInstanceIndicesModule.getDuplicateBaseInstanceIndices.calledTwice).to.be.true;
+			expect(stubs.getDuplicateBaseInstanceIndicesModule.getDuplicateBaseInstanceIndices
+				.firstCall.calledWithExactly(instance.writerGroups)
+			).to.be.true;
+			expect(stubs.getDuplicateBaseInstanceIndicesModule.getDuplicateBaseInstanceIndices
+				.secondCall.calledWithExactly(
+			instance.characterGroups)).to.be.true;
 			expect(instance.writerGroups[0].runInputValidations.calledOnce).to.be.true;
 			expect(instance.writerGroups[0].runInputValidations.calledWithExactly({ isDuplicate: false })).to.be.true;
-			expect(stubs.getDuplicateCharacterIndicesModule.getDuplicateCharacterIndices.calledOnce).to.be.true;
-			expect(stubs.getDuplicateCharacterIndicesModule.getDuplicateCharacterIndices.calledWithExactly(
-				instance.characters
-			)).to.be.true;
-			expect(instance.characters[0].validateName.calledOnce).to.be.true;
-			expect(instance.characters[0].validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.characters[0].validateUnderlyingName.calledOnce).to.be.true;
-			expect(instance.characters[0].validateUnderlyingName.calledWithExactly()).to.be.true;
-			expect(instance.characters[0].validateDifferentiator.calledOnce).to.be.true;
-			expect(instance.characters[0].validateDifferentiator.calledWithExactly()).to.be.true;
-			expect(instance.characters[0].validateQualifier.calledOnce).to.be.true;
-			expect(instance.characters[0].validateQualifier.calledWithExactly()).to.be.true;
-			expect(instance.characters[0].validateGroup.calledOnce).to.be.true;
-			expect(instance.characters[0].validateGroup.calledWithExactly()).to.be.true;
-			expect(instance.characters[0].validateCharacterNameUnderlyingNameDisparity.calledOnce).to.be.true;
-			expect(instance.characters[0].validateCharacterNameUnderlyingNameDisparity.calledWithExactly()).to.be.true;
-			expect(instance.characters[0].validateUniquenessInGroup.calledOnce).to.be.true;
-			expect(instance.characters[0].validateUniquenessInGroup.calledWithExactly(
+			expect(instance.characterGroups[0].runInputValidations.calledOnce).to.be.true;
+			expect(instance.characterGroups[0].runInputValidations.calledWithExactly(
 				{ isDuplicate: false }
 			)).to.be.true;
 


### PR DESCRIPTION
The equivalent PR for character grouping as https://github.com/andygout/theatrebase-api/pull/288 was for writer grouping.

#### Before
```js
"characters": [
	{
		"name": "Hamlet"
	}
]
```

```js
"characters": [
	{
		"name": "Julius Caesar"
	},
	{
		"name": "Octavius Caesar",
		"group": "Triumvirs after Caesar's death"
	},
	{
		"name": "Mark Antony",
		"group": "Triumvirs after Caesar's death"
	},
	{
		"name": "Marcus Brutus",
		"group": "Conspirators against Caesar"
	}
]
```

---

#### After
```js
"characterGroups": [
	{
		"characters": [
			{
				"name": "Hamlet"
			}
		]
	}
]
```

```js
"characterGroups": [
	{
		"characters": [
			{
				"name": "Julius Caesar"
			}
		]
	},
	{
		"name": "Triumvirs after Caesar's death",
		"characters": [
			{
				"name": "Octavius Caesar"
			},
			{
				"name": "Mark Antony"
			}
		]
	},
	{
		"name": "Conspirators against Caesar",
		"characters": [
			{
				"name": "Marcus Brutus"
			}
		]
	}
]
```