### PR TITLE
Enable distinct nameless playtext character groups

### DIFF
--- a/db-seeding/seeds/playtexts/julius-caesar.json
+++ b/db-seeding/seeds/playtexts/julius-caesar.json
@@ -161,7 +161,6 @@
 			]
 		},
 		{
-			"name": "Other",
 			"characters": [
 				{
 					"name": "Servant to Julius Caesar"

--- a/src/neo4j/cypher-queries/playtext.js
+++ b/src/neo4j/cypher-queries/playtext.js
@@ -202,7 +202,11 @@ const getShowQuery = () => `
 	WITH playtext, writerGroups, characterRel, character
 		ORDER BY characterRel.groupPosition, characterRel.characterPosition
 
-	WITH playtext, writerGroups, characterRel.group AS characterGroup,
+	WITH
+		playtext,
+		writerGroups,
+		characterRel.group AS characterGroup,
+		characterRel.groupPosition AS characterGroupPosition,
 		COLLECT(
 			CASE character WHEN NULL
 				THEN null
@@ -222,6 +226,7 @@ const getShowQuery = () => `
 				ELSE {
 					model: 'characterGroup',
 					name: characterGroup,
+					position: characterGroupPosition,
 					characters: characters
 				}
 			END

--- a/test-e2e/crud/playtexts-api.test.js
+++ b/test-e2e/crud/playtexts-api.test.js
@@ -543,6 +543,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 					{
 						model: 'characterGroup',
 						name: 'The Borkmans',
+						position: null,
 						characters: [
 							{
 								model: 'character',
@@ -921,6 +922,7 @@ describe('CRUD (Create, Read, Update, Delete): Playtexts API', () => {
 					{
 						model: 'characterGroup',
 						name: 'The Prozorovs',
+						position: null,
 						characters: [
 							{
 								model: 'character',

--- a/test-e2e/model-interaction/char-diff-groups-same-playtext.test.js
+++ b/test-e2e/model-interaction/char-diff-groups-same-playtext.test.js
@@ -480,6 +480,10 @@ describe('Character with multiple appearances in the same playtext in different 
 				{
 					model: 'characterGroup',
 					name: '2011',
+					position: {
+						high: 0,
+						low: 0
+					},
 					characters: [
 						{
 							model: 'character',
@@ -498,6 +502,10 @@ describe('Character with multiple appearances in the same playtext in different 
 				{
 					model: 'characterGroup',
 					name: '1990',
+					position: {
+						high: 0,
+						low: 1
+					},
 					characters: [
 						{
 							model: 'character',
@@ -522,6 +530,10 @@ describe('Character with multiple appearances in the same playtext in different 
 				{
 					model: 'characterGroup',
 					name: '1945',
+					position: {
+						high: 0,
+						low: 2
+					},
 					characters: [
 						{
 							model: 'character',


### PR DESCRIPTION
There are some playtexts in which characters are grouped separately, but where neither of those groups has a name.

E.g. Julius Caesar (playtext) has Julius Caesar (character) in his own unnamed group at the start of the dramatis personae, then some other named groups (e.g. Triumvirs after Caesar's death, Conspirators against Caesar, Tribunes), and then concludes with a second unnamed group (of peripheral characters).

Rather than name the final group 'Other' purely as a measure to ensure the groups remain separate and in their designated position, this PR allows multiple unnamed character groups to behave in this way (i.e. does not collate all the characters from unnamed character groups into a single character group that takes the position of the the first of those unnamed groups).

#### Before
Julius Caesar is grouped with the servants, messenger, senators, soldiers, plebeians, and attendants.
![before](https://user-images.githubusercontent.com/10484515/99195985-42ce1a80-2781-11eb-982f-648d7ee9618e.png)

---

#### After
Julius Caesar has his own group that is distinct from the group that includes the servants, messenger, senators, soldiers, plebeians, and attendants.
![after](https://user-images.githubusercontent.com/10484515/99195986-45c90b00-2781-11eb-8c66-be5b201bad62.png)