### PR TITLE
Revise production edit Cypher query

### DIFF
--- a/src/neo4j/cypher-queries/production.js
+++ b/src/neo4j/cypher-queries/production.js
@@ -130,7 +130,7 @@ const getEditQuery = () => `
 					qualifier: CASE role.qualifier WHEN NULL THEN '' ELSE role.qualifier END
 				}
 			END
-		) + [{ name: '', characterName: '', characterDifferentiator: '', qualifier: '' }] AS roles
+		) + [{}] AS roles
 
 	RETURN
 		'production' AS model,

--- a/test-unit/src/neo4j/cypher-queries/production.test.js
+++ b/test-unit/src/neo4j/cypher-queries/production.test.js
@@ -117,7 +117,7 @@ describe('Cypher Queries Production module', () => {
 								qualifier: CASE role.qualifier WHEN NULL THEN '' ELSE role.qualifier END
 							}
 						END
-					) + [{ name: '', characterName: '', characterDifferentiator: '', qualifier: '' }] AS roles
+					) + [{}] AS roles
 
 				RETURN
 					'production' AS model,
@@ -263,7 +263,7 @@ describe('Cypher Queries Production module', () => {
 								qualifier: CASE role.qualifier WHEN NULL THEN '' ELSE role.qualifier END
 							}
 						END
-					) + [{ name: '', characterName: '', characterDifferentiator: '', qualifier: '' }] AS roles
+					) + [{}] AS roles
 
 				RETURN
 					'production' AS model,


### PR DESCRIPTION
The `name`, `characterName`, `characterDifferentiator`, and `qualifier` role attributes need not be included in the Cypher query as the Neo4j response is provided as props to instantiate a new production instance, and that instantiation process takes care of adding those attributes to each role. 