### PR TITLE
Add E2E tests for writer + character groups grouping

### DIFF
--- a/test-e2e/model-interaction/char-groups-grouping.test.js
+++ b/test-e2e/model-interaction/char-groups-grouping.test.js
@@ -1,0 +1,125 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import { createSandbox } from 'sinon';
+import { v4 as uuid } from 'uuid';
+
+import app from '../../src/app';
+import purgeDatabase from '../test-helpers/neo4j/purge-database';
+
+describe('Nameless character groups grouping', () => {
+
+	chai.use(chaiHttp);
+
+	const JULIUS_CAESAR_PLAYTEXT_UUID = '4';
+	const JULIUS_CAESAR_CHARACTER_UUID = '5';
+	const MARK_ANTONY_CHARACTER_UUID = '6';
+	const MESSENGER_CHARACTER_UUID = '7';
+
+	let juliusCaesarPlaytext;
+
+	const sandbox = createSandbox();
+
+	before(async () => {
+
+		let uuidCallCount = 0;
+
+		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+
+		await purgeDatabase();
+
+		await chai.request(app)
+			.post('/playtexts')
+			.send({
+				name: 'Julius Caesar',
+				characterGroups: [
+					{
+						characters: [
+							{
+								name: 'Julius Caesar'
+							}
+						]
+					},
+					{
+						name: 'Triumvirs after Caesar\'s death',
+						characters: [
+							{
+								name: 'Mark Antony'
+							}
+						]
+					},
+					{
+						characters: [
+							{
+								name: 'Messenger'
+							}
+						]
+					}
+				]
+			});
+
+		juliusCaesarPlaytext = await chai.request(app)
+			.get(`/playtexts/${JULIUS_CAESAR_PLAYTEXT_UUID}`);
+
+	});
+
+	after(() => {
+
+		sandbox.restore();
+
+	});
+
+	describe('Julius Caesar (playtext)', () => {
+
+		it('keeps nameless character groups as distinct groups', () => {
+
+			const expectedCharacterGroups = [
+				{
+					model: 'characterGroup',
+					name: null,
+					position: 0,
+					characters: [
+						{
+							model: 'character',
+							uuid: JULIUS_CAESAR_CHARACTER_UUID,
+							name: 'Julius Caesar',
+							qualifier: null
+						}
+					]
+				},
+				{
+					model: 'characterGroup',
+					name: 'Triumvirs after Caesar\'s death',
+					position: 1,
+					characters: [
+						{
+							model: 'character',
+							uuid: MARK_ANTONY_CHARACTER_UUID,
+							name: 'Mark Antony',
+							qualifier: null
+						}
+					]
+				},
+				{
+					model: 'characterGroup',
+					name: null,
+					position: 2,
+					characters: [
+						{
+							model: 'character',
+							uuid: MESSENGER_CHARACTER_UUID,
+							name: 'Messenger',
+							qualifier: null
+						}
+					]
+				}
+			];
+
+			const { characterGroups } = juliusCaesarPlaytext.body;
+
+			expect(characterGroups).to.deep.equal(expectedCharacterGroups);
+
+		});
+
+	});
+
+});

--- a/test-e2e/model-interaction/wri-groups-grouping.test.js
+++ b/test-e2e/model-interaction/wri-groups-grouping.test.js
@@ -1,0 +1,113 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import { createSandbox } from 'sinon';
+import { v4 as uuid } from 'uuid';
+
+import app from '../../src/app';
+import purgeDatabase from '../test-helpers/neo4j/purge-database';
+
+describe('Nameless writer groups grouping', () => {
+
+	chai.use(chaiHttp);
+
+	const PLAYTEXT_UUID = '4';
+	const PERSON_1_UUID = '5';
+	const PERSON_2_UUID = '6';
+	const PERSON_3_UUID = '7';
+
+	let playtext;
+
+	const sandbox = createSandbox();
+
+	before(async () => {
+
+		let uuidCallCount = 0;
+
+		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+
+		await purgeDatabase();
+
+		await chai.request(app)
+			.post('/playtexts')
+			.send({
+				name: 'Playtext name',
+				writerGroups: [
+					{
+						writers: [
+							{
+								name: 'Person #1'
+							}
+						]
+					},
+					{
+						name: 'version by',
+						writers: [
+							{
+								name: 'Person #2'
+							}
+						]
+					},
+					{
+						writers: [
+							{
+								name: 'Person #3'
+							}
+						]
+					}
+				]
+			});
+
+		playtext = await chai.request(app)
+			.get(`/playtexts/${PLAYTEXT_UUID}`);
+
+	});
+
+	after(() => {
+
+		sandbox.restore();
+
+	});
+
+	describe('Playtext', () => {
+
+		it('combines nameless writer groups into a single combined group (with a name of \'by\')', () => {
+
+			const expectedWriterGroups = [
+				{
+					model: 'writerGroup',
+					name: 'by',
+					writers: [
+						{
+							model: 'person',
+							uuid: PERSON_1_UUID,
+							name: 'Person #1'
+						},
+						{
+							model: 'person',
+							uuid: PERSON_3_UUID,
+							name: 'Person #3'
+						}
+					]
+				},
+				{
+					model: 'writerGroup',
+					name: 'version by',
+					writers: [
+						{
+							model: 'person',
+							uuid: PERSON_2_UUID,
+							name: 'Person #2'
+						}
+					]
+				}
+			];
+
+			const { writerGroups } = playtext.body;
+
+			expect(writerGroups).to.deep.equal(expectedWriterGroups);
+
+		});
+
+	});
+
+});


### PR DESCRIPTION
A couple of end-to-end tests to test the writer and character groups grouping.

The character groups grouping was revised in this PR https://github.com/andygout/theatrebase-api/pull/290/files so that multiple nameless groups remain distinct (the previous behaviour, which remains the case with writer groups, is to combine nameless groups).