### PR TITLE
Amend Cypher playtext create/update query

### DIFF
--- a/src/neo4j/cypher-queries/playtext.js
+++ b/src/neo4j/cypher-queries/playtext.js
@@ -45,8 +45,7 @@ const getCreateUpdateQuery = action => {
 						THEN {
 							uuid: writerParam.uuid,
 							name: writerParam.name,
-							differentiator: writerParam.differentiator,
-							group: writerGroupParam.name
+							differentiator: writerParam.differentiator
 						}
 						ELSE existingWriter
 					END AS writerProps
@@ -84,9 +83,7 @@ const getCreateUpdateQuery = action => {
 						THEN {
 							uuid: characterParam.uuid,
 							name: COALESCE(characterParam.underlyingName, characterParam.name),
-							differentiator: characterParam.differentiator,
-							qualifier: characterParam.qualifier,
-							group: characterGroupParam.name
+							differentiator: characterParam.differentiator
 						}
 						ELSE existingCharacter
 					END AS characterProps

--- a/test-unit/src/neo4j/cypher-queries/playtext.test.js
+++ b/test-unit/src/neo4j/cypher-queries/playtext.test.js
@@ -32,8 +32,7 @@ describe('Cypher Queries Playtext module', () => {
 								THEN {
 									uuid: writerParam.uuid,
 									name: writerParam.name,
-									differentiator: writerParam.differentiator,
-									group: writerGroupParam.name
+									differentiator: writerParam.differentiator
 								}
 								ELSE existingWriter
 							END AS writerProps
@@ -71,9 +70,7 @@ describe('Cypher Queries Playtext module', () => {
 								THEN {
 									uuid: characterParam.uuid,
 									name: COALESCE(characterParam.underlyingName, characterParam.name),
-									differentiator: characterParam.differentiator,
-									qualifier: characterParam.qualifier,
-									group: characterGroupParam.name
+									differentiator: characterParam.differentiator
 								}
 								ELSE existingCharacter
 							END AS characterProps
@@ -197,8 +194,7 @@ describe('Cypher Queries Playtext module', () => {
 								THEN {
 									uuid: writerParam.uuid,
 									name: writerParam.name,
-									differentiator: writerParam.differentiator,
-									group: writerGroupParam.name
+									differentiator: writerParam.differentiator
 								}
 								ELSE existingWriter
 							END AS writerProps
@@ -236,9 +232,7 @@ describe('Cypher Queries Playtext module', () => {
 								THEN {
 									uuid: characterParam.uuid,
 									name: COALESCE(characterParam.underlyingName, characterParam.name),
-									differentiator: characterParam.differentiator,
-									qualifier: characterParam.qualifier,
-									group: characterGroupParam.name
+									differentiator: characterParam.differentiator
 								}
 								ELSE existingCharacter
 							END AS characterProps


### PR DESCRIPTION
Some unused properties are being assigned to `writerProps` and `characterProps`; where required, the values are sourced from separate params.

This PR removes the unused properties.