### PR TITLE
Fix character variant named portrayals

### DIFF
--- a/src/neo4j/cypher-queries/character.js
+++ b/src/neo4j/cypher-queries/character.js
@@ -69,7 +69,6 @@ const getShowQuery = () => `
 			character.name <> variantNamedPortrayal.roleName AND
 			(
 				character.name = variantNamedPortrayal.characterName OR
-				depictionForVariantNamedPortrayal.displayName = variantNamedPortrayal.roleName OR
 				depictionForVariantNamedPortrayal.displayName = variantNamedPortrayal.characterName
 			)
 

--- a/test-e2e/model-interaction/char-with-variant-depiction-portrayal-names.test.js
+++ b/test-e2e/model-interaction/char-with-variant-depiction-portrayal-names.test.js
@@ -161,8 +161,7 @@ describe('Character with variant depiction and portrayal names', () => {
 						name: 'Alex Hassell',
 						roles: [
 							{
-								name: 'Harry',
-								characterName: 'Henry, Prince of Wales'
+								name: 'Henry, Prince of Wales'
 							},
 							{
 								name: 'Messenger'
@@ -481,12 +480,14 @@ describe('Character with variant depiction and portrayal names', () => {
 		// Even though 'Prince Hal' already appears in the variant depiction names (i.e. variant names from playtexts),
 		// it still appears here because the corresponding portrayal was of the character from a playtext (Henry IV, Part 1)
 		// in which neither the underlying nor display name matches the role name used for the portrayal.
+		// 'Henry, Prince of Wales' does not appear in this list because the portrayal
+		// was in a production of the playtext that used this name as the display name for King Henry V,
+		// and so this name instead only appears under variant depiction names.
 		it('includes distinct variant named portrayals (i.e. portrayals in productions with names different to that in playtext)', () => {
 
 			const expectedVariantNamedPortrayals = [
 				'Hal',
 				'Hal, Prince of England',
-				'Harry',
 				'Henry V',
 				'Henry V, King of England',
 				'Prince Hal'
@@ -544,7 +545,7 @@ describe('Character with variant depiction and portrayal names', () => {
 							model: 'person',
 							uuid: ALEX_HASSELL_PERSON_UUID,
 							name: 'Alex Hassell',
-							roleName: 'Harry',
+							roleName: 'Henry, Prince of Wales',
 							qualifier: null,
 							otherRoles: [
 								{
@@ -733,7 +734,7 @@ describe('Character with variant depiction and portrayal names', () => {
 								{
 									model: 'character',
 									uuid: KING_HENRY_V_CHARACTER_UUID,
-									name: 'Harry',
+									name: 'Henry, Prince of Wales',
 									qualifier: null
 								}
 							]
@@ -993,7 +994,7 @@ describe('Character with variant depiction and portrayal names', () => {
 
 	describe('Henry IV, Part 1 at Royal Shakespeare Theatre (production)', () => {
 
-		it('includes cast with Alex Hassell as Harry using the uuid value of King Henry V', () => {
+		it('includes cast with Alex Hassell as Henry, Prince of Wales using the uuid value of King Henry V', () => {
 
 			const expectedCast = [
 				{
@@ -1004,7 +1005,7 @@ describe('Character with variant depiction and portrayal names', () => {
 						{
 							model: 'character',
 							uuid: KING_HENRY_V_CHARACTER_UUID,
-							name: 'Harry',
+							name: 'Henry, Prince of Wales',
 							qualifier: null
 						},
 						{
@@ -1275,7 +1276,7 @@ describe('Character with variant depiction and portrayal names', () => {
 
 	describe('Alex Hassell (person)', () => {
 
-		it('includes productions of their portrayals of King Henry V under variant names (Harry; Hal; Henry V, King of England) but using its uuid value', () => {
+		it('includes productions of their portrayals of King Henry V under variant names (Henry, Prince of Wales; Hal; Henry V, King of England) but using its uuid value', () => {
 
 			const expectedProductions = [
 				{
@@ -1292,7 +1293,7 @@ describe('Character with variant depiction and portrayal names', () => {
 						{
 							model: 'character',
 							uuid: KING_HENRY_V_CHARACTER_UUID,
-							name: 'Harry',
+							name: 'Henry, Prince of Wales',
 							qualifier: null
 						},
 						{


### PR DESCRIPTION
This issue was noticed when I added some data to the development database:

- The Seagull by Anton Chekhov (playtext) (original version)
  - Includes character: Konstantin Gavrilovich Treplev
- The Seagull by Anton Chekhov; version by John Donnelly (playtext) (i.e. subsequent version)
  - Includes character: Konstantin
- The Seagull at Nuffield Theatre (production of the subsequent version of the playtext by John Donnelly)
  - Alexander Cobb portrays Konstantin (i.e. role name used is 'Konstantin' rather than 'Konstantin Gavrilovich Treplev').

<img width="1302" alt="neo4j-console" src="https://user-images.githubusercontent.com/10484515/99876993-c27d3e80-2bf2-11eb-9571-5b0db6a92783.png">

However, on the character page for Konstantin Gavrilovich Treplev, 'Konstantin' is displayed as a variant named portrayal, even though it was from a production of a playtext where the role name matched the display name.

This PR amends the character Cypher show query so that a portrayal role name matching the corresponding depiction display name is not considered a variant portrayal name.

#### Before
![before](https://user-images.githubusercontent.com/10484515/99877070-767ec980-2bf3-11eb-8c7a-358d88306fc1.png)

---

#### After
![after](https://user-images.githubusercontent.com/10484515/99877073-7a125080-2bf3-11eb-98c1-6a01ae22dc56.png)