### PR TITLE
Remove character constructor attribute ordering

### DIFF
--- a/src/models/Character.js
+++ b/src/models/Character.js
@@ -10,14 +10,14 @@ export default class Character extends Base {
 
 		this.model = 'character';
 		this.uuid = uuid;
-
-		// Property assignment order in contructor dictates order of fields in CMS form
-		// where `underlyingName` is desired directly after `name`.
-		if (isAssociation) this.underlyingName = underlyingName?.trim() || '';
-
 		this.differentiator = differentiator?.trim() || '';
 
-		if (isAssociation) this.qualifier = qualifier?.trim() || '';
+		if (isAssociation) {
+
+			this.underlyingName = underlyingName?.trim() || '';
+			this.qualifier = qualifier?.trim() || '';
+
+		}
 
 	}
 


### PR DESCRIPTION
Now that the CMS form component dictates the order of the fields (see PR https://github.com/andygout/theatrebase-cms/pull/125), this no longer has to be done at a constructor level, and so this PR simplifies that logic and groups together all the attributes that only need to be applied if the character instance is an association (i.e. if the character is being added in the context of appearing in a playtext).