### PR TITLE
Fix theatre update Cypher query

### DIFF
--- a/src/neo4j/cypher-queries/theatre.js
+++ b/src/neo4j/cypher-queries/theatre.js
@@ -5,7 +5,7 @@ const getCreateUpdateQuery = action => {
 		update: `
 			MATCH (theatre:Theatre { uuid: $uuid })
 
-			OPTIONAL MATCH (theatre)-[relationship:INCLUDES_SUB_THEATRE]-(:Theatre)
+			OPTIONAL MATCH (theatre)-[relationship:INCLUDES_SUB_THEATRE]->(:Theatre)
 
 			DELETE relationship
 

--- a/test-unit/src/neo4j/cypher-queries/theatre.test.js
+++ b/test-unit/src/neo4j/cypher-queries/theatre.test.js
@@ -78,7 +78,7 @@ describe('Cypher Queries Theatre module', () => {
 			expect(removeExcessWhitespace(result)).to.equal(removeExcessWhitespace(`
 				MATCH (theatre:Theatre { uuid: $uuid })
 
-				OPTIONAL MATCH (theatre)-[relationship:INCLUDES_SUB_THEATRE]-(:Theatre)
+				OPTIONAL MATCH (theatre)-[relationship:INCLUDES_SUB_THEATRE]->(:Theatre)
 
 				DELETE relationship
 


### PR DESCRIPTION
As an example, Olivier Theatre is a sub-theatre of National Theatre. If Olivier Theatre was updated then the result would be that it would delete its relationship with its sur-theatre (National Theatre).

This PR fixes the Cypher query so that if a sub-theatre is updated then it will retain its relationship with its sur-theatre.

Future work is required to implement validations the prevent the following:
- theatre having sub-theatres that are sur-theatres
- theatre having sub-theatres that are already sub-theatres of other sur-theatres
- theatre having sub-theatres if it is already a sub-theatre itself