### PR TITLE
Add differentiator ordering clause to playtexts list Cypher query

### DIFF
--- a/src/neo4j/cypher-queries/playtext.js
+++ b/src/neo4j/cypher-queries/playtext.js
@@ -464,6 +464,9 @@ const getListQuery = () => `
 			END
 		) AS writers
 
+	WITH playtext, writerGroupName, writers
+		ORDER BY playtext.name, playtext.differentiator
+
 	RETURN
 		'playtext' AS model,
 		playtext.uuid AS uuid,
@@ -474,8 +477,6 @@ const getListQuery = () => `
 				ELSE { model: 'writerGroup', name: COALESCE(writerGroupName, 'by'), writers: writers }
 			END
 		) AS writerGroups
-
-	ORDER BY playtext.name
 
 	LIMIT 100
 `;

--- a/test-e2e/model-interaction/playtext-multi-versions-multi-wri-groups.test.js
+++ b/test-e2e/model-interaction/playtext-multi-versions-multi-wri-groups.test.js
@@ -958,6 +958,35 @@ describe('Playtexts with multiple versions and multiple writer groups', () => {
 				},
 				{
 					model: 'playtext',
+					uuid: PEER_GYNT_SUBSEQUENT_VERSION_1_PLAYTEXT_UUID,
+					name: 'Peer Gynt',
+					writerGroups: [
+						{
+							model: 'writerGroup',
+							name: 'by',
+							writers: [
+								{
+									model: 'person',
+									uuid: HENRIK_IBSEN_PERSON_UUID,
+									name: 'Henrik Ibsen'
+								}
+							]
+						},
+						{
+							model: 'writerGroup',
+							name: 'version by',
+							writers: [
+								{
+									model: 'person',
+									uuid: FRANK_MCGUINNESS_PERSON_UUID,
+									name: 'Frank McGuinness'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'playtext',
 					uuid: PEER_GYNT_SUBSEQUENT_VERSION_2_PLAYTEXT_UUID,
 					name: 'Peer Gynt',
 					writerGroups: [
@@ -996,35 +1025,6 @@ describe('Playtexts with multiple versions and multiple writer groups', () => {
 									model: 'person',
 									uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
 									name: 'Baltasar Kormákur'
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'playtext',
-					uuid: PEER_GYNT_SUBSEQUENT_VERSION_1_PLAYTEXT_UUID,
-					name: 'Peer Gynt',
-					writerGroups: [
-						{
-							model: 'writerGroup',
-							name: 'by',
-							writers: [
-								{
-									model: 'person',
-									uuid: HENRIK_IBSEN_PERSON_UUID,
-									name: 'Henrik Ibsen'
-								}
-							]
-						},
-						{
-							model: 'writerGroup',
-							name: 'version by',
-							writers: [
-								{
-									model: 'person',
-									uuid: FRANK_MCGUINNESS_PERSON_UUID,
-									name: 'Frank McGuinness'
 								}
 							]
 						}


### PR DESCRIPTION
One of the end-to-end tests (`/test-e2e/model-interection/playtext-multi-versions-multi-wri-groups.test.js`) tests the playtexts list Cypher query with playtexts that share the same name.

The test will sometimes fail because the ordering changes between tests because the playtexts are currently only ordered by name which allows for the possibility of randomness.

This PR applies a secondary ordering clause - the playtext differentiator - which will keep the ordering consistent.

In the future, the secondary ordering clause will be the year written, at which time the differentiator ordering clause can be removed.