### PR TITLE
Revise Cypher show queries

### DIFF
--- a/src/neo4j/cypher-queries/theatre.js
+++ b/src/neo4j/cypher-queries/theatre.js
@@ -88,6 +88,12 @@ const getShowQuery = () => `
 
 	OPTIONAL MATCH (surTheatre:Theatre)-[:INCLUDES_SUB_THEATRE]->(theatre)
 
+	WITH theatre,
+		CASE surTheatre WHEN NULL
+			THEN null
+			ELSE { model: 'theatre', uuid: surTheatre.uuid, name: surTheatre.name }
+		END AS surTheatre
+
 	OPTIONAL MATCH (theatre)-[subTheatreRel:INCLUDES_SUB_THEATRE]->(subTheatre:Theatre)
 
 	WITH theatre, surTheatre, subTheatre
@@ -118,10 +124,7 @@ const getShowQuery = () => `
 		theatre.uuid AS uuid,
 		theatre.name AS name,
 		theatre.differentiator AS differentiator,
-		CASE surTheatre WHEN NULL
-			THEN null
-			ELSE { model: 'theatre', uuid: surTheatre.uuid, name: surTheatre.name }
-		END AS surTheatre,
+		surTheatre,
 		subTheatres,
 		COLLECT(
 			CASE production WHEN NULL


### PR DESCRIPTION
This PR makes revisions to the production and theatre show Cypher queries so that objects are constructed earlier in the query so as to make the query's `RETURN` statement a lot simpler, i.e. essentially a list of the instance's attributes, save for attributes that need to be `COLLECT`ed and would require an additional `WITH` statement to prepare ahead of the `RETURN` statement.