### PR TITLE
Fix duplicate WRITTEN_BY/USES_SOURCE_MATERIAL relationship bug

### DIFF
--- a/src/neo4j/cypher-queries/material.js
+++ b/src/neo4j/cypher-queries/material.js
@@ -77,7 +77,7 @@ const getCreateUpdateQuery = action => {
 
 				OPTIONAL MATCH (existingWriter { name: writerParam.name })
 					WHERE
-						(existingWriter:Person OR existingWriter:Material) AND
+						(writerParam.model IN [label IN LABELS(existingWriter) | TOLOWER(label)]) AND
 						(writerParam.differentiator IS NULL AND existingWriter.differentiator IS NULL) OR
 						(writerParam.differentiator = existingWriter.differentiator)
 

--- a/test-unit/src/neo4j/cypher-queries/material.test.js
+++ b/test-unit/src/neo4j/cypher-queries/material.test.js
@@ -49,7 +49,7 @@ describe('Cypher Queries Material module', () => {
 
 						OPTIONAL MATCH (existingWriter { name: writerParam.name })
 							WHERE
-								(existingWriter:Person OR existingWriter:Material) AND
+								(writerParam.model IN [label IN LABELS(existingWriter) | TOLOWER(label)]) AND
 								(writerParam.differentiator IS NULL AND existingWriter.differentiator IS NULL) OR
 								(writerParam.differentiator = existingWriter.differentiator)
 
@@ -283,7 +283,7 @@ describe('Cypher Queries Material module', () => {
 
 						OPTIONAL MATCH (existingWriter { name: writerParam.name })
 							WHERE
-								(existingWriter:Person OR existingWriter:Material) AND
+								(writerParam.model IN [label IN LABELS(existingWriter) | TOLOWER(label)]) AND
 								(writerParam.differentiator IS NULL AND existingWriter.differentiator IS NULL) OR
 								(writerParam.differentiator = existingWriter.differentiator)
 


### PR DESCRIPTION
An interesting bug, created by doing the following via the CMS:
- create War Horse (novel)
- create War Horse (play) with War Horse (person) as writer (obviously in this context, War Horse would be intended as a source material but this mistake could easily result from forgetting to switch the model type radio button from the default `person` to `material`)
- edit War Horse (play) to amend its writing credits from War Horse (person) to War Horse (material)

This results in two `:USES_SOURCE_MATERIAL` relationships between the novel and play (it should only have one):

<img width="992" alt="Screenshot 2021-01-05 at 19 26 00" src="https://user-images.githubusercontent.com/10484515/103690183-3cdc0500-4f8c-11eb-84af-91e94ae03e4b.png">

---

The cause is this segment of the Material create/update Cypher query:
```
OPTIONAL MATCH (existingWriter { name: writerParam.name })
	WHERE
		(existingWriter:Person OR existingWriter:Material) AND
		(writerParam.differentiator IS NULL AND existingWriter.differentiator IS NULL) OR
		(writerParam.differentiator = existingWriter.differentiator)
```

Because both a person and a material called 'War Horse' exists (with the same differentiator value - in this case neither having one), this match returns two results (one for each) and the remainder of the `UNWIND` segment of the query runs for both of these rows.

Applying `DISTINCT` to the `WITH` clause will not reduce it to a single row because, quite rightly, the person called `War Horse` and the material called `War Horse` are distinct entities and will behave as such.

This solution is not ideal because the `MATCH` is not able to use a specific label (or labels) for its initial search, meaning it will search for all nodes with that `name` value regardless of their label and only scrutinise the resultant label values thereafter, which is very inefficient.

A future PR will revise this query further so that labels are employed as part of the initial search, and will likely require repeating query segments for `person` and `material` instances respectively.

N.B. It is not possible to dynamically apply labels to `MATCH` queries, e.g. `OPTIONAL MATCH (existingWriter:$label { name: writerParam.name })` without using APOC (Awesome Procedures On Cypher):
> The idea behind parametrized [sic] queries is to re-use (cache) execution plans. If a node label or a relationship type varies, the execution plan wouldn't be the same at all, thus ruining the usefulness of execution plan caching.

Ref. [Stack Overflow: In Neo4J, how to set the label as a parameter in a cypher query from Java?](https://stackoverflow.com/questions/24274364/in-neo4j-how-to-set-the-label-as-a-parameter-in-a-cypher-query-from-java#answer-24274528) (credit: [fbiville](https://stackoverflow.com/users/277128/fbiville)) - the comment is in response to a query about using Cypher with Java, but the same applies to Node.js, and is detailed in the Neo4j docs:

> Parameters cannot be used for the following constructs, as these form part of the query structure that is compiled into a query plan:
> - property keys; so, `MATCH (n) WHERE n.$param = 'something'` is invalid
> - relationship types
> - labels

#### References:
- [Stack Overflow: In Neo4J, how to set the label as a parameter in a cypher query from Java?](https://stackoverflow.com/questions/24274364/in-neo4j-how-to-set-the-label-as-a-parameter-in-a-cypher-query-from-java#answer-24274528)
- [Neo4j docs: Neo4j Cypher Manual / Syntax / Parameters](https://neo4j.com/docs/cypher-manual/current/syntax/parameters)