### PR TITLE
Refactor create/update Cypher queries

### DIFF
--- a/test-unit/src/neo4j/cypher-queries/material.test.js
+++ b/test-unit/src/neo4j/cypher-queries/material.test.js
@@ -20,35 +20,24 @@ describe('Cypher Queries Material module', () => {
 						($originalVersionMaterial.differentiator IS NULL AND existingOriginalVersionMaterial.differentiator IS NULL) OR
 						($originalVersionMaterial.differentiator = existingOriginalVersionMaterial.differentiator)
 
-				WITH
-					material,
-					CASE existingOriginalVersionMaterial WHEN NULL
-						THEN {
-							uuid: $originalVersionMaterial.uuid,
-							name: $originalVersionMaterial.name,
-							differentiator: $originalVersionMaterial.differentiator
-						}
-						ELSE existingOriginalVersionMaterial
-					END AS originalVersionMaterialProps
-
 				FOREACH (item IN CASE $originalVersionMaterial.name WHEN NULL THEN [] ELSE [1] END |
 					MERGE (originalVersionMaterial:Material {
-						uuid: originalVersionMaterialProps.uuid,
-						name: originalVersionMaterialProps.name
+						uuid: COALESCE(existingOriginalVersionMaterial.uuid, $originalVersionMaterial.uuid),
+						name: $originalVersionMaterial.name
 					})
-						ON CREATE SET originalVersionMaterial.differentiator = originalVersionMaterialProps.differentiator
+						ON CREATE SET originalVersionMaterial.differentiator = $originalVersionMaterial.differentiator
 
 					CREATE (material)-[:SUBSEQUENT_VERSION_OF]->(originalVersionMaterial)
 				)
 
 				WITH material
 
-				UNWIND (CASE $writerGroups WHEN [] THEN [{ writers: [] }] ELSE $writerGroups END) AS writerGroupParam
+				UNWIND (CASE $writerGroups WHEN [] THEN [{ writers: [] }] ELSE $writerGroups END) AS writerGroup
 
 					UNWIND
-						CASE SIZE([writer IN writerGroupParam.writers WHERE writer.model = 'person']) WHEN 0
+						CASE SIZE([writer IN writerGroup.writers WHERE writer.model = 'person']) WHEN 0
 							THEN [null]
-							ELSE [writer IN writerGroupParam.writers WHERE writer.model = 'person']
+							ELSE [writer IN writerGroup.writers WHERE writer.model = 'person']
 						END AS writerParam
 
 						OPTIONAL MATCH (existingWriter:Person { name: writerParam.name })
@@ -56,38 +45,28 @@ describe('Cypher Queries Material module', () => {
 								(writerParam.differentiator IS NULL AND existingWriter.differentiator IS NULL) OR
 								(writerParam.differentiator = existingWriter.differentiator)
 
-						WITH
-							material,
-							writerGroupParam,
-							writerParam,
-							CASE existingWriter WHEN NULL
-								THEN {
-									uuid: writerParam.uuid,
-									name: writerParam.name,
-									differentiator: writerParam.differentiator
-								}
-								ELSE existingWriter
-							END AS writerProps
-
 						FOREACH (item IN CASE WHEN writerParam IS NOT NULL AND writerParam.model = 'person' THEN [1] ELSE [] END |
-							MERGE (writer:Person { uuid: writerProps.uuid, name: writerProps.name })
-								ON CREATE SET writer.differentiator = writerProps.differentiator
+							MERGE (writer:Person {
+								uuid: COALESCE(existingWriter.uuid, writerParam.uuid),
+								name: writerParam.name
+							})
+								ON CREATE SET writer.differentiator = writerParam.differentiator
 
 							CREATE (material)-
 								[:WRITTEN_BY {
-									groupPosition: writerGroupParam.position,
+									groupPosition: writerGroup.position,
 									writerPosition: writerParam.position,
-									group: writerGroupParam.name,
-									isOriginalVersionWriter: writerGroupParam.isOriginalVersionWriter
+									group: writerGroup.name,
+									isOriginalVersionWriter: writerGroup.isOriginalVersionWriter
 								}]->(writer)
 						)
 
-					WITH DISTINCT material, writerGroupParam
+					WITH DISTINCT material, writerGroup
 
 					UNWIND
-						CASE SIZE([writer IN writerGroupParam.writers WHERE writer.model = 'material']) WHEN 0
+						CASE SIZE([writer IN writerGroup.writers WHERE writer.model = 'material']) WHEN 0
 							THEN [null]
-							ELSE [writer IN writerGroupParam.writers WHERE writer.model = 'material']
+							ELSE [writer IN writerGroup.writers WHERE writer.model = 'material']
 						END AS sourceMaterialParam
 
 						OPTIONAL MATCH (existingSourceMaterial:Material { name: sourceMaterialParam.name })
@@ -95,36 +74,26 @@ describe('Cypher Queries Material module', () => {
 								(sourceMaterialParam.differentiator IS NULL AND existingSourceMaterial.differentiator IS NULL) OR
 								(sourceMaterialParam.differentiator = existingSourceMaterial.differentiator)
 
-						WITH
-							material,
-							writerGroupParam,
-							sourceMaterialParam,
-							CASE existingSourceMaterial WHEN NULL
-								THEN {
-									uuid: sourceMaterialParam.uuid,
-									name: sourceMaterialParam.name,
-									differentiator: sourceMaterialParam.differentiator
-								}
-								ELSE existingSourceMaterial
-							END AS sourceMaterialProps
-
 						FOREACH (item IN CASE WHEN sourceMaterialParam IS NOT NULL AND sourceMaterialParam.model = 'material' THEN [1] ELSE [] END |
-							MERGE (sourceMaterial:Material { uuid: sourceMaterialProps.uuid, name: sourceMaterialProps.name })
-								ON CREATE SET sourceMaterial.differentiator = sourceMaterialProps.differentiator
+							MERGE (sourceMaterial:Material {
+								uuid: COALESCE(existingSourceMaterial.uuid, sourceMaterialParam.uuid),
+								name: sourceMaterialParam.name
+							})
+								ON CREATE SET sourceMaterial.differentiator = sourceMaterialParam.differentiator
 
 							CREATE (material)-
 								[:USES_SOURCE_MATERIAL {
-									groupPosition: writerGroupParam.position,
+									groupPosition: writerGroup.position,
 									writerPosition: sourceMaterialParam.position,
-									group: writerGroupParam.name
+									group: writerGroup.name
 								}]->(sourceMaterial)
 						)
 
 				WITH DISTINCT material
 
-				UNWIND (CASE $characterGroups WHEN [] THEN [{ characters: [] }] ELSE $characterGroups END) AS characterGroupParam
+				UNWIND (CASE $characterGroups WHEN [] THEN [{ characters: [] }] ELSE $characterGroups END) AS characterGroup
 
-					UNWIND (CASE characterGroupParam.characters WHEN [] THEN [null] ELSE characterGroupParam.characters END) AS characterParam
+					UNWIND (CASE characterGroup.characters WHEN [] THEN [null] ELSE characterGroup.characters END) AS characterParam
 
 						OPTIONAL MATCH (existingCharacter:Character {
 							name: COALESCE(characterParam.underlyingName, characterParam.name)
@@ -133,30 +102,20 @@ describe('Cypher Queries Material module', () => {
 								(characterParam.differentiator IS NULL AND existingCharacter.differentiator IS NULL) OR
 								(characterParam.differentiator = existingCharacter.differentiator)
 
-						WITH
-							material,
-							characterGroupParam,
-							characterParam,
-							CASE existingCharacter WHEN NULL
-								THEN {
-									uuid: characterParam.uuid,
-									name: COALESCE(characterParam.underlyingName, characterParam.name),
-									differentiator: characterParam.differentiator
-								}
-								ELSE existingCharacter
-							END AS characterProps
-
 						FOREACH (item IN CASE characterParam WHEN NULL THEN [] ELSE [1] END |
-							MERGE (character:Character { uuid: characterProps.uuid, name: characterProps.name })
-								ON CREATE SET character.differentiator = characterProps.differentiator
+							MERGE (character:Character {
+								uuid: COALESCE(existingCharacter.uuid, characterParam.uuid),
+								name: COALESCE(characterParam.underlyingName, characterParam.name)
+							})
+								ON CREATE SET character.differentiator = characterParam.differentiator
 
 							CREATE (material)-
 								[:INCLUDES_CHARACTER {
-									groupPosition: characterGroupParam.position,
+									groupPosition: characterGroup.position,
 									characterPosition: characterParam.position,
 									displayName: CASE characterParam.underlyingName WHEN NULL THEN null ELSE characterParam.name END,
 									qualifier: characterParam.qualifier,
-									group: characterGroupParam.name
+									group: characterGroup.name
 								}]->(character)
 						)
 
@@ -283,35 +242,24 @@ describe('Cypher Queries Material module', () => {
 						($originalVersionMaterial.differentiator IS NULL AND existingOriginalVersionMaterial.differentiator IS NULL) OR
 						($originalVersionMaterial.differentiator = existingOriginalVersionMaterial.differentiator)
 
-				WITH
-					material,
-					CASE existingOriginalVersionMaterial WHEN NULL
-						THEN {
-							uuid: $originalVersionMaterial.uuid,
-							name: $originalVersionMaterial.name,
-							differentiator: $originalVersionMaterial.differentiator
-						}
-						ELSE existingOriginalVersionMaterial
-					END AS originalVersionMaterialProps
-
 				FOREACH (item IN CASE $originalVersionMaterial.name WHEN NULL THEN [] ELSE [1] END |
 					MERGE (originalVersionMaterial:Material {
-						uuid: originalVersionMaterialProps.uuid,
-						name: originalVersionMaterialProps.name
+						uuid: COALESCE(existingOriginalVersionMaterial.uuid, $originalVersionMaterial.uuid),
+						name: $originalVersionMaterial.name
 					})
-						ON CREATE SET originalVersionMaterial.differentiator = originalVersionMaterialProps.differentiator
+						ON CREATE SET originalVersionMaterial.differentiator = $originalVersionMaterial.differentiator
 
 					CREATE (material)-[:SUBSEQUENT_VERSION_OF]->(originalVersionMaterial)
 				)
 
 				WITH material
 
-				UNWIND (CASE $writerGroups WHEN [] THEN [{ writers: [] }] ELSE $writerGroups END) AS writerGroupParam
+				UNWIND (CASE $writerGroups WHEN [] THEN [{ writers: [] }] ELSE $writerGroups END) AS writerGroup
 
 					UNWIND
-						CASE SIZE([writer IN writerGroupParam.writers WHERE writer.model = 'person']) WHEN 0
+						CASE SIZE([writer IN writerGroup.writers WHERE writer.model = 'person']) WHEN 0
 							THEN [null]
-							ELSE [writer IN writerGroupParam.writers WHERE writer.model = 'person']
+							ELSE [writer IN writerGroup.writers WHERE writer.model = 'person']
 						END AS writerParam
 
 						OPTIONAL MATCH (existingWriter:Person { name: writerParam.name })
@@ -319,38 +267,28 @@ describe('Cypher Queries Material module', () => {
 								(writerParam.differentiator IS NULL AND existingWriter.differentiator IS NULL) OR
 								(writerParam.differentiator = existingWriter.differentiator)
 
-						WITH
-							material,
-							writerGroupParam,
-							writerParam,
-							CASE existingWriter WHEN NULL
-								THEN {
-									uuid: writerParam.uuid,
-									name: writerParam.name,
-									differentiator: writerParam.differentiator
-								}
-								ELSE existingWriter
-							END AS writerProps
-
 						FOREACH (item IN CASE WHEN writerParam IS NOT NULL AND writerParam.model = 'person' THEN [1] ELSE [] END |
-							MERGE (writer:Person { uuid: writerProps.uuid, name: writerProps.name })
-								ON CREATE SET writer.differentiator = writerProps.differentiator
+							MERGE (writer:Person {
+								uuid: COALESCE(existingWriter.uuid, writerParam.uuid),
+								name: writerParam.name
+							})
+								ON CREATE SET writer.differentiator = writerParam.differentiator
 
 							CREATE (material)-
 								[:WRITTEN_BY {
-									groupPosition: writerGroupParam.position,
+									groupPosition: writerGroup.position,
 									writerPosition: writerParam.position,
-									group: writerGroupParam.name,
-									isOriginalVersionWriter: writerGroupParam.isOriginalVersionWriter
+									group: writerGroup.name,
+									isOriginalVersionWriter: writerGroup.isOriginalVersionWriter
 								}]->(writer)
 						)
 
-					WITH DISTINCT material, writerGroupParam
+					WITH DISTINCT material, writerGroup
 
 					UNWIND
-						CASE SIZE([writer IN writerGroupParam.writers WHERE writer.model = 'material']) WHEN 0
+						CASE SIZE([writer IN writerGroup.writers WHERE writer.model = 'material']) WHEN 0
 							THEN [null]
-							ELSE [writer IN writerGroupParam.writers WHERE writer.model = 'material']
+							ELSE [writer IN writerGroup.writers WHERE writer.model = 'material']
 						END AS sourceMaterialParam
 
 						OPTIONAL MATCH (existingSourceMaterial:Material { name: sourceMaterialParam.name })
@@ -358,36 +296,26 @@ describe('Cypher Queries Material module', () => {
 								(sourceMaterialParam.differentiator IS NULL AND existingSourceMaterial.differentiator IS NULL) OR
 								(sourceMaterialParam.differentiator = existingSourceMaterial.differentiator)
 
-						WITH
-							material,
-							writerGroupParam,
-							sourceMaterialParam,
-							CASE existingSourceMaterial WHEN NULL
-								THEN {
-									uuid: sourceMaterialParam.uuid,
-									name: sourceMaterialParam.name,
-									differentiator: sourceMaterialParam.differentiator
-								}
-								ELSE existingSourceMaterial
-							END AS sourceMaterialProps
-
 						FOREACH (item IN CASE WHEN sourceMaterialParam IS NOT NULL AND sourceMaterialParam.model = 'material' THEN [1] ELSE [] END |
-							MERGE (sourceMaterial:Material { uuid: sourceMaterialProps.uuid, name: sourceMaterialProps.name })
-								ON CREATE SET sourceMaterial.differentiator = sourceMaterialProps.differentiator
+							MERGE (sourceMaterial:Material {
+								uuid: COALESCE(existingSourceMaterial.uuid, sourceMaterialParam.uuid),
+								name: sourceMaterialParam.name
+							})
+								ON CREATE SET sourceMaterial.differentiator = sourceMaterialParam.differentiator
 
 							CREATE (material)-
 								[:USES_SOURCE_MATERIAL {
-									groupPosition: writerGroupParam.position,
+									groupPosition: writerGroup.position,
 									writerPosition: sourceMaterialParam.position,
-									group: writerGroupParam.name
+									group: writerGroup.name
 								}]->(sourceMaterial)
 						)
 
 				WITH DISTINCT material
 
-				UNWIND (CASE $characterGroups WHEN [] THEN [{ characters: [] }] ELSE $characterGroups END) AS characterGroupParam
+				UNWIND (CASE $characterGroups WHEN [] THEN [{ characters: [] }] ELSE $characterGroups END) AS characterGroup
 
-					UNWIND (CASE characterGroupParam.characters WHEN [] THEN [null] ELSE characterGroupParam.characters END) AS characterParam
+					UNWIND (CASE characterGroup.characters WHEN [] THEN [null] ELSE characterGroup.characters END) AS characterParam
 
 						OPTIONAL MATCH (existingCharacter:Character {
 							name: COALESCE(characterParam.underlyingName, characterParam.name)
@@ -396,30 +324,20 @@ describe('Cypher Queries Material module', () => {
 								(characterParam.differentiator IS NULL AND existingCharacter.differentiator IS NULL) OR
 								(characterParam.differentiator = existingCharacter.differentiator)
 
-						WITH
-							material,
-							characterGroupParam,
-							characterParam,
-							CASE existingCharacter WHEN NULL
-								THEN {
-									uuid: characterParam.uuid,
-									name: COALESCE(characterParam.underlyingName, characterParam.name),
-									differentiator: characterParam.differentiator
-								}
-								ELSE existingCharacter
-							END AS characterProps
-
 						FOREACH (item IN CASE characterParam WHEN NULL THEN [] ELSE [1] END |
-							MERGE (character:Character { uuid: characterProps.uuid, name: characterProps.name })
-								ON CREATE SET character.differentiator = characterProps.differentiator
+							MERGE (character:Character {
+								uuid: COALESCE(existingCharacter.uuid, characterParam.uuid),
+								name: COALESCE(characterParam.underlyingName, characterParam.name)
+							})
+								ON CREATE SET character.differentiator = characterParam.differentiator
 
 							CREATE (material)-
 								[:INCLUDES_CHARACTER {
-									groupPosition: characterGroupParam.position,
+									groupPosition: characterGroup.position,
 									characterPosition: characterParam.position,
 									displayName: CASE characterParam.underlyingName WHEN NULL THEN null ELSE characterParam.name END,
 									qualifier: characterParam.qualifier,
-									group: characterGroupParam.name
+									group: characterGroup.name
 								}]->(character)
 						)
 

--- a/test-unit/src/neo4j/cypher-queries/production.test.js
+++ b/test-unit/src/neo4j/cypher-queries/production.test.js
@@ -20,16 +20,12 @@ describe('Cypher Queries Production module', () => {
 						($material.differentiator IS NULL AND existingMaterial.differentiator IS NULL) OR
 						($material.differentiator = existingMaterial.differentiator)
 
-				WITH
-					production,
-					CASE existingMaterial WHEN NULL
-						THEN { uuid: $material.uuid, name: $material.name, differentiator: $material.differentiator }
-						ELSE existingMaterial
-					END AS materialProps
-
 				FOREACH (item IN CASE $material.name WHEN NULL THEN [] ELSE [1] END |
-					MERGE (material:Material { uuid: materialProps.uuid, name: materialProps.name })
-						ON CREATE SET material.differentiator = materialProps.differentiator
+					MERGE (material:Material {
+						uuid: COALESCE(existingMaterial.uuid, $material.uuid),
+						name: $material.name
+					})
+						ON CREATE SET material.differentiator = $material.differentiator
 
 					CREATE (production)-[:PRODUCTION_OF]->(material)
 				)
@@ -41,16 +37,12 @@ describe('Cypher Queries Production module', () => {
 						($theatre.differentiator IS NULL AND existingTheatre.differentiator IS NULL) OR
 						($theatre.differentiator = existingTheatre.differentiator)
 
-				WITH
-					production,
-					CASE existingTheatre WHEN NULL
-						THEN { uuid: $theatre.uuid, name: $theatre.name, differentiator: $theatre.differentiator }
-						ELSE existingTheatre
-					END AS theatreProps
-
 				FOREACH (item IN CASE $theatre.name WHEN NULL THEN [] ELSE [1] END |
-					MERGE (theatre:Theatre { uuid: theatreProps.uuid, name: theatreProps.name })
-						ON CREATE SET theatre.differentiator = theatreProps.differentiator
+					MERGE (theatre:Theatre {
+						uuid: COALESCE(existingTheatre.uuid, $theatre.uuid),
+						name: $theatre.name
+					})
+						ON CREATE SET theatre.differentiator = $theatre.differentiator
 
 					CREATE (production)-[:PLAYS_AT]->(theatre)
 				)
@@ -64,21 +56,12 @@ describe('Cypher Queries Production module', () => {
 							(castMemberParam.differentiator IS NULL AND existingPerson.differentiator IS NULL) OR
 							(castMemberParam.differentiator = existingPerson.differentiator)
 
-					WITH
-						production,
-						castMemberParam,
-						CASE existingPerson WHEN NULL
-							THEN {
-								uuid: castMemberParam.uuid,
-								name: castMemberParam.name,
-								differentiator: castMemberParam.differentiator
-							}
-							ELSE existingPerson
-						END AS castMemberProps
-
 					FOREACH (item IN CASE castMemberParam WHEN NULL THEN [] ELSE [1] END |
-						MERGE (person:Person { uuid: castMemberProps.uuid, name: castMemberProps.name })
-							ON CREATE SET person.differentiator = castMemberProps.differentiator
+						MERGE (castMember:Person {
+							uuid: COALESCE(existingPerson.uuid, castMemberParam.uuid),
+							name: castMemberParam.name
+						})
+							ON CREATE SET castMember.differentiator = castMemberParam.differentiator
 
 						FOREACH (role IN CASE castMemberParam.roles WHEN [] THEN [{}] ELSE castMemberParam.roles END |
 							CREATE (production)
@@ -89,7 +72,7 @@ describe('Cypher Queries Production module', () => {
 									characterName: role.characterName,
 									characterDifferentiator: role.characterDifferentiator,
 									qualifier: role.qualifier
-								}]-(person)
+								}]-(castMember)
 						)
 					)
 
@@ -166,16 +149,12 @@ describe('Cypher Queries Production module', () => {
 						($material.differentiator IS NULL AND existingMaterial.differentiator IS NULL) OR
 						($material.differentiator = existingMaterial.differentiator)
 
-				WITH
-					production,
-					CASE existingMaterial WHEN NULL
-						THEN { uuid: $material.uuid, name: $material.name, differentiator: $material.differentiator }
-						ELSE existingMaterial
-					END AS materialProps
-
 				FOREACH (item IN CASE $material.name WHEN NULL THEN [] ELSE [1] END |
-					MERGE (material:Material { uuid: materialProps.uuid, name: materialProps.name })
-						ON CREATE SET material.differentiator = materialProps.differentiator
+					MERGE (material:Material {
+						uuid: COALESCE(existingMaterial.uuid, $material.uuid),
+						name: $material.name
+					})
+						ON CREATE SET material.differentiator = $material.differentiator
 
 					CREATE (production)-[:PRODUCTION_OF]->(material)
 				)
@@ -187,16 +166,12 @@ describe('Cypher Queries Production module', () => {
 						($theatre.differentiator IS NULL AND existingTheatre.differentiator IS NULL) OR
 						($theatre.differentiator = existingTheatre.differentiator)
 
-				WITH
-					production,
-					CASE existingTheatre WHEN NULL
-						THEN { uuid: $theatre.uuid, name: $theatre.name, differentiator: $theatre.differentiator }
-						ELSE existingTheatre
-					END AS theatreProps
-
 				FOREACH (item IN CASE $theatre.name WHEN NULL THEN [] ELSE [1] END |
-					MERGE (theatre:Theatre { uuid: theatreProps.uuid, name: theatreProps.name })
-						ON CREATE SET theatre.differentiator = theatreProps.differentiator
+					MERGE (theatre:Theatre {
+						uuid: COALESCE(existingTheatre.uuid, $theatre.uuid),
+						name: $theatre.name
+					})
+						ON CREATE SET theatre.differentiator = $theatre.differentiator
 
 					CREATE (production)-[:PLAYS_AT]->(theatre)
 				)
@@ -210,21 +185,12 @@ describe('Cypher Queries Production module', () => {
 							(castMemberParam.differentiator IS NULL AND existingPerson.differentiator IS NULL) OR
 							(castMemberParam.differentiator = existingPerson.differentiator)
 
-					WITH
-						production,
-						castMemberParam,
-						CASE existingPerson WHEN NULL
-							THEN {
-								uuid: castMemberParam.uuid,
-								name: castMemberParam.name,
-								differentiator: castMemberParam.differentiator
-							}
-							ELSE existingPerson
-						END AS castMemberProps
-
 					FOREACH (item IN CASE castMemberParam WHEN NULL THEN [] ELSE [1] END |
-						MERGE (person:Person { uuid: castMemberProps.uuid, name: castMemberProps.name })
-							ON CREATE SET person.differentiator = castMemberProps.differentiator
+						MERGE (castMember:Person {
+							uuid: COALESCE(existingPerson.uuid, castMemberParam.uuid),
+							name: castMemberParam.name
+						})
+							ON CREATE SET castMember.differentiator = castMemberParam.differentiator
 
 						FOREACH (role IN CASE castMemberParam.roles WHEN [] THEN [{}] ELSE castMemberParam.roles END |
 							CREATE (production)
@@ -235,7 +201,7 @@ describe('Cypher Queries Production module', () => {
 									characterName: role.characterName,
 									characterDifferentiator: role.characterDifferentiator,
 									qualifier: role.qualifier
-								}]-(person)
+								}]-(castMember)
 						)
 					)
 

--- a/test-unit/src/neo4j/cypher-queries/theatre.test.js
+++ b/test-unit/src/neo4j/cypher-queries/theatre.test.js
@@ -22,21 +22,12 @@ describe('Cypher Queries Theatre module', () => {
 							(subTheatreParam.differentiator IS NULL AND existingTheatre.differentiator IS NULL) OR
 							(subTheatreParam.differentiator = existingTheatre.differentiator)
 
-					WITH
-						theatre,
-						subTheatreParam,
-						CASE existingTheatre WHEN NULL
-							THEN {
-								uuid: subTheatreParam.uuid,
-								name: subTheatreParam.name,
-								differentiator: subTheatreParam.differentiator
-							}
-							ELSE existingTheatre
-						END AS subTheatreProps
-
 					FOREACH (item IN CASE subTheatreParam WHEN NULL THEN [] ELSE [1] END |
-						MERGE (subTheatre:Theatre { uuid: subTheatreProps.uuid, name: subTheatreProps.name })
-							ON CREATE SET subTheatre.differentiator = subTheatreProps.differentiator
+						MERGE (subTheatre:Theatre {
+							uuid: COALESCE(existingTheatre.uuid, subTheatreParam.uuid),
+							name: subTheatreParam.name
+						})
+							ON CREATE SET subTheatre.differentiator = subTheatreParam.differentiator
 
 						CREATE (theatre)-[:INCLUDES_SUB_THEATRE { position: subTheatreParam.position }]->(subTheatre)
 					)
@@ -97,21 +88,12 @@ describe('Cypher Queries Theatre module', () => {
 							(subTheatreParam.differentiator IS NULL AND existingTheatre.differentiator IS NULL) OR
 							(subTheatreParam.differentiator = existingTheatre.differentiator)
 
-					WITH
-						theatre,
-						subTheatreParam,
-						CASE existingTheatre WHEN NULL
-							THEN {
-								uuid: subTheatreParam.uuid,
-								name: subTheatreParam.name,
-								differentiator: subTheatreParam.differentiator
-							}
-							ELSE existingTheatre
-						END AS subTheatreProps
-
 					FOREACH (item IN CASE subTheatreParam WHEN NULL THEN [] ELSE [1] END |
-						MERGE (subTheatre:Theatre { uuid: subTheatreProps.uuid, name: subTheatreProps.name })
-							ON CREATE SET subTheatre.differentiator = subTheatreProps.differentiator
+						MERGE (subTheatre:Theatre {
+							uuid: COALESCE(existingTheatre.uuid, subTheatreParam.uuid),
+							name: subTheatreParam.name
+						})
+							ON CREATE SET subTheatre.differentiator = subTheatreParam.differentiator
 
 						CREATE (theatre)-[:INCLUDES_SUB_THEATRE { position: subTheatreParam.position }]->(subTheatre)
 					)


### PR DESCRIPTION
This PR refactors some of the create/update Cypher queries:

- removes intermediary `WITH` statement following the `OPTIONAL MATCH` search for an existing instance: only the `uuid` value of an existing instance is required as the match has been performed on the `name` and `differentiator` params, meaning those params can simply be re-used in the event of a match (and would be used in the event of a non-match anyway).
- use `COALESCE` function to assign `uuid` value by assigning that from the existing instance if available but otherwise from the params.
- shorten some param names by removing the suffixed `Param` where the remaining word is not already used as an identifier.