### PR TITLE
Create Neo4j indexes on name property

### DIFF
--- a/src/neo4j/create-constraints.js
+++ b/src/neo4j/create-constraints.js
@@ -21,7 +21,7 @@ const createConstraint = async model => {
 			{ isOptionalResult: true }
 		);
 
-		console.log(`Neo4j database: Constraint created for ${model}`); // eslint-disable-line no-console
+		console.log(`Neo4j database: Constraint on uuid property created for ${model}`); // eslint-disable-line no-console
 
 	} catch (error) {
 
@@ -42,9 +42,9 @@ export default async () => {
 			{ isOptionalResult: true, isArrayResult: true }
 		);
 
-		const modelsWithConstraints = constraints.map(constraint => constraint.description.match(/:(.*) \)/)[1]);
+		const modelsWithConstraint = constraints.map(constraint => constraint.description.match(/:(.*) \)/)[1]);
 
-		const modelsToConstrain = MODELS.filter(model => !modelsWithConstraints.includes(model));
+		const modelsToConstrain = MODELS.filter(model => !modelsWithConstraint.includes(model));
 
 		console.log('Neo4j database: Creating constraints…'); // eslint-disable-line no-console
 

--- a/src/neo4j/create-indexes.js
+++ b/src/neo4j/create-indexes.js
@@ -1,0 +1,73 @@
+import directly from 'directly';
+
+import { neo4jQuery } from './query';
+
+const MODELS = [
+	'Character',
+	'Material',
+	'Person',
+	'Theatre'
+];
+
+const createIndex = async model => {
+
+	const createIndexQuery = `CREATE INDEX ON :${model}(name)`;
+
+	try {
+
+		await neo4jQuery(
+			{ query: createIndexQuery },
+			{ isOptionalResult: true }
+		);
+
+		console.log(`Neo4j database: Index on name property created for ${model}`); // eslint-disable-line no-console
+
+	} catch (error) {
+
+		console.error(`Neo4j database: Error attempting query '${createIndexQuery}': `, error); // eslint-disable-line no-console
+
+	}
+
+};
+
+export default async () => {
+
+	const callDbIndexesQuery = 'CALL db.indexes()';
+
+	try {
+
+		const indexes = await neo4jQuery(
+			{ query: callDbIndexesQuery },
+			{ isOptionalResult: true, isArrayResult: true }
+		);
+
+		const modelsWithIndex =
+			indexes
+				.filter(index => index.properties.includes('name'))
+				.map(index => index.tokenNames[0]);
+
+		const modelsToIndex = MODELS.filter(model => !modelsWithIndex.includes(model));
+
+		console.log('Neo4j database: Creating indexes…'); // eslint-disable-line no-console
+
+		if (!modelsToIndex.length) {
+
+			console.log('Neo4j database: No indexes required'); // eslint-disable-line no-console
+
+			return;
+
+		}
+
+		const modelIndexFunctions = modelsToIndex.map(model => () => createIndex(model));
+
+		await directly(1, modelIndexFunctions);
+
+		console.log('Neo4j database: All indexes created'); // eslint-disable-line no-console
+
+	} catch (error) {
+
+		console.error(`Neo4j database: Error attempting query '${callDbIndexesQuery}': `, error); // eslint-disable-line no-console
+
+	}
+
+};

--- a/src/setup.js
+++ b/src/setup.js
@@ -1,6 +1,7 @@
 import './dotenv';
 
 import createNeo4jConstraints from './neo4j/create-constraints';
+import createNeo4jIndexes from './neo4j/create-indexes';
 import { getDriver as getNeo4jDriver } from './neo4j/get-driver';
 
 const neo4jDriver = getNeo4jDriver();
@@ -8,6 +9,8 @@ const neo4jDriver = getNeo4jDriver();
 (async () => {
 
 	await createNeo4jConstraints();
+
+	await createNeo4jIndexes();
 
 	await neo4jDriver.close();
 

--- a/test-e2e/setup.test.js
+++ b/test-e2e/setup.test.js
@@ -1,7 +1,10 @@
 import createNeo4jConstraints from '../src/neo4j/create-constraints';
+import createNeo4jIndexes from '../src/neo4j/create-indexes';
 
 before(async () => {
 
 	await createNeo4jConstraints();
+
+	await createNeo4jIndexes();
 
 });


### PR DESCRIPTION
The create/update Cypher queries perform a `MATCH` on the `name` property of some of the models (Character, Material, Person, Theatre; not yet Production, which may require a UUID lookup given the manifold factors that make it unique) to try and find an existing instance, e.g.:

```
OPTIONAL MATCH (existingMaterial:Material { name: $material.name })
	WHERE
		($material.differentiator IS NULL AND existingMaterial.differentiator IS NULL) OR
		($material.differentiator = existingMaterial.differentiator)
```

As the data grows, such queries will benefit from there being an index on the `name` property.

This PR adds functionality that will apply those indexes (if not yet in place) upon the server starting, as well as upon the E2E tests starting.

Some minor amends have also been applied to the `create-constraints.js` file for symmetry with the `create-indexes.js` one.

### References:
- [Neo4j News: Labels and Schema Indexes in Neo4j](https://neo4j.com/news/labels-and-schema-indexes-in-neo4j)