### PR TITLE
Revise Cypher query to return writing entities with model-applicable props only

### DIFF
--- a/src/neo4j/cypher-queries/character.js
+++ b/src/neo4j/cypher-queries/character.js
@@ -46,7 +46,7 @@ const getShowQuery = () => `
 		ORDER BY writingEntityRel.creditPosition, writingEntityRel.entityPosition
 
 	WITH character, materialRel, material, writingEntityRel.credit AS writingCreditName,
-		COLLECT(
+		[writingEntity IN COLLECT(
 			CASE writingEntity WHEN NULL
 				THEN null
 				ELSE {
@@ -57,7 +57,10 @@ const getShowQuery = () => `
 					sourceMaterialWritingCredits: sourceMaterialWritingCredits
 				}
 			END
-		) AS writingEntities
+		) | CASE writingEntity.model WHEN 'material'
+			THEN writingEntity
+			ELSE { model: writingEntity.model, uuid: writingEntity.uuid, name: writingEntity.name }
+		END] AS writingEntities
 
 	WITH character, materialRel, material,
 		COLLECT(

--- a/src/neo4j/cypher-queries/material.js
+++ b/src/neo4j/cypher-queries/material.js
@@ -365,7 +365,7 @@ const getShowQuery = () => `
 		subsequentVersionMaterials,
 		sourcingMaterial,
 		sourcingMaterialWritingEntityRel.credit AS sourcingMaterialWritingCreditName,
-		COLLECT(
+		[sourcingMaterialWritingEntity IN COLLECT(
 			CASE sourcingMaterialWritingEntity WHEN NULL
 				THEN null
 				ELSE {
@@ -378,7 +378,14 @@ const getShowQuery = () => `
 					format: sourcingMaterialWritingEntity.format
 				}
 			END
-		) AS sourcingMaterialWritingEntities
+		) | CASE sourcingMaterialWritingEntity.model WHEN 'material'
+			THEN sourcingMaterialWritingEntity
+			ELSE {
+				model: sourcingMaterialWritingEntity.model,
+				uuid: sourcingMaterialWritingEntity.uuid,
+				name: sourcingMaterialWritingEntity.name
+			}
+		END] AS sourcingMaterialWritingEntities
 
 	WITH material, originalVersionMaterial, subsequentVersionMaterials, sourcingMaterial,
 		COLLECT(
@@ -462,7 +469,7 @@ const getShowQuery = () => `
 		subsequentVersionMaterials,
 		sourcingMaterials,
 		writingEntityRel.credit AS writingCreditName,
-		COLLECT(
+		[writingEntity IN COLLECT(
 			CASE writingEntity WHEN NULL
 				THEN null
 				ELSE {
@@ -473,7 +480,10 @@ const getShowQuery = () => `
 					sourceMaterialWritingCredits: sourceMaterialWritingCredits
 				}
 			END
-		) AS writingEntities
+		) | CASE writingEntity.model WHEN 'material'
+			THEN writingEntity
+			ELSE { model: writingEntity.model, uuid: writingEntity.uuid, name: writingEntity.name }
+		END] AS writingEntities
 
 	WITH material, originalVersionMaterial, subsequentVersionMaterials, sourcingMaterials,
 		COLLECT(
@@ -678,7 +688,7 @@ const getListQuery = () => `
 		ORDER BY writingEntityRel.creditPosition, writingEntityRel.entityPosition
 
 	WITH material, writingEntityRel.credit AS writingCreditName,
-		COLLECT(
+		[writingEntity IN COLLECT(
 			CASE writingEntity WHEN NULL
 				THEN null
 				ELSE {
@@ -689,7 +699,10 @@ const getListQuery = () => `
 					sourceMaterialWritingCredits: sourceMaterialWritingCredits
 				}
 			END
-		) AS writingEntities
+		) | CASE writingEntity.model WHEN 'material'
+			THEN writingEntity
+			ELSE { model: writingEntity.model, uuid: writingEntity.uuid, name: writingEntity.name }
+		END] AS writingEntities
 
 	WITH material, writingCreditName, writingEntities
 		ORDER BY material.name, material.differentiator

--- a/src/neo4j/cypher-queries/person.js
+++ b/src/neo4j/cypher-queries/person.js
@@ -50,7 +50,7 @@ const getShowQuery = () => `
 		ORDER BY allWritingEntityRel.creditPosition, allWritingEntityRel.entityPosition
 
 	WITH person, writerRel, material, originalVersionCredit, allWritingEntityRel.credit AS writingCreditName,
-		COLLECT(
+		[writingEntity IN COLLECT(
 			CASE writingEntity WHEN NULL
 				THEN null
 				ELSE {
@@ -61,7 +61,10 @@ const getShowQuery = () => `
 					sourceMaterialWritingCredits: sourceMaterialWritingCredits
 				}
 			END
-		) AS writingEntities
+		) | CASE writingEntity.model WHEN 'material'
+			THEN writingEntity
+			ELSE { model: writingEntity.model, uuid: writingEntity.uuid, name: writingEntity.name }
+		END] AS writingEntities
 
 	WITH person, writerRel, material, originalVersionCredit,
 		COLLECT(
@@ -150,7 +153,7 @@ const getShowQuery = () => `
 		sourcingMaterialWritingEntityRel,
 		sourcingMaterialWritingEntity,
 		sourcingMaterialWritingEntityRel.credit AS sourcingMaterialWritingCreditName,
-		COLLECT(
+		[sourcingMaterialWritingEntity IN COLLECT(
 			CASE sourcingMaterialWritingEntity WHEN NULL
 				THEN null
 				ELSE {
@@ -160,7 +163,14 @@ const getShowQuery = () => `
 					format: sourcingMaterialWritingEntity.format
 				}
 			END
-		) AS sourcingMaterialWritingEntities
+		) | CASE sourcingMaterialWritingEntity.model WHEN 'material'
+			THEN sourcingMaterialWritingEntity
+			ELSE {
+				model: sourcingMaterialWritingEntity.model,
+				uuid: sourcingMaterialWritingEntity.uuid,
+				name: sourcingMaterialWritingEntity.name
+			}
+		END] AS sourcingMaterialWritingEntities
 
 	WITH person, materials, subsequentVersionMaterials, sourcingMaterialsFromNonSpecificMaterials, sourcingMaterial,
 		COLLECT(

--- a/src/neo4j/cypher-queries/production.js
+++ b/src/neo4j/cypher-queries/production.js
@@ -200,7 +200,7 @@ const getShowQuery = () => `
 		ORDER BY writingEntityRel.creditPosition, writingEntityRel.entityPosition
 
 	WITH production, theatre, material, writingEntityRel.credit AS writingCreditName,
-		COLLECT(
+		[writingEntity IN COLLECT(
 			CASE writingEntity WHEN NULL
 				THEN null
 				ELSE {
@@ -211,7 +211,10 @@ const getShowQuery = () => `
 					sourceMaterialWritingCredits: sourceMaterialWritingCredits
 				}
 			END
-		) AS writingEntities
+		) | CASE writingEntity.model WHEN 'material'
+			THEN writingEntity
+			ELSE { model: writingEntity.model, uuid: writingEntity.uuid, name: writingEntity.name }
+		END] AS writingEntities
 
 	WITH production, theatre, material,
 		COLLECT(

--- a/test-e2e/crud/materials-api.test.js
+++ b/test-e2e/crud/materials-api.test.js
@@ -621,9 +621,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 							{
 								model: 'person',
 								uuid: HENRIK_IBSEN_PERSON_UUID,
-								name: 'Henrik Ibsen',
-								format: null,
-								sourceMaterialWritingCredits: []
+								name: 'Henrik Ibsen'
 							}
 						]
 					},
@@ -634,9 +632,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 							{
 								model: 'person',
 								uuid: DAVID_ELDRIDGE_PERSON_UUID,
-								name: 'David Eldridge',
-								format: null,
-								sourceMaterialWritingCredits: []
+								name: 'David Eldridge'
 							}
 						]
 					},
@@ -1100,9 +1096,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 							{
 								model: 'person',
 								uuid: ANTON_CHEKHOV_PERSON_UUID,
-								name: 'Anton Chekhov',
-								format: null,
-								sourceMaterialWritingCredits: []
+								name: 'Anton Chekhov'
 							}
 						]
 					},
@@ -1113,9 +1107,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 							{
 								model: 'person',
 								uuid: BENEDICT_ANDREWS_PERSON_UUID,
-								name: 'Benedict Andrews',
-								format: null,
-								sourceMaterialWritingCredits: []
+								name: 'Benedict Andrews'
 							}
 						]
 					},

--- a/test-e2e/model-interaction/material-multi-versions-multi-wri-groups.test.js
+++ b/test-e2e/model-interaction/material-multi-versions-multi-wri-groups.test.js
@@ -327,9 +327,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'person',
 							uuid: HENRIK_IBSEN_PERSON_UUID,
-							name: 'Henrik Ibsen',
-							format: null,
-							sourceMaterialWritingCredits: []
+							name: 'Henrik Ibsen'
 						}
 					]
 				}
@@ -383,9 +381,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'person',
 							uuid: HENRIK_IBSEN_PERSON_UUID,
-							name: 'Henrik Ibsen',
-							format: null,
-							sourceMaterialWritingCredits: []
+							name: 'Henrik Ibsen'
 						}
 					]
 				},
@@ -396,16 +392,12 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'person',
 							uuid: GERRY_BAMMAN_PERSON_UUID,
-							name: 'Gerry Bamman',
-							format: null,
-							sourceMaterialWritingCredits: []
+							name: 'Gerry Bamman'
 						},
 						{
 							model: 'person',
 							uuid: IRENE_B_BERMAN_PERSON_UUID,
-							name: 'Irene B Berman',
-							format: null,
-							sourceMaterialWritingCredits: []
+							name: 'Irene B Berman'
 						}
 					]
 				},
@@ -416,9 +408,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'person',
 							uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
-							name: 'Baltasar Kormákur',
-							format: null,
-							sourceMaterialWritingCredits: []
+							name: 'Baltasar Kormákur'
 						}
 					]
 				}
@@ -450,9 +440,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: null,
-									name: 'Henrik Ibsen',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Henrik Ibsen'
 								}
 							]
 						}
@@ -471,9 +459,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: null,
-									name: 'Henrik Ibsen',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Henrik Ibsen'
 								}
 							]
 						}
@@ -503,9 +489,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: null,
-									name: 'Henrik Ibsen',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Henrik Ibsen'
 								}
 							]
 						},
@@ -516,16 +500,12 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: GERRY_BAMMAN_PERSON_UUID,
-									name: 'Gerry Bamman',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Gerry Bamman'
 								},
 								{
 									model: 'person',
 									uuid: IRENE_B_BERMAN_PERSON_UUID,
-									name: 'Irene B Berman',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Irene B Berman'
 								}
 							]
 						},
@@ -536,9 +516,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
-									name: 'Baltasar Kormákur',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Baltasar Kormákur'
 								}
 							]
 						}
@@ -557,9 +535,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: null,
-									name: 'Henrik Ibsen',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Henrik Ibsen'
 								}
 							]
 						},
@@ -570,16 +546,12 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: GERRY_BAMMAN_PERSON_UUID,
-									name: 'Gerry Bamman',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Gerry Bamman'
 								},
 								{
 									model: 'person',
 									uuid: IRENE_B_BERMAN_PERSON_UUID,
-									name: 'Irene B Berman',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Irene B Berman'
 								}
 							]
 						},
@@ -590,9 +562,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
-									name: 'Baltasar Kormákur',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Baltasar Kormákur'
 								}
 							]
 						}
@@ -611,9 +581,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: null,
-									name: 'Henrik Ibsen',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Henrik Ibsen'
 								}
 							]
 						},
@@ -624,9 +592,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: FRANK_MCGUINNESS_PERSON_UUID,
-									name: 'Frank McGuinness',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Frank McGuinness'
 								}
 							]
 						}
@@ -660,9 +626,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
-									name: 'Henrik Ibsen',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Henrik Ibsen'
 								}
 							]
 						},
@@ -673,16 +637,12 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: null,
-									name: 'Gerry Bamman',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Gerry Bamman'
 								},
 								{
 									model: 'person',
 									uuid: IRENE_B_BERMAN_PERSON_UUID,
-									name: 'Irene B Berman',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Irene B Berman'
 								}
 							]
 						},
@@ -693,9 +653,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
-									name: 'Baltasar Kormákur',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Baltasar Kormákur'
 								}
 							]
 						}
@@ -714,9 +672,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
-									name: 'Henrik Ibsen',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Henrik Ibsen'
 								}
 							]
 						},
@@ -727,16 +683,12 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: null,
-									name: 'Gerry Bamman',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Gerry Bamman'
 								},
 								{
 									model: 'person',
 									uuid: IRENE_B_BERMAN_PERSON_UUID,
-									name: 'Irene B Berman',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Irene B Berman'
 								}
 							]
 						},
@@ -747,9 +699,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
-									name: 'Baltasar Kormákur',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Baltasar Kormákur'
 								}
 							]
 						}
@@ -782,9 +732,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 							{
 								model: 'person',
 								uuid: HENRIK_IBSEN_PERSON_UUID,
-								name: 'Henrik Ibsen',
-								format: null,
-								sourceMaterialWritingCredits: []
+								name: 'Henrik Ibsen'
 							}
 						]
 					},
@@ -795,16 +743,12 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 							{
 								model: 'person',
 								uuid: GERRY_BAMMAN_PERSON_UUID,
-								name: 'Gerry Bamman',
-								format: null,
-								sourceMaterialWritingCredits: []
+								name: 'Gerry Bamman'
 							},
 							{
 								model: 'person',
 								uuid: IRENE_B_BERMAN_PERSON_UUID,
-								name: 'Irene B Berman',
-								format: null,
-								sourceMaterialWritingCredits: []
+								name: 'Irene B Berman'
 							}
 						]
 					},
@@ -815,9 +759,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 							{
 								model: 'person',
 								uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
-								name: 'Baltasar Kormákur',
-								format: null,
-								sourceMaterialWritingCredits: []
+								name: 'Baltasar Kormákur'
 							}
 						]
 					}
@@ -850,9 +792,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
-									name: 'Henrik Ibsen',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Henrik Ibsen'
 								}
 							]
 						},
@@ -863,16 +803,12 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: GERRY_BAMMAN_PERSON_UUID,
-									name: 'Gerry Bamman',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Gerry Bamman'
 								},
 								{
 									model: 'person',
 									uuid: IRENE_B_BERMAN_PERSON_UUID,
-									name: 'Irene B Berman',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Irene B Berman'
 								}
 							]
 						},
@@ -883,9 +819,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
-									name: 'Baltasar Kormákur',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Baltasar Kormákur'
 								}
 							]
 						}
@@ -905,9 +839,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
-									name: 'Henrik Ibsen',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Henrik Ibsen'
 								}
 							]
 						},
@@ -918,9 +850,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: FRANK_MCGUINNESS_PERSON_UUID,
-									name: 'Frank McGuinness',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Frank McGuinness'
 								}
 							]
 						}
@@ -940,9 +870,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
-									name: 'Henrik Ibsen',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Henrik Ibsen'
 								}
 							]
 						}
@@ -980,9 +908,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
-									name: 'Henrik Ibsen',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Henrik Ibsen'
 								}
 							]
 						}
@@ -1001,9 +927,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
-									name: 'Henrik Ibsen',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Henrik Ibsen'
 								}
 							]
 						},
@@ -1014,16 +938,12 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: GERRY_BAMMAN_PERSON_UUID,
-									name: 'Gerry Bamman',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Gerry Bamman'
 								},
 								{
 									model: 'person',
 									uuid: IRENE_B_BERMAN_PERSON_UUID,
-									name: 'Irene B Berman',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Irene B Berman'
 								}
 							]
 						},
@@ -1034,9 +954,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
-									name: 'Baltasar Kormákur',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Baltasar Kormákur'
 								}
 							]
 						}
@@ -1055,9 +973,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
-									name: 'Henrik Ibsen',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Henrik Ibsen'
 								}
 							]
 						}
@@ -1076,9 +992,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
-									name: 'Henrik Ibsen',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Henrik Ibsen'
 								}
 							]
 						},
@@ -1089,9 +1003,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: FRANK_MCGUINNESS_PERSON_UUID,
-									name: 'Frank McGuinness',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Frank McGuinness'
 								}
 							]
 						}
@@ -1110,9 +1022,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
-									name: 'Henrik Ibsen',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Henrik Ibsen'
 								}
 							]
 						},
@@ -1123,16 +1033,12 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: GERRY_BAMMAN_PERSON_UUID,
-									name: 'Gerry Bamman',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Gerry Bamman'
 								},
 								{
 									model: 'person',
 									uuid: IRENE_B_BERMAN_PERSON_UUID,
-									name: 'Irene B Berman',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Irene B Berman'
 								}
 							]
 						},
@@ -1143,9 +1049,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								{
 									model: 'person',
 									uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
-									name: 'Baltasar Kormákur',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Baltasar Kormákur'
 								}
 							]
 						}

--- a/test-e2e/model-interaction/material-with-source-material.test.js
+++ b/test-e2e/model-interaction/material-with-source-material.test.js
@@ -201,9 +201,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'person',
 							uuid: RONA_MUNRO_PERSON_UUID,
-							name: 'Rona Munro',
-							format: null,
-							sourceMaterialWritingCredits: []
+							name: 'Rona Munro'
 						}
 					]
 				},
@@ -260,8 +258,7 @@ describe('Materials with source material', () => {
 								{
 									model: 'person',
 									uuid: RONA_MUNRO_PERSON_UUID,
-									name: 'Rona Munro',
-									format: null
+									name: 'Rona Munro'
 								}
 							]
 						},
@@ -323,9 +320,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'person',
 							uuid: STEVEN_BERKOFF_PERSON_UUID,
-							name: 'Steven Berkoff',
-							format: null,
-							sourceMaterialWritingCredits: []
+							name: 'Steven Berkoff'
 						}
 					]
 				},
@@ -336,9 +331,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'person',
 							uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
-							name: 'William Shakespeare',
-							format: null,
-							sourceMaterialWritingCredits: []
+							name: 'William Shakespeare'
 						}
 					]
 				}
@@ -370,9 +363,7 @@ describe('Materials with source material', () => {
 								{
 									model: 'person',
 									uuid: null,
-									name: 'Rona Munro',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Rona Munro'
 								}
 							]
 						},
@@ -431,9 +422,7 @@ describe('Materials with source material', () => {
 								{
 									model: 'person',
 									uuid: STEVEN_BERKOFF_PERSON_UUID,
-									name: 'Steven Berkoff',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Steven Berkoff'
 								}
 							]
 						},
@@ -444,9 +433,7 @@ describe('Materials with source material', () => {
 								{
 									model: 'person',
 									uuid: null,
-									name: 'William Shakespeare',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'William Shakespeare'
 								}
 							]
 						}
@@ -465,8 +452,7 @@ describe('Materials with source material', () => {
 								{
 									model: 'person',
 									uuid: RONA_MUNRO_PERSON_UUID,
-									name: 'Rona Munro',
-									format: null
+									name: 'Rona Munro'
 								}
 							]
 						},
@@ -512,9 +498,7 @@ describe('Materials with source material', () => {
 								{
 									model: 'person',
 									uuid: null,
-									name: 'Steven Berkoff',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Steven Berkoff'
 								}
 							]
 						},
@@ -525,9 +509,7 @@ describe('Materials with source material', () => {
 								{
 									model: 'person',
 									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
-									name: 'William Shakespeare',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'William Shakespeare'
 								}
 							]
 						}
@@ -560,9 +542,7 @@ describe('Materials with source material', () => {
 							{
 								model: 'person',
 								uuid: RONA_MUNRO_PERSON_UUID,
-								name: 'Rona Munro',
-								format: null,
-								sourceMaterialWritingCredits: []
+								name: 'Rona Munro'
 							}
 						]
 					},
@@ -619,9 +599,7 @@ describe('Materials with source material', () => {
 							{
 								model: 'person',
 								uuid: STEVEN_BERKOFF_PERSON_UUID,
-								name: 'Steven Berkoff',
-								format: null,
-								sourceMaterialWritingCredits: []
+								name: 'Steven Berkoff'
 							}
 						]
 					},
@@ -632,9 +610,7 @@ describe('Materials with source material', () => {
 							{
 								model: 'person',
 								uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
-								name: 'William Shakespeare',
-								format: null,
-								sourceMaterialWritingCredits: []
+								name: 'William Shakespeare'
 							}
 						]
 					}
@@ -667,9 +643,7 @@ describe('Materials with source material', () => {
 								{
 									model: 'person',
 									uuid: RONA_MUNRO_PERSON_UUID,
-									name: 'Rona Munro',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Rona Munro'
 								}
 							]
 						},
@@ -729,9 +703,7 @@ describe('Materials with source material', () => {
 								{
 									model: 'person',
 									uuid: STEVEN_BERKOFF_PERSON_UUID,
-									name: 'Steven Berkoff',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Steven Berkoff'
 								}
 							]
 						},
@@ -742,9 +714,7 @@ describe('Materials with source material', () => {
 								{
 									model: 'person',
 									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
-									name: 'William Shakespeare',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'William Shakespeare'
 								}
 							]
 						}
@@ -782,9 +752,7 @@ describe('Materials with source material', () => {
 								{
 									model: 'person',
 									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
-									name: 'William Shakespeare',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'William Shakespeare'
 								}
 							]
 						}
@@ -803,9 +771,7 @@ describe('Materials with source material', () => {
 								{
 									model: 'person',
 									uuid: STEVEN_BERKOFF_PERSON_UUID,
-									name: 'Steven Berkoff',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Steven Berkoff'
 								}
 							]
 						},
@@ -816,9 +782,7 @@ describe('Materials with source material', () => {
 								{
 									model: 'person',
 									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
-									name: 'William Shakespeare',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'William Shakespeare'
 								}
 							]
 						}
@@ -837,9 +801,7 @@ describe('Materials with source material', () => {
 								{
 									model: 'person',
 									uuid: RONA_MUNRO_PERSON_UUID,
-									name: 'Rona Munro',
-									format: null,
-									sourceMaterialWritingCredits: []
+									name: 'Rona Munro'
 								}
 							]
 						},

--- a/test-e2e/model-interaction/wri-groups-grouping.test.js
+++ b/test-e2e/model-interaction/wri-groups-grouping.test.js
@@ -81,16 +81,12 @@ describe('Nameless writer groups grouping', () => {
 						{
 							model: 'person',
 							uuid: PERSON_1_UUID,
-							name: 'Person #1',
-							format: null,
-							sourceMaterialWritingCredits: []
+							name: 'Person #1'
 						},
 						{
 							model: 'person',
 							uuid: PERSON_3_UUID,
-							name: 'Person #3',
-							format: null,
-							sourceMaterialWritingCredits: []
+							name: 'Person #3'
 						}
 					]
 				},
@@ -101,9 +97,7 @@ describe('Nameless writer groups grouping', () => {
 						{
 							model: 'person',
 							uuid: PERSON_2_UUID,
-							name: 'Person #2',
-							format: null,
-							sourceMaterialWritingCredits: []
+							name: 'Person #2'
 						}
 					]
 				}


### PR DESCRIPTION
Cypher queries currently return `writingEntities` (and `sourcingMaterialWritingEntities`) with objects that contain `format` and `sourceMaterialWritingCredits` regardless of the model.

`format` and `sourceMaterialWritingCredits` are only applicable to material entities but not for person entities.

This PR amends the Cypher queries so that person entities omit those properties that do not apply to them (and consequently will allows by `null` and `[]` respectively).