### PR TITLE
Fix source material writer ordering

### DIFF
--- a/src/neo4j/cypher-queries/character.js
+++ b/src/neo4j/cypher-queries/character.js
@@ -16,7 +16,7 @@ const getShowQuery = () => `
 		writingEntity,
 		sourceMaterialWriterRel,
 		sourceMaterialWriter
-		ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriter.entityPosition
+		ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriterRel.entityPosition
 
 	WITH
 		character,

--- a/src/neo4j/cypher-queries/material.js
+++ b/src/neo4j/cypher-queries/material.js
@@ -427,7 +427,7 @@ const getShowQuery = () => `
 		writingEntity,
 		sourceMaterialWriterRel,
 		sourceMaterialWriter
-		ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriter.entityPosition
+		ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriterRel.entityPosition
 
 	WITH
 		material,
@@ -664,7 +664,7 @@ const getListQuery = () => `
 	OPTIONAL MATCH (writingEntity:Material)-[sourceMaterialWriterRel:WRITTEN_BY]->(sourceMaterialWriter)
 
 	WITH material, writingEntityRel, writingEntity, sourceMaterialWriterRel, sourceMaterialWriter
-		ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriter.entityPosition
+		ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriterRel.entityPosition
 
 	WITH material, writingEntityRel, writingEntity, sourceMaterialWriterRel.credit AS sourceMaterialWritingCreditName,
 		COLLECT(

--- a/src/neo4j/cypher-queries/person.js
+++ b/src/neo4j/cypher-queries/person.js
@@ -19,7 +19,7 @@ const getShowQuery = () => `
 		writingEntity,
 		sourceMaterialWriterRel,
 		sourceMaterialWriter
-		ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriter.entityPosition
+		ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriterRel.entityPosition
 
 	WITH
 		person,

--- a/src/neo4j/cypher-queries/production.js
+++ b/src/neo4j/cypher-queries/production.js
@@ -170,7 +170,7 @@ const getShowQuery = () => `
 	OPTIONAL MATCH (writingEntity:Material)-[sourceMaterialWriterRel:WRITTEN_BY]->(sourceMaterialWriter)
 
 	WITH production, theatre, material, writingEntityRel, writingEntity, sourceMaterialWriterRel, sourceMaterialWriter
-		ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriter.entityPosition
+		ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriterRel.entityPosition
 
 	WITH
 		production,


### PR DESCRIPTION
There is no `entityPosition` property on `sourceMaterialWriter` so this will always be `null`, meaning source material writers will only ever be ordered by `creditPosition` alone.

This issue started manifested itself when new end-to-end tests starting intermittently failing owing to being dependent on this secondary ordering by the `entityPosition` values.