### PR TITLE
Fix person Cypher query (sourcing material writing credits)

### DIFF
--- a/src/neo4j/cypher-queries/person.js
+++ b/src/neo4j/cypher-queries/person.js
@@ -150,8 +150,6 @@ const getShowQuery = () => `
 		subsequentVersionMaterials,
 		sourcingMaterialsFromNonSpecificMaterials,
 		sourcingMaterial,
-		sourcingMaterialWritingEntityRel,
-		sourcingMaterialWritingEntity,
 		sourcingMaterialWritingEntityRel.credit AS sourcingMaterialWritingCreditName,
 		[sourcingMaterialWritingEntity IN COLLECT(
 			CASE sourcingMaterialWritingEntity WHEN NULL


### PR DESCRIPTION
This PR fixes the person show Cypher query so that writing credits correctly group the writing entities when compiling the sourcing material (from specific material) credits (i.e. when a person's work has been used as source material for a subsequent work).

This issue currently presents itself when the subsequent material has multiple writers sharing the same credit, because the query incorrectly groups the writers separately.

Test coverage will be added in the work to add company writing entities (it was in adding tests for that work that this bug was noticed).

---

#### The Girl on the Train (play)
![material](https://user-images.githubusercontent.com/10484515/106026678-08a6c080-60c2-11eb-8cd0-da6ad76bf0ca.png)

---

#### Paula Hawkins (person) - before (i.e. an 'adapted by' credit repeated for each writer even though they share the credit)
![person-before](https://user-images.githubusercontent.com/10484515/106026746-1bb99080-60c2-11eb-8fb8-916d16c95056.png)

---

#### Paula Hawkins (person) - after ('adapted by' credit is now correctly shared)
![person-after](https://user-images.githubusercontent.com/10484515/106026765-207e4480-60c2-11eb-82cf-aac43f409f6f.png)