### PR TITLE
Remove unused occurrences of ORIGINAL_VERSION credit type

### DIFF
--- a/db-seeding/seeds/materials/peer-gynt-subsequent-version.json
+++ b/db-seeding/seeds/materials/peer-gynt-subsequent-version.json
@@ -8,7 +8,6 @@
 	},
 	"writingCredits": [
 		{
-			"creditType": "ORIGINAL_VERSION",
 			"writingEntities": [
 				{
 					"name": "Henrik Ibsen"

--- a/db-seeding/seeds/materials/the-seagull-subsequent-version.json
+++ b/db-seeding/seeds/materials/the-seagull-subsequent-version.json
@@ -8,7 +8,6 @@
 	},
 	"writingCredits": [
 		{
-			"creditType": "ORIGINAL_VERSION",
 			"writingEntities": [
 				{
 					"name": "Anton Chekhov"


### PR DESCRIPTION
These should have been removed as part of https://github.com/andygout/theatrebase-api/pull/327.