### PR TITLE
Add company writing entities

### DIFF
--- a/db-seeding/seeds/materials/rock-n-roll.json
+++ b/db-seeding/seeds/materials/rock-n-roll.json
@@ -27,7 +27,8 @@
 					"name": "Max"
 				},
 				{
-					"name": "Eleanor"
+					"name": "Eleanor",
+					"differentiator": "Rock 'n' Roll"
 				},
 				{
 					"name": "Gillian"

--- a/db-seeding/seeds/materials/the-dark-philosophers.json
+++ b/db-seeding/seeds/materials/the-dark-philosophers.json
@@ -1,0 +1,129 @@
+{
+	"name": "The Dark Philosophers",
+	"format": "play",
+	"writingCredits": [
+		{
+			"name": "adapted by",
+			"writingEntities": [
+				{
+					"name": "Carl Grose"
+				},
+				{
+					"model": "company",
+					"name": "Told by an Idiot"
+				}
+			]
+		},
+		{
+			"name": "based on the life and stories of",
+			"creditType": "NON_SPECIFIC_SOURCE_MATERIAL",
+			"writingEntities": [
+				{
+					"name": "Gwyn Thomas"
+				}
+			]
+		}
+	],
+	"characterGroups": [
+		{
+			"characters": [
+				{
+					"name": "Gwyn Thomas"
+				},
+				{
+					"name": "Young Gwyn"
+				},
+				{
+					"name": "Gwyn's father"
+				}
+			]
+		},
+		{
+			"name": "The People of the Terraces",
+			"characters": [
+				{
+					"name": "Lewis"
+				},
+				{
+					"name": "No Doubt"
+				},
+				{
+					"name": "Ben",
+					"differentiator": "The Dark Philosophers"
+				},
+				{
+					"name": "The Macnaffy element"
+				},
+				{
+					"name": "Mr Wilson"
+				},
+				{
+					"name": "Mrs Wilson"
+				},
+				{
+					"name": "Hannah"
+				},
+				{
+					"name": "Danny"
+				},
+				{
+					"name": "Naboth"
+				},
+				{
+					"name": "Eli"
+				},
+				{
+					"name": "Colenso"
+				},
+				{
+					"name": "Emrys"
+				},
+				{
+					"name": "Simeon"
+				},
+				{
+					"name": "Clarisse"
+				},
+				{
+					"name": "Vera"
+				},
+				{
+					"name": "Bess"
+				},
+				{
+					"name": "Elsa"
+				},
+				{
+					"name": "Eleanor",
+					"differentiator": "The Dark Philosophers"
+				},
+				{
+					"name": "Oscar"
+				},
+				{
+					"name": "Meg"
+				}
+			]
+		},
+		{
+			"name": "Others",
+			"characters": [
+				{
+					"name": "TV studio runner"
+				},
+				{
+					"name": "Michael Parkinson"
+				},
+				{
+					"name": "Billy Connelly"
+				},
+				{
+					"name": "Dolly Parton"
+				},
+				{
+					"name": "Oxford students"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/materials/the-dumb-waiter.json
+++ b/db-seeding/seeds/materials/the-dumb-waiter.json
@@ -14,7 +14,8 @@
 		{
 			"characters": [
 				{
-					"name": "Ben"
+					"name": "Ben",
+					"differentiator": "The Dumb Waiter"
 				},
 				{
 					"name": "Gus"

--- a/db-seeding/seeds/materials/the-girl-on-the-train-film.json
+++ b/db-seeding/seeds/materials/the-girl-on-the-train-film.json
@@ -1,0 +1,14 @@
+{
+	"name": "The Girl on the Train",
+	"differentiator": "2",
+	"format": "film",
+	"writingCredits": [
+		{
+			"writingEntities": [
+				{
+					"name": "Dreamworks"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/materials/the-girl-on-the-train-novel.json
+++ b/db-seeding/seeds/materials/the-girl-on-the-train-novel.json
@@ -1,0 +1,14 @@
+{
+	"name": "The Girl on the Train",
+	"differentiator": "1",
+	"format": "novel",
+	"writingCredits": [
+		{
+			"writingEntities": [
+				{
+					"name": "Paula Hawkins"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/materials/the-girl-on-the-train-play.json
+++ b/db-seeding/seeds/materials/the-girl-on-the-train-play.json
@@ -1,0 +1,60 @@
+{
+	"name": "The Girl on the Train",
+	"differentiator": "3",
+	"format": "play",
+	"writingCredits": [
+		{
+			"name": "based on",
+			"writingEntities": [
+				{
+					"model": "material",
+					"name": "The Girl on the Train",
+					"differentiator": "1"
+				},
+				{
+					"model": "material",
+					"name": "The Girl on the Train",
+					"differentiator": "2"
+				}
+			]
+		},
+		{
+			"name": "adapted by",
+			"writingEntities": [
+				{
+					"name": "Rachel Wagstaff"
+				},
+				{
+					"name": "Duncan Abel"
+				}
+			]
+		}
+	],
+	"characterGroups": [
+		{
+			"characters": [
+				{
+					"name": "Rachel Watson"
+				},
+				{
+					"name": "D.I. Gaskill"
+				},
+				{
+					"name": "Anna Watson"
+				},
+				{
+					"name": "Megan Hipwell"
+				},
+				{
+					"name": "Tom Watson"
+				},
+				{
+					"name": "Scott Hipwell"
+				},
+				{
+					"name": "Kamal Abdic"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/productions/the-dark-philosophers.json
+++ b/db-seeding/seeds/productions/the-dark-philosophers.json
@@ -1,0 +1,35 @@
+{
+	"name": "The Dark Philosophers",
+	"material": {
+		"name": "The Dark Philosophers"
+	},
+	"theatre": {
+		"name": "The Riverfront"
+	},
+	"cast": [
+		{
+			"name": "David Charles"
+		},
+		{
+			"name": "Nia Davies"
+		},
+		{
+			"name": "Nia Gwynne"
+		},
+		{
+			"name": "Ryan Hacker"
+		},
+		{
+			"name": "Daniel Hawksford"
+		},
+		{
+			"name": "Bettrys Jones"
+		},
+		{
+			"name": "Matthew Owen"
+		},
+		{
+			"name": "Glyn Pritchard"
+		}
+	]
+}

--- a/db-seeding/seeds/productions/the-girl-on-the-train.json
+++ b/db-seeding/seeds/productions/the-girl-on-the-train.json
@@ -1,0 +1,86 @@
+{
+	"name": "The Girl on the Train",
+	"material": {
+		"name": "The Girl on the Train",
+		"differentiator": "3"
+	},
+	"theatre": {
+		"name": "Duke of York's Theatre"
+	},
+	"cast": [
+		{
+			"name": "Samantha Womack",
+			"roles": [
+				{
+					"name": "Rachel Watson"
+				}
+			]
+		},
+		{
+			"name": "Alex Ferns",
+			"roles": [
+				{
+					"name": "Detective Inspector Gaskill",
+					"characterName": "D.I. Gaskill"
+				}
+			]
+		},
+		{
+			"name": "Marc Elliott",
+			"roles": [
+				{
+					"name": "Dr Kamal Abdic",
+					"characterName": "Kamal Abdic"
+				}
+			]
+		},
+		{
+			"name": "Philip McGinley",
+			"roles": [
+				{
+					"name": "Scott Hipwell"
+				}
+			]
+		},
+		{
+			"name": "Kirsty Oswald",
+			"roles": [
+				{
+					"name": "Megan Hipwell"
+				}
+			]
+		},
+		{
+			"name": "Adam Jackson-Smith",
+			"roles": [
+				{
+					"name": "Tom Watson"
+				}
+			]
+		},
+		{
+			"name": "Lowenna Melrose",
+			"roles": [
+				{
+					"name": "Anna Watson"
+				}
+			]
+		},
+		{
+			"name": "Matt Concannon",
+			"roles": [
+				{
+					"name": "Ensemble"
+				}
+			]
+		},
+		{
+			"name": "Phillipa Flynn",
+			"roles": [
+				{
+					"name": "Ensemble"
+				}
+			]
+		}
+	]
+}

--- a/src/models/WritingCredit.js
+++ b/src/models/WritingCredit.js
@@ -1,6 +1,6 @@
 import { getDuplicateWritingEntityIndices } from '../lib/get-duplicate-indices';
 import Base from './Base';
-import { Person, Material } from '.';
+import { Company, Person, Material } from '.';
 import { CREDIT_TYPES } from '../utils/constants';
 
 export default class WritingCredit extends Base {
@@ -16,9 +16,14 @@ export default class WritingCredit extends Base {
 
 		this.writingEntities = writingEntities
 			? writingEntities.map(writingEntity => {
-				return writingEntity.model === 'material'
-					? new Material({ ...writingEntity, isAssociation: true })
-					: new Person(writingEntity);
+				switch (writingEntity.model) {
+					case 'company':
+						return new Company(writingEntity);
+					case 'material':
+						return new Material({ ...writingEntity, isAssociation: true });
+					default:
+						return new Person(writingEntity);
+				}
 			})
 			: [];
 

--- a/src/neo4j/cypher-queries/character.js
+++ b/src/neo4j/cypher-queries/character.js
@@ -4,7 +4,7 @@ const getShowQuery = () => `
 	OPTIONAL MATCH (character)<-[materialRel:INCLUDES_CHARACTER]-(material:Material)
 
 	OPTIONAL MATCH (material)-[writingEntityRel:WRITTEN_BY|USES_SOURCE_MATERIAL]->(writingEntity)
-		WHERE writingEntity:Person OR writingEntity:Material
+		WHERE writingEntity:Person OR writingEntity:Company OR writingEntity:Material
 
 	OPTIONAL MATCH (writingEntity:Material)-[sourceMaterialWriterRel:WRITTEN_BY]->(sourceMaterialWriter)
 
@@ -28,7 +28,11 @@ const getShowQuery = () => `
 		COLLECT(
 			CASE sourceMaterialWriter WHEN NULL
 				THEN null
-				ELSE { model: 'person', uuid: sourceMaterialWriter.uuid, name: sourceMaterialWriter.name }
+				ELSE {
+					model: TOLOWER(HEAD(LABELS(sourceMaterialWriter))),
+					uuid: sourceMaterialWriter.uuid,
+					name: sourceMaterialWriter.name
+				}
 			END
 		) AS sourceMaterialWriters
 

--- a/src/neo4j/cypher-queries/company.js
+++ b/src/neo4j/cypher-queries/company.js
@@ -1,11 +1,229 @@
 const getShowQuery = () => `
 	MATCH (company:Company { uuid: $uuid })
 
+	OPTIONAL MATCH (company)<-[writerRel:WRITTEN_BY]-(material:Material)
+
+	OPTIONAL MATCH (material)-[:SUBSEQUENT_VERSION_OF]->(:Material)-[originalVersionCredit:WRITTEN_BY]->(company)
+
+	OPTIONAL MATCH (material)-[allWritingEntityRel:WRITTEN_BY|USES_SOURCE_MATERIAL]->(writingEntity)
+		WHERE writingEntity:Person OR writingEntity:Company OR writingEntity:Material
+
+	OPTIONAL MATCH (writingEntity:Material)-[sourceMaterialWriterRel:WRITTEN_BY]->(sourceMaterialWriter)
+
+	WITH
+		company,
+		writerRel,
+		material,
+		originalVersionCredit,
+		allWritingEntityRel,
+		writingEntity,
+		sourceMaterialWriterRel,
+		sourceMaterialWriter
+		ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriterRel.entityPosition
+
+	WITH
+		company,
+		writerRel,
+		material,
+		originalVersionCredit,
+		allWritingEntityRel,
+		writingEntity,
+		sourceMaterialWriterRel.credit AS sourceMaterialWritingCreditName,
+		COLLECT(
+			CASE sourceMaterialWriter WHEN NULL
+				THEN null
+				ELSE {
+					model: TOLOWER(HEAD(LABELS(sourceMaterialWriter))),
+					uuid: sourceMaterialWriter.uuid,
+					name: sourceMaterialWriter.name
+				}
+			END
+		) AS sourceMaterialWriters
+
+	WITH company, writerRel, material, originalVersionCredit, allWritingEntityRel, writingEntity,
+		COLLECT(
+			CASE SIZE(sourceMaterialWriters) WHEN 0
+				THEN null
+				ELSE {
+					model: 'writingCredit',
+					name: COALESCE(sourceMaterialWritingCreditName, 'by'),
+					writingEntities: sourceMaterialWriters
+				}
+			END
+		) AS sourceMaterialWritingCredits
+		ORDER BY allWritingEntityRel.creditPosition, allWritingEntityRel.entityPosition
+
+	WITH company, writerRel, material, originalVersionCredit, allWritingEntityRel.credit AS writingCreditName,
+		[writingEntity IN COLLECT(
+			CASE writingEntity WHEN NULL
+				THEN null
+				ELSE {
+					model: TOLOWER(HEAD(LABELS(writingEntity))),
+					uuid: CASE WHEN writingEntity.uuid = company.uuid THEN null ELSE writingEntity.uuid END,
+					name: writingEntity.name,
+					format: writingEntity.format,
+					sourceMaterialWritingCredits: sourceMaterialWritingCredits
+				}
+			END
+		) | CASE writingEntity.model WHEN 'material'
+			THEN writingEntity
+			ELSE { model: writingEntity.model, uuid: writingEntity.uuid, name: writingEntity.name }
+		END] AS writingEntities
+
+	WITH company, writerRel, material, originalVersionCredit,
+		COLLECT(
+			CASE SIZE(writingEntities) WHEN 0
+				THEN null
+				ELSE {
+					model: 'writingCredit',
+					name: COALESCE(writingCreditName, 'by'),
+					writingEntities: writingEntities
+				}
+			END
+		) AS writingCredits
+		ORDER BY material.name
+
+	WITH company,
+		COLLECT(
+			CASE material WHEN NULL
+				THEN null
+				ELSE {
+					model: 'material',
+					uuid: material.uuid,
+					name: material.name,
+					format: material.format,
+					writingCredits: writingCredits,
+					creditType: writerRel.creditType,
+					originalVersionCredit: originalVersionCredit
+				}
+			END
+		) AS materials
+
+	WITH
+		company,
+		[
+			material IN materials WHERE material.creditType IS NULL AND material.originalVersionCredit IS NULL |
+			{
+				model: material.model,
+				uuid: material.uuid,
+				name: material.name,
+				format: material.format,
+				writingCredits: material.writingCredits
+			}
+		] AS materials,
+		[
+			material IN materials WHERE material.originalVersionCredit IS NOT NULL |
+			{
+				model: material.model,
+				uuid: material.uuid,
+				name: material.name,
+				format: material.format,
+				writingCredits: material.writingCredits
+			}
+		] AS subsequentVersionMaterials,
+		[
+			material IN materials WHERE material.creditType = 'NON_SPECIFIC_SOURCE_MATERIAL' |
+			{
+				model: material.model,
+				uuid: material.uuid,
+				name: material.name,
+				format: material.format,
+				writingCredits: material.writingCredits
+			}
+		] AS sourcingMaterialsFromNonSpecificMaterials
+
+	OPTIONAL MATCH (company)<-[:WRITTEN_BY]-(:Material)<-[:USES_SOURCE_MATERIAL]-(sourcingMaterial:Material)
+
+	OPTIONAL MATCH (sourcingMaterial)-[sourcingMaterialWritingEntityRel:WRITTEN_BY|USES_SOURCE_MATERIAL]->
+		(sourcingMaterialWritingEntity)
+		WHERE
+			sourcingMaterialWritingEntity:Person OR
+			sourcingMaterialWritingEntity:Company OR
+			sourcingMaterialWritingEntity:Material
+
+	WITH
+		company,
+		materials,
+		subsequentVersionMaterials,
+		sourcingMaterialsFromNonSpecificMaterials,
+		sourcingMaterial,
+		sourcingMaterialWritingEntityRel,
+		sourcingMaterialWritingEntity
+		ORDER BY sourcingMaterialWritingEntityRel.creditPosition, sourcingMaterialWritingEntityRel.entityPosition
+
+	WITH
+		company,
+		materials,
+		subsequentVersionMaterials,
+		sourcingMaterialsFromNonSpecificMaterials,
+		sourcingMaterial,
+		sourcingMaterialWritingEntityRel.credit AS sourcingMaterialWritingCreditName,
+		[sourcingMaterialWritingEntity IN COLLECT(
+			CASE sourcingMaterialWritingEntity WHEN NULL
+				THEN null
+				ELSE {
+					model: TOLOWER(HEAD(LABELS(sourcingMaterialWritingEntity))),
+					uuid: sourcingMaterialWritingEntity.uuid,
+					name: sourcingMaterialWritingEntity.name,
+					format: sourcingMaterialWritingEntity.format
+				}
+			END
+		) | CASE sourcingMaterialWritingEntity.model WHEN 'material'
+			THEN sourcingMaterialWritingEntity
+			ELSE {
+				model: sourcingMaterialWritingEntity.model,
+				uuid: sourcingMaterialWritingEntity.uuid,
+				name: sourcingMaterialWritingEntity.name
+			}
+		END] AS sourcingMaterialWritingEntities
+
+	WITH company, materials, subsequentVersionMaterials, sourcingMaterialsFromNonSpecificMaterials, sourcingMaterial,
+		COLLECT(
+			CASE SIZE(sourcingMaterialWritingEntities) WHEN 0
+				THEN null
+				ELSE {
+					model: 'writingCredit',
+					name: COALESCE(sourcingMaterialWritingCreditName, 'by'),
+					writingEntities: sourcingMaterialWritingEntities
+				}
+			END
+		) AS sourcingMaterialWritingCredits
+
+	WITH company, materials, subsequentVersionMaterials, sourcingMaterialsFromNonSpecificMaterials,
+		COLLECT(
+			CASE sourcingMaterial WHEN NULL
+				THEN null
+				ELSE {
+					model: 'material',
+					uuid: sourcingMaterial.uuid,
+					name: sourcingMaterial.name,
+					format: sourcingMaterial.format,
+					writingCredits: sourcingMaterialWritingCredits
+				}
+			END
+		) AS sourcingMaterialsFromSpecificMaterials
+
+	WITH
+		company,
+		materials,
+		subsequentVersionMaterials,
+		sourcingMaterialsFromNonSpecificMaterials + sourcingMaterialsFromSpecificMaterials AS sourcingMaterials
+
+	UNWIND (CASE sourcingMaterials WHEN [] THEN [null] ELSE sourcingMaterials END) AS sourcingMaterial
+
+		WITH company, materials, subsequentVersionMaterials, sourcingMaterial
+			ORDER BY sourcingMaterial.name
+
+	WITH DISTINCT company, materials, subsequentVersionMaterials, COLLECT(sourcingMaterial) AS sourcingMaterials
+
 	RETURN
 		'company' AS model,
 		company.uuid AS uuid,
 		company.name AS name,
-		company.differentiator AS differentiator
+		company.differentiator AS differentiator,
+		materials,
+		subsequentVersionMaterials,
+		sourcingMaterials
 `;
 
 export {

--- a/src/neo4j/cypher-queries/person.js
+++ b/src/neo4j/cypher-queries/person.js
@@ -6,7 +6,7 @@ const getShowQuery = () => `
 	OPTIONAL MATCH (material)-[:SUBSEQUENT_VERSION_OF]->(:Material)-[originalVersionCredit:WRITTEN_BY]->(person)
 
 	OPTIONAL MATCH (material)-[allWritingEntityRel:WRITTEN_BY|USES_SOURCE_MATERIAL]->(writingEntity)
-		WHERE writingEntity:Person OR writingEntity:Material
+		WHERE writingEntity:Person OR writingEntity:Company OR writingEntity:Material
 
 	OPTIONAL MATCH (writingEntity:Material)-[sourceMaterialWriterRel:WRITTEN_BY]->(sourceMaterialWriter)
 
@@ -32,7 +32,11 @@ const getShowQuery = () => `
 		COLLECT(
 			CASE sourceMaterialWriter WHEN NULL
 				THEN null
-				ELSE { model: 'person', uuid: sourceMaterialWriter.uuid, name: sourceMaterialWriter.name }
+				ELSE {
+					model: TOLOWER(HEAD(LABELS(sourceMaterialWriter))),
+					uuid: sourceMaterialWriter.uuid,
+					name: sourceMaterialWriter.name
+				}
 			END
 		) AS sourceMaterialWriters
 
@@ -132,7 +136,10 @@ const getShowQuery = () => `
 
 	OPTIONAL MATCH (sourcingMaterial)-[sourcingMaterialWritingEntityRel:WRITTEN_BY|USES_SOURCE_MATERIAL]->
 		(sourcingMaterialWritingEntity)
-		WHERE sourcingMaterialWritingEntity:Person OR sourcingMaterialWritingEntity:Material
+		WHERE
+			sourcingMaterialWritingEntity:Person OR
+			sourcingMaterialWritingEntity:Company OR
+			sourcingMaterialWritingEntity:Material
 
 	WITH
 		person,

--- a/src/neo4j/cypher-queries/production.js
+++ b/src/neo4j/cypher-queries/production.js
@@ -165,7 +165,7 @@ const getShowQuery = () => `
 	OPTIONAL MATCH (production)-[materialRel:PRODUCTION_OF]->(material:Material)
 
 	OPTIONAL MATCH (material)-[writingEntityRel:WRITTEN_BY|USES_SOURCE_MATERIAL]->(writingEntity)
-		WHERE writingEntity:Person OR writingEntity:Material
+		WHERE writingEntity:Person OR writingEntity:Company OR writingEntity:Material
 
 	OPTIONAL MATCH (writingEntity:Material)-[sourceMaterialWriterRel:WRITTEN_BY]->(sourceMaterialWriter)
 
@@ -182,7 +182,11 @@ const getShowQuery = () => `
 		COLLECT(
 			CASE sourceMaterialWriter WHEN NULL
 				THEN null
-				ELSE { model: 'person', uuid: sourceMaterialWriter.uuid, name: sourceMaterialWriter.name }
+				ELSE {
+					model: TOLOWER(HEAD(LABELS(sourceMaterialWriter))),
+					uuid: sourceMaterialWriter.uuid,
+					name: sourceMaterialWriter.name
+				}
 			END
 		) AS sourceMaterialWriters
 

--- a/test-e2e/crud/companies-api.test.js
+++ b/test-e2e/crud/companies-api.test.js
@@ -127,7 +127,10 @@ describe('CRUD (Create, Read, Update, Delete): Companies API', () => {
 				model: 'company',
 				uuid: COMPANY_UUID,
 				name: 'Royal Shakespeare Company',
-				differentiator: null
+				differentiator: null,
+				materials: [],
+				subsequentVersionMaterials: [],
+				sourcingMaterials: []
 			};
 
 			expect(response).to.have.status(200);

--- a/test-e2e/crud/materials-api.test.js
+++ b/test-e2e/crud/materials-api.test.js
@@ -336,21 +336,23 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 
 	describe('CRUD with full range of attributes assigned values', () => {
 
-		const MATERIAL_UUID = '8';
-		const JOHN_GABRIEL_BORKMAN_ORIGINAL_VERSION_MATERIAL_UUID = '9';
-		const HENRIK_IBSEN_PERSON_UUID = '10';
-		const DAVID_ELDRIDGE_PERSON_UUID = '11';
-		const JOHN_GABRIEL_BORKMAN_SOURCE_MATERIAL_MATERIAL_UUID = '12';
-		const JOHN_GABRIEL_BORKMAN_CHARACTER_UUID = '13';
-		const GUNHILD_BORKMAN_CHARACTER_UUID = '14';
-		const ERHART_BORKMAN_CHARACTER_UUID = '15';
-		const THREE_SISTERS_ORIGINAL_VERSION_MATERIAL_UUID = '23';
-		const ANTON_CHEKHOV_PERSON_UUID = '24';
-		const BENEDICT_ANDREWS_PERSON_UUID = '25';
-		const THREE_SISTERS_SOURCE_MATERIAL_MATERIAL_UUID = '26';
-		const OLGA_SERGEYEVNA_PROZOROVA_CHARACTER_UUID = '27';
-		const MARIA_SERGEYEVNA_KULYGINA_CHARACTER_UUID = '28';
-		const IRINA_SERGEYEVNA_PROZOROVA_CHARACTER_UUID = '29';
+		const MATERIAL_UUID = '9';
+		const JOHN_GABRIEL_BORKMAN_ORIGINAL_VERSION_MATERIAL_UUID = '10';
+		const HENRIK_IBSEN_PERSON_UUID = '11';
+		const IBSEN_THEATRE_COMPANY_UUID = '12';
+		const DAVID_ELDRIDGE_PERSON_UUID = '13';
+		const JOHN_GABRIEL_BORKMAN_SOURCE_MATERIAL_MATERIAL_UUID = '14';
+		const JOHN_GABRIEL_BORKMAN_CHARACTER_UUID = '15';
+		const GUNHILD_BORKMAN_CHARACTER_UUID = '16';
+		const ERHART_BORKMAN_CHARACTER_UUID = '17';
+		const THREE_SISTERS_ORIGINAL_VERSION_MATERIAL_UUID = '26';
+		const ANTON_CHEKHOV_PERSON_UUID = '27';
+		const CHEKHOV_THEATRE_COMPANY_UUID = '28';
+		const BENEDICT_ANDREWS_PERSON_UUID = '29';
+		const THREE_SISTERS_SOURCE_MATERIAL_MATERIAL_UUID = '30';
+		const OLGA_SERGEYEVNA_PROZOROVA_CHARACTER_UUID = '31';
+		const MARIA_SERGEYEVNA_KULYGINA_CHARACTER_UUID = '32';
+		const IRINA_SERGEYEVNA_PROZOROVA_CHARACTER_UUID = '33';
 
 		before(async () => {
 
@@ -388,6 +390,12 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 							writingEntities: [
 								{
 									name: 'Henrik Ibsen',
+									differentiator: '1'
+								},
+								// Contrivance for purposes of test.
+								{
+									model: 'company',
+									name: 'Ibsen Theatre Company',
 									differentiator: '1'
 								}
 							]
@@ -463,6 +471,12 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 							{
 								model: 'person',
 								name: 'Henrik Ibsen',
+								differentiator: '1',
+								errors: {}
+							},
+							{
+								model: 'company',
+								name: 'Ibsen Theatre Company',
 								differentiator: '1',
 								errors: {}
 							},
@@ -622,6 +636,11 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 								model: 'person',
 								uuid: HENRIK_IBSEN_PERSON_UUID,
 								name: 'Henrik Ibsen'
+							},
+							{
+								model: 'company',
+								uuid: IBSEN_THEATRE_COMPANY_UUID,
+								name: 'Ibsen Theatre Company'
 							}
 						]
 					},
@@ -714,6 +733,12 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 							{
 								model: 'person',
 								name: 'Henrik Ibsen',
+								differentiator: '1',
+								errors: {}
+							},
+							{
+								model: 'company',
+								name: 'Ibsen Theatre Company',
 								differentiator: '1',
 								errors: {}
 							},
@@ -864,6 +889,12 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 								{
 									name: 'Anton Chekhov',
 									differentiator: '1'
+								},
+								// Contrivance for purposes of test.
+								{
+									model: 'company',
+									name: 'Chekhov Theatre Company',
+									differentiator: '1'
 								}
 							]
 						},
@@ -938,6 +969,12 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 							{
 								model: 'person',
 								name: 'Anton Chekhov',
+								differentiator: '1',
+								errors: {}
+							},
+							{
+								model: 'company',
+								name: 'Chekhov Theatre Company',
 								differentiator: '1',
 								errors: {}
 							},
@@ -1097,6 +1134,11 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 								model: 'person',
 								uuid: ANTON_CHEKHOV_PERSON_UUID,
 								name: 'Anton Chekhov'
+							},
+							{
+								model: 'company',
+								uuid: CHEKHOV_THEATRE_COMPANY_UUID,
+								name: 'Chekhov Theatre Company'
 							}
 						]
 					},

--- a/test-e2e/model-interaction/material-multi-versions-multi-wri-groups.test.js
+++ b/test-e2e/model-interaction/material-multi-versions-multi-wri-groups.test.js
@@ -10,23 +10,27 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 
 	chai.use(chaiHttp);
 
-	const PEER_GYNT_ORIGINAL_VERSION_MATERIAL_UUID = '4';
-	const HENRIK_IBSEN_PERSON_UUID = '6';
-	const PEER_GYNT_CHARACTER_UUID = '7';
-	const PEER_GYNT_SUBSEQUENT_VERSION_1_MATERIAL_UUID = '13';
-	const FRANK_MCGUINNESS_PERSON_UUID = '16';
-	const PEER_GYNT_SUBSEQUENT_VERSION_2_MATERIAL_UUID = '25';
-	const GERRY_BAMMAN_PERSON_UUID = '28';
-	const IRENE_B_BERMAN_PERSON_UUID = '29';
-	const BALTASAR_KORMÁKUR_PERSON_UUID = '30';
-	const GHOSTS_ORIGINAL_VERSION_MATERIAL_UUID = '35';
-	const GHOSTS_SUBSEQUENT_VERSION_MATERIAL_UUID = '44';
-	const PEER_GYNT_BARBICAN_PRODUCTION_UUID = '50';
+	const PEER_GYNT_ORIGINAL_VERSION_MATERIAL_UUID = '5';
+	const HENRIK_IBSEN_PERSON_UUID = '7';
+	const IBSEN_THEATRE_COMPANY_UUID = '8';
+	const PEER_GYNT_CHARACTER_UUID = '9';
+	const PEER_GYNT_SUBSEQUENT_VERSION_1_MATERIAL_UUID = '16';
+	const FRANK_MCGUINNESS_PERSON_UUID = '20';
+	const PEER_GYNT_SUBSEQUENT_VERSION_2_MATERIAL_UUID = '31';
+	const GERRY_BAMMAN_PERSON_UUID = '35';
+	const BAMMAN_THEATRE_COMPANY_UUID = '36';
+	const IRENE_B_BERMAN_PERSON_UUID = '37';
+	const BALTASAR_KORMÁKUR_PERSON_UUID = '38';
+	const GHOSTS_ORIGINAL_VERSION_MATERIAL_UUID = '44';
+	const GHOSTS_SUBSEQUENT_VERSION_MATERIAL_UUID = '56';
+	const PEER_GYNT_BARBICAN_PRODUCTION_UUID = '64';
 
 	let peerGyntOriginalMaterial;
 	let peerGyntSubsequentVersion2Material;
 	let henrikIbsenPerson;
 	let gerryBammanPerson;
+	let ibsenTheatreCompany;
+	let bammanTheatreCompany;
 	let peerGyntCharacter;
 	let peerGyntBarbicanProduction;
 
@@ -51,6 +55,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						writingEntities: [
 							{
 								name: 'Henrik Ibsen'
+							},
+							// Contrivance for purposes of test.
+							{
+								model: 'company',
+								name: 'Ibsen Theatre Company'
 							}
 						]
 					}
@@ -81,6 +90,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						writingEntities: [
 							{
 								name: 'Henrik Ibsen'
+							},
+							// Contrivance for purposes of test.
+							{
+								model: 'company',
+								name: 'Ibsen Theatre Company'
 							}
 						]
 					},
@@ -119,6 +133,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						writingEntities: [
 							{
 								name: 'Henrik Ibsen'
+							},
+							// Contrivance for purposes of test.
+							{
+								model: 'company',
+								name: 'Ibsen Theatre Company'
 							}
 						]
 					},
@@ -127,6 +146,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						writingEntities: [
 							{
 								name: 'Gerry Bamman'
+							},
+							// Contrivance for purposes of test.
+							{
+								model: 'company',
+								name: 'Bamman Theatre Company'
 							},
 							{
 								name: 'Irene B Berman'
@@ -164,6 +188,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						writingEntities: [
 							{
 								name: 'Henrik Ibsen'
+							},
+							// Contrivance for purposes of test.
+							{
+								model: 'company',
+								name: 'Ibsen Theatre Company'
 							}
 						]
 					}
@@ -186,6 +215,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						writingEntities: [
 							{
 								name: 'Henrik Ibsen'
+							},
+							// Contrivance for purposes of test.
+							{
+								model: 'company',
+								name: 'Ibsen Theatre Company'
 							}
 						]
 					},
@@ -194,6 +228,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						writingEntities: [
 							{
 								name: 'Gerry Bamman'
+							},
+							// Contrivance for purposes of test.
+							{
+								model: 'company',
+								name: 'Bamman Theatre Company'
 							},
 							{
 								name: 'Irene B Berman'
@@ -236,6 +275,12 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 		gerryBammanPerson = await chai.request(app)
 			.get(`/people/${GERRY_BAMMAN_PERSON_UUID}`);
 
+		ibsenTheatreCompany = await chai.request(app)
+			.get(`/companies/${IBSEN_THEATRE_COMPANY_UUID}`);
+
+		bammanTheatreCompany = await chai.request(app)
+			.get(`/companies/${BAMMAN_THEATRE_COMPANY_UUID}`);
+
 		peerGyntCharacter = await chai.request(app)
 			.get(`/characters/${PEER_GYNT_CHARACTER_UUID}`);
 
@@ -269,6 +314,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 									model: 'person',
 									uuid: GERRY_BAMMAN_PERSON_UUID,
 									name: 'Gerry Bamman'
+								},
+								{
+									model: 'company',
+									uuid: BAMMAN_THEATRE_COMPANY_UUID,
+									name: 'Bamman Theatre Company'
 								},
 								{
 									model: 'person',
@@ -328,6 +378,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 							model: 'person',
 							uuid: HENRIK_IBSEN_PERSON_UUID,
 							name: 'Henrik Ibsen'
+						},
+						{
+							model: 'company',
+							uuid: IBSEN_THEATRE_COMPANY_UUID,
+							name: 'Ibsen Theatre Company'
 						}
 					]
 				}
@@ -359,6 +414,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								model: 'person',
 								uuid: HENRIK_IBSEN_PERSON_UUID,
 								name: 'Henrik Ibsen'
+							},
+							{
+								model: 'company',
+								uuid: IBSEN_THEATRE_COMPANY_UUID,
+								name: 'Ibsen Theatre Company'
 							}
 						]
 					}
@@ -382,6 +442,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 							model: 'person',
 							uuid: HENRIK_IBSEN_PERSON_UUID,
 							name: 'Henrik Ibsen'
+						},
+						{
+							model: 'company',
+							uuid: IBSEN_THEATRE_COMPANY_UUID,
+							name: 'Ibsen Theatre Company'
 						}
 					]
 				},
@@ -393,6 +458,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 							model: 'person',
 							uuid: GERRY_BAMMAN_PERSON_UUID,
 							name: 'Gerry Bamman'
+						},
+						{
+							model: 'company',
+							uuid: BAMMAN_THEATRE_COMPANY_UUID,
+							name: 'Bamman Theatre Company'
 						},
 						{
 							model: 'person',
@@ -441,6 +511,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 									model: 'person',
 									uuid: null,
 									name: 'Henrik Ibsen'
+								},
+								{
+									model: 'company',
+									uuid: IBSEN_THEATRE_COMPANY_UUID,
+									name: 'Ibsen Theatre Company'
 								}
 							]
 						}
@@ -460,6 +535,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 									model: 'person',
 									uuid: null,
 									name: 'Henrik Ibsen'
+								},
+								{
+									model: 'company',
+									uuid: IBSEN_THEATRE_COMPANY_UUID,
+									name: 'Ibsen Theatre Company'
 								}
 							]
 						}
@@ -490,6 +570,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 									model: 'person',
 									uuid: null,
 									name: 'Henrik Ibsen'
+								},
+								{
+									model: 'company',
+									uuid: IBSEN_THEATRE_COMPANY_UUID,
+									name: 'Ibsen Theatre Company'
 								}
 							]
 						},
@@ -501,6 +586,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 									model: 'person',
 									uuid: GERRY_BAMMAN_PERSON_UUID,
 									name: 'Gerry Bamman'
+								},
+								{
+									model: 'company',
+									uuid: BAMMAN_THEATRE_COMPANY_UUID,
+									name: 'Bamman Theatre Company'
 								},
 								{
 									model: 'person',
@@ -536,6 +626,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 									model: 'person',
 									uuid: null,
 									name: 'Henrik Ibsen'
+								},
+								{
+									model: 'company',
+									uuid: IBSEN_THEATRE_COMPANY_UUID,
+									name: 'Ibsen Theatre Company'
 								}
 							]
 						},
@@ -547,6 +642,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 									model: 'person',
 									uuid: GERRY_BAMMAN_PERSON_UUID,
 									name: 'Gerry Bamman'
+								},
+								{
+									model: 'company',
+									uuid: BAMMAN_THEATRE_COMPANY_UUID,
+									name: 'Bamman Theatre Company'
 								},
 								{
 									model: 'person',
@@ -582,6 +682,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 									model: 'person',
 									uuid: null,
 									name: 'Henrik Ibsen'
+								},
+								{
+									model: 'company',
+									uuid: IBSEN_THEATRE_COMPANY_UUID,
+									name: 'Ibsen Theatre Company'
 								}
 							]
 						},
@@ -627,6 +732,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
 									name: 'Henrik Ibsen'
+								},
+								{
+									model: 'company',
+									uuid: IBSEN_THEATRE_COMPANY_UUID,
+									name: 'Ibsen Theatre Company'
 								}
 							]
 						},
@@ -638,6 +748,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 									model: 'person',
 									uuid: null,
 									name: 'Gerry Bamman'
+								},
+								{
+									model: 'company',
+									uuid: BAMMAN_THEATRE_COMPANY_UUID,
+									name: 'Bamman Theatre Company'
 								},
 								{
 									model: 'person',
@@ -673,6 +788,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
 									name: 'Henrik Ibsen'
+								},
+								{
+									model: 'company',
+									uuid: IBSEN_THEATRE_COMPANY_UUID,
+									name: 'Ibsen Theatre Company'
 								}
 							]
 						},
@@ -684,6 +804,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 									model: 'person',
 									uuid: null,
 									name: 'Gerry Bamman'
+								},
+								{
+									model: 'company',
+									uuid: BAMMAN_THEATRE_COMPANY_UUID,
+									name: 'Bamman Theatre Company'
 								},
 								{
 									model: 'person',
@@ -715,6 +840,354 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 
 	});
 
+	describe('Ibsen Theatre Company (company)', () => {
+
+		it('includes materials they have written (in which their uuid is nullified)', () => {
+
+			const expectedMaterials = [
+				{
+					model: 'material',
+					uuid: GHOSTS_ORIGINAL_VERSION_MATERIAL_UUID,
+					name: 'Ghosts',
+					format: 'play',
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: HENRIK_IBSEN_PERSON_UUID,
+									name: 'Henrik Ibsen'
+								},
+								{
+									model: 'company',
+									uuid: null,
+									name: 'Ibsen Theatre Company'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'material',
+					uuid: PEER_GYNT_ORIGINAL_VERSION_MATERIAL_UUID,
+					name: 'Peer Gynt',
+					format: 'play',
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: HENRIK_IBSEN_PERSON_UUID,
+									name: 'Henrik Ibsen'
+								},
+								{
+									model: 'company',
+									uuid: null,
+									name: 'Ibsen Theatre Company'
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { materials } = ibsenTheatreCompany.body;
+
+			expect(materials).to.deep.equal(expectedMaterials);
+
+		});
+
+		it('includes subsequent versions of materials they originally wrote (in which their uuid is nullified), with corresponding writers', () => {
+
+			const expectedSubsequentVersionMaterials = [
+				{
+					model: 'material',
+					uuid: GHOSTS_SUBSEQUENT_VERSION_MATERIAL_UUID,
+					name: 'Ghosts',
+					format: 'play',
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: HENRIK_IBSEN_PERSON_UUID,
+									name: 'Henrik Ibsen'
+								},
+								{
+									model: 'company',
+									uuid: null,
+									name: 'Ibsen Theatre Company'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'translated by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: GERRY_BAMMAN_PERSON_UUID,
+									name: 'Gerry Bamman'
+								},
+								{
+									model: 'company',
+									uuid: BAMMAN_THEATRE_COMPANY_UUID,
+									name: 'Bamman Theatre Company'
+								},
+								{
+									model: 'person',
+									uuid: IRENE_B_BERMAN_PERSON_UUID,
+									name: 'Irene B Berman'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'adapted by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
+									name: 'Baltasar Kormákur'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'material',
+					uuid: PEER_GYNT_SUBSEQUENT_VERSION_2_MATERIAL_UUID,
+					name: 'Peer Gynt',
+					format: 'play',
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: HENRIK_IBSEN_PERSON_UUID,
+									name: 'Henrik Ibsen'
+								},
+								{
+									model: 'company',
+									uuid: null,
+									name: 'Ibsen Theatre Company'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'translated by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: GERRY_BAMMAN_PERSON_UUID,
+									name: 'Gerry Bamman'
+								},
+								{
+									model: 'company',
+									uuid: BAMMAN_THEATRE_COMPANY_UUID,
+									name: 'Bamman Theatre Company'
+								},
+								{
+									model: 'person',
+									uuid: IRENE_B_BERMAN_PERSON_UUID,
+									name: 'Irene B Berman'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'adapted by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
+									name: 'Baltasar Kormákur'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'material',
+					uuid: PEER_GYNT_SUBSEQUENT_VERSION_1_MATERIAL_UUID,
+					name: 'Peer Gynt',
+					format: 'play',
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: HENRIK_IBSEN_PERSON_UUID,
+									name: 'Henrik Ibsen'
+								},
+								{
+									model: 'company',
+									uuid: null,
+									name: 'Ibsen Theatre Company'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'version by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: FRANK_MCGUINNESS_PERSON_UUID,
+									name: 'Frank McGuinness'
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { subsequentVersionMaterials } = ibsenTheatreCompany.body;
+
+			expect(subsequentVersionMaterials).to.deep.equal(expectedSubsequentVersionMaterials);
+
+		});
+
+	});
+
+	describe('Bamman Theatre Company (company)', () => {
+
+		it('includes materials they have written (in which their uuid is nullified), with corresponding writers', () => {
+
+			const expectedMaterials = [
+				{
+					model: 'material',
+					uuid: GHOSTS_SUBSEQUENT_VERSION_MATERIAL_UUID,
+					name: 'Ghosts',
+					format: 'play',
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: HENRIK_IBSEN_PERSON_UUID,
+									name: 'Henrik Ibsen'
+								},
+								{
+									model: 'company',
+									uuid: IBSEN_THEATRE_COMPANY_UUID,
+									name: 'Ibsen Theatre Company'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'translated by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: GERRY_BAMMAN_PERSON_UUID,
+									name: 'Gerry Bamman'
+								},
+								{
+									model: 'company',
+									uuid: null,
+									name: 'Bamman Theatre Company'
+								},
+								{
+									model: 'person',
+									uuid: IRENE_B_BERMAN_PERSON_UUID,
+									name: 'Irene B Berman'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'adapted by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
+									name: 'Baltasar Kormákur'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'material',
+					uuid: PEER_GYNT_SUBSEQUENT_VERSION_2_MATERIAL_UUID,
+					name: 'Peer Gynt',
+					format: 'play',
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: HENRIK_IBSEN_PERSON_UUID,
+									name: 'Henrik Ibsen'
+								},
+								{
+									model: 'company',
+									uuid: IBSEN_THEATRE_COMPANY_UUID,
+									name: 'Ibsen Theatre Company'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'translated by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: GERRY_BAMMAN_PERSON_UUID,
+									name: 'Gerry Bamman'
+								},
+								{
+									model: 'company',
+									uuid: null,
+									name: 'Bamman Theatre Company'
+								},
+								{
+									model: 'person',
+									uuid: IRENE_B_BERMAN_PERSON_UUID,
+									name: 'Irene B Berman'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'adapted by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
+									name: 'Baltasar Kormákur'
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { materials } = bammanTheatreCompany.body;
+
+			expect(materials).to.deep.equal(expectedMaterials);
+
+		});
+
+	});
+
 	describe('Peer Gynt at Barbican (production)', () => {
 
 		it('includes in its material data the writers of the material', () => {
@@ -733,6 +1206,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								model: 'person',
 								uuid: HENRIK_IBSEN_PERSON_UUID,
 								name: 'Henrik Ibsen'
+							},
+							{
+								model: 'company',
+								uuid: IBSEN_THEATRE_COMPANY_UUID,
+								name: 'Ibsen Theatre Company'
 							}
 						]
 					},
@@ -744,6 +1222,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								model: 'person',
 								uuid: GERRY_BAMMAN_PERSON_UUID,
 								name: 'Gerry Bamman'
+							},
+							{
+								model: 'company',
+								uuid: BAMMAN_THEATRE_COMPANY_UUID,
+								name: 'Bamman Theatre Company'
 							},
 							{
 								model: 'person',
@@ -793,6 +1276,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
 									name: 'Henrik Ibsen'
+								},
+								{
+									model: 'company',
+									uuid: IBSEN_THEATRE_COMPANY_UUID,
+									name: 'Ibsen Theatre Company'
 								}
 							]
 						},
@@ -804,6 +1292,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 									model: 'person',
 									uuid: GERRY_BAMMAN_PERSON_UUID,
 									name: 'Gerry Bamman'
+								},
+								{
+									model: 'company',
+									uuid: BAMMAN_THEATRE_COMPANY_UUID,
+									name: 'Bamman Theatre Company'
 								},
 								{
 									model: 'person',
@@ -840,6 +1333,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
 									name: 'Henrik Ibsen'
+								},
+								{
+									model: 'company',
+									uuid: IBSEN_THEATRE_COMPANY_UUID,
+									name: 'Ibsen Theatre Company'
 								}
 							]
 						},
@@ -871,6 +1369,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
 									name: 'Henrik Ibsen'
+								},
+								{
+									model: 'company',
+									uuid: IBSEN_THEATRE_COMPANY_UUID,
+									name: 'Ibsen Theatre Company'
 								}
 							]
 						}
@@ -909,6 +1412,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
 									name: 'Henrik Ibsen'
+								},
+								{
+									model: 'company',
+									uuid: IBSEN_THEATRE_COMPANY_UUID,
+									name: 'Ibsen Theatre Company'
 								}
 							]
 						}
@@ -928,6 +1436,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
 									name: 'Henrik Ibsen'
+								},
+								{
+									model: 'company',
+									uuid: IBSEN_THEATRE_COMPANY_UUID,
+									name: 'Ibsen Theatre Company'
 								}
 							]
 						},
@@ -939,6 +1452,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 									model: 'person',
 									uuid: GERRY_BAMMAN_PERSON_UUID,
 									name: 'Gerry Bamman'
+								},
+								{
+									model: 'company',
+									uuid: BAMMAN_THEATRE_COMPANY_UUID,
+									name: 'Bamman Theatre Company'
 								},
 								{
 									model: 'person',
@@ -974,6 +1492,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
 									name: 'Henrik Ibsen'
+								},
+								{
+									model: 'company',
+									uuid: IBSEN_THEATRE_COMPANY_UUID,
+									name: 'Ibsen Theatre Company'
 								}
 							]
 						}
@@ -993,6 +1516,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
 									name: 'Henrik Ibsen'
+								},
+								{
+									model: 'company',
+									uuid: IBSEN_THEATRE_COMPANY_UUID,
+									name: 'Ibsen Theatre Company'
 								}
 							]
 						},
@@ -1023,6 +1551,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
 									name: 'Henrik Ibsen'
+								},
+								{
+									model: 'company',
+									uuid: IBSEN_THEATRE_COMPANY_UUID,
+									name: 'Ibsen Theatre Company'
 								}
 							]
 						},
@@ -1034,6 +1567,11 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 									model: 'person',
 									uuid: GERRY_BAMMAN_PERSON_UUID,
 									name: 'Gerry Bamman'
+								},
+								{
+									model: 'company',
+									uuid: BAMMAN_THEATRE_COMPANY_UUID,
+									name: 'Bamman Theatre Company'
 								},
 								{
 									model: 'person',

--- a/test-e2e/model-interaction/material-with-source-material.test.js
+++ b/test-e2e/model-interaction/material-with-source-material.test.js
@@ -10,17 +10,20 @@ describe('Materials with source material', () => {
 
 	chai.use(chaiHttp);
 
-	const A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID = '3';
-	const WILLIAM_SHAKESPEARE_PERSON_UUID = '5';
-	const THE_INDIAN_BOY_MATERIAL_UUID = '11';
-	const RONA_MUNRO_PERSON_UUID = '13';
-	const THE_INDIAN_BOY_CHARACTER_UUID = '15';
-	const SHAKESPEARES_VILLAINS_MATERIAL_UUID = '21';
-	const STEVEN_BERKOFF_PERSON_UUID = '23';
-	const IAGO_CHARACTER_UUID = '25';
-	const THE_INDIAN_BOY_ROYAL_SHAKESPEARE_THEATRE_PRODUCTION_UUID = '26';
-	const ROYAL_SHAKESPEARE_THEATRE_UUID = '28';
-	const SHAKESPEARES_VILLAINS_THEATRE_ROYAL_HAYMARKET_PRODUCTION_UUID = '29';
+	const A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID = '4';
+	const WILLIAM_SHAKESPEARE_PERSON_UUID = '6';
+	const THE_KINGS_MEN_COMPANY_UUID = '7';
+	const THE_INDIAN_BOY_MATERIAL_UUID = '14';
+	const RONA_MUNRO_PERSON_UUID = '16';
+	const ROYAL_SHAKESPEARE_COMPANY_UUID = '17';
+	const THE_INDIAN_BOY_CHARACTER_UUID = '19';
+	const SHAKESPEARES_VILLAINS_MATERIAL_UUID = '27';
+	const STEVEN_BERKOFF_PERSON_UUID = '29';
+	const EAST_PRODUCTIONS_COMPANY_UUID = '30';
+	const IAGO_CHARACTER_UUID = '33';
+	const THE_INDIAN_BOY_ROYAL_SHAKESPEARE_THEATRE_PRODUCTION_UUID = '34';
+	const ROYAL_SHAKESPEARE_THEATRE_UUID = '36';
+	const SHAKESPEARES_VILLAINS_THEATRE_ROYAL_HAYMARKET_PRODUCTION_UUID = '37';
 
 	let theIndianBoyMaterial;
 	let aMidsummerNightsDreamMaterial;
@@ -28,6 +31,9 @@ describe('Materials with source material', () => {
 	let ronaMunroPerson;
 	let williamShakespearePerson;
 	let stevenBerkoffPerson;
+	let theKingsMenCompany;
+	let royalShakespeareCompany;
+	let eastProductionsCompany;
 	let theIndianBoyRoyalShakespeareTheatreProduction;
 	let shakespearesVillainsTheatreRoyalHaymarketProduction;
 	let theIndianBoyCharacter;
@@ -53,6 +59,11 @@ describe('Materials with source material', () => {
 						writingEntities: [
 							{
 								name: 'William Shakespeare'
+							},
+							// Contrivance for purposes of test.
+							{
+								model: 'company',
+								name: 'The King\'s Men'
 							}
 						]
 					}
@@ -69,6 +80,11 @@ describe('Materials with source material', () => {
 						writingEntities: [
 							{
 								name: 'Rona Munro'
+							},
+							// Contrivance for purposes of test.
+							{
+								model: 'company',
+								name: 'Royal Shakespeare Company'
 							}
 						]
 					},
@@ -103,6 +119,11 @@ describe('Materials with source material', () => {
 						writingEntities: [
 							{
 								name: 'Steven Berkoff'
+							},
+							// Contrivance for purposes of test.
+							{
+								model: 'company',
+								name: 'East Productions'
 							}
 						]
 					},
@@ -112,6 +133,11 @@ describe('Materials with source material', () => {
 						writingEntities: [
 							{
 								name: 'William Shakespeare'
+							},
+							// Contrivance for purposes of test.
+							{
+								model: 'company',
+								name: 'The King\'s Men'
 							}
 						]
 					}
@@ -169,6 +195,15 @@ describe('Materials with source material', () => {
 		stevenBerkoffPerson = await chai.request(app)
 			.get(`/people/${STEVEN_BERKOFF_PERSON_UUID}`);
 
+		theKingsMenCompany = await chai.request(app)
+			.get(`/companies/${THE_KINGS_MEN_COMPANY_UUID}`);
+
+		royalShakespeareCompany = await chai.request(app)
+			.get(`/companies/${ROYAL_SHAKESPEARE_COMPANY_UUID}`);
+
+		eastProductionsCompany = await chai.request(app)
+			.get(`/companies/${EAST_PRODUCTIONS_COMPANY_UUID}`);
+
 		theIndianBoyRoyalShakespeareTheatreProduction = await chai.request(app)
 			.get(`/productions/${THE_INDIAN_BOY_ROYAL_SHAKESPEARE_THEATRE_PRODUCTION_UUID}`);
 
@@ -202,6 +237,11 @@ describe('Materials with source material', () => {
 							model: 'person',
 							uuid: RONA_MUNRO_PERSON_UUID,
 							name: 'Rona Munro'
+						},
+						{
+							model: 'company',
+							uuid: ROYAL_SHAKESPEARE_COMPANY_UUID,
+							name: 'Royal Shakespeare Company'
 						}
 					]
 				},
@@ -223,6 +263,11 @@ describe('Materials with source material', () => {
 											model: 'person',
 											uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
 											name: 'William Shakespeare'
+										},
+										{
+											model: 'company',
+											uuid: THE_KINGS_MEN_COMPANY_UUID,
+											name: 'The King\'s Men'
 										}
 									]
 								}
@@ -259,6 +304,11 @@ describe('Materials with source material', () => {
 									model: 'person',
 									uuid: RONA_MUNRO_PERSON_UUID,
 									name: 'Rona Munro'
+								},
+								{
+									model: 'company',
+									uuid: ROYAL_SHAKESPEARE_COMPANY_UUID,
+									name: 'Royal Shakespeare Company'
 								}
 							]
 						},
@@ -321,6 +371,11 @@ describe('Materials with source material', () => {
 							model: 'person',
 							uuid: STEVEN_BERKOFF_PERSON_UUID,
 							name: 'Steven Berkoff'
+						},
+						{
+							model: 'company',
+							uuid: EAST_PRODUCTIONS_COMPANY_UUID,
+							name: 'East Productions'
 						}
 					]
 				},
@@ -332,6 +387,11 @@ describe('Materials with source material', () => {
 							model: 'person',
 							uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
 							name: 'William Shakespeare'
+						},
+						{
+							model: 'company',
+							uuid: THE_KINGS_MEN_COMPANY_UUID,
+							name: 'The King\'s Men'
 						}
 					]
 				}
@@ -364,6 +424,11 @@ describe('Materials with source material', () => {
 									model: 'person',
 									uuid: null,
 									name: 'Rona Munro'
+								},
+								{
+									model: 'company',
+									uuid: ROYAL_SHAKESPEARE_COMPANY_UUID,
+									name: 'Royal Shakespeare Company'
 								}
 							]
 						},
@@ -385,6 +450,11 @@ describe('Materials with source material', () => {
 													model: 'person',
 													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
 													name: 'William Shakespeare'
+												},
+												{
+													model: 'company',
+													uuid: THE_KINGS_MEN_COMPANY_UUID,
+													name: 'The King\'s Men'
 												}
 											]
 										}
@@ -423,6 +493,11 @@ describe('Materials with source material', () => {
 									model: 'person',
 									uuid: STEVEN_BERKOFF_PERSON_UUID,
 									name: 'Steven Berkoff'
+								},
+								{
+									model: 'company',
+									uuid: EAST_PRODUCTIONS_COMPANY_UUID,
+									name: 'East Productions'
 								}
 							]
 						},
@@ -434,6 +509,11 @@ describe('Materials with source material', () => {
 									model: 'person',
 									uuid: null,
 									name: 'William Shakespeare'
+								},
+								{
+									model: 'company',
+									uuid: THE_KINGS_MEN_COMPANY_UUID,
+									name: 'The King\'s Men'
 								}
 							]
 						}
@@ -453,6 +533,11 @@ describe('Materials with source material', () => {
 									model: 'person',
 									uuid: RONA_MUNRO_PERSON_UUID,
 									name: 'Rona Munro'
+								},
+								{
+									model: 'company',
+									uuid: ROYAL_SHAKESPEARE_COMPANY_UUID,
+									name: 'Royal Shakespeare Company'
 								}
 							]
 						},
@@ -499,6 +584,11 @@ describe('Materials with source material', () => {
 									model: 'person',
 									uuid: null,
 									name: 'Steven Berkoff'
+								},
+								{
+									model: 'company',
+									uuid: EAST_PRODUCTIONS_COMPANY_UUID,
+									name: 'East Productions'
 								}
 							]
 						},
@@ -510,6 +600,11 @@ describe('Materials with source material', () => {
 									model: 'person',
 									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
 									name: 'William Shakespeare'
+								},
+								{
+									model: 'company',
+									uuid: THE_KINGS_MEN_COMPANY_UUID,
+									name: 'The King\'s Men'
 								}
 							]
 						}
@@ -518,6 +613,221 @@ describe('Materials with source material', () => {
 			];
 
 			const { materials } = stevenBerkoffPerson.body;
+
+			expect(materials).to.deep.equal(expectedMaterials);
+
+		});
+
+	});
+
+	describe('The King\'s Men (company)', () => {
+
+		it('includes materials that used their work as source material (both specific and non-specific), with corresponding writers', () => {
+
+			const expectedSourcingMaterials = [
+				{
+					model: 'material',
+					uuid: SHAKESPEARES_VILLAINS_MATERIAL_UUID,
+					name: 'Shakespeare\'s Villains',
+					format: 'play',
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: STEVEN_BERKOFF_PERSON_UUID,
+									name: 'Steven Berkoff'
+								},
+								{
+									model: 'company',
+									uuid: EAST_PRODUCTIONS_COMPANY_UUID,
+									name: 'East Productions'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'based on works by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+									name: 'William Shakespeare'
+								},
+								{
+									model: 'company',
+									uuid: null,
+									name: 'The King\'s Men'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'material',
+					uuid: THE_INDIAN_BOY_MATERIAL_UUID,
+					name: 'The Indian Boy',
+					format: 'play',
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: RONA_MUNRO_PERSON_UUID,
+									name: 'Rona Munro'
+								},
+								{
+									model: 'company',
+									uuid: ROYAL_SHAKESPEARE_COMPANY_UUID,
+									name: 'Royal Shakespeare Company'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'inspired by',
+							writingEntities: [
+								{
+									model: 'material',
+									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
+									name: 'A Midsummer Night\'s Dream',
+									format: 'play'
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { sourcingMaterials } = theKingsMenCompany.body;
+
+			expect(sourcingMaterials).to.deep.equal(expectedSourcingMaterials);
+
+		});
+
+	});
+
+	describe('Royal Shakespeare Company (company)', () => {
+
+		it('includes materials they have written (in which their uuid is nullified), with corresponding writers', () => {
+
+			const expectedMaterials = [
+				{
+					model: 'material',
+					uuid: THE_INDIAN_BOY_MATERIAL_UUID,
+					name: 'The Indian Boy',
+					format: 'play',
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: RONA_MUNRO_PERSON_UUID,
+									name: 'Rona Munro'
+								},
+								{
+									model: 'company',
+									uuid: null,
+									name: 'Royal Shakespeare Company'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'inspired by',
+							writingEntities: [
+								{
+									model: 'material',
+									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
+									name: 'A Midsummer Night\'s Dream',
+									format: 'play',
+									sourceMaterialWritingCredits: [
+										{
+											model: 'writingCredit',
+											name: 'by',
+											writingEntities: [
+												{
+													model: 'person',
+													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+													name: 'William Shakespeare'
+												},
+												{
+													model: 'company',
+													uuid: THE_KINGS_MEN_COMPANY_UUID,
+													name: 'The King\'s Men'
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { materials } = royalShakespeareCompany.body;
+
+			expect(materials).to.deep.equal(expectedMaterials);
+
+		});
+
+	});
+
+	describe('East Productions (company)', () => {
+
+		it('includes materials they have written (in which their uuid is nullified), with corresponding writers', () => {
+
+			const expectedMaterials = [
+				{
+					model: 'material',
+					uuid: SHAKESPEARES_VILLAINS_MATERIAL_UUID,
+					name: 'Shakespeare\'s Villains',
+					format: 'play',
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: STEVEN_BERKOFF_PERSON_UUID,
+									name: 'Steven Berkoff'
+								},
+								{
+									model: 'company',
+									uuid: null,
+									name: 'East Productions'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'based on works by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+									name: 'William Shakespeare'
+								},
+								{
+									model: 'company',
+									uuid: THE_KINGS_MEN_COMPANY_UUID,
+									name: 'The King\'s Men'
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { materials } = eastProductionsCompany.body;
 
 			expect(materials).to.deep.equal(expectedMaterials);
 
@@ -543,6 +853,11 @@ describe('Materials with source material', () => {
 								model: 'person',
 								uuid: RONA_MUNRO_PERSON_UUID,
 								name: 'Rona Munro'
+							},
+							{
+								model: 'company',
+								uuid: ROYAL_SHAKESPEARE_COMPANY_UUID,
+								name: 'Royal Shakespeare Company'
 							}
 						]
 					},
@@ -564,6 +879,11 @@ describe('Materials with source material', () => {
 												model: 'person',
 												uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
 												name: 'William Shakespeare'
+											},
+											{
+												model: 'company',
+												uuid: THE_KINGS_MEN_COMPANY_UUID,
+												name: 'The King\'s Men'
 											}
 										]
 									}
@@ -600,6 +920,11 @@ describe('Materials with source material', () => {
 								model: 'person',
 								uuid: STEVEN_BERKOFF_PERSON_UUID,
 								name: 'Steven Berkoff'
+							},
+							{
+								model: 'company',
+								uuid: EAST_PRODUCTIONS_COMPANY_UUID,
+								name: 'East Productions'
 							}
 						]
 					},
@@ -611,6 +936,11 @@ describe('Materials with source material', () => {
 								model: 'person',
 								uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
 								name: 'William Shakespeare'
+							},
+							{
+								model: 'company',
+								uuid: THE_KINGS_MEN_COMPANY_UUID,
+								name: 'The King\'s Men'
 							}
 						]
 					}
@@ -644,6 +974,11 @@ describe('Materials with source material', () => {
 									model: 'person',
 									uuid: RONA_MUNRO_PERSON_UUID,
 									name: 'Rona Munro'
+								},
+								{
+									model: 'company',
+									uuid: ROYAL_SHAKESPEARE_COMPANY_UUID,
+									name: 'Royal Shakespeare Company'
 								}
 							]
 						},
@@ -665,6 +1000,11 @@ describe('Materials with source material', () => {
 													model: 'person',
 													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
 													name: 'William Shakespeare'
+												},
+												{
+													model: 'company',
+													uuid: THE_KINGS_MEN_COMPANY_UUID,
+													name: 'The King\'s Men'
 												}
 											]
 										}
@@ -704,6 +1044,11 @@ describe('Materials with source material', () => {
 									model: 'person',
 									uuid: STEVEN_BERKOFF_PERSON_UUID,
 									name: 'Steven Berkoff'
+								},
+								{
+									model: 'company',
+									uuid: EAST_PRODUCTIONS_COMPANY_UUID,
+									name: 'East Productions'
 								}
 							]
 						},
@@ -715,6 +1060,11 @@ describe('Materials with source material', () => {
 									model: 'person',
 									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
 									name: 'William Shakespeare'
+								},
+								{
+									model: 'company',
+									uuid: THE_KINGS_MEN_COMPANY_UUID,
+									name: 'The King\'s Men'
 								}
 							]
 						}
@@ -753,6 +1103,11 @@ describe('Materials with source material', () => {
 									model: 'person',
 									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
 									name: 'William Shakespeare'
+								},
+								{
+									model: 'company',
+									uuid: THE_KINGS_MEN_COMPANY_UUID,
+									name: 'The King\'s Men'
 								}
 							]
 						}
@@ -772,6 +1127,11 @@ describe('Materials with source material', () => {
 									model: 'person',
 									uuid: STEVEN_BERKOFF_PERSON_UUID,
 									name: 'Steven Berkoff'
+								},
+								{
+									model: 'company',
+									uuid: EAST_PRODUCTIONS_COMPANY_UUID,
+									name: 'East Productions'
 								}
 							]
 						},
@@ -783,6 +1143,11 @@ describe('Materials with source material', () => {
 									model: 'person',
 									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
 									name: 'William Shakespeare'
+								},
+								{
+									model: 'company',
+									uuid: THE_KINGS_MEN_COMPANY_UUID,
+									name: 'The King\'s Men'
 								}
 							]
 						}
@@ -802,6 +1167,11 @@ describe('Materials with source material', () => {
 									model: 'person',
 									uuid: RONA_MUNRO_PERSON_UUID,
 									name: 'Rona Munro'
+								},
+								{
+									model: 'company',
+									uuid: ROYAL_SHAKESPEARE_COMPANY_UUID,
+									name: 'Royal Shakespeare Company'
 								}
 							]
 						},
@@ -823,6 +1193,11 @@ describe('Materials with source material', () => {
 													model: 'person',
 													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
 													name: 'William Shakespeare'
+												},
+												{
+													model: 'company',
+													uuid: THE_KINGS_MEN_COMPANY_UUID,
+													name: 'The King\'s Men'
 												}
 											]
 										}

--- a/test-e2e/uniqueness-in-db/materials-api.test.js
+++ b/test-e2e/uniqueness-in-db/materials-api.test.js
@@ -645,6 +645,154 @@ describe('Uniqueness in database: Materials API', () => {
 
 	});
 
+	describe('Material writer (company) uniqueness in database', () => {
+
+		const UNTITLED_MATERIAL_UUID = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+
+		const expectedCompanyGateTheatreCompany1 = {
+			model: 'company',
+			name: 'Gate Theatre Company',
+			differentiator: '',
+			errors: {}
+		};
+
+		const expectedCompanyGateTheatreCompany2 = {
+			model: 'company',
+			name: 'Gate Theatre Company',
+			differentiator: '1',
+			errors: {}
+		};
+
+		before(async () => {
+
+			let uuidCallCount = 0;
+
+			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+
+			await purgeDatabase();
+
+			await createNode({
+				label: 'Material',
+				uuid: UNTITLED_MATERIAL_UUID,
+				name: 'Untitled'
+			});
+
+		});
+
+		after(() => {
+
+			sandbox.restore();
+
+		});
+
+		it('updates material and creates writer (company) that does not have a differentiator', async () => {
+
+			expect(await countNodesWithLabel('Company')).to.equal(0);
+
+			const response = await chai.request(app)
+				.put(`/materials/${UNTITLED_MATERIAL_UUID}`)
+				.send({
+					name: 'Untitled',
+					writingCredits: [
+						{
+							writingEntities: [
+								{
+									model: 'company',
+									name: 'Gate Theatre Company'
+								}
+							]
+						}
+					]
+				});
+
+			expect(response).to.have.status(200);
+			expect(response.body.writingCredits[0].writingEntities[0]).to.deep.equal(expectedCompanyGateTheatreCompany1);
+			expect(await countNodesWithLabel('Company')).to.equal(1);
+
+		});
+
+		it('updates material and creates writer (company) that has same name as existing writer but uses a differentiator', async () => {
+
+			expect(await countNodesWithLabel('Company')).to.equal(1);
+
+			const response = await chai.request(app)
+				.put(`/materials/${UNTITLED_MATERIAL_UUID}`)
+				.send({
+					name: 'Untitled',
+					writingCredits: [
+						{
+							writingEntities: [
+								{
+									model: 'company',
+									name: 'Gate Theatre Company',
+									differentiator: '1'
+								}
+							]
+						}
+					]
+				});
+
+			expect(response).to.have.status(200);
+			expect(response.body.writingCredits[0].writingEntities[0]).to.deep.equal(expectedCompanyGateTheatreCompany2);
+			expect(await countNodesWithLabel('Company')).to.equal(2);
+
+		});
+
+		it('updates material and uses existing writer (company) that does not have a differentiator', async () => {
+
+			expect(await countNodesWithLabel('Company')).to.equal(2);
+
+			const response = await chai.request(app)
+				.put(`/materials/${UNTITLED_MATERIAL_UUID}`)
+				.send({
+					name: 'Untitled',
+					writingCredits: [
+						{
+							writingEntities: [
+								{
+									model: 'company',
+									name: 'Gate Theatre Company'
+								}
+							]
+						}
+					]
+				});
+
+			expect(response).to.have.status(200);
+			expect(response.body.writingCredits[0].writingEntities[0]).to.deep.equal(expectedCompanyGateTheatreCompany1);
+			expect(await countNodesWithLabel('Company')).to.equal(2);
+
+		});
+
+		it('updates material and uses existing writer (company) that has a differentiator', async () => {
+
+			expect(await countNodesWithLabel('Company')).to.equal(2);
+
+			const response = await chai.request(app)
+				.put(`/materials/${UNTITLED_MATERIAL_UUID}`)
+				.send({
+					name: 'Untitled',
+					writingCredits: [
+						{
+							writingEntities: [
+								{
+									model: 'company',
+									name: 'Gate Theatre Company',
+									differentiator: '1'
+								}
+							]
+						}
+					]
+				});
+
+			expect(response).to.have.status(200);
+			expect(response.body.writingCredits[0].writingEntities[0]).to.deep.equal(expectedCompanyGateTheatreCompany2);
+			expect(await countNodesWithLabel('Company')).to.equal(2);
+
+		});
+
+	});
+
 	describe('Material writer (source material) uniqueness in database', () => {
 
 		const THE_INDIAN_BOY_MATERIAL_UUID = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';

--- a/test-int/instance-validation-failures/material.test.js
+++ b/test-int/instance-validation-failures/material.test.js
@@ -431,7 +431,7 @@ describe('Material instance', () => {
 
 		});
 
-		context('writer name value exceeds maximum limit', () => {
+		context('writing entity (person) name value exceeds maximum limit', () => {
 
 			it('assigns appropriate error', async () => {
 
@@ -497,7 +497,7 @@ describe('Material instance', () => {
 
 		});
 
-		context('writer differentiator value exceeds maximum limit', () => {
+		context('writing entity (person) differentiator value exceeds maximum limit', () => {
 
 			it('assigns appropriate error', async () => {
 
@@ -545,6 +545,141 @@ describe('Material instance', () => {
 									model: 'person',
 									uuid: undefined,
 									name: 'Henrik Ibsen',
+									differentiator: ABOVE_MAX_LENGTH_STRING,
+									errors: {
+										differentiator: [
+											'Value is too long'
+										]
+									}
+								}
+							]
+						}
+					],
+					characterGroups: []
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+		context('writing entity (company) name value exceeds maximum limit', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instanceProps = {
+					name: 'Rosmersholm',
+					writingCredits: [
+						{
+							writingEntities: [
+								{
+									model: 'company',
+									name: ABOVE_MAX_LENGTH_STRING
+								}
+							]
+						}
+					]
+				};
+
+				const instance = new Material(instanceProps);
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					model: 'material',
+					uuid: undefined,
+					name: 'Rosmersholm',
+					differentiator: '',
+					format: '',
+					hasErrors: true,
+					errors: {},
+					originalVersionMaterial: {
+						model: 'material',
+						uuid: undefined,
+						name: '',
+						differentiator: '',
+						errors: {}
+					},
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: '',
+							creditType: null,
+							errors: {},
+							writingEntities: [
+								{
+									model: 'company',
+									uuid: undefined,
+									name: ABOVE_MAX_LENGTH_STRING,
+									differentiator: '',
+									errors: {
+										name: [
+											'Value is too long'
+										]
+									}
+								}
+							]
+						}
+					],
+					characterGroups: []
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+		context('writing entity (company) differentiator value exceeds maximum limit', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instanceProps = {
+					name: 'Rosmersholm',
+					writingCredits: [
+						{
+							writingEntities: [
+								{
+									model: 'company',
+									name: 'Ibsen Theatre Company',
+									differentiator: ABOVE_MAX_LENGTH_STRING
+								}
+							]
+						}
+					]
+				};
+
+				const instance = new Material(instanceProps);
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					model: 'material',
+					uuid: undefined,
+					name: 'Rosmersholm',
+					differentiator: '',
+					format: '',
+					hasErrors: true,
+					errors: {},
+					originalVersionMaterial: {
+						model: 'material',
+						uuid: undefined,
+						name: '',
+						differentiator: '',
+						errors: {}
+					},
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: '',
+							creditType: null,
+							errors: {},
+							writingEntities: [
+								{
+									model: 'company',
+									uuid: undefined,
+									name: 'Ibsen Theatre Company',
 									differentiator: ABOVE_MAX_LENGTH_STRING,
 									errors: {
 										differentiator: [

--- a/test-unit/src/lib/get-duplicate-indices.test.js
+++ b/test-unit/src/lib/get-duplicate-indices.test.js
@@ -246,12 +246,18 @@ describe('Get Duplicate Indices module', () => {
 						{ name: 'Foo', differentiator: '', model: '' },
 						{ name: 'Foo', differentiator: '1', model: '' },
 						{ name: 'Foo', differentiator: '2', model: '' },
+						{ name: 'Foo', differentiator: '', model: 'company' },
+						{ name: 'Foo', differentiator: '1', model: 'company' },
+						{ name: 'Foo', differentiator: '2', model: 'company' },
 						{ name: 'Foo', differentiator: '', model: 'material' },
 						{ name: 'Foo', differentiator: '1', model: 'material' },
 						{ name: 'Foo', differentiator: '2', model: 'material' },
 						{ name: 'Bar', differentiator: '', model: '' },
 						{ name: 'Bar', differentiator: '1', model: '' },
 						{ name: 'Bar', differentiator: '2', model: '' },
+						{ name: 'Bar', differentiator: '', model: 'company' },
+						{ name: 'Bar', differentiator: '1', model: 'company' },
+						{ name: 'Bar', differentiator: '2', model: 'company' },
 						{ name: 'Bar', differentiator: '', model: 'material' },
 						{ name: 'Bar', differentiator: '1', model: 'material' },
 						{ name: 'Bar', differentiator: '2', model: 'material' }
@@ -272,6 +278,7 @@ describe('Get Duplicate Indices module', () => {
 					[
 						{ name: 'Foo', differentiator: '1', model: '' },
 						{ name: 'Bar', differentiator: '1', model: 'material' },
+						{ name: 'Bar', differentiator: '1', model: 'company' },
 						{ name: '', differentiator: '1', model: '' },
 						{ name: 'Baz', differentiator: '1', model: '' },
 						{ name: 'Foo', differentiator: '1', model: '' },
@@ -281,7 +288,7 @@ describe('Get Duplicate Indices module', () => {
 					]
 				);
 
-				expect(result).to.deep.equal([0, 1, 4, 5]);
+				expect(result).to.deep.equal([0, 1, 5, 6]);
 
 			});
 

--- a/test-unit/src/models/WritingCredit.test.js
+++ b/test-unit/src/models/WritingCredit.test.js
@@ -2,11 +2,17 @@ import { expect } from 'chai';
 import proxyquire from 'proxyquire';
 import { assert, createStubInstance, spy, stub } from 'sinon';
 
-import { Person, Material } from '../../../src/models';
+import { Company, Person, Material } from '../../../src/models';
 
 describe('WritingCredit model', () => {
 
 	let stubs;
+
+	const CompanyStub = function () {
+
+		return createStubInstance(Company);
+
+	};
 
 	const MaterialStub = function () {
 
@@ -27,6 +33,7 @@ describe('WritingCredit model', () => {
 				getDuplicateWritingEntityIndices: stub().returns([])
 			},
 			models: {
+				Company: CompanyStub,
 				Material: MaterialStub,
 				Person: PersonStub
 			}
@@ -93,6 +100,10 @@ describe('WritingCredit model', () => {
 							name: 'David Eldridge'
 						},
 						{
+							model: 'company',
+							name: 'Told by an Idiot'
+						},
+						{
 							model: 'material',
 							name: 'A Midsummer Night\'s Dream'
 						},
@@ -100,10 +111,18 @@ describe('WritingCredit model', () => {
 							name: ''
 						},
 						{
+							model: 'company',
+							name: ''
+						},
+						{
 							model: 'material',
 							name: ''
 						},
 						{
+							name: ' '
+						},
+						{
+							model: 'company',
 							name: ' '
 						},
 						{
@@ -113,13 +132,16 @@ describe('WritingCredit model', () => {
 					]
 				};
 				const instance = createInstance(props);
-				expect(instance.writingEntities.length).to.equal(6);
+				expect(instance.writingEntities.length).to.equal(9);
 				expect(instance.writingEntities[0] instanceof Person).to.be.true;
-				expect(instance.writingEntities[1] instanceof Material).to.be.true;
-				expect(instance.writingEntities[2] instanceof Person).to.be.true;
-				expect(instance.writingEntities[3] instanceof Material).to.be.true;
-				expect(instance.writingEntities[4] instanceof Person).to.be.true;
+				expect(instance.writingEntities[1] instanceof Company).to.be.true;
+				expect(instance.writingEntities[2] instanceof Material).to.be.true;
+				expect(instance.writingEntities[3] instanceof Person).to.be.true;
+				expect(instance.writingEntities[4] instanceof Company).to.be.true;
 				expect(instance.writingEntities[5] instanceof Material).to.be.true;
+				expect(instance.writingEntities[6] instanceof Person).to.be.true;
+				expect(instance.writingEntities[7] instanceof Company).to.be.true;
+				expect(instance.writingEntities[8] instanceof Material).to.be.true;
 
 			});
 
@@ -138,15 +160,19 @@ describe('WritingCredit model', () => {
 						name: 'David Eldridge'
 					},
 					{
+						model: 'company',
+						name: 'Told by an Idiot'
+					},
+					{
 						model: 'material',
 						name: 'A Midsummer Night\'s Dream'
 					}
 				]
 			};
 			const instance = createInstance(props);
-			instance.writingEntities[1].model = 'material';
-			instance.writingEntities[1].name = 'A Midsummer Night\'s Dream';
-			instance.writingEntities[1].differentiator = '1';
+			instance.writingEntities[2].model = 'material';
+			instance.writingEntities[2].name = 'A Midsummer Night\'s Dream';
+			instance.writingEntities[2].differentiator = '1';
 			spy(instance, 'validateName');
 			spy(instance, 'validateUniquenessInGroup');
 			instance.runInputValidations(
@@ -158,7 +184,14 @@ describe('WritingCredit model', () => {
 				stubs.getDuplicateIndicesModule.getDuplicateWritingEntityIndices,
 				instance.writingEntities[0].validateName,
 				instance.writingEntities[0].validateDifferentiator,
-				instance.writingEntities[0].validateUniquenessInGroup
+				instance.writingEntities[0].validateUniquenessInGroup,
+				instance.writingEntities[1].validateName,
+				instance.writingEntities[1].validateDifferentiator,
+				instance.writingEntities[1].validateUniquenessInGroup,
+				instance.writingEntities[2].validateName,
+				instance.writingEntities[2].validateDifferentiator,
+				instance.writingEntities[2].validateNoAssociationWithSelf,
+				instance.writingEntities[2].validateUniquenessInGroup
 			);
 			expect(instance.validateName.calledOnce).to.be.true;
 			expect(instance.validateName.calledWithExactly({ isRequired: false })).to.be.true;
@@ -179,12 +212,21 @@ describe('WritingCredit model', () => {
 			expect(instance.writingEntities[1].validateName.calledWithExactly({ isRequired: false })).to.be.true;
 			expect(instance.writingEntities[1].validateDifferentiator.calledOnce).to.be.true;
 			expect(instance.writingEntities[1].validateDifferentiator.calledWithExactly()).to.be.true;
-			expect(instance.writingEntities[1].validateNoAssociationWithSelf.calledOnce).to.be.true;
-			expect(instance.writingEntities[1].validateNoAssociationWithSelf.calledWithExactly(
-				'The Indian Boy', '1'
-			)).to.be.true;
+			expect(instance.writingEntities[1].validateNoAssociationWithSelf.notCalled).to.be.true;
 			expect(instance.writingEntities[1].validateUniquenessInGroup.calledOnce).to.be.true;
 			expect(instance.writingEntities[1].validateUniquenessInGroup.calledWithExactly(
+				{ isDuplicate: false }
+			)).to.be.true;
+			expect(instance.writingEntities[2].validateName.calledOnce).to.be.true;
+			expect(instance.writingEntities[2].validateName.calledWithExactly({ isRequired: false })).to.be.true;
+			expect(instance.writingEntities[2].validateDifferentiator.calledOnce).to.be.true;
+			expect(instance.writingEntities[2].validateDifferentiator.calledWithExactly()).to.be.true;
+			expect(instance.writingEntities[2].validateNoAssociationWithSelf.calledOnce).to.be.true;
+			expect(instance.writingEntities[2].validateNoAssociationWithSelf.calledWithExactly(
+				'The Indian Boy', '1'
+			)).to.be.true;
+			expect(instance.writingEntities[2].validateUniquenessInGroup.calledOnce).to.be.true;
+			expect(instance.writingEntities[2].validateUniquenessInGroup.calledWithExactly(
 				{ isDuplicate: false }
 			)).to.be.true;
 


### PR DESCRIPTION
Sometimes companies are included in the writing credits of material. This PR adds the functionality for such relationships to be handled.

The examples are not comprehensive: credits on character, person, and production profile pages are also all now able to include any credited companies in the relevant section.

---

#### The Dark Philosophers (material)
![the-dark-philosopers-material](https://user-images.githubusercontent.com/10484515/106174573-17a67500-618d-11eb-9937-e7ef74d5c398.png)

---

#### Told by an Idiot (company)
![told-by-an-idiot-company](https://user-images.githubusercontent.com/10484515/106174581-1a08cf00-618d-11eb-9ab7-7c4003a428ed.png)

---

#### The Girl on the Train (material) (play)
![girl-on-the-train-material-play](https://user-images.githubusercontent.com/10484515/106174587-1bd29280-618d-11eb-9056-28d81a15cc4f.png)

---

#### Dreamworks (company)
![dreamworks-company](https://user-images.githubusercontent.com/10484515/106174593-1ecd8300-618d-11eb-9cd3-75ff717c0b1f.png)

---

#### The Seagull (subsequent version) (material: play)
N.B. Contrivance for purposes of example.
![the-seagull-material-play-subsequent-version](https://user-images.githubusercontent.com/10484515/106174602-20974680-618d-11eb-8246-986647edc5ba.png)

---

#### Chekhov Theatre Company (company)
N.B. Contrivance for purposes of example.
![chekhov-theatre-company](https://user-images.githubusercontent.com/10484515/106174605-22610a00-618d-11eb-96d9-9eab5d5b5d26.png)