### PR TITLE
Amend material create/update Cypher query

### DIFF
--- a/src/neo4j/cypher-queries/material.js
+++ b/src/neo4j/cypher-queries/material.js
@@ -74,7 +74,7 @@ const getCreateUpdateQuery = action => {
 						(writingEntityParam.differentiator IS NULL AND existingWriter.differentiator IS NULL) OR
 						(writingEntityParam.differentiator = existingWriter.differentiator)
 
-				FOREACH (item IN CASE WHEN writingEntityParam IS NOT NULL AND writingEntityParam.model = 'person' THEN [1] ELSE [] END |
+				FOREACH (item IN CASE WHEN writingEntityParam IS NOT NULL THEN [1] ELSE [] END |
 					MERGE (entity:Person {
 						uuid: COALESCE(existingWriter.uuid, writingEntityParam.uuid),
 						name: writingEntityParam.name
@@ -103,7 +103,7 @@ const getCreateUpdateQuery = action => {
 						(writingEntityParam.differentiator IS NULL AND existingWriter.differentiator IS NULL) OR
 						(writingEntityParam.differentiator = existingWriter.differentiator)
 
-				FOREACH (item IN CASE WHEN writingEntityParam IS NOT NULL AND writingEntityParam.model = 'company' THEN [1] ELSE [] END |
+				FOREACH (item IN CASE WHEN writingEntityParam IS NOT NULL THEN [1] ELSE [] END |
 					MERGE (entity:Company {
 						uuid: COALESCE(existingWriter.uuid, writingEntityParam.uuid),
 						name: writingEntityParam.name
@@ -132,7 +132,7 @@ const getCreateUpdateQuery = action => {
 						(sourceMaterialParam.differentiator IS NULL AND existingSourceMaterial.differentiator IS NULL) OR
 						(sourceMaterialParam.differentiator = existingSourceMaterial.differentiator)
 
-				FOREACH (item IN CASE WHEN sourceMaterialParam IS NOT NULL AND sourceMaterialParam.model = 'material' THEN [1] ELSE [] END |
+				FOREACH (item IN CASE WHEN sourceMaterialParam IS NOT NULL THEN [1] ELSE [] END |
 					MERGE (sourceMaterial:Material {
 						uuid: COALESCE(existingSourceMaterial.uuid, sourceMaterialParam.uuid),
 						name: sourceMaterialParam.name

--- a/test-unit/src/neo4j/cypher-queries/material.test.js
+++ b/test-unit/src/neo4j/cypher-queries/material.test.js
@@ -45,7 +45,7 @@ describe('Cypher Queries Material module', () => {
 								(writingEntityParam.differentiator IS NULL AND existingWriter.differentiator IS NULL) OR
 								(writingEntityParam.differentiator = existingWriter.differentiator)
 
-						FOREACH (item IN CASE WHEN writingEntityParam IS NOT NULL AND writingEntityParam.model = 'person' THEN [1] ELSE [] END |
+						FOREACH (item IN CASE WHEN writingEntityParam IS NOT NULL THEN [1] ELSE [] END |
 							MERGE (entity:Person {
 								uuid: COALESCE(existingWriter.uuid, writingEntityParam.uuid),
 								name: writingEntityParam.name
@@ -74,7 +74,7 @@ describe('Cypher Queries Material module', () => {
 								(writingEntityParam.differentiator IS NULL AND existingWriter.differentiator IS NULL) OR
 								(writingEntityParam.differentiator = existingWriter.differentiator)
 
-						FOREACH (item IN CASE WHEN writingEntityParam IS NOT NULL AND writingEntityParam.model = 'company' THEN [1] ELSE [] END |
+						FOREACH (item IN CASE WHEN writingEntityParam IS NOT NULL THEN [1] ELSE [] END |
 							MERGE (entity:Company {
 								uuid: COALESCE(existingWriter.uuid, writingEntityParam.uuid),
 								name: writingEntityParam.name
@@ -103,7 +103,7 @@ describe('Cypher Queries Material module', () => {
 								(sourceMaterialParam.differentiator IS NULL AND existingSourceMaterial.differentiator IS NULL) OR
 								(sourceMaterialParam.differentiator = existingSourceMaterial.differentiator)
 
-						FOREACH (item IN CASE WHEN sourceMaterialParam IS NOT NULL AND sourceMaterialParam.model = 'material' THEN [1] ELSE [] END |
+						FOREACH (item IN CASE WHEN sourceMaterialParam IS NOT NULL THEN [1] ELSE [] END |
 							MERGE (sourceMaterial:Material {
 								uuid: COALESCE(existingSourceMaterial.uuid, sourceMaterialParam.uuid),
 								name: sourceMaterialParam.name
@@ -301,7 +301,7 @@ describe('Cypher Queries Material module', () => {
 								(writingEntityParam.differentiator IS NULL AND existingWriter.differentiator IS NULL) OR
 								(writingEntityParam.differentiator = existingWriter.differentiator)
 
-						FOREACH (item IN CASE WHEN writingEntityParam IS NOT NULL AND writingEntityParam.model = 'person' THEN [1] ELSE [] END |
+						FOREACH (item IN CASE WHEN writingEntityParam IS NOT NULL THEN [1] ELSE [] END |
 							MERGE (entity:Person {
 								uuid: COALESCE(existingWriter.uuid, writingEntityParam.uuid),
 								name: writingEntityParam.name
@@ -330,7 +330,7 @@ describe('Cypher Queries Material module', () => {
 								(writingEntityParam.differentiator IS NULL AND existingWriter.differentiator IS NULL) OR
 								(writingEntityParam.differentiator = existingWriter.differentiator)
 
-						FOREACH (item IN CASE WHEN writingEntityParam IS NOT NULL AND writingEntityParam.model = 'company' THEN [1] ELSE [] END |
+						FOREACH (item IN CASE WHEN writingEntityParam IS NOT NULL THEN [1] ELSE [] END |
 							MERGE (entity:Company {
 								uuid: COALESCE(existingWriter.uuid, writingEntityParam.uuid),
 								name: writingEntityParam.name
@@ -359,7 +359,7 @@ describe('Cypher Queries Material module', () => {
 								(sourceMaterialParam.differentiator IS NULL AND existingSourceMaterial.differentiator IS NULL) OR
 								(sourceMaterialParam.differentiator = existingSourceMaterial.differentiator)
 
-						FOREACH (item IN CASE WHEN sourceMaterialParam IS NOT NULL AND sourceMaterialParam.model = 'material' THEN [1] ELSE [] END |
+						FOREACH (item IN CASE WHEN sourceMaterialParam IS NOT NULL THEN [1] ELSE [] END |
 							MERGE (sourceMaterial:Material {
 								uuid: COALESCE(existingSourceMaterial.uuid, sourceMaterialParam.uuid),
 								name: sourceMaterialParam.name


### PR DESCRIPTION
This PR amends the material create/update Cypher query: it removes conditionals from the `CASE WHEN` statements because the `UNWIND` statement already ensures that the condition has been met (meaning the `CASE WHEN` statement is unnecessarily re-checking the condition).