### PR TITLE
Add material database seed for second subsequent version of Peer Gynt

### DIFF
--- a/db-seeding/seeds/materials/peer-gynt-subsequent-version-1.json
+++ b/db-seeding/seeds/materials/peer-gynt-subsequent-version-1.json
@@ -1,0 +1,154 @@
+{
+	"name": "Peer Gynt",
+	"differentiator": "2",
+	"format": "play",
+	"originalVersionMaterial": {
+		"name": "Peer Gynt",
+		"differentiator": "1"
+	},
+	"writingCredits": [
+		{
+			"writingEntities": [
+				{
+					"name": "Henrik Ibsen"
+				}
+			]
+		},
+		{
+			"name": "version by",
+			"writingEntities": [
+				{
+					"name": "Frank McGuiness"
+				}
+			]
+		}
+	],
+	"characterGroups": [
+		{
+			"characters": [
+				{
+					"name": "Ase",
+					"underlyingName": "Åse"
+				},
+				{
+					"name": "Peer Gynt"
+				},
+				{
+					"name": "Kari"
+				},
+				{
+					"name": "Aslak"
+				},
+				{
+					"name": "Bridegroom",
+					"underlyingName": "The bridegroom"
+				},
+				{
+					"name": "Solveig's Father"
+				},
+				{
+					"name": "Bridegroom's Mother",
+					"underlyingName": "The bridegroom's parents"
+				},
+				{
+					"name": "Solveig"
+				},
+				{
+					"name": "Ingrid"
+				},
+				{
+					"name": "Helga"
+				},
+				{
+					"name": "Mountain Girls",
+					"underlyingName": "Three alpine dairymaids"
+				},
+				{
+					"name": "Green Woman",
+					"underlyingName": "A green-clad woman"
+				},
+				{
+					"name": "Troll King",
+					"underlyingName": "The Old Man of the Mountains"
+				},
+				{
+					"name": "Voice of the Great Boyg",
+					"underlyingName": "The Bøyg"
+				},
+				{
+					"name": "Brat",
+					"underlyingName": "An ugly brat"
+				},
+				{
+					"name": "Trumpeterstrale",
+					"underlyingName": "Herr Trumpeterstrale"
+				},
+				{
+					"name": "Cotton",
+					"underlyingName": "Master Cotton"
+				},
+				{
+					"name": "Ballon",
+					"underlyingName": "Monsieur Ballon"
+				},
+				{
+					"name": "Von Eberkopf",
+					"underlyingName": "Herr von Eberkopf"
+				},
+				{
+					"name": "Anitra"
+				},
+				{
+					"name": "Begriffenfeldt",
+					"underlyingName": "Dr Begriffenfeldt"
+				},
+				{
+					"name": "Huhu"
+				},
+				{
+					"name": "Fellah"
+				},
+				{
+					"name": "Hussain",
+					"underlyingName": "Hussein"
+				},
+				{
+					"name": "Captain",
+					"underlyingName": "A Norwegian skipper"
+				},
+				{
+					"name": "Lookout"
+				},
+				{
+					"name": "Ship's Mate",
+					"underlyingName": "Norwegian skipper's crew"
+				},
+				{
+					"name": "Bosun"
+				},
+				{
+					"name": "Cook",
+					"underlyingName": "A master cook"
+				},
+				{
+					"name": "Strange Traveller",
+					"underlyingName": "A strange passenger"
+				},
+				{
+					"name": "Seaman"
+				},
+				{
+					"name": "Priest"
+				},
+				{
+					"name": "Button Moulder",
+					"underlyingName": "A button-molder"
+				},
+				{
+					"name": "Thin Man",
+					"underlyingName": "The Lean One"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/materials/peer-gynt-subsequent-version-2.json
+++ b/db-seeding/seeds/materials/peer-gynt-subsequent-version-2.json
@@ -1,6 +1,6 @@
 {
 	"name": "Peer Gynt",
-	"differentiator": "2",
+	"differentiator": "3",
 	"format": "play",
 	"originalVersionMaterial": {
 		"name": "Peer Gynt",

--- a/db-seeding/seeds/productions/peer-gynt-barbican.json
+++ b/db-seeding/seeds/productions/peer-gynt-barbican.json
@@ -2,7 +2,7 @@
 	"name": "Peer Gynt",
 	"material": {
 		"name": "Peer Gynt",
-		"differentiator": "2"
+		"differentiator": "3"
 	},
 	"theatre": {
 		"name": "The Pit"

--- a/db-seeding/seeds/productions/peer-gynt-nt.json
+++ b/db-seeding/seeds/productions/peer-gynt-nt.json
@@ -1,0 +1,294 @@
+{
+	"name": "Peer Gynt",
+	"material": {
+		"name": "Peer Gynt",
+		"differentiator": "2"
+	},
+	"theatre": {
+		"name": "Olivier Theatre"
+	},
+	"cast": [
+		{
+			"name": "Sorcha Cusack",
+			"roles": [
+				{
+					"name": "Ase"
+				}
+			]
+		},
+		{
+			"name": "Chiwetel Ejiofor",
+			"roles": [
+				{
+					"name": "Peer Gynt"
+				}
+			]
+		},
+		{
+			"name": "Annie Farr",
+			"roles": [
+				{
+					"name": "Kari"
+				}
+			]
+		},
+		{
+			"name": "Andy Williams",
+			"roles": [
+				{
+					"name": "Aslak"
+				}
+			]
+		},
+		{
+			"name": "Anthony Taylor",
+			"roles": [
+				{
+					"name": "Bridegroom"
+				}
+			]
+		},
+		{
+			"name": "John O'Toole",
+			"roles": [
+				{
+					"name": "Solveig's Father"
+				},
+				{
+					"name": "Captain"
+				}
+			]
+		},
+		{
+			"name": "Marcella Riordan",
+			"roles": [
+				{
+					"name": "Bridegroom's Mother"
+				}
+			]
+		},
+		{
+			"name": "Olwen Fouéré",
+			"roles": [
+				{
+					"name": "Solveig"
+				}
+			]
+		},
+		{
+			"name": "Melanie MacHugh",
+			"roles": [
+				{
+					"name": "Ingrid"
+				}
+			]
+		},
+		{
+			"name": "Valerie Spelman",
+			"roles": [
+				{
+					"name": "Helga"
+				}
+			]
+		},
+		{
+			"name": "Ciara Adams",
+			"roles": [
+				{
+					"name": "Mountain Girl",
+					"characterName": "Mountain Girls"
+				}
+			]
+		},
+		{
+			"name": "Brigid Duffy",
+			"roles": [
+				{
+					"name": "Mountain Girl",
+					"characterName": "Mountain Girls"
+				}
+			]
+		},
+		{
+			"name": "Viviana Verveen",
+			"roles": [
+				{
+					"name": "Mountain Girl",
+					"characterName": "Mountain Girls"
+				}
+			]
+		},
+		{
+			"name": "Susan Aderin",
+			"roles": [
+				{
+					"name": "Green Woman"
+				}
+			]
+		},
+		{
+			"name": "Lloyd Hutchinson",
+			"roles": [
+				{
+					"name": "Troll King"
+				}
+			]
+		},
+		{
+			"name": "Jason Rose",
+			"roles": [
+				{
+					"name": "Voice of the Great Boyg"
+				}
+			]
+		},
+		{
+			"name": "Adrian Sarple",
+			"roles": [
+				{
+					"name": "Brat"
+				}
+			]
+		},
+		{
+			"name": "Patrick O'Kane",
+			"roles": [
+				{
+					"name": "Peer Gynt"
+				}
+			]
+		},
+		{
+			"name": "Ruairi Conaghan",
+			"roles": [
+				{
+					"name": "Trumpeterstrale"
+				},
+				{
+					"name": "Fellah"
+				}
+			]
+		},
+		{
+			"name": "Benny Young",
+			"roles": [
+				{
+					"name": "Cotton"
+				},
+				{
+					"name": "Priest"
+				}
+			]
+		},
+		{
+			"name": "Stephen Hogan",
+			"roles": [
+				{
+					"name": "Ballon"
+				},
+				{
+					"name": "Begriffenfeldt"
+				}
+			]
+		},
+		{
+			"name": "Paul Hickey",
+			"roles": [
+				{
+					"name": "Von Eberkopf"
+				},
+				{
+					"name": "Strange Traveller"
+				}
+			]
+		},
+		{
+			"name": "Amanda Symonds",
+			"roles": [
+				{
+					"name": "Anitra"
+				}
+			]
+		},
+		{
+			"name": "Anthony Renshaw",
+			"roles": [
+				{
+					"name": "Huhu"
+				}
+			]
+		},
+		{
+			"name": "Jeff Diamond",
+			"roles": [
+				{
+					"name": "Hussain"
+				}
+			]
+		},
+		{
+			"name": "Joseph Marcell",
+			"roles": [
+				{
+					"name": "Peer Gynt"
+				}
+			]
+		},
+		{
+			"name": "Victor Power",
+			"roles": [
+				{
+					"name": "Lookout"
+				}
+			]
+		},
+		{
+			"name": "Craig Conway",
+			"roles": [
+				{
+					"name": "Ship's Mate"
+				}
+			]
+		},
+		{
+			"name": "Christopher John Hall",
+			"roles": [
+				{
+					"name": "Bosun"
+				}
+			]
+		},
+		{
+			"name": "Kolade Agboke",
+			"roles": [
+				{
+					"name": "Cook"
+				}
+			]
+		},
+		{
+			"name": "Adam Jones",
+			"roles": [
+				{
+					"name": "Seaman"
+				}
+			]
+		},
+		{
+			"name": "Ronald Pickup",
+			"roles": [
+				{
+					"name": "Button Moulder"
+				}
+			]
+		},
+		{
+			"name": "John Rogan",
+			"roles": [
+				{
+					"name": "Thin Man"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
This PR adds a database seed for a second subsequent version of Peer Gynt by Henrik Ibsen (the version by Frank McGuiness performed at the National Theatre in 2000).

This allows the seeds to apply a scenario included in the end-to-end tests (`/model-interaction/material-multi-versions-multi-wri-groups.test.js`) which was broken by work on another branch, demonstrating that having this scenario in the seeded data is also useful for the purposes of debugging Cypher queries.