### PR TITLE
Modify company + person Cypher show queries

### DIFF
--- a/src/neo4j/cypher-queries/company.js
+++ b/src/neo4j/cypher-queries/company.js
@@ -1,108 +1,134 @@
 const getShowQuery = () => `
 	MATCH (company:Company { uuid: $uuid })
 
-	OPTIONAL MATCH (company)<-[writerRel:WRITTEN_BY]-(material:Material)
+	OPTIONAL MATCH (company)<-[:WRITTEN_BY|USES_SOURCE_MATERIAL*1..2]-(material:Material)
 
-	OPTIONAL MATCH (material)-[:SUBSEQUENT_VERSION_OF]->(:Material)-[originalVersionCredit:WRITTEN_BY]->(company)
+	WITH company, COLLECT(material) AS materials
 
-	OPTIONAL MATCH (material)-[allWritingEntityRel:WRITTEN_BY|USES_SOURCE_MATERIAL]->(writingEntity)
-		WHERE writingEntity:Person OR writingEntity:Company OR writingEntity:Material
+	UNWIND (CASE materials WHEN [] THEN [null] ELSE materials END) AS material
 
-	OPTIONAL MATCH (writingEntity:Material)-[sourceMaterialWriterRel:WRITTEN_BY]->(sourceMaterialWriter)
+		OPTIONAL MATCH (company)<-[writerRel:WRITTEN_BY]-(material:Material)
 
-	WITH
-		company,
-		writerRel,
-		material,
-		originalVersionCredit,
-		allWritingEntityRel,
-		writingEntity,
-		sourceMaterialWriterRel,
-		sourceMaterialWriter
-		ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriterRel.entityPosition
+		OPTIONAL MATCH (company)<-[originalVersionCredit:WRITTEN_BY]-(:Material)<-[:SUBSEQUENT_VERSION_OF]-(material)
 
-	WITH
-		company,
-		writerRel,
-		material,
-		originalVersionCredit,
-		allWritingEntityRel,
-		writingEntity,
-		sourceMaterialWriterRel.credit AS sourceMaterialWritingCreditName,
-		COLLECT(
-			CASE sourceMaterialWriter WHEN NULL
-				THEN null
-				ELSE {
-					model: TOLOWER(HEAD(LABELS(sourceMaterialWriter))),
-					uuid: sourceMaterialWriter.uuid,
-					name: sourceMaterialWriter.name
-				}
-			END
-		) AS sourceMaterialWriters
+		OPTIONAL MATCH (company)<-[sourceMaterialCredit:WRITTEN_BY]-(:Material)<-[:USES_SOURCE_MATERIAL]-(material)
 
-	WITH company, writerRel, material, originalVersionCredit, allWritingEntityRel, writingEntity,
-		COLLECT(
-			CASE SIZE(sourceMaterialWriters) WHEN 0
-				THEN null
-				ELSE {
-					model: 'writingCredit',
-					name: COALESCE(sourceMaterialWritingCreditName, 'by'),
-					writingEntities: sourceMaterialWriters
-				}
-			END
-		) AS sourceMaterialWritingCredits
-		ORDER BY allWritingEntityRel.creditPosition, allWritingEntityRel.entityPosition
+		OPTIONAL MATCH (material)-[writingEntityRel:WRITTEN_BY|USES_SOURCE_MATERIAL]->(writingEntity)
+			WHERE writingEntity:Person OR writingEntity:Company OR writingEntity:Material
 
-	WITH company, writerRel, material, originalVersionCredit, allWritingEntityRel.credit AS writingCreditName,
-		[writingEntity IN COLLECT(
-			CASE writingEntity WHEN NULL
-				THEN null
-				ELSE {
-					model: TOLOWER(HEAD(LABELS(writingEntity))),
-					uuid: CASE writingEntity.uuid WHEN company.uuid THEN null ELSE writingEntity.uuid END,
-					name: writingEntity.name,
-					format: writingEntity.format,
-					sourceMaterialWritingCredits: sourceMaterialWritingCredits
-				}
-			END
-		) | CASE writingEntity.model WHEN 'material'
-			THEN writingEntity
-			ELSE { model: writingEntity.model, uuid: writingEntity.uuid, name: writingEntity.name }
-		END] AS writingEntities
+		OPTIONAL MATCH (writingEntity:Material)-[sourceMaterialWriterRel:WRITTEN_BY]->(sourceMaterialWriter)
 
-	WITH company, writerRel, material, originalVersionCredit,
-		COLLECT(
-			CASE SIZE(writingEntities) WHEN 0
-				THEN null
-				ELSE {
-					model: 'writingCredit',
-					name: COALESCE(writingCreditName, 'by'),
-					writingEntities: writingEntities
-				}
-			END
-		) AS writingCredits
-		ORDER BY material.name
+		WITH
+			company,
+			writerRel,
+			material,
+			originalVersionCredit,
+			sourceMaterialCredit,
+			writingEntityRel,
+			writingEntity,
+			sourceMaterialWriterRel,
+			sourceMaterialWriter
+			ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriterRel.entityPosition
 
-	WITH company,
-		COLLECT(
-			CASE material WHEN NULL
-				THEN null
-				ELSE {
-					model: 'material',
-					uuid: material.uuid,
-					name: material.name,
-					format: material.format,
-					writingCredits: writingCredits,
-					creditType: writerRel.creditType,
-					originalVersionCredit: originalVersionCredit
-				}
-			END
-		) AS materials
+		WITH
+			company,
+			writerRel,
+			material,
+			originalVersionCredit,
+			sourceMaterialCredit,
+			writingEntityRel,
+			writingEntity,
+			sourceMaterialWriterRel.credit AS sourceMaterialWritingCreditName,
+			COLLECT(
+				CASE sourceMaterialWriter WHEN NULL
+					THEN null
+					ELSE {
+						model: TOLOWER(HEAD(LABELS(sourceMaterialWriter))),
+						uuid: CASE sourceMaterialWriter.uuid WHEN company.uuid
+							THEN null
+							ELSE sourceMaterialWriter.uuid
+						END,
+						name: sourceMaterialWriter.name
+					}
+				END
+			) AS sourceMaterialWriters
+
+		WITH company, writerRel, material, originalVersionCredit, sourceMaterialCredit, writingEntityRel, writingEntity,
+			COLLECT(
+				CASE SIZE(sourceMaterialWriters) WHEN 0
+					THEN null
+					ELSE {
+						model: 'writingCredit',
+						name: COALESCE(sourceMaterialWritingCreditName, 'by'),
+						writingEntities: sourceMaterialWriters
+					}
+				END
+			) AS sourceMaterialWritingCredits
+			ORDER BY writingEntityRel.creditPosition, writingEntityRel.entityPosition
+
+		WITH
+			company,
+			writerRel,
+			material,
+			originalVersionCredit,
+			sourceMaterialCredit,
+			writingEntityRel.credit AS writingCreditName,
+			[writingEntity IN COLLECT(
+				CASE writingEntity WHEN NULL
+					THEN null
+					ELSE {
+						model: TOLOWER(HEAD(LABELS(writingEntity))),
+						uuid: CASE writingEntity.uuid WHEN company.uuid THEN null ELSE writingEntity.uuid END,
+						name: writingEntity.name,
+						format: writingEntity.format,
+						sourceMaterialWritingCredits: sourceMaterialWritingCredits
+					}
+				END
+			) | CASE writingEntity.model WHEN 'material'
+				THEN writingEntity
+				ELSE { model: writingEntity.model, uuid: writingEntity.uuid, name: writingEntity.name }
+			END] AS writingEntities
+
+		WITH company, writerRel, material, originalVersionCredit, sourceMaterialCredit,
+			COLLECT(
+				CASE SIZE(writingEntities) WHEN 0
+					THEN null
+					ELSE {
+						model: 'writingCredit',
+						name: COALESCE(writingCreditName, 'by'),
+						writingEntities: writingEntities
+					}
+				END
+			) AS writingCredits
+			ORDER BY material.name
+
+		WITH company,
+			COLLECT(
+				CASE material WHEN NULL
+					THEN null
+					ELSE {
+						model: 'material',
+						uuid: material.uuid,
+						name: material.name,
+						format: material.format,
+						writingCredits: writingCredits,
+						creditType: writerRel.creditType,
+						originalVersionCredit: originalVersionCredit,
+						sourceMaterialCredit: sourceMaterialCredit
+					}
+				END
+			) AS materials
+
+		WITH DISTINCT company, materials
 
 	WITH
 		company,
 		[
-			material IN materials WHERE material.creditType IS NULL AND material.originalVersionCredit IS NULL |
+			material IN materials WHERE ALL(x IN [
+				material.originalVersionCredit,
+				material.sourceMaterialCredit,
+				material.creditType
+			] WHERE x IS NULL) |
 			{
 				model: material.model,
 				uuid: material.uuid,
@@ -122,7 +148,9 @@ const getShowQuery = () => `
 			}
 		] AS subsequentVersionMaterials,
 		[
-			material IN materials WHERE material.creditType = 'NON_SPECIFIC_SOURCE_MATERIAL' |
+			material IN materials WHERE
+				material.sourceMaterialCredit IS NOT NULL OR
+				material.creditType = 'NON_SPECIFIC_SOURCE_MATERIAL' |
 			{
 				model: material.model,
 				uuid: material.uuid,
@@ -130,91 +158,7 @@ const getShowQuery = () => `
 				format: material.format,
 				writingCredits: material.writingCredits
 			}
-		] AS sourcingMaterialsFromNonSpecificMaterials
-
-	OPTIONAL MATCH (company)<-[:WRITTEN_BY]-(:Material)<-[:USES_SOURCE_MATERIAL]-(sourcingMaterial:Material)
-
-	OPTIONAL MATCH (sourcingMaterial)-[sourcingMaterialWritingEntityRel:WRITTEN_BY|USES_SOURCE_MATERIAL]->
-		(sourcingMaterialWritingEntity)
-		WHERE
-			sourcingMaterialWritingEntity:Person OR
-			sourcingMaterialWritingEntity:Company OR
-			sourcingMaterialWritingEntity:Material
-
-	WITH
-		company,
-		materials,
-		subsequentVersionMaterials,
-		sourcingMaterialsFromNonSpecificMaterials,
-		sourcingMaterial,
-		sourcingMaterialWritingEntityRel,
-		sourcingMaterialWritingEntity
-		ORDER BY sourcingMaterialWritingEntityRel.creditPosition, sourcingMaterialWritingEntityRel.entityPosition
-
-	WITH
-		company,
-		materials,
-		subsequentVersionMaterials,
-		sourcingMaterialsFromNonSpecificMaterials,
-		sourcingMaterial,
-		sourcingMaterialWritingEntityRel.credit AS sourcingMaterialWritingCreditName,
-		[sourcingMaterialWritingEntity IN COLLECT(
-			CASE sourcingMaterialWritingEntity WHEN NULL
-				THEN null
-				ELSE {
-					model: TOLOWER(HEAD(LABELS(sourcingMaterialWritingEntity))),
-					uuid: sourcingMaterialWritingEntity.uuid,
-					name: sourcingMaterialWritingEntity.name,
-					format: sourcingMaterialWritingEntity.format
-				}
-			END
-		) | CASE sourcingMaterialWritingEntity.model WHEN 'material'
-			THEN sourcingMaterialWritingEntity
-			ELSE {
-				model: sourcingMaterialWritingEntity.model,
-				uuid: sourcingMaterialWritingEntity.uuid,
-				name: sourcingMaterialWritingEntity.name
-			}
-		END] AS sourcingMaterialWritingEntities
-
-	WITH company, materials, subsequentVersionMaterials, sourcingMaterialsFromNonSpecificMaterials, sourcingMaterial,
-		COLLECT(
-			CASE SIZE(sourcingMaterialWritingEntities) WHEN 0
-				THEN null
-				ELSE {
-					model: 'writingCredit',
-					name: COALESCE(sourcingMaterialWritingCreditName, 'by'),
-					writingEntities: sourcingMaterialWritingEntities
-				}
-			END
-		) AS sourcingMaterialWritingCredits
-
-	WITH company, materials, subsequentVersionMaterials, sourcingMaterialsFromNonSpecificMaterials,
-		COLLECT(
-			CASE sourcingMaterial WHEN NULL
-				THEN null
-				ELSE {
-					model: 'material',
-					uuid: sourcingMaterial.uuid,
-					name: sourcingMaterial.name,
-					format: sourcingMaterial.format,
-					writingCredits: sourcingMaterialWritingCredits
-				}
-			END
-		) AS sourcingMaterialsFromSpecificMaterials
-
-	WITH
-		company,
-		materials,
-		subsequentVersionMaterials,
-		sourcingMaterialsFromNonSpecificMaterials + sourcingMaterialsFromSpecificMaterials AS sourcingMaterials
-
-	UNWIND (CASE sourcingMaterials WHEN [] THEN [null] ELSE sourcingMaterials END) AS sourcingMaterial
-
-		WITH company, materials, subsequentVersionMaterials, sourcingMaterial
-			ORDER BY sourcingMaterial.name
-
-	WITH DISTINCT company, materials, subsequentVersionMaterials, COLLECT(sourcingMaterial) AS sourcingMaterials
+		] AS sourcingMaterials
 
 	RETURN
 		'company' AS model,

--- a/test-e2e/model-interaction/material-multi-versions-multi-wri-groups.test.js
+++ b/test-e2e/model-interaction/material-multi-versions-multi-wri-groups.test.js
@@ -614,6 +614,41 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 				},
 				{
 					model: 'material',
+					uuid: PEER_GYNT_SUBSEQUENT_VERSION_1_MATERIAL_UUID,
+					name: 'Peer Gynt',
+					format: 'play',
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: null,
+									name: 'Henrik Ibsen'
+								},
+								{
+									model: 'company',
+									uuid: IBSEN_THEATRE_COMPANY_UUID,
+									name: 'Ibsen Theatre Company'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'version by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: FRANK_MCGUINNESS_PERSON_UUID,
+									name: 'Frank McGuinness'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'material',
 					uuid: PEER_GYNT_SUBSEQUENT_VERSION_2_MATERIAL_UUID,
 					name: 'Peer Gynt',
 					format: 'play',
@@ -663,41 +698,6 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 									model: 'person',
 									uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
 									name: 'Baltasar Kormákur'
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'material',
-					uuid: PEER_GYNT_SUBSEQUENT_VERSION_1_MATERIAL_UUID,
-					name: 'Peer Gynt',
-					format: 'play',
-					writingCredits: [
-						{
-							model: 'writingCredit',
-							name: 'by',
-							writingEntities: [
-								{
-									model: 'person',
-									uuid: null,
-									name: 'Henrik Ibsen'
-								},
-								{
-									model: 'company',
-									uuid: IBSEN_THEATRE_COMPANY_UUID,
-									name: 'Ibsen Theatre Company'
-								}
-							]
-						},
-						{
-							model: 'writingCredit',
-							name: 'version by',
-							writingEntities: [
-								{
-									model: 'person',
-									uuid: FRANK_MCGUINNESS_PERSON_UUID,
-									name: 'Frank McGuinness'
 								}
 							]
 						}
@@ -962,6 +962,41 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 				},
 				{
 					model: 'material',
+					uuid: PEER_GYNT_SUBSEQUENT_VERSION_1_MATERIAL_UUID,
+					name: 'Peer Gynt',
+					format: 'play',
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: HENRIK_IBSEN_PERSON_UUID,
+									name: 'Henrik Ibsen'
+								},
+								{
+									model: 'company',
+									uuid: null,
+									name: 'Ibsen Theatre Company'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'version by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: FRANK_MCGUINNESS_PERSON_UUID,
+									name: 'Frank McGuinness'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'material',
 					uuid: PEER_GYNT_SUBSEQUENT_VERSION_2_MATERIAL_UUID,
 					name: 'Peer Gynt',
 					format: 'play',
@@ -1011,41 +1046,6 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 									model: 'person',
 									uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
 									name: 'Baltasar Kormákur'
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'material',
-					uuid: PEER_GYNT_SUBSEQUENT_VERSION_1_MATERIAL_UUID,
-					name: 'Peer Gynt',
-					format: 'play',
-					writingCredits: [
-						{
-							model: 'writingCredit',
-							name: 'by',
-							writingEntities: [
-								{
-									model: 'person',
-									uuid: HENRIK_IBSEN_PERSON_UUID,
-									name: 'Henrik Ibsen'
-								},
-								{
-									model: 'company',
-									uuid: null,
-									name: 'Ibsen Theatre Company'
-								}
-							]
-						},
-						{
-							model: 'writingCredit',
-							name: 'version by',
-							writingEntities: [
-								{
-									model: 'person',
-									uuid: FRANK_MCGUINNESS_PERSON_UUID,
-									name: 'Frank McGuinness'
 								}
 							]
 						}

--- a/test-e2e/model-interaction/material-with-source-material.test.js
+++ b/test-e2e/model-interaction/material-with-source-material.test.js
@@ -549,7 +549,25 @@ describe('Materials with source material', () => {
 									model: 'material',
 									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
 									name: 'A Midsummer Night\'s Dream',
-									format: 'play'
+									format: 'play',
+									sourceMaterialWritingCredits: [
+										{
+											model: 'writingCredit',
+											name: 'by',
+											writingEntities: [
+												{
+													model: 'person',
+													uuid: null,
+													name: 'William Shakespeare'
+												},
+												{
+													model: 'company',
+													uuid: THE_KINGS_MEN_COMPANY_UUID,
+													name: 'The King\'s Men'
+												}
+											]
+										}
+									]
 								}
 							]
 						}
@@ -695,7 +713,25 @@ describe('Materials with source material', () => {
 									model: 'material',
 									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
 									name: 'A Midsummer Night\'s Dream',
-									format: 'play'
+									format: 'play',
+									sourceMaterialWritingCredits: [
+										{
+											model: 'writingCredit',
+											name: 'by',
+											writingEntities: [
+												{
+													model: 'person',
+													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+													name: 'William Shakespeare'
+												},
+												{
+													model: 'company',
+													uuid: null,
+													name: 'The King\'s Men'
+												}
+											]
+										}
+									]
 								}
 							]
 						}


### PR DESCRIPTION
This PR modifies the company and person Cypher show queries to avoid repetition of acquiring writing credit data: it starts by identifying all the applicable material nodes (regardless of how they are later grouped), then `UNWIND`s that collection, performing the same operations to acquire the writing credit data, before then filtering the collection into the respective groups (e.g. `materials`, `subsequentVersionMaterials`, `sourcingMaterials`).

The result is much shorter queries to which it should also be easier to add additional groups in the future.

It also comes with the added benefit of responses now including credited source material writers for the **Materials as source material writer** credits (which was work that was going to have been done at some point in the future in any case, so this saves us from having to do that later):

---

#### Dreamworks (company) - before:
![dreamworks-company-before](https://user-images.githubusercontent.com/10484515/106659140-398d6680-6596-11eb-88c0-79e708973090.png)

---

#### Dreamworks (company) - after:
![dreamworks-company-after](https://user-images.githubusercontent.com/10484515/106659154-3e521a80-6596-11eb-8e4e-f5a36d4a0988.png)