### PR TITLE
Modify material Cypher show query

### DIFF
--- a/test-e2e/model-interaction/material-with-source-material.test.js
+++ b/test-e2e/model-interaction/material-with-source-material.test.js
@@ -320,7 +320,25 @@ describe('Materials with source material', () => {
 									model: 'material',
 									uuid: null,
 									name: 'A Midsummer Night\'s Dream',
-									format: 'play'
+									format: 'play',
+									sourceMaterialWritingCredits: [
+										{
+											model: 'writingCredit',
+											name: 'by',
+											writingEntities: [
+												{
+													model: 'person',
+													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+													name: 'William Shakespeare'
+												},
+												{
+													model: 'company',
+													uuid: THE_KINGS_MEN_COMPANY_UUID,
+													name: 'The King\'s Men'
+												}
+											]
+										}
+									]
 								}
 							]
 						}


### PR DESCRIPTION
A similar piece of work to https://github.com/andygout/theatrebase-api/pull/343, doing the same sort of simplifications for the material Cypher show query as was done for the company + person Cypher show queries.

> This PR modifies the company and person Cypher show queries to avoid repetition of acquiring writing credit data: it starts by identifying all the applicable material nodes (regardless of how they are later grouped), then `UNWIND`s that collection, performing the same operations to acquire the writing credit data, before then filtering the collection into the respective groups (e.g. `materials`, `subsequentVersionMaterials`, `sourcingMaterials`).

> The result is much shorter queries to which it should also be easier to add additional groups in the future.

> It also comes with the added benefit of responses now including credited source material writers for the **Materials as source material writer** credits (which was work that was going to have been done at some point in the future in any case, so this saves us from having to do that later):

N.B. In the case of materials, the **Materials as source material writer** credits mentioned above apply to its **Materials as source material** credits.

---

#### The Girl on the Train (material - novel) - before:
![the-girl-on-the-train-novel-before](https://user-images.githubusercontent.com/10484515/106953604-78542580-672a-11eb-992d-4e83b533d572.png)

---

#### The Girl on the Train (material - novel) - after:
![the-girl-on-the-train-novel-after](https://user-images.githubusercontent.com/10484515/106953615-7be7ac80-672a-11eb-9aaf-f67af3671ff5.png)

---

#### A Midsummer Night's Dream (material - play) - before:
![a-midsummer-nights-dream-before](https://user-images.githubusercontent.com/10484515/106953622-7e4a0680-672a-11eb-8c20-4cedb93c563d.png)

---

#### A Midsummer Night's Dream (material - play) - after:
![a-midsummer-nights-dream-after](https://user-images.githubusercontent.com/10484515/106953830-c5d09280-672a-11eb-95ec-c89300f95b17.png)