### PR TITLE
Fix material show Cypher query

### DIFF
--- a/src/neo4j/cypher-queries/material.js
+++ b/src/neo4j/cypher-queries/material.js
@@ -487,9 +487,7 @@ const getShowQuery = () => `
 			END
 		) AS characterGroups
 
-	OPTIONAL MATCH (material)<-[:PRODUCTION_OF]-(production:Production)
-
-	OPTIONAL MATCH (material)<-[:USES_SOURCE_MATERIAL]-(:Material)<-[:PRODUCTION_OF]-(sourcingMaterialProduction:Production)
+	OPTIONAL MATCH (material)<-[:USES_SOURCE_MATERIAL|PRODUCTION_OF*1..2]-(production:Production)
 
 	WITH
 		material,
@@ -498,7 +496,7 @@ const getShowQuery = () => `
 		subsequentVersionMaterials,
 		sourcingMaterials,
 		characterGroups,
-		COLLECT(production) + COLLECT(sourcingMaterialProduction) AS productions
+		COLLECT(production) AS productions
 
 	UNWIND (CASE productions WHEN [] THEN [null] ELSE productions END) AS production
 

--- a/test-e2e/model-interaction/material-with-source-material.test.js
+++ b/test-e2e/model-interaction/material-with-source-material.test.js
@@ -13,23 +13,30 @@ describe('Materials with source material', () => {
 	const A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID = '4';
 	const WILLIAM_SHAKESPEARE_PERSON_UUID = '6';
 	const THE_KINGS_MEN_COMPANY_UUID = '7';
-	const THE_INDIAN_BOY_MATERIAL_UUID = '14';
-	const RONA_MUNRO_PERSON_UUID = '16';
-	const ROYAL_SHAKESPEARE_COMPANY_UUID = '17';
-	const THE_INDIAN_BOY_CHARACTER_UUID = '19';
-	const SHAKESPEARES_VILLAINS_MATERIAL_UUID = '27';
-	const STEVEN_BERKOFF_PERSON_UUID = '29';
-	const EAST_PRODUCTIONS_COMPANY_UUID = '30';
-	const IAGO_CHARACTER_UUID = '33';
-	const THE_INDIAN_BOY_ROYAL_SHAKESPEARE_THEATRE_PRODUCTION_UUID = '34';
-	const ROYAL_SHAKESPEARE_THEATRE_UUID = '36';
-	const SHAKESPEARES_VILLAINS_THEATRE_ROYAL_HAYMARKET_PRODUCTION_UUID = '37';
+	const THE_DONKEY_SHOW_MATERIAL_UUID = '13';
+	const DIANE_PAULUS_PERSON_UUID = '15';
+	const RANDY_WEINER_PERSON_UUID = '16';
+	const THE_INDIAN_BOY_MATERIAL_UUID = '24';
+	const RONA_MUNRO_PERSON_UUID = '26';
+	const ROYAL_SHAKESPEARE_COMPANY_UUID = '27';
+	const THE_INDIAN_BOY_CHARACTER_UUID = '29';
+	const SHAKESPEARES_VILLAINS_MATERIAL_UUID = '37';
+	const STEVEN_BERKOFF_PERSON_UUID = '39';
+	const EAST_PRODUCTIONS_COMPANY_UUID = '40';
+	const IAGO_CHARACTER_UUID = '43';
+	const A_MIDSUMMER_NIGHTS_DREAM_NOVELLO_THEATRE_PRODUCTION_UUID = '44';
+	const NOVELLO_THEATRE_UUID = '46';
+	const THE_DONKEY_SHOW_HANOVER_GRAND_PRODUCTION_UUID = '47';
+	const HANOVER_GRAND_THEATRE_UUID = '49';
+	const THE_INDIAN_BOY_ROYAL_SHAKESPEARE_THEATRE_PRODUCTION_UUID = '50';
+	const ROYAL_SHAKESPEARE_THEATRE_UUID = '52';
+	const SHAKESPEARES_VILLAINS_THEATRE_ROYAL_HAYMARKET_PRODUCTION_UUID = '53';
 
-	let theIndianBoyMaterial;
 	let aMidsummerNightsDreamMaterial;
+	let theIndianBoyMaterial;
 	let shakespearesVillainsMaterial;
-	let ronaMunroPerson;
 	let williamShakespearePerson;
+	let ronaMunroPerson;
 	let stevenBerkoffPerson;
 	let theKingsMenCompany;
 	let royalShakespeareCompany;
@@ -64,6 +71,35 @@ describe('Materials with source material', () => {
 							{
 								model: 'company',
 								name: 'The King\'s Men'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'The Donkey Show',
+				format: 'musical',
+				writingCredits: [
+					{
+						name: 'book by',
+						writingEntities: [
+							{
+								name: 'Diane Paulus'
+							},
+							{
+								name: 'Randy Weiner'
+							}
+						]
+					},
+					{
+						name: 'based on',
+						writingEntities: [
+							{
+								model: 'material',
+								name: 'A Midsummer Night\'s Dream'
 							}
 						]
 					}
@@ -156,6 +192,30 @@ describe('Materials with source material', () => {
 		await chai.request(app)
 			.post('/productions')
 			.send({
+				name: 'A Midsummer Night\'s Dream',
+				material: {
+					name: 'A Midsummer Night\'s Dream'
+				},
+				theatre: {
+					name: 'Novello Theatre'
+				}
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'The Donkey Show',
+				material: {
+					name: 'The Donkey Show'
+				},
+				theatre: {
+					name: 'Hanover Grand'
+				}
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
 				name: 'The Indian Boy',
 				material: {
 					name: 'The Indian Boy'
@@ -177,20 +237,20 @@ describe('Materials with source material', () => {
 				}
 			});
 
-		theIndianBoyMaterial = await chai.request(app)
-			.get(`/materials/${THE_INDIAN_BOY_MATERIAL_UUID}`);
-
 		aMidsummerNightsDreamMaterial = await chai.request(app)
 			.get(`/materials/${A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID}`);
+
+		theIndianBoyMaterial = await chai.request(app)
+			.get(`/materials/${THE_INDIAN_BOY_MATERIAL_UUID}`);
 
 		shakespearesVillainsMaterial = await chai.request(app)
 			.get(`/materials/${SHAKESPEARES_VILLAINS_MATERIAL_UUID}`);
 
-		ronaMunroPerson = await chai.request(app)
-			.get(`/people/${RONA_MUNRO_PERSON_UUID}`);
-
 		williamShakespearePerson = await chai.request(app)
 			.get(`/people/${WILLIAM_SHAKESPEARE_PERSON_UUID}`);
+
+		ronaMunroPerson = await chai.request(app)
+			.get(`/people/${RONA_MUNRO_PERSON_UUID}`);
 
 		stevenBerkoffPerson = await chai.request(app)
 			.get(`/people/${STEVEN_BERKOFF_PERSON_UUID}`);
@@ -221,6 +281,184 @@ describe('Materials with source material', () => {
 	after(() => {
 
 		sandbox.restore();
+
+	});
+
+	describe('A Midsummer Night\'s Dream (material)', () => {
+
+		it('includes materials that used it as source material (in which their uuid is nullified), with corresponding writers', () => {
+
+			const expectedSourcingMaterials = [
+				{
+					model: 'material',
+					uuid: THE_DONKEY_SHOW_MATERIAL_UUID,
+					name: 'The Donkey Show',
+					format: 'musical',
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'book by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: DIANE_PAULUS_PERSON_UUID,
+									name: 'Diane Paulus'
+								},
+								{
+									model: 'person',
+									uuid: RANDY_WEINER_PERSON_UUID,
+									name: 'Randy Weiner'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'based on',
+							writingEntities: [
+								{
+									model: 'material',
+									uuid: null,
+									name: 'A Midsummer Night\'s Dream',
+									format: 'play',
+									sourceMaterialWritingCredits: [
+										{
+											model: 'writingCredit',
+											name: 'by',
+											writingEntities: [
+												{
+													model: 'person',
+													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+													name: 'William Shakespeare'
+												},
+												{
+													model: 'company',
+													uuid: THE_KINGS_MEN_COMPANY_UUID,
+													name: 'The King\'s Men'
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'material',
+					uuid: THE_INDIAN_BOY_MATERIAL_UUID,
+					name: 'The Indian Boy',
+					format: 'play',
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: RONA_MUNRO_PERSON_UUID,
+									name: 'Rona Munro'
+								},
+								{
+									model: 'company',
+									uuid: ROYAL_SHAKESPEARE_COMPANY_UUID,
+									name: 'Royal Shakespeare Company'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'inspired by',
+							writingEntities: [
+								{
+									model: 'material',
+									uuid: null,
+									name: 'A Midsummer Night\'s Dream',
+									format: 'play',
+									sourceMaterialWritingCredits: [
+										{
+											model: 'writingCredit',
+											name: 'by',
+											writingEntities: [
+												{
+													model: 'person',
+													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+													name: 'William Shakespeare'
+												},
+												{
+													model: 'company',
+													uuid: THE_KINGS_MEN_COMPANY_UUID,
+													name: 'The King\'s Men'
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { sourcingMaterials } = aMidsummerNightsDreamMaterial.body;
+
+			expect(sourcingMaterials).to.deep.equal(expectedSourcingMaterials);
+
+		});
+
+		it('includes productions of material', () => {
+
+			const expectedProductions = [
+				{
+					model: 'production',
+					uuid: A_MIDSUMMER_NIGHTS_DREAM_NOVELLO_THEATRE_PRODUCTION_UUID,
+					name: 'A Midsummer Night\'s Dream',
+					theatre: {
+						model: 'theatre',
+						uuid: NOVELLO_THEATRE_UUID,
+						name: 'Novello Theatre',
+						surTheatre: null
+					}
+				}
+			];
+
+			const { productions } = aMidsummerNightsDreamMaterial.body;
+
+			expect(productions).to.deep.equal(expectedProductions);
+
+		});
+
+		it('includes productions of materials that used it as source material', () => {
+
+			const expectedSourcingMaterialProductions = [
+				{
+					model: 'production',
+					uuid: THE_DONKEY_SHOW_HANOVER_GRAND_PRODUCTION_UUID,
+					name: 'The Donkey Show',
+					theatre: {
+						model: 'theatre',
+						uuid: HANOVER_GRAND_THEATRE_UUID,
+						name: 'Hanover Grand',
+						surTheatre: null
+					}
+				},
+				{
+					model: 'production',
+					uuid: THE_INDIAN_BOY_ROYAL_SHAKESPEARE_THEATRE_PRODUCTION_UUID,
+					name: 'The Indian Boy',
+					theatre: {
+						model: 'theatre',
+						uuid: ROYAL_SHAKESPEARE_THEATRE_UUID,
+						name: 'Royal Shakespeare Theatre',
+						surTheatre: null
+					}
+				}
+			];
+
+			const { sourcingMaterialProductions } = aMidsummerNightsDreamMaterial.body;
+
+			expect(sourcingMaterialProductions).to.deep.equal(expectedSourcingMaterialProductions);
+
+		});
 
 	});
 
@@ -285,97 +523,6 @@ describe('Materials with source material', () => {
 
 	});
 
-	describe('A Midsummer Night\'s Dream (material)', () => {
-
-		it('includes materials that used it as source material (in which their uuid is nullified), with corresponding writers', () => {
-
-			const expectedSourcingMaterials = [
-				{
-					model: 'material',
-					uuid: THE_INDIAN_BOY_MATERIAL_UUID,
-					name: 'The Indian Boy',
-					format: 'play',
-					writingCredits: [
-						{
-							model: 'writingCredit',
-							name: 'by',
-							writingEntities: [
-								{
-									model: 'person',
-									uuid: RONA_MUNRO_PERSON_UUID,
-									name: 'Rona Munro'
-								},
-								{
-									model: 'company',
-									uuid: ROYAL_SHAKESPEARE_COMPANY_UUID,
-									name: 'Royal Shakespeare Company'
-								}
-							]
-						},
-						{
-							model: 'writingCredit',
-							name: 'inspired by',
-							writingEntities: [
-								{
-									model: 'material',
-									uuid: null,
-									name: 'A Midsummer Night\'s Dream',
-									format: 'play',
-									sourceMaterialWritingCredits: [
-										{
-											model: 'writingCredit',
-											name: 'by',
-											writingEntities: [
-												{
-													model: 'person',
-													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
-													name: 'William Shakespeare'
-												},
-												{
-													model: 'company',
-													uuid: THE_KINGS_MEN_COMPANY_UUID,
-													name: 'The King\'s Men'
-												}
-											]
-										}
-									]
-								}
-							]
-						}
-					]
-				}
-			];
-
-			const { sourcingMaterials } = aMidsummerNightsDreamMaterial.body;
-
-			expect(sourcingMaterials).to.deep.equal(expectedSourcingMaterials);
-
-		});
-
-		it('includes productions of materials that used it as source material', () => {
-
-			const expectedSourcingMaterialProductions = [
-				{
-					model: 'production',
-					uuid: THE_INDIAN_BOY_ROYAL_SHAKESPEARE_THEATRE_PRODUCTION_UUID,
-					name: 'The Indian Boy',
-					theatre: {
-						model: 'theatre',
-						uuid: ROYAL_SHAKESPEARE_THEATRE_UUID,
-						name: 'Royal Shakespeare Theatre',
-						surTheatre: null
-					}
-				}
-			];
-
-			const { sourcingMaterialProductions } = aMidsummerNightsDreamMaterial.body;
-
-			expect(sourcingMaterialProductions).to.deep.equal(expectedSourcingMaterialProductions);
-
-		});
-
-	});
-
 	describe('Shakespeare\'s Villains (material)', () => {
 
 		it('includes writers of this material and its source material grouped by their respective credits', () => {
@@ -418,6 +565,169 @@ describe('Materials with source material', () => {
 			const { writingCredits } = shakespearesVillainsMaterial.body;
 
 			expect(writingCredits).to.deep.equal(expectedWritingCredits);
+
+		});
+
+	});
+
+	describe('William Shakespeare (person)', () => {
+
+		it('includes materials that used their work as source material (both specific and non-specific), with corresponding writers', () => {
+
+			const expectedSourcingMaterials = [
+				{
+					model: 'material',
+					uuid: SHAKESPEARES_VILLAINS_MATERIAL_UUID,
+					name: 'Shakespeare\'s Villains',
+					format: 'play',
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: STEVEN_BERKOFF_PERSON_UUID,
+									name: 'Steven Berkoff'
+								},
+								{
+									model: 'company',
+									uuid: EAST_PRODUCTIONS_COMPANY_UUID,
+									name: 'East Productions'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'based on works by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: null,
+									name: 'William Shakespeare'
+								},
+								{
+									model: 'company',
+									uuid: THE_KINGS_MEN_COMPANY_UUID,
+									name: 'The King\'s Men'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'material',
+					uuid: THE_DONKEY_SHOW_MATERIAL_UUID,
+					name: 'The Donkey Show',
+					format: 'musical',
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'book by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: DIANE_PAULUS_PERSON_UUID,
+									name: 'Diane Paulus'
+								},
+								{
+									model: 'person',
+									uuid: RANDY_WEINER_PERSON_UUID,
+									name: 'Randy Weiner'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'based on',
+							writingEntities: [
+								{
+									model: 'material',
+									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
+									name: 'A Midsummer Night\'s Dream',
+									format: 'play',
+									sourceMaterialWritingCredits: [
+										{
+											model: 'writingCredit',
+											name: 'by',
+											writingEntities: [
+												{
+													model: 'person',
+													uuid: null,
+													name: 'William Shakespeare'
+												},
+												{
+													model: 'company',
+													uuid: THE_KINGS_MEN_COMPANY_UUID,
+													name: 'The King\'s Men'
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'material',
+					uuid: THE_INDIAN_BOY_MATERIAL_UUID,
+					name: 'The Indian Boy',
+					format: 'play',
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: RONA_MUNRO_PERSON_UUID,
+									name: 'Rona Munro'
+								},
+								{
+									model: 'company',
+									uuid: ROYAL_SHAKESPEARE_COMPANY_UUID,
+									name: 'Royal Shakespeare Company'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'inspired by',
+							writingEntities: [
+								{
+									model: 'material',
+									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
+									name: 'A Midsummer Night\'s Dream',
+									format: 'play',
+									sourceMaterialWritingCredits: [
+										{
+											model: 'writingCredit',
+											name: 'by',
+											writingEntities: [
+												{
+													model: 'person',
+													uuid: null,
+													name: 'William Shakespeare'
+												},
+												{
+													model: 'company',
+													uuid: THE_KINGS_MEN_COMPANY_UUID,
+													name: 'The King\'s Men'
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { sourcingMaterials } = williamShakespearePerson.body;
+
+			expect(sourcingMaterials).to.deep.equal(expectedSourcingMaterials);
 
 		});
 
@@ -487,115 +797,6 @@ describe('Materials with source material', () => {
 			const { materials } = ronaMunroPerson.body;
 
 			expect(materials).to.deep.equal(expectedMaterials);
-
-		});
-
-	});
-
-	describe('William Shakespeare (person)', () => {
-
-		it('includes materials that used their work as source material (both specific and non-specific), with corresponding writers', () => {
-
-			const expectedSourcingMaterials = [
-				{
-					model: 'material',
-					uuid: SHAKESPEARES_VILLAINS_MATERIAL_UUID,
-					name: 'Shakespeare\'s Villains',
-					format: 'play',
-					writingCredits: [
-						{
-							model: 'writingCredit',
-							name: 'by',
-							writingEntities: [
-								{
-									model: 'person',
-									uuid: STEVEN_BERKOFF_PERSON_UUID,
-									name: 'Steven Berkoff'
-								},
-								{
-									model: 'company',
-									uuid: EAST_PRODUCTIONS_COMPANY_UUID,
-									name: 'East Productions'
-								}
-							]
-						},
-						{
-							model: 'writingCredit',
-							name: 'based on works by',
-							writingEntities: [
-								{
-									model: 'person',
-									uuid: null,
-									name: 'William Shakespeare'
-								},
-								{
-									model: 'company',
-									uuid: THE_KINGS_MEN_COMPANY_UUID,
-									name: 'The King\'s Men'
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'material',
-					uuid: THE_INDIAN_BOY_MATERIAL_UUID,
-					name: 'The Indian Boy',
-					format: 'play',
-					writingCredits: [
-						{
-							model: 'writingCredit',
-							name: 'by',
-							writingEntities: [
-								{
-									model: 'person',
-									uuid: RONA_MUNRO_PERSON_UUID,
-									name: 'Rona Munro'
-								},
-								{
-									model: 'company',
-									uuid: ROYAL_SHAKESPEARE_COMPANY_UUID,
-									name: 'Royal Shakespeare Company'
-								}
-							]
-						},
-						{
-							model: 'writingCredit',
-							name: 'inspired by',
-							writingEntities: [
-								{
-									model: 'material',
-									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
-									name: 'A Midsummer Night\'s Dream',
-									format: 'play',
-									sourceMaterialWritingCredits: [
-										{
-											model: 'writingCredit',
-											name: 'by',
-											writingEntities: [
-												{
-													model: 'person',
-													uuid: null,
-													name: 'William Shakespeare'
-												},
-												{
-													model: 'company',
-													uuid: THE_KINGS_MEN_COMPANY_UUID,
-													name: 'The King\'s Men'
-												}
-											]
-										}
-									]
-								}
-							]
-						}
-					]
-				}
-			];
-
-			const { sourcingMaterials } = williamShakespearePerson.body;
-
-			expect(sourcingMaterials).to.deep.equal(expectedSourcingMaterials);
 
 		});
 
@@ -696,6 +897,60 @@ describe('Materials with source material', () => {
 									model: 'company',
 									uuid: null,
 									name: 'The King\'s Men'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'material',
+					uuid: THE_DONKEY_SHOW_MATERIAL_UUID,
+					name: 'The Donkey Show',
+					format: 'musical',
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'book by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: DIANE_PAULUS_PERSON_UUID,
+									name: 'Diane Paulus'
+								},
+								{
+									model: 'person',
+									uuid: RANDY_WEINER_PERSON_UUID,
+									name: 'Randy Weiner'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'based on',
+							writingEntities: [
+								{
+									model: 'material',
+									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
+									name: 'A Midsummer Night\'s Dream',
+									format: 'play',
+									sourceMaterialWritingCredits: [
+										{
+											model: 'writingCredit',
+											name: 'by',
+											writingEntities: [
+												{
+													model: 'person',
+													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+													name: 'William Shakespeare'
+												},
+												{
+													model: 'company',
+													uuid: null,
+													name: 'The King\'s Men'
+												}
+											]
+										}
+									]
 								}
 							]
 						}
@@ -1202,6 +1457,60 @@ describe('Materials with source material', () => {
 									model: 'company',
 									uuid: THE_KINGS_MEN_COMPANY_UUID,
 									name: 'The King\'s Men'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'material',
+					uuid: THE_DONKEY_SHOW_MATERIAL_UUID,
+					name: 'The Donkey Show',
+					format: 'musical',
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'book by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: DIANE_PAULUS_PERSON_UUID,
+									name: 'Diane Paulus'
+								},
+								{
+									model: 'person',
+									uuid: RANDY_WEINER_PERSON_UUID,
+									name: 'Randy Weiner'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'based on',
+							writingEntities: [
+								{
+									model: 'material',
+									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
+									name: 'A Midsummer Night\'s Dream',
+									format: 'play',
+									sourceMaterialWritingCredits: [
+										{
+											model: 'writingCredit',
+											name: 'by',
+											writingEntities: [
+												{
+													model: 'person',
+													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+													name: 'William Shakespeare'
+												},
+												{
+													model: 'company',
+													uuid: THE_KINGS_MEN_COMPANY_UUID,
+													name: 'The King\'s Men'
+												}
+											]
+										}
+									]
 								}
 							]
 						}


### PR DESCRIPTION
This PR fixes the following bug (and adds end-to-end tests to prevent regressions):

If a material has multiple productions of materials that use the subject material as source material (e.g. if A Midsummer Night's dream (play) has a production of The Indian Boy (play) and The Donkey Show (musical), or even two productions of The Indian Boy (play)), then this will create duplicates of its direct productions.

---

#### A Midsummer Night's Dream (material - play) - before:
![before](https://user-images.githubusercontent.com/10484515/107117350-b0b24b80-6871-11eb-9958-99e976560b6f.png)

---

#### A Midsummer Night's Dream (material - play) - after:
![after](https://user-images.githubusercontent.com/10484515/107117352-b314a580-6871-11eb-8f56-3cc28b885529.png)