### PR TITLE
Remove unnecessary DISTINCT commands from Cypher queries

### DIFF
--- a/src/neo4j/cypher-queries/company.js
+++ b/src/neo4j/cypher-queries/company.js
@@ -119,10 +119,11 @@ const getShowQuery = () => `
 				END
 			) AS materials
 
-		WITH DISTINCT company, materials
-
-	WITH
-		company,
+	RETURN
+		'company' AS model,
+		company.uuid AS uuid,
+		company.name AS name,
+		company.differentiator AS differentiator,
 		[
 			material IN materials WHERE ALL(x IN [
 				'originalVersionCredit',
@@ -159,15 +160,6 @@ const getShowQuery = () => `
 				writingCredits: material.writingCredits
 			}
 		] AS sourcingMaterials
-
-	RETURN
-		'company' AS model,
-		company.uuid AS uuid,
-		company.name AS name,
-		company.differentiator AS differentiator,
-		materials,
-		subsequentVersionMaterials,
-		sourcingMaterials
 `;
 
 export {

--- a/src/neo4j/cypher-queries/material.js
+++ b/src/neo4j/cypher-queries/material.js
@@ -403,8 +403,6 @@ const getShowQuery = () => `
 				END
 			) AS relatedMaterials
 
-		WITH DISTINCT material, relatedMaterials
-
 		WITH
 			material,
 			HEAD([

--- a/src/neo4j/cypher-queries/person.js
+++ b/src/neo4j/cypher-queries/person.js
@@ -119,8 +119,6 @@ const getShowQuery = () => `
 				END
 			) AS materials
 
-		WITH DISTINCT person, materials
-
 	WITH
 		person,
 		[


### PR DESCRIPTION
If these DISTINCT commands are required (and found exactly where in the future) then end-to-end tests should be written to capture those cases.