### PR TITLE
Upgrade Docker Neo4j image version 4.0.3 -> 4.2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     docker:
       - image: circleci/node:14.13.0
-      - image: neo4j:4.0.3
+      - image: neo4j:4.2.1
         environment:
           NEO4J_AUTH: none
     steps:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     neo4j:
         container_name: neo4j-test
-        image: neo4j:4.0.3
+        image: neo4j:4.2.1
         environment:
             - NEO4J_AUTH=none
         ports:


### PR DESCRIPTION
I have upgraded the version of my Neo4j Desktop to 4.2.1 so this PR makes the corresponding upgrades to the Docker Neo4j images used for the end-to-end tests.