### PR TITLE
Correct production show Cypher query

### DIFF
--- a/src/neo4j/cypher-queries/production.js
+++ b/src/neo4j/cypher-queries/production.js
@@ -382,7 +382,7 @@ const getShowQuery = () => `
 				THEN null
 				ELSE {
 					model: TOLOWER(HEAD(LABELS(creativeEntity))),
-					uuid: CASE creativeEntity.uuid WHEN material.uuid THEN null ELSE creativeEntity.uuid END,
+					uuid: creativeEntity.uuid,
 					name: creativeEntity.name
 				}
 			END


### PR DESCRIPTION
Some copy-pasting made as part of this PR https://github.com/andygout/theatrebase-api/pull/351 has included an unnecessary conditional for the assignment of the creativeEntities' uuid values.

This PR corrects that uuid assignment.