### PR TITLE
Revise production Cypher queries to apply same props to company + person

### DIFF
--- a/src/neo4j/cypher-queries/production.js
+++ b/src/neo4j/cypher-queries/production.js
@@ -190,7 +190,7 @@ const getEditQuery = () => `
 		ORDER BY creativeEntityRel.creditPosition, creativeEntityRel.entityPosition
 
 	WITH production, material, theatre, cast, creativeEntityRel.credit AS creativeCreditName,
-		[creativeEntity IN COLLECT(
+		COLLECT(
 			CASE creativeEntity WHEN NULL
 				THEN null
 				ELSE {
@@ -199,14 +199,7 @@ const getEditQuery = () => `
 					differentiator: creativeEntity.differentiator
 				}
 			END
-		) | CASE creativeEntity.model WHEN 'company'
-			THEN creativeEntity
-			ELSE {
-				model: creativeEntity.model,
-				name: creativeEntity.name,
-				differentiator: creativeEntity.differentiator
-			}
-		END] + [{}] AS creativeEntities
+		) + [{}] AS creativeEntities
 
 	RETURN
 		'production' AS model,
@@ -377,7 +370,7 @@ const getShowQuery = () => `
 		ORDER BY creativeEntityRel.creditPosition, creativeEntityRel.entityPosition
 
 	WITH production, material, theatre, cast, creativeEntityRel.credit AS creativeCreditName,
-		[creativeEntity IN COLLECT(
+		COLLECT(
 			CASE WHEN creativeEntity IS NULL
 				THEN null
 				ELSE {
@@ -386,10 +379,7 @@ const getShowQuery = () => `
 					name: creativeEntity.name
 				}
 			END
-		) | CASE creativeEntity.model WHEN 'company'
-			THEN creativeEntity
-			ELSE { model: creativeEntity.model, uuid: creativeEntity.uuid, name: creativeEntity.name }
-		END] AS creativeEntities
+		) AS creativeEntities
 
 	RETURN
 		'production' AS model,

--- a/test-unit/src/neo4j/cypher-queries/production.test.js
+++ b/test-unit/src/neo4j/cypher-queries/production.test.js
@@ -175,7 +175,7 @@ describe('Cypher Queries Production module', () => {
 					ORDER BY creativeEntityRel.creditPosition, creativeEntityRel.entityPosition
 
 				WITH production, material, theatre, cast, creativeEntityRel.credit AS creativeCreditName,
-					[creativeEntity IN COLLECT(
+					COLLECT(
 						CASE creativeEntity WHEN NULL
 							THEN null
 							ELSE {
@@ -184,14 +184,7 @@ describe('Cypher Queries Production module', () => {
 								differentiator: creativeEntity.differentiator
 							}
 						END
-					) | CASE creativeEntity.model WHEN 'company'
-						THEN creativeEntity
-						ELSE {
-							model: creativeEntity.model,
-							name: creativeEntity.name,
-							differentiator: creativeEntity.differentiator
-						}
-					END] + [{}] AS creativeEntities
+					) + [{}] AS creativeEntities
 
 				RETURN
 					'production' AS model,
@@ -402,7 +395,7 @@ describe('Cypher Queries Production module', () => {
 					ORDER BY creativeEntityRel.creditPosition, creativeEntityRel.entityPosition
 
 				WITH production, material, theatre, cast, creativeEntityRel.credit AS creativeCreditName,
-					[creativeEntity IN COLLECT(
+					COLLECT(
 						CASE creativeEntity WHEN NULL
 							THEN null
 							ELSE {
@@ -411,14 +404,7 @@ describe('Cypher Queries Production module', () => {
 								differentiator: creativeEntity.differentiator
 							}
 						END
-					) | CASE creativeEntity.model WHEN 'company'
-						THEN creativeEntity
-						ELSE {
-							model: creativeEntity.model,
-							name: creativeEntity.name,
-							differentiator: creativeEntity.differentiator
-						}
-					END] + [{}] AS creativeEntities
+					) + [{}] AS creativeEntities
 
 				RETURN
 					'production' AS model,


### PR DESCRIPTION
This PR removes leftover code from https://github.com/andygout/theatrebase-api/pull/351 because an attempt was made (and revoked before merging that PR) to include a `creditedMembers` property which will only be present for companies but not people.

The `creditedMembers` property has been removed for the time being (to be implemented in a future branch), meaning that in the meantime company and person objects have the same properties and that this processing is therefore doing nothing and can be removed.