### PR TITLE
Fix Neo4j create indexes script

### DIFF
--- a/src/neo4j/create-indexes.js
+++ b/src/neo4j/create-indexes.js
@@ -45,7 +45,7 @@ export default async () => {
 		const modelsWithIndex =
 			indexes
 				.filter(index => index.properties.includes('name'))
-				.map(index => index.tokenNames[0]);
+				.map(index => index.labelsOrTypes[0]);
 
 		const modelsToIndex = MODELS.filter(model => !modelsWithIndex.includes(model));
 


### PR DESCRIPTION
I recently (20 Feb 2021) updated my local Neo4j Desktop instance to v4.2.1 (ref. https://github.com/andygout/theatrebase-api/pull/353) and it is now producing the following error upon running the create constraint/index scripts (which are triggered upon server startup):

`Neo4j database: Error attempting query 'CALL db.indexes()':  TypeError: Cannot read property '0' of undefined`

The property name has changed from `tokenNames` to `labelsOrTypes` (see below database response to `CALL db.indexes()`).

This PR corrects the sought property.

```
[
	{
		"id": 1,
		"name": "constraint_23b8b85c",
		"state": "ONLINE",
		"populationPercent": 100,
		"uniqueness": "UNIQUE",
		"type": "BTREE",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Character"
		],
		"properties": [
			"uuid"
		],
		"provider": "native-btree-1.0"
	},
	{
		"id": 11,
		"name": "constraint_287f064c",
		"state": "ONLINE",
		"populationPercent": 100,
		"uniqueness": "UNIQUE",
		"type": "BTREE",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Theatre"
		],
		"properties": [
			"uuid"
		],
		"provider": "native-btree-1.0"
	},
	{
		"id": 3,
		"name": "constraint_6a39a125",
		"state": "ONLINE",
		"populationPercent": 100,
		"uniqueness": "UNIQUE",
		"type": "BTREE",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Company"
		],
		"properties": [
			"uuid"
		],
		"provider": "native-btree-1.0"
	},
	{
		"id": 9,
		"name": "constraint_706a2664",
		"state": "ONLINE",
		"populationPercent": 100,
		"uniqueness": "UNIQUE",
		"type": "BTREE",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Production"
		],
		"properties": [
			"uuid"
		],
		"provider": "native-btree-1.0"
	},
	{
		"id": 7,
		"name": "constraint_fb8c403a",
		"state": "ONLINE",
		"populationPercent": 100,
		"uniqueness": "UNIQUE",
		"type": "BTREE",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Person"
		],
		"properties": [
			"uuid"
		],
		"provider": "native-btree-1.0"
	},
	{
		"id": 5,
		"name": "constraint_fc85c6ee",
		"state": "ONLINE",
		"populationPercent": 100,
		"uniqueness": "UNIQUE",
		"type": "BTREE",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Material"
		],
		"properties": [
			"uuid"
		],
		"provider": "native-btree-1.0"
	},
	{
		"id": 17,
		"name": "index_315d273c",
		"state": "ONLINE",
		"populationPercent": 100,
		"uniqueness": "NONUNIQUE",
		"type": "BTREE",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Theatre"
		],
		"properties": [
			"name"
		],
		"provider": "native-btree-1.0"
	},
	{
		"id": 16,
		"name": "index_5c0607ad",
		"state": "ONLINE",
		"populationPercent": 100,
		"uniqueness": "NONUNIQUE",
		"type": "BTREE",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Person"
		],
		"properties": [
			"name"
		],
		"provider": "native-btree-1.0"
	},
	{
		"id": 15,
		"name": "index_bf3d1a88",
		"state": "ONLINE",
		"populationPercent": 100,
		"uniqueness": "NONUNIQUE",
		"type": "BTREE",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Material"
		],
		"properties": [
			"name"
		],
		"provider": "native-btree-1.0"
	},
	{
		"id": 13,
		"name": "index_e95cfe92",
		"state": "ONLINE",
		"populationPercent": 100,
		"uniqueness": "NONUNIQUE",
		"type": "BTREE",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Character"
		],
		"properties": [
			"name"
		],
		"provider": "native-btree-1.0"
	},
	{
		"id": 14,
		"name": "index_facc95fe",
		"state": "ONLINE",
		"populationPercent": 100,
		"uniqueness": "NONUNIQUE",
		"type": "BTREE",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Company"
		],
		"properties": [
			"name"
		],
		"provider": "native-btree-1.0"
	}
]
```