### PR TITLE
Update show constraints/indexes Cypher queries

### DIFF
--- a/src/neo4j/create-constraints.js
+++ b/src/neo4j/create-constraints.js
@@ -34,7 +34,7 @@ const createConstraint = async model => {
 
 export default async () => {
 
-	const callDbConstraintsQuery = 'CALL db.constraints()';
+	const callDbConstraintsQuery = 'SHOW CONSTRAINTS';
 
 	try {
 
@@ -43,7 +43,7 @@ export default async () => {
 			{ isOptionalResult: true, isArrayResult: true }
 		);
 
-		const modelsWithConstraint = constraints.map(constraint => constraint.description.match(/:(.*) \)/)[1]);
+		const modelsWithConstraint = constraints.map(constraint => constraint.labelsOrTypes[0]);
 
 		const modelsToConstrain = MODELS.filter(model => !modelsWithConstraint.includes(model));
 

--- a/src/neo4j/create-indexes.js
+++ b/src/neo4j/create-indexes.js
@@ -33,7 +33,7 @@ const createIndex = async model => {
 
 export default async () => {
 
-	const callDbIndexesQuery = 'CALL db.indexes()';
+	const callDbIndexesQuery = 'SHOW INDEXES';
 
 	try {
 


### PR DESCRIPTION
Running `CALL db.constraints()` in the Neo4j Console warns: `The query used a deprecated procedure. ('db.constraints' has been replaced by 'SHOW CONSTRAINTS command')`.

Running `CALL db.indexes()` in the Neo4j Console warns: `The query used a deprecated procedure. ('db.indexes' has been replaced by 'SHOW INDEXES command')`.

These are likely as a result of recently (20 Feb 2021) upgrading my Neo4j Desktop instance to v4.2.1 (ref. https://github.com/andygout/theatrebase-api/pull/353).

This PR updates those Cypher queries accordingly.

The response from `CALL db.constraints()` differs to `SHOW CONSTRAINTS`, and so also requires a change to the script for creating constraints to use the correct property and avoid this error:

`Neo4j database: Error attempting query 'SHOW CONSTRAINTS':  TypeError: Cannot read property 'match' of undefined`

#### `CALL db.constraints()` response:
```
[
	{
		"name": "constraint_23b8b85c",
		"description": "CONSTRAINT ON ( character:Character ) ASSERT (character.uuid) IS UNIQUE",
		"details": "Constraint( id=2, name='constraint_23b8b85c', type='UNIQUENESS', schema=(:Character {uuid}), ownedIndex=1 )"
	},
	{
		"name": "constraint_287f064c",
		"description": "CONSTRAINT ON ( theatre:Theatre ) ASSERT (theatre.uuid) IS UNIQUE",
		"details": "Constraint( id=12, name='constraint_287f064c', type='UNIQUENESS', schema=(:Theatre {uuid}), ownedIndex=11 )"
	},
	{
		"name": "constraint_6a39a125",
		"description": "CONSTRAINT ON ( company:Company ) ASSERT (company.uuid) IS UNIQUE",
		"details": "Constraint( id=4, name='constraint_6a39a125', type='UNIQUENESS', schema=(:Company {uuid}), ownedIndex=3 )"
	},
	{
		"name": "constraint_706a2664",
		"description": "CONSTRAINT ON ( production:Production ) ASSERT (production.uuid) IS UNIQUE",
		"details": "Constraint( id=10, name='constraint_706a2664', type='UNIQUENESS', schema=(:Production {uuid}), ownedIndex=9 )"
	},
	{
		"name": "constraint_fb8c403a",
		"description": "CONSTRAINT ON ( person:Person ) ASSERT (person.uuid) IS UNIQUE",
		"details": "Constraint( id=8, name='constraint_fb8c403a', type='UNIQUENESS', schema=(:Person {uuid}), ownedIndex=7 )"
	},
	{
		"name": "constraint_fc85c6ee",
		"description": "CONSTRAINT ON ( material:Material ) ASSERT (material.uuid) IS UNIQUE",
		"details": "Constraint( id=6, name='constraint_fc85c6ee', type='UNIQUENESS', schema=(:Material {uuid}), ownedIndex=5 )"
	}
]
```

#### `SHOW CONSTRAINTS` response:
```
[
	{
		"id": 2,
		"name": "constraint_23b8b85c",
		"type": "UNIQUENESS",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Character"
		],
		"properties": [
			"uuid"
		],
		"ownedIndexId": 1
	},
	{
		"id": 12,
		"name": "constraint_287f064c",
		"type": "UNIQUENESS",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Theatre"
		],
		"properties": [
			"uuid"
		],
		"ownedIndexId": 11
	},
	{
		"id": 4,
		"name": "constraint_6a39a125",
		"type": "UNIQUENESS",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Company"
		],
		"properties": [
			"uuid"
		],
		"ownedIndexId": 3
	},
	{
		"id": 10,
		"name": "constraint_706a2664",
		"type": "UNIQUENESS",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Production"
		],
		"properties": [
			"uuid"
		],
		"ownedIndexId": 9
	},
	{
		"id": 8,
		"name": "constraint_fb8c403a",
		"type": "UNIQUENESS",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Person"
		],
		"properties": [
			"uuid"
		],
		"ownedIndexId": 7
	},
	{
		"id": 6,
		"name": "constraint_fc85c6ee",
		"type": "UNIQUENESS",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Material"
		],
		"properties": [
			"uuid"
		],
		"ownedIndexId": 5
	}
]
```