### PR TITLE
Make E2E test constant names consistent

### DIFF
--- a/test-e2e/crud/productions-api.test.js
+++ b/test-e2e/crud/productions-api.test.js
@@ -354,28 +354,28 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 	describe('CRUD with full range of attributes assigned values', () => {
 
 		const PRODUCTION_UUID = '0';
-		const THE_TRAGEDY_OF_HAMLET_PRINCE_OF_DENMARK_UUID = '1';
+		const THE_TRAGEDY_OF_HAMLET_PRINCE_OF_DENMARK_MATERIAL_UUID = '1';
 		const NATIONAL_THEATRE_UUID = '2';
-		const RORY_KINNEAR_UUID = '3';
-		const JAMES_LAURENSON_UUID = '4';
-		const MICHAEL_SHELDON_UUID = '5';
-		const LEO_STAAR_UUID = '6';
-		const NICHOLAS_HYTNER_UUID = '7';
+		const RORY_KINNEAR_PERSON_UUID = '3';
+		const JAMES_LAURENSON_PERSON_UUID = '4';
+		const MICHAEL_SHELDON_PERSON_UUID = '5';
+		const LEO_STAAR_PERSON_UUID = '6';
+		const NICHOLAS_HYTNER_PERSON_UUID = '7';
 		const HANDSPRING_PUPPET_COMPANY_UUID = '8';
-		const BEN_RINGHAM_UUID = '9';
-		const MAX_RINGHAM_UUID = '10';
-		const FIFTY_NINE_PRODUCTIONS_UUID = '11';
-		const THE_TRAGEDY_OF_KING_RICHARD_III_UUID = '12';
+		const BEN_RINGHAM_PERSON_UUID = '9';
+		const MAX_RINGHAM_PERSON_UUID = '10';
+		const FIFTY_NINE_PRODUCTIONS_COMPANY_UUID = '11';
+		const THE_TRAGEDY_OF_KING_RICHARD_III_MATERIAL_UUID = '12';
 		const ALMEIDA_THEATRE_UUID = '13';
-		const RALPH_FIENNES_UUID = '14';
-		const TOM_CANTON_UUID = '15';
-		const MARK_HADFIELD_UUID = '16';
-		const JOSH_COLLINS_UUID = '17';
-		const RUPERT_GOOLD_UUID = '18';
-		const RC_ANNIE_LTD_UUID = '19';
-		const HILDEGARD_BECHTLER_UUID = '20';
-		const CHLOE_LAMFORD_UUID = '21';
-		const AUTOGRAPH_UUID = '22';
+		const RALPH_FIENNES_PERSON_UUID = '14';
+		const TOM_CANTON_PERSON_UUID = '15';
+		const MARK_HADFIELD_PERSON_UUID = '16';
+		const JOSH_COLLINS_PERSON_UUID = '17';
+		const RUPERT_GOOLD_PERSON_UUID = '18';
+		const RC_ANNIE_LTD_COMPANY_UUID = '19';
+		const HILDEGARD_BECHTLER_PERSON_UUID = '20';
+		const CHLOE_LAMFORD_PERSON_UUID = '21';
+		const AUTOGRAPH_COMPANY_UUID = '22';
 
 		before(async () => {
 
@@ -767,7 +767,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 				name: 'Hamlet',
 				material: {
 					model: 'material',
-					uuid: THE_TRAGEDY_OF_HAMLET_PRINCE_OF_DENMARK_UUID,
+					uuid: THE_TRAGEDY_OF_HAMLET_PRINCE_OF_DENMARK_MATERIAL_UUID,
 					name: 'The Tragedy of Hamlet, Prince of Denmark',
 					format: null,
 					writingCredits: []
@@ -781,7 +781,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 				cast: [
 					{
 						model: 'person',
-						uuid: RORY_KINNEAR_UUID,
+						uuid: RORY_KINNEAR_PERSON_UUID,
 						name: 'Rory Kinnear',
 						roles: [
 							{
@@ -794,7 +794,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 					},
 					{
 						model: 'person',
-						uuid: JAMES_LAURENSON_UUID,
+						uuid: JAMES_LAURENSON_PERSON_UUID,
 						name: 'James Laurenson',
 						roles: [
 							{
@@ -813,7 +813,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 					},
 					{
 						model: 'person',
-						uuid: MICHAEL_SHELDON_UUID,
+						uuid: MICHAEL_SHELDON_PERSON_UUID,
 						name: 'Michael Sheldon',
 						roles: [
 							{
@@ -832,7 +832,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 					},
 					{
 						model: 'person',
-						uuid: LEO_STAAR_UUID,
+						uuid: LEO_STAAR_PERSON_UUID,
 						name: 'Leo Staar',
 						roles: [
 							{
@@ -848,7 +848,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 						creativeEntities: [
 							{
 								model: 'person',
-								uuid: NICHOLAS_HYTNER_UUID,
+								uuid: NICHOLAS_HYTNER_PERSON_UUID,
 								name: 'Nicholas Hytner'
 							}
 						]
@@ -870,12 +870,12 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 						creativeEntities: [
 							{
 								model: 'person',
-								uuid: BEN_RINGHAM_UUID,
+								uuid: BEN_RINGHAM_PERSON_UUID,
 								name: 'Ben Ringham'
 							},
 							{
 								model: 'person',
-								uuid: MAX_RINGHAM_UUID,
+								uuid: MAX_RINGHAM_PERSON_UUID,
 								name: 'Max Ringham'
 							}
 						]
@@ -886,7 +886,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 						creativeEntities: [
 							{
 								model: 'company',
-								uuid: FIFTY_NINE_PRODUCTIONS_UUID,
+								uuid: FIFTY_NINE_PRODUCTIONS_COMPANY_UUID,
 								name: '59 Productions'
 							}
 						]
@@ -1521,7 +1521,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 				name: 'Richard III',
 				material: {
 					model: 'material',
-					uuid: THE_TRAGEDY_OF_KING_RICHARD_III_UUID,
+					uuid: THE_TRAGEDY_OF_KING_RICHARD_III_MATERIAL_UUID,
 					name: 'The Tragedy of King Richard III',
 					format: null,
 					writingCredits: []
@@ -1535,7 +1535,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 				cast: [
 					{
 						model: 'person',
-						uuid: RALPH_FIENNES_UUID,
+						uuid: RALPH_FIENNES_PERSON_UUID,
 						name: 'Ralph Fiennes',
 						roles: [
 							{
@@ -1548,7 +1548,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 					},
 					{
 						model: 'person',
-						uuid: TOM_CANTON_UUID,
+						uuid: TOM_CANTON_PERSON_UUID,
 						name: 'Tom Canton',
 						roles: [
 							{
@@ -1567,7 +1567,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 					},
 					{
 						model: 'person',
-						uuid: MARK_HADFIELD_UUID,
+						uuid: MARK_HADFIELD_PERSON_UUID,
 						name: 'Mark Hadfield',
 						roles: [
 							{
@@ -1586,7 +1586,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 					},
 					{
 						model: 'person',
-						uuid: JOSH_COLLINS_UUID,
+						uuid: JOSH_COLLINS_PERSON_UUID,
 						name: 'Josh Collins',
 						roles: [
 							{
@@ -1602,7 +1602,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 						creativeEntities: [
 							{
 								model: 'person',
-								uuid: RUPERT_GOOLD_UUID,
+								uuid: RUPERT_GOOLD_PERSON_UUID,
 								name: 'Rupert Goold'
 							}
 						]
@@ -1613,7 +1613,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 						creativeEntities: [
 							{
 								model: 'company',
-								uuid: RC_ANNIE_LTD_UUID,
+								uuid: RC_ANNIE_LTD_COMPANY_UUID,
 								name: 'RC-Annie'
 							}
 						]
@@ -1624,12 +1624,12 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 						creativeEntities: [
 							{
 								model: 'person',
-								uuid: HILDEGARD_BECHTLER_UUID,
+								uuid: HILDEGARD_BECHTLER_PERSON_UUID,
 								name: 'Hildegard Bechtler'
 							},
 							{
 								model: 'person',
-								uuid: CHLOE_LAMFORD_UUID,
+								uuid: CHLOE_LAMFORD_PERSON_UUID,
 								name: 'Chloe Lamford'
 							}
 						]
@@ -1640,7 +1640,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 						creativeEntities: [
 							{
 								model: 'company',
-								uuid: AUTOGRAPH_UUID,
+								uuid: AUTOGRAPH_COMPANY_UUID,
 								name: 'Autograph'
 							}
 						]

--- a/test-e2e/uniqueness-in-db/productions-api.test.js
+++ b/test-e2e/uniqueness-in-db/productions-api.test.js
@@ -404,7 +404,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 	describe('Production creative entity (person) uniqueness in database', () => {
 
-		const GIRL_NO_7_THEATRE_503_PRODUCTION_UUID = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+		const GIRL_NO_7_PRODUCTION_UUID = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
 
 		const expectedPersonPaulHiggins1 = {
 			model: 'person',
@@ -430,7 +430,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			await createNode({
 				label: 'Production',
-				uuid: GIRL_NO_7_THEATRE_503_PRODUCTION_UUID,
+				uuid: GIRL_NO_7_PRODUCTION_UUID,
 				name: 'Girl No 7'
 			});
 
@@ -447,7 +447,7 @@ describe('Uniqueness in database: Productions API', () => {
 			expect(await countNodesWithLabel('Person')).to.equal(0);
 
 			const response = await chai.request(app)
-				.put(`/productions/${GIRL_NO_7_THEATRE_503_PRODUCTION_UUID}`)
+				.put(`/productions/${GIRL_NO_7_PRODUCTION_UUID}`)
 				.send({
 					name: 'Girl No 7',
 					creativeCredits: [
@@ -473,7 +473,7 @@ describe('Uniqueness in database: Productions API', () => {
 			expect(await countNodesWithLabel('Person')).to.equal(1);
 
 			const response = await chai.request(app)
-				.put(`/productions/${GIRL_NO_7_THEATRE_503_PRODUCTION_UUID}`)
+				.put(`/productions/${GIRL_NO_7_PRODUCTION_UUID}`)
 				.send({
 					name: 'Girl No 7',
 					creativeCredits: [
@@ -500,7 +500,7 @@ describe('Uniqueness in database: Productions API', () => {
 			expect(await countNodesWithLabel('Person')).to.equal(2);
 
 			const response = await chai.request(app)
-				.put(`/productions/${GIRL_NO_7_THEATRE_503_PRODUCTION_UUID}`)
+				.put(`/productions/${GIRL_NO_7_PRODUCTION_UUID}`)
 				.send({
 					name: 'Girl No 7',
 					creativeCredits: [
@@ -526,7 +526,7 @@ describe('Uniqueness in database: Productions API', () => {
 			expect(await countNodesWithLabel('Person')).to.equal(2);
 
 			const response = await chai.request(app)
-				.put(`/productions/${GIRL_NO_7_THEATRE_503_PRODUCTION_UUID}`)
+				.put(`/productions/${GIRL_NO_7_PRODUCTION_UUID}`)
 				.send({
 					name: 'Girl No 7',
 					creativeCredits: [
@@ -552,7 +552,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 	describe('Production creative entity (company) uniqueness in database', () => {
 
-		const MOTHER_COURAGE_AND_HER_CHILDREN_OLIVIER_PRODUCTION_UUID = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+		const MOTHER_COURAGE_AND_HER_CHILDREN_PRODUCTION_UUID = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
 
 		const expectedCompanyAutograph1 = {
 			model: 'company',
@@ -578,7 +578,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			await createNode({
 				label: 'Production',
-				uuid: MOTHER_COURAGE_AND_HER_CHILDREN_OLIVIER_PRODUCTION_UUID,
+				uuid: MOTHER_COURAGE_AND_HER_CHILDREN_PRODUCTION_UUID,
 				name: 'Mother Courage and Her Children'
 			});
 
@@ -595,7 +595,7 @@ describe('Uniqueness in database: Productions API', () => {
 			expect(await countNodesWithLabel('Company')).to.equal(0);
 
 			const response = await chai.request(app)
-				.put(`/productions/${MOTHER_COURAGE_AND_HER_CHILDREN_OLIVIER_PRODUCTION_UUID}`)
+				.put(`/productions/${MOTHER_COURAGE_AND_HER_CHILDREN_PRODUCTION_UUID}`)
 				.send({
 					name: 'Mother Courage and Her Children',
 					creativeCredits: [
@@ -622,7 +622,7 @@ describe('Uniqueness in database: Productions API', () => {
 			expect(await countNodesWithLabel('Company')).to.equal(1);
 
 			const response = await chai.request(app)
-				.put(`/productions/${MOTHER_COURAGE_AND_HER_CHILDREN_OLIVIER_PRODUCTION_UUID}`)
+				.put(`/productions/${MOTHER_COURAGE_AND_HER_CHILDREN_PRODUCTION_UUID}`)
 				.send({
 					name: 'Mother Courage and Her Children',
 					creativeCredits: [
@@ -650,7 +650,7 @@ describe('Uniqueness in database: Productions API', () => {
 			expect(await countNodesWithLabel('Company')).to.equal(2);
 
 			const response = await chai.request(app)
-				.put(`/productions/${MOTHER_COURAGE_AND_HER_CHILDREN_OLIVIER_PRODUCTION_UUID}`)
+				.put(`/productions/${MOTHER_COURAGE_AND_HER_CHILDREN_PRODUCTION_UUID}`)
 				.send({
 					name: 'Mother Courage and Her Children',
 					creativeCredits: [
@@ -677,7 +677,7 @@ describe('Uniqueness in database: Productions API', () => {
 			expect(await countNodesWithLabel('Company')).to.equal(2);
 
 			const response = await chai.request(app)
-				.put(`/productions/${MOTHER_COURAGE_AND_HER_CHILDREN_OLIVIER_PRODUCTION_UUID}`)
+				.put(`/productions/${MOTHER_COURAGE_AND_HER_CHILDREN_PRODUCTION_UUID}`)
 				.send({
 					name: 'Mother Courage and Her Children',
 					creativeCredits: [


### PR DESCRIPTION
It is useful for end-to-end test constant names to indicate the model of the UUID value to which they point.

It is unnecessary for productions to include a theatre name in their constant name when the corresponding data does not include theatre information, even if it is based on a real-life production that naturally will have a corresponding theatre.