### PR TITLE
Shorten Cypher query CASE WHEN statements

### DIFF
--- a/src/neo4j/cypher-queries/material.js
+++ b/src/neo4j/cypher-queries/material.js
@@ -74,7 +74,7 @@ const getCreateUpdateQuery = action => {
 						(writingEntityParam.differentiator IS NULL AND existingWriter.differentiator IS NULL) OR
 						(writingEntityParam.differentiator = existingWriter.differentiator)
 
-				FOREACH (item IN CASE WHEN writingEntityParam IS NOT NULL THEN [1] ELSE [] END |
+				FOREACH (item IN CASE writingEntityParam WHEN NULL THEN [] ELSE [1] END |
 					MERGE (entity:Person {
 						uuid: COALESCE(existingWriter.uuid, writingEntityParam.uuid),
 						name: writingEntityParam.name
@@ -103,7 +103,7 @@ const getCreateUpdateQuery = action => {
 						(writingEntityParam.differentiator IS NULL AND existingWriter.differentiator IS NULL) OR
 						(writingEntityParam.differentiator = existingWriter.differentiator)
 
-				FOREACH (item IN CASE WHEN writingEntityParam IS NOT NULL THEN [1] ELSE [] END |
+				FOREACH (item IN CASE writingEntityParam WHEN NULL THEN [] ELSE [1] END |
 					MERGE (entity:Company {
 						uuid: COALESCE(existingWriter.uuid, writingEntityParam.uuid),
 						name: writingEntityParam.name
@@ -132,7 +132,7 @@ const getCreateUpdateQuery = action => {
 						(sourceMaterialParam.differentiator IS NULL AND existingSourceMaterial.differentiator IS NULL) OR
 						(sourceMaterialParam.differentiator = existingSourceMaterial.differentiator)
 
-				FOREACH (item IN CASE WHEN sourceMaterialParam IS NOT NULL THEN [1] ELSE [] END |
+				FOREACH (item IN CASE sourceMaterialParam WHEN NULL THEN [] ELSE [1] END |
 					MERGE (sourceMaterial:Material {
 						uuid: COALESCE(existingSourceMaterial.uuid, sourceMaterialParam.uuid),
 						name: sourceMaterialParam.name
@@ -312,7 +312,7 @@ const getShowQuery = () => `
 			isOriginalVersionWritingEntity,
 			sourceMaterialWriterRel.credit AS sourceMaterialWritingCreditName,
 			COLLECT(
-				CASE WHEN sourceMaterialWriter IS NULL
+				CASE sourceMaterialWriter WHEN NULL
 					THEN null
 					ELSE sourceMaterialWriter {
 						model: TOLOWER(HEAD(LABELS(sourceMaterialWriter))),

--- a/src/neo4j/cypher-queries/production.js
+++ b/src/neo4j/cypher-queries/production.js
@@ -98,7 +98,7 @@ const getCreateUpdateQuery = action => {
 						(creativeEntityParam.differentiator IS NULL AND existingCreative.differentiator IS NULL) OR
 						(creativeEntityParam.differentiator = existingCreative.differentiator)
 
-				FOREACH (item IN CASE WHEN creativeEntityParam IS NOT NULL THEN [1] ELSE [] END |
+				FOREACH (item IN CASE creativeEntityParam WHEN NULL THEN [] ELSE [1] END |
 					MERGE (entity:Person {
 						uuid: COALESCE(existingCreative.uuid, creativeEntityParam.uuid),
 						name: creativeEntityParam.name
@@ -126,7 +126,7 @@ const getCreateUpdateQuery = action => {
 						(creativeEntityParam.differentiator IS NULL AND existingCreative.differentiator IS NULL) OR
 						(creativeEntityParam.differentiator = existingCreative.differentiator)
 
-				FOREACH (item IN CASE WHEN creativeEntityParam IS NOT NULL THEN [1] ELSE [] END |
+				FOREACH (item IN CASE creativeEntityParam WHEN NULL THEN [] ELSE [1] END |
 					MERGE (entity:Company {
 						uuid: COALESCE(existingCreative.uuid, creativeEntityParam.uuid),
 						name: creativeEntityParam.name
@@ -353,7 +353,7 @@ const getShowQuery = () => `
 
 	WITH production, material, theatre, cast, creativeEntityRel.credit AS creativeCreditName,
 		COLLECT(
-			CASE WHEN creativeEntity IS NULL
+			CASE creativeEntity WHEN NULL
 				THEN null
 				ELSE creativeEntity { model: TOLOWER(HEAD(LABELS(creativeEntity))), .uuid, .name }
 			END

--- a/test-e2e/test-helpers/neo4j/is-node-existent.js
+++ b/test-e2e/test-helpers/neo4j/is-node-existent.js
@@ -10,7 +10,7 @@ export default async opts => {
 		MATCH (n:${label} { name: $name, uuid: $uuid })
 
 		RETURN
-			CASE WHEN COUNT(n) = 1
+			CASE COUNT(n) WHEN 1
 				THEN true
 				ELSE false
 			END AS exists

--- a/test-unit/src/neo4j/cypher-queries/material.test.js
+++ b/test-unit/src/neo4j/cypher-queries/material.test.js
@@ -45,7 +45,7 @@ describe('Cypher Queries Material module', () => {
 								(writingEntityParam.differentiator IS NULL AND existingWriter.differentiator IS NULL) OR
 								(writingEntityParam.differentiator = existingWriter.differentiator)
 
-						FOREACH (item IN CASE WHEN writingEntityParam IS NOT NULL THEN [1] ELSE [] END |
+						FOREACH (item IN CASE writingEntityParam WHEN NULL THEN [] ELSE [1] END |
 							MERGE (entity:Person {
 								uuid: COALESCE(existingWriter.uuid, writingEntityParam.uuid),
 								name: writingEntityParam.name
@@ -74,7 +74,7 @@ describe('Cypher Queries Material module', () => {
 								(writingEntityParam.differentiator IS NULL AND existingWriter.differentiator IS NULL) OR
 								(writingEntityParam.differentiator = existingWriter.differentiator)
 
-						FOREACH (item IN CASE WHEN writingEntityParam IS NOT NULL THEN [1] ELSE [] END |
+						FOREACH (item IN CASE writingEntityParam WHEN NULL THEN [] ELSE [1] END |
 							MERGE (entity:Company {
 								uuid: COALESCE(existingWriter.uuid, writingEntityParam.uuid),
 								name: writingEntityParam.name
@@ -103,7 +103,7 @@ describe('Cypher Queries Material module', () => {
 								(sourceMaterialParam.differentiator IS NULL AND existingSourceMaterial.differentiator IS NULL) OR
 								(sourceMaterialParam.differentiator = existingSourceMaterial.differentiator)
 
-						FOREACH (item IN CASE WHEN sourceMaterialParam IS NOT NULL THEN [1] ELSE [] END |
+						FOREACH (item IN CASE sourceMaterialParam WHEN NULL THEN [] ELSE [1] END |
 							MERGE (sourceMaterial:Material {
 								uuid: COALESCE(existingSourceMaterial.uuid, sourceMaterialParam.uuid),
 								name: sourceMaterialParam.name
@@ -297,7 +297,7 @@ describe('Cypher Queries Material module', () => {
 								(writingEntityParam.differentiator IS NULL AND existingWriter.differentiator IS NULL) OR
 								(writingEntityParam.differentiator = existingWriter.differentiator)
 
-						FOREACH (item IN CASE WHEN writingEntityParam IS NOT NULL THEN [1] ELSE [] END |
+						FOREACH (item IN CASE writingEntityParam WHEN NULL THEN [] ELSE [1] END |
 							MERGE (entity:Person {
 								uuid: COALESCE(existingWriter.uuid, writingEntityParam.uuid),
 								name: writingEntityParam.name
@@ -326,7 +326,7 @@ describe('Cypher Queries Material module', () => {
 								(writingEntityParam.differentiator IS NULL AND existingWriter.differentiator IS NULL) OR
 								(writingEntityParam.differentiator = existingWriter.differentiator)
 
-						FOREACH (item IN CASE WHEN writingEntityParam IS NOT NULL THEN [1] ELSE [] END |
+						FOREACH (item IN CASE writingEntityParam WHEN NULL THEN [] ELSE [1] END |
 							MERGE (entity:Company {
 								uuid: COALESCE(existingWriter.uuid, writingEntityParam.uuid),
 								name: writingEntityParam.name
@@ -355,7 +355,7 @@ describe('Cypher Queries Material module', () => {
 								(sourceMaterialParam.differentiator IS NULL AND existingSourceMaterial.differentiator IS NULL) OR
 								(sourceMaterialParam.differentiator = existingSourceMaterial.differentiator)
 
-						FOREACH (item IN CASE WHEN sourceMaterialParam IS NOT NULL THEN [1] ELSE [] END |
+						FOREACH (item IN CASE sourceMaterialParam WHEN NULL THEN [] ELSE [1] END |
 							MERGE (sourceMaterial:Material {
 								uuid: COALESCE(existingSourceMaterial.uuid, sourceMaterialParam.uuid),
 								name: sourceMaterialParam.name

--- a/test-unit/src/neo4j/cypher-queries/production.test.js
+++ b/test-unit/src/neo4j/cypher-queries/production.test.js
@@ -91,7 +91,7 @@ describe('Cypher Queries Production module', () => {
 								(creativeEntityParam.differentiator IS NULL AND existingCreative.differentiator IS NULL) OR
 								(creativeEntityParam.differentiator = existingCreative.differentiator)
 
-						FOREACH (item IN CASE WHEN creativeEntityParam IS NOT NULL THEN [1] ELSE [] END |
+						FOREACH (item IN CASE creativeEntityParam WHEN NULL THEN [] ELSE [1] END |
 							MERGE (entity:Person {
 								uuid: COALESCE(existingCreative.uuid, creativeEntityParam.uuid),
 								name: creativeEntityParam.name
@@ -119,7 +119,7 @@ describe('Cypher Queries Production module', () => {
 								(creativeEntityParam.differentiator IS NULL AND existingCreative.differentiator IS NULL) OR
 								(creativeEntityParam.differentiator = existingCreative.differentiator)
 
-						FOREACH (item IN CASE WHEN creativeEntityParam IS NOT NULL THEN [1] ELSE [] END |
+						FOREACH (item IN CASE creativeEntityParam WHEN NULL THEN [] ELSE [1] END |
 							MERGE (entity:Company {
 								uuid: COALESCE(existingCreative.uuid, creativeEntityParam.uuid),
 								name: creativeEntityParam.name
@@ -307,7 +307,7 @@ describe('Cypher Queries Production module', () => {
 								(creativeEntityParam.differentiator IS NULL AND existingCreative.differentiator IS NULL) OR
 								(creativeEntityParam.differentiator = existingCreative.differentiator)
 
-						FOREACH (item IN CASE WHEN creativeEntityParam IS NOT NULL THEN [1] ELSE [] END |
+						FOREACH (item IN CASE creativeEntityParam WHEN NULL THEN [] ELSE [1] END |
 							MERGE (entity:Person {
 								uuid: COALESCE(existingCreative.uuid, creativeEntityParam.uuid),
 								name: creativeEntityParam.name
@@ -335,7 +335,7 @@ describe('Cypher Queries Production module', () => {
 								(creativeEntityParam.differentiator IS NULL AND existingCreative.differentiator IS NULL) OR
 								(creativeEntityParam.differentiator = existingCreative.differentiator)
 
-						FOREACH (item IN CASE WHEN creativeEntityParam IS NOT NULL THEN [1] ELSE [] END |
+						FOREACH (item IN CASE creativeEntityParam WHEN NULL THEN [] ELSE [1] END |
 							MERGE (entity:Company {
 								uuid: COALESCE(existingCreative.uuid, creativeEntityParam.uuid),
 								name: creativeEntityParam.name


### PR DESCRIPTION
This PR revises the syntax of Cypher query `CASE WHEN` statements to make them more succinct.