### PR TITLE
Rename cast member productions from productions -> castMemberProductions

### DIFF
--- a/test-e2e/crud/people-api.test.js
+++ b/test-e2e/crud/people-api.test.js
@@ -132,7 +132,7 @@ describe('CRUD (Create, Read, Update, Delete): People API', () => {
 				subsequentVersionMaterials: [],
 				sourcingMaterials: [],
 				rightsGrantorMaterials: [],
-				productions: [],
+				castMemberProductions: [],
 				creativeProductions: []
 			};
 

--- a/test-e2e/model-interaction/cast-member-diff-roles-of-material.test.js
+++ b/test-e2e/model-interaction/cast-member-diff-roles-of-material.test.js
@@ -345,7 +345,7 @@ describe('Cast member performing different roles in different productions of sam
 
 		it('includes production with his portrayal of King Lear', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: KING_LEAR_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
@@ -367,9 +367,9 @@ describe('Cast member performing different roles in different productions of sam
 				}
 			];
 
-			const { productions } = michaelGambonPerson.body;
+			const { castMemberProductions } = michaelGambonPerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 
@@ -379,7 +379,7 @@ describe('Cast member performing different roles in different productions of sam
 
 		it('includes production with his respective portrayals of King Lear and the Fool', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: KING_LEAR_BARBICAN_PRODUCTION_UUID,
@@ -420,9 +420,9 @@ describe('Cast member performing different roles in different productions of sam
 				}
 			];
 
-			const { productions } = antonySherPerson.body;
+			const { castMemberProductions } = antonySherPerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 
@@ -432,7 +432,7 @@ describe('Cast member performing different roles in different productions of sam
 
 		it('includes production with his portrayal of the Fool', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: KING_LEAR_BARBICAN_PRODUCTION_UUID,
@@ -454,9 +454,9 @@ describe('Cast member performing different roles in different productions of sam
 				}
 			];
 
-			const { productions } = grahamTurnerPerson.body;
+			const { castMemberProductions } = grahamTurnerPerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 

--- a/test-e2e/model-interaction/cast-member-same-role-of-material.test.js
+++ b/test-e2e/model-interaction/cast-member-same-role-of-material.test.js
@@ -230,7 +230,7 @@ describe('Cast member performing same role in different productions of same mate
 
 		it('includes production with her respective portrayals of Titania', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: A_MIDSUMMER_NIGHTS_DREAM_ROSE_PRODUCTION_UUID,
@@ -271,9 +271,9 @@ describe('Cast member performing same role in different productions of same mate
 				}
 			];
 
-			const { productions } = judiDenchPerson.body;
+			const { castMemberProductions } = judiDenchPerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 

--- a/test-e2e/model-interaction/cast-member-with-multi-prods.test.js
+++ b/test-e2e/model-interaction/cast-member-with-multi-prods.test.js
@@ -126,7 +126,7 @@ describe('Cast member with multiple production credits', () => {
 
 		it('includes productions in which cast member performed (including characters they portrayed)', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: CITY_OF_ANGELS_PRINCE_OF_WALES_PRODUCTION_UUID,
@@ -210,9 +210,9 @@ describe('Cast member with multiple production credits', () => {
 				}
 			];
 
-			const { productions } = susannahFellowsPerson.body;
+			const { castMemberProductions } = susannahFellowsPerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 

--- a/test-e2e/model-interaction/char-diff-groups-same-material.test.js
+++ b/test-e2e/model-interaction/char-diff-groups-same-material.test.js
@@ -652,7 +652,7 @@ describe('Character with multiple appearances in the same material in different 
 
 		it('includes in their production credits their portrayal of Maša Kos without a qualifier (as it is not required)', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
@@ -674,9 +674,9 @@ describe('Character with multiple appearances in the same material in different 
 				}
 			];
 
-			const { productions } = siobhanFinneranPerson.body;
+			const { castMemberProductions } = siobhanFinneranPerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 
@@ -686,7 +686,7 @@ describe('Character with multiple appearances in the same material in different 
 
 		it('includes in their production credits their portrayal of Rose King without a qualifier (as it is not required)', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
@@ -708,9 +708,9 @@ describe('Character with multiple appearances in the same material in different 
 				}
 			];
 
-			const { productions } = joHerbertPerson.body;
+			const { castMemberProductions } = joHerbertPerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 
@@ -720,7 +720,7 @@ describe('Character with multiple appearances in the same material in different 
 
 		it('includes in their production credits their portrayal of Aleksander King with its corresponding qualifier (i.e. 1990)', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
@@ -742,9 +742,9 @@ describe('Character with multiple appearances in the same material in different 
 				}
 			];
 
-			const { productions } = jamesLaurensonPerson.body;
+			const { castMemberProductions } = jamesLaurensonPerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 
@@ -754,7 +754,7 @@ describe('Character with multiple appearances in the same material in different 
 
 		it('includes in their production credits their portrayal of Alisa Kos with its corresponding qualifier (i.e. 2011)', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
@@ -776,9 +776,9 @@ describe('Character with multiple appearances in the same material in different 
 				}
 			];
 
-			const { productions } = jodieMcNeePerson.body;
+			const { castMemberProductions } = jodieMcNeePerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 
@@ -788,7 +788,7 @@ describe('Character with multiple appearances in the same material in different 
 
 		it('includes in their production credits their portrayal of Aleksander King with its corresponding qualifier (i.e. 1945)', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
@@ -810,9 +810,9 @@ describe('Character with multiple appearances in the same material in different 
 				}
 			];
 
-			const { productions } = alexPricePerson.body;
+			const { castMemberProductions } = alexPricePerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 
@@ -822,7 +822,7 @@ describe('Character with multiple appearances in the same material in different 
 
 		it('includes in their production credits their portrayal of Alisa Kos with its corresponding qualifier (i.e. 1990)', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: THREE_WINTERS_NATIONAL_PRODUCTION_UUID,
@@ -844,9 +844,9 @@ describe('Character with multiple appearances in the same material in different 
 				}
 			];
 
-			const { productions } = bebeSandersPerson.body;
+			const { castMemberProductions } = bebeSandersPerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 

--- a/test-e2e/model-interaction/char-multi-appearances-same-material.test.js
+++ b/test-e2e/model-interaction/char-multi-appearances-same-material.test.js
@@ -439,7 +439,7 @@ describe('Character with multiple appearances in the same material under differe
 
 		it('includes in their production credits their portrayal of Esme with its corresponding qualifier (i.e. younger)', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: ROCK_N_ROLL_ROYAL_COURT_PRODUCTION_UUID,
@@ -467,9 +467,9 @@ describe('Character with multiple appearances in the same material under differe
 				}
 			];
 
-			const { productions } = aliceEvePerson.body;
+			const { castMemberProductions } = aliceEvePerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 
@@ -479,7 +479,7 @@ describe('Character with multiple appearances in the same material under differe
 
 		it('includes in their production credits their portrayal of Esme with its corresponding qualifier (i.e. older)', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: ROCK_N_ROLL_ROYAL_COURT_PRODUCTION_UUID,
@@ -507,9 +507,9 @@ describe('Character with multiple appearances in the same material under differe
 				}
 			];
 
-			const { productions } = sineadCusackPerson.body;
+			const { castMemberProductions } = sineadCusackPerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 

--- a/test-e2e/model-interaction/char-with-variant-depiction-portrayal-names.test.js
+++ b/test-e2e/model-interaction/char-with-variant-depiction-portrayal-names.test.js
@@ -1284,7 +1284,7 @@ describe('Character with variant depiction and portrayal names', () => {
 
 		it('includes productions of their portrayals of King Henry V under variant names (Henry, Prince of Wales; Hal; Henry V) but using its uuid value', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: HENRY_IV_PART_1_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
@@ -1362,9 +1362,9 @@ describe('Character with variant depiction and portrayal names', () => {
 				}
 			];
 
-			const { productions } = alexHassellPerson.body;
+			const { castMemberProductions } = alexHassellPerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 
@@ -1374,7 +1374,7 @@ describe('Character with variant depiction and portrayal names', () => {
 
 		it('includes productions of their portrayals of King Henry V under variant names (Prince Hal; Hal, Prince of England) but using its uuid value', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: HENRY_IV_PART_1_NATIONAL_PRODUCTION_UUID,
@@ -1427,9 +1427,9 @@ describe('Character with variant depiction and portrayal names', () => {
 				}
 			];
 
-			const { productions } = matthewMacfadyenPerson.body;
+			const { castMemberProductions } = matthewMacfadyenPerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 
@@ -1439,7 +1439,7 @@ describe('Character with variant depiction and portrayal names', () => {
 
 		it('includes productions of their portrayals of King Henry V under variant names (Henry V) but using its uuid value', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: HENRY_V_NATIONAL_PRODUCTION_UUID,
@@ -1467,9 +1467,9 @@ describe('Character with variant depiction and portrayal names', () => {
 				}
 			];
 
-			const { productions } = adrianLesterPerson.body;
+			const { castMemberProductions } = adrianLesterPerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 

--- a/test-e2e/model-interaction/char-with-variant-names-diff-materials.test.js
+++ b/test-e2e/model-interaction/char-with-variant-names-diff-materials.test.js
@@ -616,7 +616,7 @@ describe('Character with variant names from productions of different materials',
 
 		it('includes production with their portrayal of Hamlet under a variant name (Hamlet, Prince of Denmark)', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: HAMLET_NATIONAL_PRODUCTION_UUID,
@@ -638,9 +638,9 @@ describe('Character with variant names from productions of different materials',
 				}
 			];
 
-			const { productions } = roryKinnearPerson.body;
+			const { castMemberProductions } = roryKinnearPerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 
@@ -650,7 +650,7 @@ describe('Character with variant names from productions of different materials',
 
 		it('includes production with their portrayal of Hamlet under a variant name (Prince Hamlet)', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: ROSENCRANTZ_AND_GUILDENSTERN_ARE_DEAD_HAYMARKET_PRODUCTION_UUID,
@@ -672,9 +672,9 @@ describe('Character with variant names from productions of different materials',
 				}
 			];
 
-			const { productions } = jackHawkinsPerson.body;
+			const { castMemberProductions } = jackHawkinsPerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 
@@ -684,7 +684,7 @@ describe('Character with variant names from productions of different materials',
 
 		it('includes production with their portrayal of Hamlet under a variant name (Spirit of Hamlet)', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: FORTINBRAS_LA_JOLLA_PRODUCTION_UUID,
@@ -706,9 +706,9 @@ describe('Character with variant names from productions of different materials',
 				}
 			];
 
-			const { productions } = donReillyPerson.body;
+			const { castMemberProductions } = donReillyPerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 
@@ -718,7 +718,7 @@ describe('Character with variant names from productions of different materials',
 
 		it('includes production with their portrayal of Hamlet under a variant name (Hamlet, Prince of Denmark)', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: HAMLETMACHINE_TEATRO_SAN_NICOLÒ_PRODUCTION_UUID,
@@ -740,9 +740,9 @@ describe('Character with variant names from productions of different materials',
 				}
 			];
 
-			const { productions } = gabrieleCicirelloPerson.body;
+			const { castMemberProductions } = gabrieleCicirelloPerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 

--- a/test-e2e/model-interaction/char-with-variant-names-same-material.test.js
+++ b/test-e2e/model-interaction/char-with-variant-names-same-material.test.js
@@ -461,7 +461,7 @@ describe('Character with variant names from productions of the same material', (
 
 		it('includes production with his portrayal of Ghost of King Hamlet under a variant name (Ghost)', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: HAMLET_ALMEIDA_PRODUCTION_UUID,
@@ -489,9 +489,9 @@ describe('Character with variant names from productions of the same material', (
 				}
 			];
 
-			const { productions } = davidRintoulPerson.body;
+			const { castMemberProductions } = davidRintoulPerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 
@@ -501,7 +501,7 @@ describe('Character with variant names from productions of the same material', (
 
 		it('includes production with his portrayal of Ghost of King Hamlet under same name as in material (Ghost of King Hamlet)', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: HAMLET_NOVELLO_PRODUCTION_UUID,
@@ -529,9 +529,9 @@ describe('Character with variant names from productions of the same material', (
 				}
 			];
 
-			const { productions } = patrickStewartPerson.body;
+			const { castMemberProductions } = patrickStewartPerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 
@@ -541,7 +541,7 @@ describe('Character with variant names from productions of the same material', (
 
 		it('includes production with his portrayal of Ghost of King Hamlet under a variant name (King Hamlet)', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: HAMLET_WYNDHAMS_PRODUCTION_UUID,
@@ -569,9 +569,9 @@ describe('Character with variant names from productions of the same material', (
 				}
 			];
 
-			const { productions } = peterEyrePerson.body;
+			const { castMemberProductions } = peterEyrePerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 

--- a/test-e2e/model-interaction/diff-chars-same-name-diff-materials.test.js
+++ b/test-e2e/model-interaction/diff-chars-same-name-diff-materials.test.js
@@ -387,7 +387,7 @@ describe('Different characters with the same name from different materials', () 
 
 		it('includes in their production credits their portrayal of Demetrius (#1) (i.e. and not Demetrius (#2))', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: A_MIDSUMMER_NIGHTS_DREAM_NOVELLO_PRODUCTION_UUID,
@@ -409,9 +409,9 @@ describe('Different characters with the same name from different materials', () 
 				}
 			];
 
-			const { productions } = oscarPearcePerson.body;
+			const { castMemberProductions } = oscarPearcePerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 
@@ -421,7 +421,7 @@ describe('Different characters with the same name from different materials', () 
 
 		it('includes in their production credits their portrayal of Demetrius (#2) (i.e. and not Demetrius (#1))', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: TITUS_ANDRONICUS_GLOBE_PRODUCTION_UUID,
@@ -443,9 +443,9 @@ describe('Different characters with the same name from different materials', () 
 				}
 			];
 
-			const { productions } = samAlexanderPerson.body;
+			const { castMemberProductions } = samAlexanderPerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 

--- a/test-e2e/model-interaction/diff-chars-same-name-same-material.test.js
+++ b/test-e2e/model-interaction/diff-chars-same-name-same-material.test.js
@@ -330,7 +330,7 @@ describe('Different characters with the same name from the same material', () =>
 
 		it('includes in their production credits their portrayal of Cinna (#1) (i.e. and not Cinna (#2))', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: JULIUS_CAESAR_BARBICAN_PRODUCTION_UUID,
@@ -358,9 +358,9 @@ describe('Different characters with the same name from the same material', () =>
 				}
 			];
 
-			const { productions } = paulShearerPerson.body;
+			const { castMemberProductions } = paulShearerPerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 
@@ -370,7 +370,7 @@ describe('Different characters with the same name from the same material', () =>
 
 		it('includes in their production credits their portrayal of Cinna (#2) (i.e. and not Cinna (#1))', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: JULIUS_CAESAR_BARBICAN_PRODUCTION_UUID,
@@ -392,9 +392,9 @@ describe('Different characters with the same name from the same material', () =>
 				}
 			];
 
-			const { productions } = leoWringerPerson.body;
+			const { castMemberProductions } = leoWringerPerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 

--- a/test-e2e/model-interaction/roles-with-alternating-cast.test.js
+++ b/test-e2e/model-interaction/roles-with-alternating-cast.test.js
@@ -474,7 +474,7 @@ describe('Roles with alternating cast', () => {
 
 		it('includes production with his portrayals of Austin and Lee', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: TRUE_WEST_CRUCIBLE_PRODUCTION_UUID,
@@ -502,9 +502,9 @@ describe('Roles with alternating cast', () => {
 				}
 			];
 
-			const { productions } = nigelHarmanPerson.body;
+			const { castMemberProductions } = nigelHarmanPerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 
@@ -514,7 +514,7 @@ describe('Roles with alternating cast', () => {
 
 		it('includes production with his portrayals of Lee and Austin', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: TRUE_WEST_CRUCIBLE_PRODUCTION_UUID,
@@ -542,9 +542,9 @@ describe('Roles with alternating cast', () => {
 				}
 			];
 
-			const { productions } = johnLightPerson.body;
+			const { castMemberProductions } = johnLightPerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 
@@ -554,7 +554,7 @@ describe('Roles with alternating cast', () => {
 
 		it('includes production with his portrayals of Austin and Lee', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: TRUE_WEST_VAUDEVILLE_PRODUCTION_UUID,
@@ -582,9 +582,9 @@ describe('Roles with alternating cast', () => {
 				}
 			];
 
-			const { productions } = kitHaringtonPerson.body;
+			const { castMemberProductions } = kitHaringtonPerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 
@@ -594,7 +594,7 @@ describe('Roles with alternating cast', () => {
 
 		it('includes production with his portrayals of Lee and Austin', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: TRUE_WEST_VAUDEVILLE_PRODUCTION_UUID,
@@ -622,9 +622,9 @@ describe('Roles with alternating cast', () => {
 				}
 			];
 
-			const { productions } = johnnyFlynnPerson.body;
+			const { castMemberProductions } = johnnyFlynnPerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 

--- a/test-e2e/model-interaction/theatre-with-sub-theatres.test.js
+++ b/test-e2e/model-interaction/theatre-with-sub-theatres.test.js
@@ -438,7 +438,7 @@ describe('Theatre with sub-theatres', () => {
 
 		it('includes in their production credits the theatre and, where applicable, its sur-theatre', () => {
 
-			const expectedProductions = [
+			const expectedCastMemberProductions = [
 				{
 					model: 'production',
 					uuid: MOTHER_COURAGE_AND_HER_CHILDREN_OLIVIER_PRODUCTION_UUID,
@@ -483,9 +483,9 @@ describe('Theatre with sub-theatres', () => {
 				}
 			];
 
-			const { productions } = fionaShawPerson.body;
+			const { castMemberProductions } = fionaShawPerson.body;
 
-			expect(productions).to.deep.equal(expectedProductions);
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 
 		});
 


### PR DESCRIPTION
Now that a person can have productions in which they have a creative credit as well as a cast member credit, it is important to differentiate the different types.

This PR renames person credit `productions` (which until now meant productions in which they were a cast member) to the more specific `castMemberProductions`.