### PR TITLE
Rename PERFORMS_IN rel to HAS_CAST_MEMBER

### DIFF
--- a/src/neo4j/cypher-queries/character.js
+++ b/src/neo4j/cypher-queries/character.js
@@ -108,7 +108,7 @@ const getShowQuery = () => `
 	WITH character, materials, COLLECT(DISTINCT(variantNamedDepiction.displayName)) AS variantNamedDepictions
 
 	OPTIONAL MATCH (character)<-[depictionForVariantNamedPortrayal:INCLUDES_CHARACTER]-(:Material)
-		<-[:PRODUCTION_OF]-(:Production)<-[variantNamedPortrayal:PERFORMS_IN]-(:Person)
+		<-[:PRODUCTION_OF]-(:Production)-[variantNamedPortrayal:HAS_CAST_MEMBER]->(:Person)
 		WHERE
 			character.name <> variantNamedPortrayal.roleName AND
 			(
@@ -123,7 +123,7 @@ const getShowQuery = () => `
 		COLLECT(DISTINCT(variantNamedPortrayal.roleName)) AS variantNamedPortrayals
 
 	OPTIONAL MATCH (character)<-[characterDepiction:INCLUDES_CHARACTER]-(materialForProduction:Material)
-		<-[productionRel:PRODUCTION_OF]-(production:Production)<-[role:PERFORMS_IN]-(person:Person)
+		<-[productionRel:PRODUCTION_OF]-(production:Production)-[role:HAS_CAST_MEMBER]->(person:Person)
 		WHERE
 			(
 				character.name IN [role.roleName, role.characterName] OR
@@ -131,14 +131,14 @@ const getShowQuery = () => `
 			) AND
 			(role.characterDifferentiator IS NULL OR character.differentiator = role.characterDifferentiator)
 
-	OPTIONAL MATCH (production)<-[otherRole:PERFORMS_IN]-(person)
+	OPTIONAL MATCH (production)-[otherRole:HAS_CAST_MEMBER]->(person)
 		WHERE
 			otherRole.roleName <> character.name AND
 			(otherRole.characterName IS NULL OR otherRole.characterName <> character.name) AND
 			(characterDepiction.displayName IS NULL OR otherRole.roleName <> characterDepiction.displayName) AND
 			((otherRole.characterName IS NULL OR characterDepiction.displayName IS NULL) OR otherRole.characterName <> characterDepiction.displayName)
 
-	OPTIONAL MATCH (person)-[otherRole]->(production)-[productionRel]->
+	OPTIONAL MATCH (person)<-[otherRole]-(production)-[productionRel]->
 		(materialForProduction)-[otherCharacterDepiction:INCLUDES_CHARACTER]->(otherCharacter:Character)
 		WHERE
 			(

--- a/src/neo4j/cypher-queries/person.js
+++ b/src/neo4j/cypher-queries/person.js
@@ -120,7 +120,7 @@ const getShowQuery = () => `
 				END
 			) AS materials
 
-	OPTIONAL MATCH (person)-[role:PERFORMS_IN]->(castMemberProduction:Production)
+	OPTIONAL MATCH (person)<-[role:HAS_CAST_MEMBER]-(castMemberProduction:Production)
 
 	OPTIONAL MATCH (castMemberProduction)-[:PLAYS_AT]->(theatre:Theatre)
 

--- a/src/neo4j/cypher-queries/production.js
+++ b/src/neo4j/cypher-queries/production.js
@@ -72,14 +72,14 @@ const getCreateUpdateQuery = action => {
 
 				FOREACH (role IN CASE castMemberParam.roles WHEN [] THEN [{}] ELSE castMemberParam.roles END |
 					CREATE (production)
-						<-[:PERFORMS_IN {
+						-[:HAS_CAST_MEMBER {
 							castMemberPosition: castMemberParam.position,
 							rolePosition: role.position,
 							roleName: role.name,
 							characterName: role.characterName,
 							characterDifferentiator: role.characterDifferentiator,
 							qualifier: role.qualifier
-						}]-(castMember)
+						}]->(castMember)
 				)
 			)
 
@@ -157,7 +157,7 @@ const getEditQuery = () => `
 
 	OPTIONAL MATCH (production)-[:PLAYS_AT]->(theatre:Theatre)
 
-	OPTIONAL MATCH (production)<-[role:PERFORMS_IN]-(castMember:Person)
+	OPTIONAL MATCH (production)-[role:HAS_CAST_MEMBER]->(castMember:Person)
 
 	WITH production, material, theatre, role, castMember
 		ORDER BY role.castMemberPosition, role.rolePosition
@@ -311,9 +311,9 @@ const getShowQuery = () => `
 			END
 		) AS writingCredits
 
-	OPTIONAL MATCH (production)<-[role:PERFORMS_IN]-(castMember:Person)
+	OPTIONAL MATCH (production)-[role:HAS_CAST_MEMBER]->(castMember:Person)
 
-	OPTIONAL MATCH (castMember)-[role]->(production)-[materialRel]->
+	OPTIONAL MATCH (castMember)<-[role]-(production)-[materialRel]->
 		(material)-[characterRel:INCLUDES_CHARACTER]->(character:Character)
 		WHERE
 			(

--- a/test-e2e/instance-validation-failures/people-api.test.js
+++ b/test-e2e/instance-validation-failures/people-api.test.js
@@ -223,11 +223,11 @@ describe('Instance validation failures: People API', () => {
 			});
 
 			await createRelationship({
-				sourceLabel: 'Person',
-				sourceUuid: JUDI_DENCH_PERSON_UUID,
-				destinationLabel: 'Production',
-				destinationUuid: A_MIDSUMMER_NIGHTS_DREAM_ROSE_PRODUCTION_UUID,
-				relationshipName: 'PERFORMS_IN'
+				sourceLabel: 'Production',
+				sourceUuid: A_MIDSUMMER_NIGHTS_DREAM_ROSE_PRODUCTION_UUID,
+				destinationLabel: 'Person',
+				destinationUuid: JUDI_DENCH_PERSON_UUID,
+				relationshipName: 'HAS_CAST_MEMBER'
 			});
 
 		});

--- a/test-unit/src/neo4j/cypher-queries/production.test.js
+++ b/test-unit/src/neo4j/cypher-queries/production.test.js
@@ -65,14 +65,14 @@ describe('Cypher Queries Production module', () => {
 
 						FOREACH (role IN CASE castMemberParam.roles WHEN [] THEN [{}] ELSE castMemberParam.roles END |
 							CREATE (production)
-								<-[:PERFORMS_IN {
+								-[:HAS_CAST_MEMBER {
 									castMemberPosition: castMemberParam.position,
 									rolePosition: role.position,
 									roleName: role.name,
 									characterName: role.characterName,
 									characterDifferentiator: role.characterDifferentiator,
 									qualifier: role.qualifier
-								}]-(castMember)
+								}]->(castMember)
 						)
 					)
 
@@ -142,7 +142,7 @@ describe('Cypher Queries Production module', () => {
 
 				OPTIONAL MATCH (production)-[:PLAYS_AT]->(theatre:Theatre)
 
-				OPTIONAL MATCH (production)<-[role:PERFORMS_IN]-(castMember:Person)
+				OPTIONAL MATCH (production)-[role:HAS_CAST_MEMBER]->(castMember:Person)
 
 				WITH production, material, theatre, role, castMember
 					ORDER BY role.castMemberPosition, role.rolePosition
@@ -281,14 +281,14 @@ describe('Cypher Queries Production module', () => {
 
 						FOREACH (role IN CASE castMemberParam.roles WHEN [] THEN [{}] ELSE castMemberParam.roles END |
 							CREATE (production)
-								<-[:PERFORMS_IN {
+								-[:HAS_CAST_MEMBER {
 									castMemberPosition: castMemberParam.position,
 									rolePosition: role.position,
 									roleName: role.name,
 									characterName: role.characterName,
 									characterDifferentiator: role.characterDifferentiator,
 									qualifier: role.qualifier
-								}]-(castMember)
+								}]->(castMember)
 						)
 					)
 
@@ -358,7 +358,7 @@ describe('Cypher Queries Production module', () => {
 
 				OPTIONAL MATCH (production)-[:PLAYS_AT]->(theatre:Theatre)
 
-				OPTIONAL MATCH (production)<-[role:PERFORMS_IN]-(castMember:Person)
+				OPTIONAL MATCH (production)-[role:HAS_CAST_MEMBER]->(castMember:Person)
 
 				WITH production, material, theatre, role, castMember
 					ORDER BY role.castMemberPosition, role.rolePosition


### PR DESCRIPTION
The relationship between productions and their creative team members is `:HAS_CREATIVE_MEMBER`.

For consistency, this PR renames the relationships between productions and their cast members from `:PERFORMS_IN` to `:HAS_CAST_MEMBER` (and changes the direction of the relationship so that it corresponds to the updated wording).