### PR TITLE
Correct usage of Get Duplicate Indices module

### DIFF
--- a/src/models/Material.js
+++ b/src/models/Material.js
@@ -1,4 +1,4 @@
-import { getDuplicateBaseInstanceIndices } from '../lib/get-duplicate-indices';
+import { getDuplicateNameIndices } from '../lib/get-duplicate-indices';
 import Base from './Base';
 import { CharacterGroup, WritingCredit } from '.';
 
@@ -54,7 +54,7 @@ export default class Material extends Base {
 
 		this.originalVersionMaterial.validateNoAssociationWithSelf(this.name, this.differentiator);
 
-		const duplicateWritingCreditIndices = getDuplicateBaseInstanceIndices(this.writingCredits);
+		const duplicateWritingCreditIndices = getDuplicateNameIndices(this.writingCredits);
 
 		this.writingCredits.forEach((writingCredit, index) =>
 			writingCredit.runInputValidations({
@@ -63,7 +63,7 @@ export default class Material extends Base {
 			})
 		);
 
-		const duplicateCharacterGroupIndices = getDuplicateBaseInstanceIndices(this.characterGroups);
+		const duplicateCharacterGroupIndices = getDuplicateNameIndices(this.characterGroups);
 
 		this.characterGroups.forEach((characterGroup, index) =>
 			characterGroup.runInputValidations({ isDuplicate: duplicateCharacterGroupIndices.includes(index) })

--- a/src/models/Production.js
+++ b/src/models/Production.js
@@ -1,4 +1,4 @@
-import { getDuplicateNameIndices } from '../lib/get-duplicate-indices';
+import { getDuplicateBaseInstanceIndices, getDuplicateNameIndices } from '../lib/get-duplicate-indices';
 import Base from './Base';
 import { CastMember, CreativeCredit, Material, Theatre } from '.';
 
@@ -35,7 +35,7 @@ export default class Production extends Base {
 
 		this.material.validateDifferentiator();
 
-		const duplicateCastMemberIndices = getDuplicateNameIndices(this.cast);
+		const duplicateCastMemberIndices = getDuplicateBaseInstanceIndices(this.cast);
 
 		this.cast.forEach((castMember, index) =>
 			castMember.runInputValidations({ isDuplicate: duplicateCastMemberIndices.includes(index) })

--- a/test-unit/src/models/Material.test.js
+++ b/test-unit/src/models/Material.test.js
@@ -24,7 +24,7 @@ describe('Material model', () => {
 
 		stubs = {
 			getDuplicateIndicesModule: {
-				getDuplicateBaseInstanceIndices: stub().returns([])
+				getDuplicateNameIndices: stub().returns([])
 			},
 			models: {
 				CharacterGroup: CharacterGroupStub,
@@ -402,9 +402,9 @@ describe('Material model', () => {
 				instance.validateFormat,
 				instance.originalVersionMaterial.validateName,
 				instance.originalVersionMaterial.validateDifferentiator,
-				stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices,
+				stubs.getDuplicateIndicesModule.getDuplicateNameIndices,
 				instance.writingCredits[0].runInputValidations,
-				stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices,
+				stubs.getDuplicateIndicesModule.getDuplicateNameIndices,
 				instance.characterGroups[0].runInputValidations
 			);
 			expect(instance.validateName.calledOnce).to.be.true;
@@ -417,11 +417,11 @@ describe('Material model', () => {
 			expect(instance.originalVersionMaterial.validateName.calledWithExactly({ isRequired: false })).to.be.true;
 			expect(instance.originalVersionMaterial.validateDifferentiator.calledOnce).to.be.true;
 			expect(instance.originalVersionMaterial.validateDifferentiator.calledWithExactly()).to.be.true;
-			expect(stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices.calledTwice).to.be.true;
-			expect(stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices
+			expect(stubs.getDuplicateIndicesModule.getDuplicateNameIndices.calledTwice).to.be.true;
+			expect(stubs.getDuplicateIndicesModule.getDuplicateNameIndices
 				.firstCall.calledWithExactly(instance.writingCredits)
 			).to.be.true;
-			expect(stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices
+			expect(stubs.getDuplicateIndicesModule.getDuplicateNameIndices
 				.secondCall.calledWithExactly(
 			instance.characterGroups)).to.be.true;
 			expect(instance.writingCredits[0].runInputValidations.calledOnce).to.be.true;

--- a/test-unit/src/models/Production.test.js
+++ b/test-unit/src/models/Production.test.js
@@ -36,6 +36,7 @@ describe('Production model', () => {
 
 		stubs = {
 			getDuplicateIndicesModule: {
+				getDuplicateBaseInstanceIndices: stub().returns([]),
 				getDuplicateNameIndices: stub().returns([])
 			},
 			Base: {
@@ -205,8 +206,9 @@ describe('Production model', () => {
 				instance.theatre.validateDifferentiator,
 				instance.material.validateName,
 				instance.material.validateDifferentiator,
-				stubs.getDuplicateIndicesModule.getDuplicateNameIndices,
+				stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices,
 				instance.cast[0].runInputValidations,
+				stubs.getDuplicateIndicesModule.getDuplicateNameIndices,
 				instance.creativeCredits[0].runInputValidations
 			);
 			expect(instance.validateName.calledOnce).to.be.true;
@@ -219,13 +221,14 @@ describe('Production model', () => {
 			expect(instance.material.validateName.calledWithExactly({ isRequired: false })).to.be.true;
 			expect(instance.material.validateDifferentiator.calledOnce).to.be.true;
 			expect(instance.material.validateDifferentiator.calledWithExactly()).to.be.true;
-			expect(stubs.getDuplicateIndicesModule.getDuplicateNameIndices.calledTwice).to.be.true;
-			expect(stubs.getDuplicateIndicesModule.getDuplicateNameIndices.getCall(0).calledWithExactly(
+			expect(stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices.calledOnce).to.be.true;
+			expect(stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices.getCall(0).calledWithExactly(
 				instance.cast
 			)).to.be.true;
 			expect(instance.cast[0].runInputValidations.calledOnce).to.be.true;
 			expect(instance.cast[0].runInputValidations.calledWithExactly({ isDuplicate: false })).to.be.true;
-			expect(stubs.getDuplicateIndicesModule.getDuplicateNameIndices.getCall(1).calledWithExactly(
+			expect(stubs.getDuplicateIndicesModule.getDuplicateNameIndices.calledOnce).to.be.true;
+			expect(stubs.getDuplicateIndicesModule.getDuplicateNameIndices.calledWithExactly(
 				instance.creativeCredits
 			)).to.be.true;
 			expect(instance.creativeCredits[0].runInputValidations.calledOnce).to.be.true;


### PR DESCRIPTION
This PR fixes the application of functions from the Get Duplicate Indices module (including reverting changes that put the code into an incorrect state, as happened in this PR https://github.com/andygout/theatrebase-api/pull/351), e.g.

- Cast member duplicates are currently being checked with `getDuplicateNameIndices`, meaning that when two cast members with the same name but with distinct differentiators (to indicate they are different people) are present the API will return an error on the basis that they are duplicates. This PR replaces it with `getDuplicateBaseInstanceIndices` to ensure that only true duplicates are caught.
- Writing credit duplicates are currently being checked with `getDuplicateBaseInstanceIndices`, when in fact they only need their name value checking. So while `getDuplicateBaseInstanceIndices` will still be able to catch duplicates on that basis (i.e. the `differentiator` value does not exist for writing credits so will always be the same value for each instance), the right function for the job is `getDuplicateNameIndices`, which this PR corrects.