### PR TITLE
Revise Get Duplicate Indices module functions

### DIFF
--- a/src/lib/get-duplicate-indices.js
+++ b/src/lib/get-duplicate-indices.js
@@ -5,9 +5,9 @@ const getDuplicateBaseInstanceIndices = arrayOfObjects => {
 		const isDuplicate =
 			!!object.name.length &&
 			arrayOfObjects.find((comparisonObject, comparisonIndex) =>
+				index !== comparisonIndex &&
 				object.name === comparisonObject.name &&
-				object.differentiator === comparisonObject.differentiator &&
-				index !== comparisonIndex
+				object.differentiator === comparisonObject.differentiator
 			);
 
 		if (isDuplicate) accumulator.push(index);
@@ -41,10 +41,10 @@ const getDuplicateCharacterIndices = arrayOfObjects => {
 		const isDuplicate =
 			!!object.name.length &&
 			arrayOfObjects.find((comparisonObject, comparisonIndex) =>
+				index !== comparisonIndex &&
 				isDuplicateCharacterName(object, comparisonObject) &&
 				object.differentiator === comparisonObject.differentiator &&
-				object.qualifier === comparisonObject.qualifier &&
-				index !== comparisonIndex
+				object.qualifier === comparisonObject.qualifier
 			);
 
 		if (isDuplicate) accumulator.push(index);
@@ -62,10 +62,10 @@ const getDuplicateEntityIndices = arrayOfObjects => {
 		const isDuplicate =
 			!!object.name.length &&
 			arrayOfObjects.find((comparisonObject, comparisonIndex) =>
-				object.name === comparisonObject.name &&
-				object.differentiator === comparisonObject.differentiator &&
+				index !== comparisonIndex &&
 				object.model === comparisonObject.model &&
-				index !== comparisonIndex
+				object.name === comparisonObject.name &&
+				object.differentiator === comparisonObject.differentiator
 			);
 
 		if (isDuplicate) accumulator.push(index);
@@ -83,8 +83,8 @@ const getDuplicateNameIndices = arrayOfObjects => {
 		const isDuplicate =
 			!!object.name.length &&
 			arrayOfObjects.find((comparisonObject, comparisonIndex) =>
-				object.name === comparisonObject.name &&
-				index !== comparisonIndex
+				index !== comparisonIndex &&
+				object.name === comparisonObject.name
 			);
 
 		if (isDuplicate) accumulator.push(index);
@@ -118,10 +118,10 @@ const getDuplicateRoleIndices = arrayOfObjects => {
 		const isDuplicate =
 			!!object.name.length &&
 			arrayOfObjects.find((comparisonObject, comparisonIndex) =>
+				index !== comparisonIndex &&
 				isDuplicateRoleName(object, comparisonObject) &&
 				object.characterDifferentiator === comparisonObject.characterDifferentiator &&
-				object.qualifier === comparisonObject.qualifier &&
-				index !== comparisonIndex
+				object.qualifier === comparisonObject.qualifier
 			);
 
 		if (isDuplicate) accumulator.push(index);

--- a/test-unit/src/lib/get-duplicate-indices.test.js
+++ b/test-unit/src/lib/get-duplicate-indices.test.js
@@ -155,24 +155,24 @@ describe('Get Duplicate Indices module', () => {
 
 				const result = getDuplicateEntityIndices(
 					[
-						{ name: 'Foo', differentiator: '', model: '' },
-						{ name: 'Foo', differentiator: '1', model: '' },
-						{ name: 'Foo', differentiator: '2', model: '' },
-						{ name: 'Foo', differentiator: '', model: 'company' },
-						{ name: 'Foo', differentiator: '1', model: 'company' },
-						{ name: 'Foo', differentiator: '2', model: 'company' },
-						{ name: 'Foo', differentiator: '', model: 'material' },
-						{ name: 'Foo', differentiator: '1', model: 'material' },
-						{ name: 'Foo', differentiator: '2', model: 'material' },
-						{ name: 'Bar', differentiator: '', model: '' },
-						{ name: 'Bar', differentiator: '1', model: '' },
-						{ name: 'Bar', differentiator: '2', model: '' },
-						{ name: 'Bar', differentiator: '', model: 'company' },
-						{ name: 'Bar', differentiator: '1', model: 'company' },
-						{ name: 'Bar', differentiator: '2', model: 'company' },
-						{ name: 'Bar', differentiator: '', model: 'material' },
-						{ name: 'Bar', differentiator: '1', model: 'material' },
-						{ name: 'Bar', differentiator: '2', model: 'material' }
+						{ model: '', name: 'Foo', differentiator: '' },
+						{ model: '', name: 'Foo', differentiator: '1' },
+						{ model: '', name: 'Foo', differentiator: '2' },
+						{ model: 'company', name: 'Foo', differentiator: '' },
+						{ model: 'company', name: 'Foo', differentiator: '1' },
+						{ model: 'company', name: 'Foo', differentiator: '2' },
+						{ model: 'material', name: 'Foo', differentiator: '' },
+						{ model: 'material', name: 'Foo', differentiator: '1' },
+						{ model: 'material', name: 'Foo', differentiator: '2' },
+						{ model: '', name: 'Bar', differentiator: '' },
+						{ model: '', name: 'Bar', differentiator: '1' },
+						{ model: '', name: 'Bar', differentiator: '2' },
+						{ model: 'company', name: 'Bar', differentiator: '' },
+						{ model: 'company', name: 'Bar', differentiator: '1' },
+						{ model: 'company', name: 'Bar', differentiator: '2' },
+						{ model: 'material', name: 'Bar', differentiator: '' },
+						{ model: 'material', name: 'Bar', differentiator: '1' },
+						{ model: 'material', name: 'Bar', differentiator: '2' }
 					]
 				);
 
@@ -188,15 +188,15 @@ describe('Get Duplicate Indices module', () => {
 
 				const result = getDuplicateEntityIndices(
 					[
-						{ name: 'Foo', differentiator: '1', model: '' },
-						{ name: 'Bar', differentiator: '1', model: 'material' },
-						{ name: 'Bar', differentiator: '1', model: 'company' },
-						{ name: '', differentiator: '1', model: '' },
-						{ name: 'Baz', differentiator: '1', model: '' },
-						{ name: 'Foo', differentiator: '1', model: '' },
-						{ name: 'Bar', differentiator: '1', model: 'material' },
-						{ name: '', differentiator: '1', model: '' },
-						{ name: 'Qux', differentiator: '1', model: '' }
+						{ model: '', name: 'Foo', differentiator: '1' },
+						{ model: 'material', name: 'Bar', differentiator: '1' },
+						{ model: 'company', name: 'Bar', differentiator: '1' },
+						{ model: '', name: '', differentiator: '1' },
+						{ model: '', name: 'Baz', differentiator: '1' },
+						{ model: '', name: 'Foo', differentiator: '1' },
+						{ model: 'material', name: 'Bar', differentiator: '1' },
+						{ model: '', name: '', differentiator: '1' },
+						{ model: '', name: 'Qux', differentiator: '1' }
 					]
 				);
 


### PR DESCRIPTION
This PR makes the following changes to the Get Duplicate Indices module:
- For efficiency, the `index !== comparisonIndex` check should be first as it will always happen at some point while others (e.g. `object.name === comparisonObject.name`) are not guaranteed. This means there will always be at least one exclusion that can be applied at the earliest opportunity.
- For consistency, the check in `getDuplicateEntityIndices` for `model` should appear before `name` and `differentiator` so that it reflects the standard ordering applied to these entity properties throughout the code.