### PR TITLE
Use Cypher EXISTS() function

### DIFF
--- a/src/neo4j/cypher-queries/character.js
+++ b/src/neo4j/cypher-queries/character.js
@@ -100,7 +100,7 @@ const getShowQuery = () => `
 		) AS materials
 
 	OPTIONAL MATCH (character)<-[variantNamedDepiction:INCLUDES_CHARACTER]-(:Material)
-		WHERE variantNamedDepiction.displayName IS NOT NULL
+		WHERE EXISTS(variantNamedDepiction.displayName)
 
 	WITH character, materials, variantNamedDepiction
 		ORDER BY variantNamedDepiction.displayName


### PR DESCRIPTION
Uses the Cypher `EXISTS()` function to determine the presence of a property.

The negation of the function - `NOT EXISTS()` (E.G. `NOT EXISTS(material.creditType)`) - could have been used to determine the absence of a property, but the choice has been made to stick with `IS NULL` (e.g. `material.creditType IS NULL`) because:
- overall it is a short expression, i.e. uses less characters, and so keeps the query expressions more succinct
- a positive assertion makes the query more human-readable; negative assertions ultimately require more thinking

### References:
- [Predicate functions - Neo4j Cypher Manual: `exists()`](https://neo4j.com/docs/cypher-manual/current/functions/predicate/#functions-exists)