### PR TITLE
Revise Cypher query formatting

### DIFF
--- a/src/neo4j/cypher-queries/character.js
+++ b/src/neo4j/cypher-queries/character.js
@@ -136,7 +136,10 @@ const getShowQuery = () => `
 			otherRole.roleName <> character.name AND
 			(otherRole.characterName IS NULL OR otherRole.characterName <> character.name) AND
 			(characterDepiction.displayName IS NULL OR otherRole.roleName <> characterDepiction.displayName) AND
-			((otherRole.characterName IS NULL OR characterDepiction.displayName IS NULL) OR otherRole.characterName <> characterDepiction.displayName)
+			(
+				(otherRole.characterName IS NULL OR characterDepiction.displayName IS NULL) OR
+				otherRole.characterName <> characterDepiction.displayName
+			)
 
 	OPTIONAL MATCH (person)<-[otherRole]-(production)-[productionRel]->
 		(materialForProduction)-[otherCharacterDepiction:INCLUDES_CHARACTER]->(otherCharacter:Character)
@@ -145,7 +148,10 @@ const getShowQuery = () => `
 				otherCharacter.name IN [otherRole.roleName, otherRole.characterName] OR
 				otherCharacterDepiction.displayName IN [otherRole.roleName, otherRole.characterName]
 			) AND
-			(otherRole.characterDifferentiator IS NULL OR otherCharacter.differentiator = otherRole.characterDifferentiator)
+			(
+				otherRole.characterDifferentiator IS NULL OR
+				otherCharacter.differentiator = otherRole.characterDifferentiator
+			)
 
 	OPTIONAL MATCH (production)-[:PLAYS_AT]->(theatre:Theatre)
 

--- a/src/neo4j/cypher-queries/material.js
+++ b/src/neo4j/cypher-queries/material.js
@@ -46,8 +46,11 @@ const getCreateUpdateQuery = action => {
 
 		OPTIONAL MATCH (existingOriginalVersionMaterial:Material { name: $originalVersionMaterial.name })
 			WHERE
-				($originalVersionMaterial.differentiator IS NULL AND existingOriginalVersionMaterial.differentiator IS NULL) OR
-				($originalVersionMaterial.differentiator = existingOriginalVersionMaterial.differentiator)
+				(
+					$originalVersionMaterial.differentiator IS NULL AND
+					existingOriginalVersionMaterial.differentiator IS NULL
+				) OR
+				$originalVersionMaterial.differentiator = existingOriginalVersionMaterial.differentiator
 
 		FOREACH (item IN CASE $originalVersionMaterial.name WHEN NULL THEN [] ELSE [1] END |
 			MERGE (originalVersionMaterial:Material {
@@ -72,7 +75,7 @@ const getCreateUpdateQuery = action => {
 				OPTIONAL MATCH (existingWritingPerson:Person { name: writingPersonParam.name })
 					WHERE
 						(writingPersonParam.differentiator IS NULL AND existingWritingPerson.differentiator IS NULL) OR
-						(writingPersonParam.differentiator = existingWritingPerson.differentiator)
+						writingPersonParam.differentiator = existingWritingPerson.differentiator
 
 				FOREACH (item IN CASE writingPersonParam WHEN NULL THEN [] ELSE [1] END |
 					MERGE (writingPerson:Person {
@@ -100,8 +103,11 @@ const getCreateUpdateQuery = action => {
 
 				OPTIONAL MATCH (existingWritingCompany:Company { name: writingCompanyParam.name })
 					WHERE
-						(writingCompanyParam.differentiator IS NULL AND existingWritingCompany.differentiator IS NULL) OR
-						(writingCompanyParam.differentiator = existingWritingCompany.differentiator)
+						(
+							writingCompanyParam.differentiator IS NULL AND
+							existingWritingCompany.differentiator IS NULL
+						) OR
+						writingCompanyParam.differentiator = existingWritingCompany.differentiator
 
 				FOREACH (item IN CASE writingCompanyParam WHEN NULL THEN [] ELSE [1] END |
 					MERGE (writingCompany:Company {
@@ -129,8 +135,11 @@ const getCreateUpdateQuery = action => {
 
 				OPTIONAL MATCH (existingSourceMaterial:Material { name: sourceMaterialParam.name })
 					WHERE
-						(sourceMaterialParam.differentiator IS NULL AND existingSourceMaterial.differentiator IS NULL) OR
-						(sourceMaterialParam.differentiator = existingSourceMaterial.differentiator)
+						(
+							sourceMaterialParam.differentiator IS NULL AND
+							existingSourceMaterial.differentiator IS NULL
+						) OR
+						sourceMaterialParam.differentiator = existingSourceMaterial.differentiator
 
 				FOREACH (item IN CASE sourceMaterialParam WHEN NULL THEN [] ELSE [1] END |
 					MERGE (sourceMaterial:Material {
@@ -151,14 +160,17 @@ const getCreateUpdateQuery = action => {
 
 		UNWIND (CASE $characterGroups WHEN [] THEN [{ characters: [] }] ELSE $characterGroups END) AS characterGroup
 
-			UNWIND (CASE characterGroup.characters WHEN [] THEN [null] ELSE characterGroup.characters END) AS characterParam
+			UNWIND (CASE characterGroup.characters WHEN []
+				THEN [null]
+				ELSE characterGroup.characters
+			END) AS characterParam
 
 				OPTIONAL MATCH (existingCharacter:Character {
 					name: COALESCE(characterParam.underlyingName, characterParam.name)
 				})
 					WHERE
 						(characterParam.differentiator IS NULL AND existingCharacter.differentiator IS NULL) OR
-						(characterParam.differentiator = existingCharacter.differentiator)
+						characterParam.differentiator = existingCharacter.differentiator
 
 				FOREACH (item IN CASE characterParam WHEN NULL THEN [] ELSE [1] END |
 					MERGE (character:Character {
@@ -171,7 +183,10 @@ const getCreateUpdateQuery = action => {
 						[:INCLUDES_CHARACTER {
 							groupPosition: characterGroup.position,
 							characterPosition: characterParam.position,
-							displayName: CASE characterParam.underlyingName WHEN NULL THEN null ELSE characterParam.name END,
+							displayName: CASE characterParam.underlyingName WHEN NULL
+								THEN null
+								ELSE characterParam.name
+							END,
 							qualifier: characterParam.qualifier,
 							group: characterGroup.name
 						}]->(character)
@@ -249,7 +264,10 @@ const getEditQuery = () => `
 		material.format AS format,
 		{
 			name: CASE originalVersionMaterial.name WHEN NULL THEN '' ELSE originalVersionMaterial.name END,
-			differentiator: CASE originalVersionMaterial.differentiator WHEN NULL THEN '' ELSE originalVersionMaterial.differentiator END
+			differentiator: CASE originalVersionMaterial.differentiator WHEN NULL
+				THEN ''
+				ELSE originalVersionMaterial.differentiator
+			END
 		} AS originalVersionMaterial,
 		writingCredits,
 		COLLECT(

--- a/src/neo4j/cypher-queries/person.js
+++ b/src/neo4j/cypher-queries/person.js
@@ -176,7 +176,9 @@ const getShowQuery = () => `
 
 	OPTIONAL MATCH (creativeProduction)-[companyCreativeRel:HAS_CREATIVE_TEAM_MEMBER]->
 		(creativeEmployerCompany:Company { uuid: personCreativeRel.creditedCompanyUuid })
-		WHERE personCreativeRel.creditPosition IS NULL OR personCreativeRel.creditPosition = companyCreativeRel.creditPosition
+		WHERE
+			personCreativeRel.creditPosition IS NULL OR
+			personCreativeRel.creditPosition = companyCreativeRel.creditPosition
 
 	UNWIND (CASE WHEN companyCreativeRel IS NOT NULL AND EXISTS(companyCreativeRel.creditedMemberUuids)
 		THEN [uuid IN companyCreativeRel.creditedMemberUuids]
@@ -187,7 +189,10 @@ const getShowQuery = () => `
 			(coCreditedMember:Person { uuid: coCreditedMemberUuid })
 			WHERE
 				coCreditedMember.uuid <> person.uuid AND
-				(companyCreativeRel.creditPosition IS NULL OR companyCreativeRel.creditPosition = coCreditedMemberRel.creditPosition)
+				(
+					companyCreativeRel.creditPosition IS NULL OR
+					companyCreativeRel.creditPosition = coCreditedMemberRel.creditPosition
+				)
 
 		WITH
 			person,
@@ -227,7 +232,10 @@ const getShowQuery = () => `
 		WHERE
 			(coCreativeEntity:Person OR coCreativeEntity:Company) AND
 			coCreativeEntityRel.creditedCompanyUuid IS NULL AND
-			(entityCreativeRel.creditPosition IS NULL OR entityCreativeRel.creditPosition = coCreativeEntityRel.creditPosition) AND
+			(
+				entityCreativeRel.creditPosition IS NULL OR
+				entityCreativeRel.creditPosition = coCreativeEntityRel.creditPosition
+			) AND
 			coCreativeEntity.uuid <> entity.uuid
 
 	UNWIND (CASE WHEN coCreativeEntityRel IS NOT NULL AND EXISTS(coCreativeEntityRel.creditedMemberUuids)

--- a/src/neo4j/cypher-queries/production.js
+++ b/src/neo4j/cypher-queries/production.js
@@ -25,7 +25,7 @@ const getCreateUpdateQuery = action => {
 		OPTIONAL MATCH (existingMaterial:Material { name: $material.name })
 			WHERE
 				($material.differentiator IS NULL AND existingMaterial.differentiator IS NULL) OR
-				($material.differentiator = existingMaterial.differentiator)
+				$material.differentiator = existingMaterial.differentiator
 
 		FOREACH (item IN CASE $material.name WHEN NULL THEN [] ELSE [1] END |
 			MERGE (material:Material {
@@ -42,7 +42,7 @@ const getCreateUpdateQuery = action => {
 		OPTIONAL MATCH (existingTheatre:Theatre { name: $theatre.name })
 			WHERE
 				($theatre.differentiator IS NULL AND existingTheatre.differentiator IS NULL) OR
-				($theatre.differentiator = existingTheatre.differentiator)
+				$theatre.differentiator = existingTheatre.differentiator
 
 		FOREACH (item IN CASE $theatre.name WHEN NULL THEN [] ELSE [1] END |
 			MERGE (theatre:Theatre {
@@ -61,7 +61,7 @@ const getCreateUpdateQuery = action => {
 			OPTIONAL MATCH (existingPerson:Person { name: castMemberParam.name })
 				WHERE
 					(castMemberParam.differentiator IS NULL AND existingPerson.differentiator IS NULL) OR
-					(castMemberParam.differentiator = existingPerson.differentiator)
+					castMemberParam.differentiator = existingPerson.differentiator
 
 			FOREACH (item IN CASE castMemberParam WHEN NULL THEN [] ELSE [1] END |
 				MERGE (castMember:Person {
@@ -85,7 +85,10 @@ const getCreateUpdateQuery = action => {
 
 		WITH DISTINCT production
 
-		UNWIND (CASE $creativeCredits WHEN [] THEN [{ creativeEntities: [] }] ELSE $creativeCredits END) AS creativeCredit
+		UNWIND (CASE $creativeCredits WHEN []
+			THEN [{ creativeEntities: [] }]
+			ELSE $creativeCredits
+		END) AS creativeCredit
 
 			UNWIND
 				CASE SIZE([entity IN creativeCredit.creativeEntities WHERE entity.model = 'person']) WHEN 0
@@ -95,8 +98,11 @@ const getCreateUpdateQuery = action => {
 
 				OPTIONAL MATCH (existingCreativePerson:Person { name: creativePersonParam.name })
 					WHERE
-						(creativePersonParam.differentiator IS NULL AND existingCreativePerson.differentiator IS NULL) OR
-						(creativePersonParam.differentiator = existingCreativePerson.differentiator)
+						(
+							creativePersonParam.differentiator IS NULL AND
+							existingCreativePerson.differentiator IS NULL
+						) OR
+						creativePersonParam.differentiator = existingCreativePerson.differentiator
 
 				FOREACH (item IN CASE creativePersonParam WHEN NULL THEN [] ELSE [1] END |
 					MERGE (creativePerson:Person {
@@ -123,8 +129,11 @@ const getCreateUpdateQuery = action => {
 
 				OPTIONAL MATCH (existingCreativeCompany:Company { name: creativeCompanyParam.name })
 					WHERE
-						(creativeCompanyParam.differentiator IS NULL AND existingCreativeCompany.differentiator IS NULL) OR
-						(creativeCompanyParam.differentiator = existingCreativeCompany.differentiator)
+						(
+							creativeCompanyParam.differentiator IS NULL AND
+							existingCreativeCompany.differentiator IS NULL
+						) OR
+						creativeCompanyParam.differentiator = existingCreativeCompany.differentiator
 
 				FOREACH (item IN CASE creativeCompanyParam WHEN NULL THEN [] ELSE [1] END |
 					MERGE (creativeCompany:Company {
@@ -152,7 +161,7 @@ const getCreateUpdateQuery = action => {
 					OPTIONAL MATCH (creditedCompany:Company { name: creativeCompanyParam.name })
 						WHERE
 							(creativeCompanyParam.differentiator IS NULL AND creditedCompany.differentiator IS NULL) OR
-							(creativeCompanyParam.differentiator = creditedCompany.differentiator)
+							creativeCompanyParam.differentiator = creditedCompany.differentiator
 
 					OPTIONAL MATCH (creditedCompany)<-[creativeCompanyRel:HAS_CREATIVE_TEAM_MEMBER]-(production)
 						WHERE
@@ -162,7 +171,7 @@ const getCreateUpdateQuery = action => {
 					OPTIONAL MATCH (existingPerson:Person { name: creditedMemberParam.name })
 						WHERE
 							(creditedMemberParam.differentiator IS NULL AND existingPerson.differentiator IS NULL) OR
-							(creditedMemberParam.differentiator = existingPerson.differentiator)
+							creditedMemberParam.differentiator = existingPerson.differentiator
 
 					FOREACH (item IN CASE WHEN SIZE(creativeCompanyParam.creditedMembers) > 0 THEN [1] ELSE [] END |
 						SET creativeCompanyRel.creditedMemberUuids = []
@@ -214,7 +223,10 @@ const getEditQuery = () => `
 				ELSE {
 					name: role.roleName,
 					characterName: CASE role.characterName WHEN NULL THEN '' ELSE role.characterName END,
-					characterDifferentiator: CASE role.characterDifferentiator WHEN NULL THEN '' ELSE role.characterDifferentiator END,
+					characterDifferentiator: CASE role.characterDifferentiator WHEN NULL
+						THEN ''
+						ELSE role.characterDifferentiator
+					END,
 					qualifier: CASE role.qualifier WHEN NULL THEN '' ELSE role.qualifier END
 				}
 			END
@@ -444,7 +456,9 @@ const getShowQuery = () => `
 
 			OPTIONAL MATCH (production)-[creditedMemberRel:HAS_CREATIVE_TEAM_MEMBER]->
 				(creditedMember:Person { uuid: creditedMemberUuid })
-				WHERE creativeEntityRel.creditPosition IS NULL OR creativeEntityRel.creditPosition = creditedMemberRel.creditPosition
+				WHERE
+					creativeEntityRel.creditPosition IS NULL OR
+					creativeEntityRel.creditPosition = creditedMemberRel.creditPosition
 
 			WITH production, material, theatre, cast, creativeEntityRel, creativeEntity, creditedMember
 				ORDER BY creditedMemberRel.memberPosition

--- a/src/neo4j/cypher-queries/shared.js
+++ b/src/neo4j/cypher-queries/shared.js
@@ -11,11 +11,11 @@ const getDuplicateRecordCountQuery = model => `
 		WHERE
 			(
 				($differentiator IS NULL AND n.differentiator IS NULL) OR
-				($differentiator = n.differentiator)
+				$differentiator = n.differentiator
 			) AND
 			(
-				($uuid IS NULL) OR
-				($uuid <> n.uuid)
+				$uuid IS NULL OR
+				$uuid <> n.uuid
 			)
 
 	RETURN SIGN(COUNT(n)) AS instanceCount

--- a/src/neo4j/cypher-queries/theatre.js
+++ b/src/neo4j/cypher-queries/theatre.js
@@ -27,7 +27,7 @@ const getCreateUpdateQuery = action => {
 			OPTIONAL MATCH (existingTheatre:Theatre { name: subTheatreParam.name })
 				WHERE
 					(subTheatreParam.differentiator IS NULL AND existingTheatre.differentiator IS NULL) OR
-					(subTheatreParam.differentiator = existingTheatre.differentiator)
+					subTheatreParam.differentiator = existingTheatre.differentiator
 
 			FOREACH (item IN CASE subTheatreParam WHEN NULL THEN [] ELSE [1] END |
 				MERGE (subTheatre:Theatre {

--- a/test-unit/src/neo4j/cypher-queries/material.test.js
+++ b/test-unit/src/neo4j/cypher-queries/material.test.js
@@ -17,8 +17,11 @@ describe('Cypher Queries Material module', () => {
 
 				OPTIONAL MATCH (existingOriginalVersionMaterial:Material { name: $originalVersionMaterial.name })
 					WHERE
-						($originalVersionMaterial.differentiator IS NULL AND existingOriginalVersionMaterial.differentiator IS NULL) OR
-						($originalVersionMaterial.differentiator = existingOriginalVersionMaterial.differentiator)
+						(
+							$originalVersionMaterial.differentiator IS NULL AND
+							existingOriginalVersionMaterial.differentiator IS NULL
+						) OR
+						$originalVersionMaterial.differentiator = existingOriginalVersionMaterial.differentiator
 
 				FOREACH (item IN CASE $originalVersionMaterial.name WHEN NULL THEN [] ELSE [1] END |
 					MERGE (originalVersionMaterial:Material {
@@ -43,7 +46,7 @@ describe('Cypher Queries Material module', () => {
 						OPTIONAL MATCH (existingWritingPerson:Person { name: writingPersonParam.name })
 							WHERE
 								(writingPersonParam.differentiator IS NULL AND existingWritingPerson.differentiator IS NULL) OR
-								(writingPersonParam.differentiator = existingWritingPerson.differentiator)
+								writingPersonParam.differentiator = existingWritingPerson.differentiator
 
 						FOREACH (item IN CASE writingPersonParam WHEN NULL THEN [] ELSE [1] END |
 							MERGE (writingPerson:Person {
@@ -71,8 +74,11 @@ describe('Cypher Queries Material module', () => {
 
 						OPTIONAL MATCH (existingWritingCompany:Company { name: writingCompanyParam.name })
 							WHERE
-								(writingCompanyParam.differentiator IS NULL AND existingWritingCompany.differentiator IS NULL) OR
-								(writingCompanyParam.differentiator = existingWritingCompany.differentiator)
+								(
+									writingCompanyParam.differentiator IS NULL AND
+									existingWritingCompany.differentiator IS NULL
+								) OR
+								writingCompanyParam.differentiator = existingWritingCompany.differentiator
 
 						FOREACH (item IN CASE writingCompanyParam WHEN NULL THEN [] ELSE [1] END |
 							MERGE (writingCompany:Company {
@@ -100,8 +106,11 @@ describe('Cypher Queries Material module', () => {
 
 						OPTIONAL MATCH (existingSourceMaterial:Material { name: sourceMaterialParam.name })
 							WHERE
-								(sourceMaterialParam.differentiator IS NULL AND existingSourceMaterial.differentiator IS NULL) OR
-								(sourceMaterialParam.differentiator = existingSourceMaterial.differentiator)
+								(
+									sourceMaterialParam.differentiator IS NULL AND
+									existingSourceMaterial.differentiator IS NULL
+								) OR
+								sourceMaterialParam.differentiator = existingSourceMaterial.differentiator
 
 						FOREACH (item IN CASE sourceMaterialParam WHEN NULL THEN [] ELSE [1] END |
 							MERGE (sourceMaterial:Material {
@@ -122,14 +131,17 @@ describe('Cypher Queries Material module', () => {
 
 				UNWIND (CASE $characterGroups WHEN [] THEN [{ characters: [] }] ELSE $characterGroups END) AS characterGroup
 
-					UNWIND (CASE characterGroup.characters WHEN [] THEN [null] ELSE characterGroup.characters END) AS characterParam
+					UNWIND (CASE characterGroup.characters WHEN []
+						THEN [null]
+						ELSE characterGroup.characters
+					END) AS characterParam
 
 						OPTIONAL MATCH (existingCharacter:Character {
 							name: COALESCE(characterParam.underlyingName, characterParam.name)
 						})
 							WHERE
 								(characterParam.differentiator IS NULL AND existingCharacter.differentiator IS NULL) OR
-								(characterParam.differentiator = existingCharacter.differentiator)
+								characterParam.differentiator = existingCharacter.differentiator
 
 						FOREACH (item IN CASE characterParam WHEN NULL THEN [] ELSE [1] END |
 							MERGE (character:Character {
@@ -142,7 +154,10 @@ describe('Cypher Queries Material module', () => {
 								[:INCLUDES_CHARACTER {
 									groupPosition: characterGroup.position,
 									characterPosition: characterParam.position,
-									displayName: CASE characterParam.underlyingName WHEN NULL THEN null ELSE characterParam.name END,
+									displayName: CASE characterParam.underlyingName WHEN NULL
+										THEN null
+										ELSE characterParam.name
+									END,
 									qualifier: characterParam.qualifier,
 									group: characterGroup.name
 								}]->(character)
@@ -212,7 +227,10 @@ describe('Cypher Queries Material module', () => {
 					material.format AS format,
 					{
 						name: CASE originalVersionMaterial.name WHEN NULL THEN '' ELSE originalVersionMaterial.name END,
-						differentiator: CASE originalVersionMaterial.differentiator WHEN NULL THEN '' ELSE originalVersionMaterial.differentiator END
+						differentiator: CASE originalVersionMaterial.differentiator WHEN NULL
+							THEN ''
+							ELSE originalVersionMaterial.differentiator
+						END
 					} AS originalVersionMaterial,
 					writingCredits,
 					COLLECT(
@@ -269,8 +287,11 @@ describe('Cypher Queries Material module', () => {
 
 				OPTIONAL MATCH (existingOriginalVersionMaterial:Material { name: $originalVersionMaterial.name })
 					WHERE
-						($originalVersionMaterial.differentiator IS NULL AND existingOriginalVersionMaterial.differentiator IS NULL) OR
-						($originalVersionMaterial.differentiator = existingOriginalVersionMaterial.differentiator)
+						(
+							$originalVersionMaterial.differentiator IS NULL AND
+							existingOriginalVersionMaterial.differentiator IS NULL
+						) OR
+						$originalVersionMaterial.differentiator = existingOriginalVersionMaterial.differentiator
 
 				FOREACH (item IN CASE $originalVersionMaterial.name WHEN NULL THEN [] ELSE [1] END |
 					MERGE (originalVersionMaterial:Material {
@@ -295,7 +316,7 @@ describe('Cypher Queries Material module', () => {
 						OPTIONAL MATCH (existingWritingPerson:Person { name: writingPersonParam.name })
 							WHERE
 								(writingPersonParam.differentiator IS NULL AND existingWritingPerson.differentiator IS NULL) OR
-								(writingPersonParam.differentiator = existingWritingPerson.differentiator)
+								writingPersonParam.differentiator = existingWritingPerson.differentiator
 
 						FOREACH (item IN CASE writingPersonParam WHEN NULL THEN [] ELSE [1] END |
 							MERGE (writingPerson:Person {
@@ -323,8 +344,11 @@ describe('Cypher Queries Material module', () => {
 
 						OPTIONAL MATCH (existingWritingCompany:Company { name: writingCompanyParam.name })
 							WHERE
-								(writingCompanyParam.differentiator IS NULL AND existingWritingCompany.differentiator IS NULL) OR
-								(writingCompanyParam.differentiator = existingWritingCompany.differentiator)
+								(
+									writingCompanyParam.differentiator IS NULL AND
+									existingWritingCompany.differentiator IS NULL
+								) OR
+								writingCompanyParam.differentiator = existingWritingCompany.differentiator
 
 						FOREACH (item IN CASE writingCompanyParam WHEN NULL THEN [] ELSE [1] END |
 							MERGE (writingCompany:Company {
@@ -352,8 +376,11 @@ describe('Cypher Queries Material module', () => {
 
 						OPTIONAL MATCH (existingSourceMaterial:Material { name: sourceMaterialParam.name })
 							WHERE
-								(sourceMaterialParam.differentiator IS NULL AND existingSourceMaterial.differentiator IS NULL) OR
-								(sourceMaterialParam.differentiator = existingSourceMaterial.differentiator)
+								(
+									sourceMaterialParam.differentiator IS NULL AND
+									existingSourceMaterial.differentiator IS NULL
+								) OR
+								sourceMaterialParam.differentiator = existingSourceMaterial.differentiator
 
 						FOREACH (item IN CASE sourceMaterialParam WHEN NULL THEN [] ELSE [1] END |
 							MERGE (sourceMaterial:Material {
@@ -374,14 +401,17 @@ describe('Cypher Queries Material module', () => {
 
 				UNWIND (CASE $characterGroups WHEN [] THEN [{ characters: [] }] ELSE $characterGroups END) AS characterGroup
 
-					UNWIND (CASE characterGroup.characters WHEN [] THEN [null] ELSE characterGroup.characters END) AS characterParam
+					UNWIND (CASE characterGroup.characters WHEN []
+						THEN [null]
+						ELSE characterGroup.characters
+					END) AS characterParam
 
 						OPTIONAL MATCH (existingCharacter:Character {
 							name: COALESCE(characterParam.underlyingName, characterParam.name)
 						})
 							WHERE
 								(characterParam.differentiator IS NULL AND existingCharacter.differentiator IS NULL) OR
-								(characterParam.differentiator = existingCharacter.differentiator)
+								characterParam.differentiator = existingCharacter.differentiator
 
 						FOREACH (item IN CASE characterParam WHEN NULL THEN [] ELSE [1] END |
 							MERGE (character:Character {
@@ -394,7 +424,10 @@ describe('Cypher Queries Material module', () => {
 								[:INCLUDES_CHARACTER {
 									groupPosition: characterGroup.position,
 									characterPosition: characterParam.position,
-									displayName: CASE characterParam.underlyingName WHEN NULL THEN null ELSE characterParam.name END,
+									displayName: CASE characterParam.underlyingName WHEN NULL
+										THEN null
+										ELSE characterParam.name
+									END,
 									qualifier: characterParam.qualifier,
 									group: characterGroup.name
 								}]->(character)
@@ -464,7 +497,10 @@ describe('Cypher Queries Material module', () => {
 					material.format AS format,
 					{
 						name: CASE originalVersionMaterial.name WHEN NULL THEN '' ELSE originalVersionMaterial.name END,
-						differentiator: CASE originalVersionMaterial.differentiator WHEN NULL THEN '' ELSE originalVersionMaterial.differentiator END
+						differentiator: CASE originalVersionMaterial.differentiator WHEN NULL
+							THEN ''
+							ELSE originalVersionMaterial.differentiator
+						END
 					} AS originalVersionMaterial,
 					writingCredits,
 					COLLECT(

--- a/test-unit/src/neo4j/cypher-queries/production.test.js
+++ b/test-unit/src/neo4j/cypher-queries/production.test.js
@@ -18,7 +18,7 @@ describe('Cypher Queries Production module', () => {
 				OPTIONAL MATCH (existingMaterial:Material { name: $material.name })
 					WHERE
 						($material.differentiator IS NULL AND existingMaterial.differentiator IS NULL) OR
-						($material.differentiator = existingMaterial.differentiator)
+						$material.differentiator = existingMaterial.differentiator
 
 				FOREACH (item IN CASE $material.name WHEN NULL THEN [] ELSE [1] END |
 					MERGE (material:Material {
@@ -35,7 +35,7 @@ describe('Cypher Queries Production module', () => {
 				OPTIONAL MATCH (existingTheatre:Theatre { name: $theatre.name })
 					WHERE
 						($theatre.differentiator IS NULL AND existingTheatre.differentiator IS NULL) OR
-						($theatre.differentiator = existingTheatre.differentiator)
+						$theatre.differentiator = existingTheatre.differentiator
 
 				FOREACH (item IN CASE $theatre.name WHEN NULL THEN [] ELSE [1] END |
 					MERGE (theatre:Theatre {
@@ -54,7 +54,7 @@ describe('Cypher Queries Production module', () => {
 					OPTIONAL MATCH (existingPerson:Person { name: castMemberParam.name })
 						WHERE
 							(castMemberParam.differentiator IS NULL AND existingPerson.differentiator IS NULL) OR
-							(castMemberParam.differentiator = existingPerson.differentiator)
+							castMemberParam.differentiator = existingPerson.differentiator
 
 					FOREACH (item IN CASE castMemberParam WHEN NULL THEN [] ELSE [1] END |
 						MERGE (castMember:Person {
@@ -78,7 +78,10 @@ describe('Cypher Queries Production module', () => {
 
 				WITH DISTINCT production
 
-				UNWIND (CASE $creativeCredits WHEN [] THEN [{ creativeEntities: [] }] ELSE $creativeCredits END) AS creativeCredit
+				UNWIND (CASE $creativeCredits WHEN []
+					THEN [{ creativeEntities: [] }]
+					ELSE $creativeCredits
+				END) AS creativeCredit
 
 					UNWIND
 						CASE SIZE([entity IN creativeCredit.creativeEntities WHERE entity.model = 'person']) WHEN 0
@@ -88,8 +91,11 @@ describe('Cypher Queries Production module', () => {
 
 						OPTIONAL MATCH (existingCreativePerson:Person { name: creativePersonParam.name })
 							WHERE
-								(creativePersonParam.differentiator IS NULL AND existingCreativePerson.differentiator IS NULL) OR
-								(creativePersonParam.differentiator = existingCreativePerson.differentiator)
+								(
+									creativePersonParam.differentiator IS NULL AND
+									existingCreativePerson.differentiator IS NULL
+								) OR
+								creativePersonParam.differentiator = existingCreativePerson.differentiator
 
 						FOREACH (item IN CASE creativePersonParam WHEN NULL THEN [] ELSE [1] END |
 							MERGE (creativePerson:Person {
@@ -116,8 +122,11 @@ describe('Cypher Queries Production module', () => {
 
 						OPTIONAL MATCH (existingCreativeCompany:Company { name: creativeCompanyParam.name })
 							WHERE
-								(creativeCompanyParam.differentiator IS NULL AND existingCreativeCompany.differentiator IS NULL) OR
-								(creativeCompanyParam.differentiator = existingCreativeCompany.differentiator)
+								(
+									creativeCompanyParam.differentiator IS NULL AND
+									existingCreativeCompany.differentiator IS NULL
+								) OR
+								creativeCompanyParam.differentiator = existingCreativeCompany.differentiator
 
 						FOREACH (item IN CASE creativeCompanyParam WHEN NULL THEN [] ELSE [1] END |
 							MERGE (creativeCompany:Company {
@@ -145,7 +154,7 @@ describe('Cypher Queries Production module', () => {
 							OPTIONAL MATCH (creditedCompany:Company { name: creativeCompanyParam.name })
 								WHERE
 									(creativeCompanyParam.differentiator IS NULL AND creditedCompany.differentiator IS NULL) OR
-									(creativeCompanyParam.differentiator = creditedCompany.differentiator)
+									creativeCompanyParam.differentiator = creditedCompany.differentiator
 
 							OPTIONAL MATCH (creditedCompany)<-[creativeCompanyRel:HAS_CREATIVE_TEAM_MEMBER]-(production)
 								WHERE
@@ -155,7 +164,7 @@ describe('Cypher Queries Production module', () => {
 							OPTIONAL MATCH (existingPerson:Person { name: creditedMemberParam.name })
 								WHERE
 									(creditedMemberParam.differentiator IS NULL AND existingPerson.differentiator IS NULL) OR
-									(creditedMemberParam.differentiator = existingPerson.differentiator)
+									creditedMemberParam.differentiator = existingPerson.differentiator
 
 							FOREACH (item IN CASE WHEN SIZE(creativeCompanyParam.creditedMembers) > 0 THEN [1] ELSE [] END |
 								SET creativeCompanyRel.creditedMemberUuids = []
@@ -199,7 +208,10 @@ describe('Cypher Queries Production module', () => {
 							ELSE {
 								name: role.roleName,
 								characterName: CASE role.characterName WHEN NULL THEN '' ELSE role.characterName END,
-								characterDifferentiator: CASE role.characterDifferentiator WHEN NULL THEN '' ELSE role.characterDifferentiator END,
+								characterDifferentiator: CASE role.characterDifferentiator WHEN NULL
+									THEN ''
+									ELSE role.characterDifferentiator
+								END,
 								qualifier: CASE role.qualifier WHEN NULL THEN '' ELSE role.qualifier END
 							}
 						END
@@ -311,7 +323,7 @@ describe('Cypher Queries Production module', () => {
 				OPTIONAL MATCH (existingMaterial:Material { name: $material.name })
 					WHERE
 						($material.differentiator IS NULL AND existingMaterial.differentiator IS NULL) OR
-						($material.differentiator = existingMaterial.differentiator)
+						$material.differentiator = existingMaterial.differentiator
 
 				FOREACH (item IN CASE $material.name WHEN NULL THEN [] ELSE [1] END |
 					MERGE (material:Material {
@@ -328,7 +340,7 @@ describe('Cypher Queries Production module', () => {
 				OPTIONAL MATCH (existingTheatre:Theatre { name: $theatre.name })
 					WHERE
 						($theatre.differentiator IS NULL AND existingTheatre.differentiator IS NULL) OR
-						($theatre.differentiator = existingTheatre.differentiator)
+						$theatre.differentiator = existingTheatre.differentiator
 
 				FOREACH (item IN CASE $theatre.name WHEN NULL THEN [] ELSE [1] END |
 					MERGE (theatre:Theatre {
@@ -347,7 +359,7 @@ describe('Cypher Queries Production module', () => {
 					OPTIONAL MATCH (existingPerson:Person { name: castMemberParam.name })
 						WHERE
 							(castMemberParam.differentiator IS NULL AND existingPerson.differentiator IS NULL) OR
-							(castMemberParam.differentiator = existingPerson.differentiator)
+							castMemberParam.differentiator = existingPerson.differentiator
 
 					FOREACH (item IN CASE castMemberParam WHEN NULL THEN [] ELSE [1] END |
 						MERGE (castMember:Person {
@@ -371,7 +383,10 @@ describe('Cypher Queries Production module', () => {
 
 				WITH DISTINCT production
 
-				UNWIND (CASE $creativeCredits WHEN [] THEN [{ creativeEntities: [] }] ELSE $creativeCredits END) AS creativeCredit
+				UNWIND (CASE $creativeCredits WHEN []
+					THEN [{ creativeEntities: [] }]
+					ELSE $creativeCredits
+				END) AS creativeCredit
 
 					UNWIND
 						CASE SIZE([entity IN creativeCredit.creativeEntities WHERE entity.model = 'person']) WHEN 0
@@ -381,8 +396,11 @@ describe('Cypher Queries Production module', () => {
 
 						OPTIONAL MATCH (existingCreativePerson:Person { name: creativePersonParam.name })
 							WHERE
-								(creativePersonParam.differentiator IS NULL AND existingCreativePerson.differentiator IS NULL) OR
-								(creativePersonParam.differentiator = existingCreativePerson.differentiator)
+								(
+									creativePersonParam.differentiator IS NULL AND
+									existingCreativePerson.differentiator IS NULL
+								) OR
+								creativePersonParam.differentiator = existingCreativePerson.differentiator
 
 						FOREACH (item IN CASE creativePersonParam WHEN NULL THEN [] ELSE [1] END |
 							MERGE (creativePerson:Person {
@@ -409,8 +427,11 @@ describe('Cypher Queries Production module', () => {
 
 						OPTIONAL MATCH (existingCreativeCompany:Company { name: creativeCompanyParam.name })
 							WHERE
-								(creativeCompanyParam.differentiator IS NULL AND existingCreativeCompany.differentiator IS NULL) OR
-								(creativeCompanyParam.differentiator = existingCreativeCompany.differentiator)
+								(
+									creativeCompanyParam.differentiator IS NULL AND
+									existingCreativeCompany.differentiator IS NULL
+								) OR
+								creativeCompanyParam.differentiator = existingCreativeCompany.differentiator
 
 						FOREACH (item IN CASE creativeCompanyParam WHEN NULL THEN [] ELSE [1] END |
 							MERGE (creativeCompany:Company {
@@ -438,7 +459,7 @@ describe('Cypher Queries Production module', () => {
 							OPTIONAL MATCH (creditedCompany:Company { name: creativeCompanyParam.name })
 								WHERE
 									(creativeCompanyParam.differentiator IS NULL AND creditedCompany.differentiator IS NULL) OR
-									(creativeCompanyParam.differentiator = creditedCompany.differentiator)
+									creativeCompanyParam.differentiator = creditedCompany.differentiator
 
 							OPTIONAL MATCH (creditedCompany)<-[creativeCompanyRel:HAS_CREATIVE_TEAM_MEMBER]-(production)
 								WHERE
@@ -448,7 +469,7 @@ describe('Cypher Queries Production module', () => {
 							OPTIONAL MATCH (existingPerson:Person { name: creditedMemberParam.name })
 								WHERE
 									(creditedMemberParam.differentiator IS NULL AND existingPerson.differentiator IS NULL) OR
-									(creditedMemberParam.differentiator = existingPerson.differentiator)
+									creditedMemberParam.differentiator = existingPerson.differentiator
 
 							FOREACH (item IN CASE WHEN SIZE(creativeCompanyParam.creditedMembers) > 0 THEN [1] ELSE [] END |
 								SET creativeCompanyRel.creditedMemberUuids = []
@@ -492,7 +513,10 @@ describe('Cypher Queries Production module', () => {
 							ELSE {
 								name: role.roleName,
 								characterName: CASE role.characterName WHEN NULL THEN '' ELSE role.characterName END,
-								characterDifferentiator: CASE role.characterDifferentiator WHEN NULL THEN '' ELSE role.characterDifferentiator END,
+								characterDifferentiator: CASE role.characterDifferentiator WHEN NULL
+									THEN ''
+									ELSE role.characterDifferentiator
+								END,
 								qualifier: CASE role.qualifier WHEN NULL THEN '' ELSE role.qualifier END
 							}
 						END

--- a/test-unit/src/neo4j/cypher-queries/shared.test.js
+++ b/test-unit/src/neo4j/cypher-queries/shared.test.js
@@ -57,11 +57,11 @@ describe('Cypher Queries Shared module', () => {
 					WHERE
 						(
 							($differentiator IS NULL AND n.differentiator IS NULL) OR
-							($differentiator = n.differentiator)
+							$differentiator = n.differentiator
 						) AND
 						(
-							($uuid IS NULL) OR
-							($uuid <> n.uuid)
+							$uuid IS NULL OR
+							$uuid <> n.uuid
 						)
 
 				RETURN SIGN(COUNT(n)) AS instanceCount

--- a/test-unit/src/neo4j/cypher-queries/theatre.test.js
+++ b/test-unit/src/neo4j/cypher-queries/theatre.test.js
@@ -20,7 +20,7 @@ describe('Cypher Queries Theatre module', () => {
 					OPTIONAL MATCH (existingTheatre:Theatre { name: subTheatreParam.name })
 						WHERE
 							(subTheatreParam.differentiator IS NULL AND existingTheatre.differentiator IS NULL) OR
-							(subTheatreParam.differentiator = existingTheatre.differentiator)
+							subTheatreParam.differentiator = existingTheatre.differentiator
 
 					FOREACH (item IN CASE subTheatreParam WHEN NULL THEN [] ELSE [1] END |
 						MERGE (subTheatre:Theatre {
@@ -83,7 +83,7 @@ describe('Cypher Queries Theatre module', () => {
 					OPTIONAL MATCH (existingTheatre:Theatre { name: subTheatreParam.name })
 						WHERE
 							(subTheatreParam.differentiator IS NULL AND existingTheatre.differentiator IS NULL) OR
-							(subTheatreParam.differentiator = existingTheatre.differentiator)
+							subTheatreParam.differentiator = existingTheatre.differentiator
 
 					FOREACH (item IN CASE subTheatreParam WHEN NULL THEN [] ELSE [1] END |
 						MERGE (subTheatre:Theatre {


### PR DESCRIPTION
Revises Cypher formatting to:
- Remove unnecessary parentheses
- Ensure lines stay within 120 character limit