### PR TITLE
Use Cypher COALESCE() function

### DIFF
--- a/src/neo4j/cypher-queries/material.js
+++ b/src/neo4j/cypher-queries/material.js
@@ -263,11 +263,8 @@ const getEditQuery = () => `
 		material.differentiator AS differentiator,
 		material.format AS format,
 		{
-			name: CASE originalVersionMaterial.name WHEN NULL THEN '' ELSE originalVersionMaterial.name END,
-			differentiator: CASE originalVersionMaterial.differentiator WHEN NULL
-				THEN ''
-				ELSE originalVersionMaterial.differentiator
-			END
+			name: COALESCE(originalVersionMaterial.name, ''),
+			differentiator: COALESCE(originalVersionMaterial.differentiator, '')
 		} AS originalVersionMaterial,
 		writingCredits,
 		COLLECT(

--- a/src/neo4j/cypher-queries/production.js
+++ b/src/neo4j/cypher-queries/production.js
@@ -222,12 +222,9 @@ const getEditQuery = () => `
 				THEN null
 				ELSE {
 					name: role.roleName,
-					characterName: CASE role.characterName WHEN NULL THEN '' ELSE role.characterName END,
-					characterDifferentiator: CASE role.characterDifferentiator WHEN NULL
-						THEN ''
-						ELSE role.characterDifferentiator
-					END,
-					qualifier: CASE role.qualifier WHEN NULL THEN '' ELSE role.qualifier END
+					characterName: COALESCE(role.characterName, ''),
+					characterDifferentiator: COALESCE(role.characterDifferentiator, ''),
+					qualifier: COALESCE(role.qualifier, '')
 				}
 			END
 		) + [{}] AS roles
@@ -255,10 +252,7 @@ const getEditQuery = () => `
 
 	UNWIND (CASE creativeEntities WHEN [] THEN [null] ELSE creativeEntities END) AS creativeEntity
 
-		UNWIND (CASE creativeEntity.creditedMemberUuids WHEN NULL
-			THEN [null]
-			ELSE creativeEntity.creditedMemberUuids
-		END) AS creditedMemberUuid
+		UNWIND (COALESCE(creativeEntity.creditedMemberUuids, [null])) AS creditedMemberUuid
 
 			OPTIONAL MATCH (production)-[creditedMemberRel:HAS_CREATIVE_TEAM_MEMBER]->
 				(creditedMember:Person { uuid: creditedMemberUuid })
@@ -290,14 +284,8 @@ const getEditQuery = () => `
 		'production' AS model,
 		production.uuid AS uuid,
 		production.name AS name,
-		{
-			name: CASE material.name WHEN NULL THEN '' ELSE material.name END,
-			differentiator: CASE material.differentiator WHEN NULL THEN '' ELSE material.differentiator END
-		} AS material,
-		{
-			name: CASE theatre.name WHEN NULL THEN '' ELSE theatre.name END,
-			differentiator: CASE theatre.differentiator WHEN NULL THEN '' ELSE theatre.differentiator END
-		} AS theatre,
+		{ name: COALESCE(material.name, ''), differentiator: COALESCE(material.differentiator, '') } AS material,
+		{ name: COALESCE(theatre.name, ''), differentiator: COALESCE(theatre.differentiator, '') } AS theatre,
 		cast,
 		COLLECT(
 			CASE WHEN creativeCreditName IS NULL AND SIZE(creativeEntities) = 1
@@ -449,10 +437,7 @@ const getShowQuery = () => `
 
 	UNWIND (CASE creativeEntities WHEN [] THEN [null] ELSE creativeEntities END) AS creativeEntity
 
-		UNWIND (CASE creativeEntity.creditedMemberUuids WHEN NULL
-			THEN [null]
-			ELSE creativeEntity.creditedMemberUuids
-		END) AS creditedMemberUuid
+		UNWIND (COALESCE(creativeEntity.creditedMemberUuids, [null])) AS creditedMemberUuid
 
 			OPTIONAL MATCH (production)-[creditedMemberRel:HAS_CREATIVE_TEAM_MEMBER]->
 				(creditedMember:Person { uuid: creditedMemberUuid })

--- a/test-unit/src/neo4j/cypher-queries/material.test.js
+++ b/test-unit/src/neo4j/cypher-queries/material.test.js
@@ -226,11 +226,8 @@ describe('Cypher Queries Material module', () => {
 					material.differentiator AS differentiator,
 					material.format AS format,
 					{
-						name: CASE originalVersionMaterial.name WHEN NULL THEN '' ELSE originalVersionMaterial.name END,
-						differentiator: CASE originalVersionMaterial.differentiator WHEN NULL
-							THEN ''
-							ELSE originalVersionMaterial.differentiator
-						END
+						name: COALESCE(originalVersionMaterial.name, ''),
+						differentiator: COALESCE(originalVersionMaterial.differentiator, '')
 					} AS originalVersionMaterial,
 					writingCredits,
 					COLLECT(
@@ -496,11 +493,8 @@ describe('Cypher Queries Material module', () => {
 					material.differentiator AS differentiator,
 					material.format AS format,
 					{
-						name: CASE originalVersionMaterial.name WHEN NULL THEN '' ELSE originalVersionMaterial.name END,
-						differentiator: CASE originalVersionMaterial.differentiator WHEN NULL
-							THEN ''
-							ELSE originalVersionMaterial.differentiator
-						END
+						name: COALESCE(originalVersionMaterial.name, ''),
+						differentiator: COALESCE(originalVersionMaterial.differentiator, '')
 					} AS originalVersionMaterial,
 					writingCredits,
 					COLLECT(

--- a/test-unit/src/neo4j/cypher-queries/production.test.js
+++ b/test-unit/src/neo4j/cypher-queries/production.test.js
@@ -207,12 +207,9 @@ describe('Cypher Queries Production module', () => {
 							THEN null
 							ELSE {
 								name: role.roleName,
-								characterName: CASE role.characterName WHEN NULL THEN '' ELSE role.characterName END,
-								characterDifferentiator: CASE role.characterDifferentiator WHEN NULL
-									THEN ''
-									ELSE role.characterDifferentiator
-								END,
-								qualifier: CASE role.qualifier WHEN NULL THEN '' ELSE role.qualifier END
+								characterName: COALESCE(role.characterName, ''),
+								characterDifferentiator: COALESCE(role.characterDifferentiator, ''),
+								qualifier: COALESCE(role.qualifier, '')
 							}
 						END
 					) + [{}] AS roles
@@ -240,10 +237,7 @@ describe('Cypher Queries Production module', () => {
 
 				UNWIND (CASE creativeEntities WHEN [] THEN [null] ELSE creativeEntities END) AS creativeEntity
 
-					UNWIND (CASE creativeEntity.creditedMemberUuids WHEN NULL
-						THEN [null]
-						ELSE creativeEntity.creditedMemberUuids
-					END) AS creditedMemberUuid
+					UNWIND (COALESCE(creativeEntity.creditedMemberUuids, [null])) AS creditedMemberUuid
 
 						OPTIONAL MATCH (production)-[creditedMemberRel:HAS_CREATIVE_TEAM_MEMBER]->
 							(creditedMember:Person { uuid: creditedMemberUuid })
@@ -275,14 +269,8 @@ describe('Cypher Queries Production module', () => {
 					'production' AS model,
 					production.uuid AS uuid,
 					production.name AS name,
-					{
-						name: CASE material.name WHEN NULL THEN '' ELSE material.name END,
-						differentiator: CASE material.differentiator WHEN NULL THEN '' ELSE material.differentiator END
-					} AS material,
-					{
-						name: CASE theatre.name WHEN NULL THEN '' ELSE theatre.name END,
-						differentiator: CASE theatre.differentiator WHEN NULL THEN '' ELSE theatre.differentiator END
-					} AS theatre,
+					{ name: COALESCE(material.name, ''), differentiator: COALESCE(material.differentiator, '') } AS material,
+					{ name: COALESCE(theatre.name, ''), differentiator: COALESCE(theatre.differentiator, '') } AS theatre,
 					cast,
 					COLLECT(
 						CASE WHEN creativeCreditName IS NULL AND SIZE(creativeEntities) = 1
@@ -512,12 +500,9 @@ describe('Cypher Queries Production module', () => {
 							THEN null
 							ELSE {
 								name: role.roleName,
-								characterName: CASE role.characterName WHEN NULL THEN '' ELSE role.characterName END,
-								characterDifferentiator: CASE role.characterDifferentiator WHEN NULL
-									THEN ''
-									ELSE role.characterDifferentiator
-								END,
-								qualifier: CASE role.qualifier WHEN NULL THEN '' ELSE role.qualifier END
+								characterName: COALESCE(role.characterName, ''),
+								characterDifferentiator: COALESCE(role.characterDifferentiator, ''),
+								qualifier: COALESCE(role.qualifier, '')
 							}
 						END
 					) + [{}] AS roles
@@ -545,10 +530,7 @@ describe('Cypher Queries Production module', () => {
 
 				UNWIND (CASE creativeEntities WHEN [] THEN [null] ELSE creativeEntities END) AS creativeEntity
 
-					UNWIND (CASE creativeEntity.creditedMemberUuids WHEN NULL
-						THEN [null]
-						ELSE creativeEntity.creditedMemberUuids
-					END) AS creditedMemberUuid
+					UNWIND (COALESCE(creativeEntity.creditedMemberUuids, [null])) AS creditedMemberUuid
 
 						OPTIONAL MATCH (production)-[creditedMemberRel:HAS_CREATIVE_TEAM_MEMBER]->
 							(creditedMember:Person { uuid: creditedMemberUuid })
@@ -580,14 +562,8 @@ describe('Cypher Queries Production module', () => {
 					'production' AS model,
 					production.uuid AS uuid,
 					production.name AS name,
-					{
-						name: CASE material.name WHEN NULL THEN '' ELSE material.name END,
-						differentiator: CASE material.differentiator WHEN NULL THEN '' ELSE material.differentiator END
-					} AS material,
-					{
-						name: CASE theatre.name WHEN NULL THEN '' ELSE theatre.name END,
-						differentiator: CASE theatre.differentiator WHEN NULL THEN '' ELSE theatre.differentiator END
-					} AS theatre,
+					{ name: COALESCE(material.name, ''), differentiator: COALESCE(material.differentiator, '') } AS material,
+					{ name: COALESCE(theatre.name, ''), differentiator: COALESCE(theatre.differentiator, '') } AS theatre,
 					cast,
 					COLLECT(
 						CASE WHEN creativeCreditName IS NULL AND SIZE(creativeEntities) = 1


### PR DESCRIPTION
Uses the Cypher `COALESCE()` function where possible to make Cypher query expressions more succinct.

### References:
- [Scalar functions - Neo4j Cypher Manual: `coalesce()`](https://neo4j.com/docs/cypher-manual/current/functions/scalar/#functions-coalesce)