### PR TITLE
Rename prepareAsParams filter functions

### DIFF
--- a/src/lib/prepare-as-params.js
+++ b/src/lib/prepare-as-params.js
@@ -15,15 +15,15 @@ export const prepareAsParams = instance => {
 
 	const recordedInstances = [];
 
-	const filterBasedOnNameProperty = key => item =>
+	const hasNameOrIsExempt = key => item =>
 		!Object.prototype.hasOwnProperty.call(item, 'name')
 		|| !!item.name.length
 		|| EMPTY_NAME_EXCEPTION_KEYS.includes(key);
 
-	const filterOutWritingCreditsWithNoNamedEntities = key => item =>
+	const isNotWritingCreditWithoutNamedEntity = key => item =>
 		key !== WRITING_CREDITS || item.writingEntities.some(entity => !!entity.name);
 
-	const filterOutCharacterGroupsWithNoNamedCharacters = key => item =>
+	const isNotCharacterGroupWithoutNamedCharacter = key => item =>
 		key !== CHARACTER_GROUPS || item.characters.some(character => !!character.name);
 
 	const applyPositionPropertyAndRecurseObject = (item, index, array) => {
@@ -54,9 +54,9 @@ export const prepareAsParams = instance => {
 
 				accumulator[key] =
 					value
-						.filter(filterBasedOnNameProperty(key))
-						.filter(filterOutWritingCreditsWithNoNamedEntities(key))
-						.filter(filterOutCharacterGroupsWithNoNamedCharacters(key))
+						.filter(hasNameOrIsExempt(key))
+						.filter(isNotWritingCreditWithoutNamedEntity(key))
+						.filter(isNotCharacterGroupWithoutNamedCharacter(key))
 						.map(applyPositionPropertyAndRecurseObject)
 						.filter(Boolean);
 


### PR DESCRIPTION
The functions called by the `Array.prototype.filter()` in the Prepare As Params module return a Boolean value, so their name should reflect that, i.e. being with `is` or `has`.

The functions themselves do not apply the filtering and so their names should not include `filter`.

### References:
[Array.prototype.filter()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter) - this includes an example function whose name - `isBigEnough` - demonstrates this convention.