### PR TITLE
Use getters for class instance model values

### DIFF
--- a/src/lib/prepare-as-params.js
+++ b/src/lib/prepare-as-params.js
@@ -30,7 +30,7 @@ export const prepareAsParams = instance => {
 
 		if (isObjectWithKeys(item)) {
 
-			if (array.length > 1) item = { ...item, position: index };
+			if (array.length > 1) item = { ...item, model: item.model, position: index };
 
 			return applyModifications(item);
 
@@ -42,7 +42,7 @@ export const prepareAsParams = instance => {
 
 	const applyModifications = instance => {
 
-		return Object.keys(instance).reduce((accumulator, key) => {
+		return Object.keys(instance).concat(['model']).reduce((accumulator, key) => {
 
 			const value = instance[key];
 

--- a/src/models/Base.js
+++ b/src/models/Base.js
@@ -20,6 +20,12 @@ export default class Base {
 
 	}
 
+	toJSON () {
+
+		return Object.assign({}, { model: this.model }, this);
+
+	}
+
 	hasDifferentiatorProperty () {
 
 		return Object.prototype.hasOwnProperty.call(this, 'differentiator');

--- a/src/models/Character.js
+++ b/src/models/Character.js
@@ -8,7 +8,6 @@ export default class Character extends Base {
 
 		const { uuid, differentiator, underlyingName, qualifier, isAssociation } = props;
 
-		this.model = 'character';
 		this.uuid = uuid;
 		this.differentiator = differentiator?.trim() || '';
 
@@ -18,6 +17,12 @@ export default class Character extends Base {
 			this.qualifier = qualifier?.trim() || '';
 
 		}
+
+	}
+
+	get model () {
+
+		return 'character';
 
 	}
 

--- a/src/models/CharacterGroup.js
+++ b/src/models/CharacterGroup.js
@@ -10,10 +10,15 @@ export default class CharacterGroup extends Base {
 
 		const { characters } = props;
 
-		this.model = 'characterGroup';
 		this.characters = characters
 			? characters.map(character => new Character({ ...character, isAssociation: true }))
 			: [];
+
+	}
+
+	get model () {
+
+		return 'characterGroup';
 
 	}
 

--- a/src/models/Company.js
+++ b/src/models/Company.js
@@ -9,7 +9,6 @@ export default class Company extends Base {
 
 		const { uuid, differentiator, creditedMembers, isProductionAssociation } = props;
 
-		this.model = 'company';
 		this.uuid = uuid;
 		this.differentiator = differentiator?.trim() || '';
 
@@ -20,6 +19,12 @@ export default class Company extends Base {
 				: [];
 
 		}
+
+	}
+
+	get model () {
+
+		return 'company';
 
 	}
 

--- a/src/models/CreativeCredit.js
+++ b/src/models/CreativeCredit.js
@@ -10,8 +10,6 @@ export default class CreativeCredit extends Base {
 
 		const { creativeEntities } = props;
 
-		this.model = 'creativeCredit';
-
 		this.creativeEntities = creativeEntities
 			? creativeEntities.map(creativeEntity => {
 				switch (creativeEntity.model) {
@@ -22,6 +20,12 @@ export default class CreativeCredit extends Base {
 				}
 			})
 			: [];
+
+	}
+
+	get model () {
+
+		return 'creativeCredit';
 
 	}
 

--- a/src/models/Material.js
+++ b/src/models/Material.js
@@ -18,7 +18,6 @@ export default class Material extends Base {
 			isAssociation
 		} = props;
 
-		this.model = 'material';
 		this.uuid = uuid;
 		this.differentiator = differentiator?.trim() || '';
 
@@ -37,6 +36,12 @@ export default class Material extends Base {
 				: [];
 
 		}
+
+	}
+
+	get model () {
+
+		return 'material';
 
 	}
 

--- a/src/models/Person.js
+++ b/src/models/Person.js
@@ -8,9 +8,14 @@ export default class Person extends Base {
 
 		const { uuid, differentiator } = props;
 
-		this.model = 'person';
 		this.uuid = uuid;
 		this.differentiator = differentiator?.trim() || '';
+
+	}
+
+	get model () {
+
+		return 'person';
 
 	}
 

--- a/src/models/Production.js
+++ b/src/models/Production.js
@@ -10,7 +10,6 @@ export default class Production extends Base {
 
 		const { uuid, theatre, material, cast, creativeCredits } = props;
 
-		this.model = 'production';
 		this.uuid = uuid;
 		this.material = new Material({ ...material, isAssociation: true });
 		this.theatre = new Theatre({ ...theatre, isAssociation: true });
@@ -20,6 +19,12 @@ export default class Production extends Base {
 		this.creativeCredits = creativeCredits
 			? creativeCredits.map(creativeCredit => new CreativeCredit(creativeCredit))
 			: [];
+
+	}
+
+	get model () {
+
+		return 'production';
 
 	}
 

--- a/src/models/Role.js
+++ b/src/models/Role.js
@@ -8,10 +8,15 @@ export default class Role extends Base {
 
 		const { characterName, characterDifferentiator, qualifier } = props;
 
-		this.model = 'role';
 		this.characterName = characterName?.trim() || '';
 		this.characterDifferentiator = characterDifferentiator?.trim() || '';
 		this.qualifier = qualifier?.trim() || '';
+
+	}
+
+	get model () {
+
+		return 'role';
 
 	}
 

--- a/src/models/Theatre.js
+++ b/src/models/Theatre.js
@@ -9,7 +9,6 @@ export default class Theatre extends Base {
 
 		const { uuid, differentiator, subTheatres, isAssociation } = props;
 
-		this.model = 'theatre';
 		this.uuid = uuid;
 		this.differentiator = differentiator?.trim() || '';
 
@@ -20,6 +19,12 @@ export default class Theatre extends Base {
 				: [];
 
 		}
+
+	}
+
+	get model () {
+
+		return 'theatre';
 
 	}
 

--- a/src/models/WritingCredit.js
+++ b/src/models/WritingCredit.js
@@ -11,7 +11,6 @@ export default class WritingCredit extends Base {
 
 		const { creditType, writingEntities } = props;
 
-		this.model = 'writingCredit';
 		this.creditType = CREDIT_TYPES[creditType] || null;
 
 		this.writingEntities = writingEntities
@@ -26,6 +25,12 @@ export default class WritingCredit extends Base {
 				}
 			})
 			: [];
+
+	}
+
+	get model () {
+
+		return 'writingCredit';
 
 	}
 

--- a/test-int/instance-validation-failures/character.test.js
+++ b/test-int/instance-validation-failures/character.test.js
@@ -34,7 +34,6 @@ describe('Character instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'character',
 					uuid: undefined,
 					name: '',
 					differentiator: '',
@@ -61,7 +60,6 @@ describe('Character instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'character',
 					uuid: undefined,
 					name: ABOVE_MAX_LENGTH_STRING,
 					differentiator: '',
@@ -88,7 +86,6 @@ describe('Character instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'character',
 					uuid: undefined,
 					name: 'Hamlet',
 					differentiator: ABOVE_MAX_LENGTH_STRING,
@@ -125,7 +122,6 @@ describe('Character instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'character',
 					uuid: undefined,
 					name: 'Hamlet',
 					differentiator: '',

--- a/test-int/instance-validation-failures/company.test.js
+++ b/test-int/instance-validation-failures/company.test.js
@@ -34,7 +34,6 @@ describe('Company instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'company',
 					uuid: undefined,
 					name: '',
 					differentiator: '',
@@ -61,7 +60,6 @@ describe('Company instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'company',
 					uuid: undefined,
 					name: ABOVE_MAX_LENGTH_STRING,
 					differentiator: '',
@@ -88,7 +86,6 @@ describe('Company instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'company',
 					uuid: undefined,
 					name: 'Playful Productions',
 					differentiator: ABOVE_MAX_LENGTH_STRING,
@@ -125,7 +122,6 @@ describe('Company instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'company',
 					uuid: undefined,
 					name: 'Playful Productions',
 					differentiator: '',

--- a/test-int/instance-validation-failures/material.test.js
+++ b/test-int/instance-validation-failures/material.test.js
@@ -34,7 +34,6 @@ describe('Material instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'material',
 					uuid: undefined,
 					name: '',
 					differentiator: '',
@@ -46,7 +45,6 @@ describe('Material instance', () => {
 						]
 					},
 					originalVersionMaterial: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -71,7 +69,6 @@ describe('Material instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'material',
 					uuid: undefined,
 					name: ABOVE_MAX_LENGTH_STRING,
 					differentiator: '',
@@ -83,7 +80,6 @@ describe('Material instance', () => {
 						]
 					},
 					originalVersionMaterial: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -108,7 +104,6 @@ describe('Material instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'material',
 					uuid: undefined,
 					name: 'Rosmersholm',
 					differentiator: ABOVE_MAX_LENGTH_STRING,
@@ -120,7 +115,6 @@ describe('Material instance', () => {
 						]
 					},
 					originalVersionMaterial: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -145,7 +139,6 @@ describe('Material instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'material',
 					uuid: undefined,
 					name: 'Rosmersholm',
 					differentiator: '',
@@ -157,7 +150,6 @@ describe('Material instance', () => {
 						]
 					},
 					originalVersionMaterial: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -189,7 +181,6 @@ describe('Material instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'material',
 					uuid: undefined,
 					name: 'Rosmersholm',
 					differentiator: '',
@@ -197,7 +188,6 @@ describe('Material instance', () => {
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
-						model: 'material',
 						uuid: undefined,
 						name: ABOVE_MAX_LENGTH_STRING,
 						differentiator: '',
@@ -234,7 +224,6 @@ describe('Material instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'material',
 					uuid: undefined,
 					name: 'Rosmersholm',
 					differentiator: '',
@@ -242,7 +231,6 @@ describe('Material instance', () => {
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
-						model: 'material',
 						uuid: undefined,
 						name: 'Rosmersholm',
 						differentiator: ABOVE_MAX_LENGTH_STRING,
@@ -278,7 +266,6 @@ describe('Material instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'material',
 					uuid: undefined,
 					name: 'Rosmersholm',
 					differentiator: '',
@@ -286,7 +273,6 @@ describe('Material instance', () => {
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
-						model: 'material',
 						uuid: undefined,
 						name: 'Rosmersholm',
 						differentiator: '',
@@ -327,7 +313,6 @@ describe('Material instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'material',
 					uuid: undefined,
 					name: 'Rosmersholm',
 					differentiator: '',
@@ -335,7 +320,6 @@ describe('Material instance', () => {
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -343,7 +327,6 @@ describe('Material instance', () => {
 					},
 					writingCredits: [
 						{
-							model: 'writingCredit',
 							name: ABOVE_MAX_LENGTH_STRING,
 							creditType: null,
 							errors: {
@@ -384,7 +367,6 @@ describe('Material instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'material',
 					uuid: undefined,
 					name: 'Rosmersholm',
 					differentiator: '',
@@ -392,7 +374,6 @@ describe('Material instance', () => {
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -400,7 +381,6 @@ describe('Material instance', () => {
 					},
 					writingCredits: [
 						{
-							model: 'writingCredit',
 							name: 'version by',
 							creditType: null,
 							errors: {
@@ -411,7 +391,6 @@ describe('Material instance', () => {
 							writingEntities: []
 						},
 						{
-							model: 'writingCredit',
 							name: 'version by',
 							creditType: null,
 							errors: {
@@ -453,7 +432,6 @@ describe('Material instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'material',
 					uuid: undefined,
 					name: 'Rosmersholm',
 					differentiator: '',
@@ -461,7 +439,6 @@ describe('Material instance', () => {
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -469,13 +446,11 @@ describe('Material instance', () => {
 					},
 					writingCredits: [
 						{
-							model: 'writingCredit',
 							name: '',
 							creditType: null,
 							errors: {},
 							writingEntities: [
 								{
-									model: 'person',
 									uuid: undefined,
 									name: ABOVE_MAX_LENGTH_STRING,
 									differentiator: '',
@@ -520,7 +495,6 @@ describe('Material instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'material',
 					uuid: undefined,
 					name: 'Rosmersholm',
 					differentiator: '',
@@ -528,7 +502,6 @@ describe('Material instance', () => {
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -536,13 +509,11 @@ describe('Material instance', () => {
 					},
 					writingCredits: [
 						{
-							model: 'writingCredit',
 							name: '',
 							creditType: null,
 							errors: {},
 							writingEntities: [
 								{
-									model: 'person',
 									uuid: undefined,
 									name: 'Henrik Ibsen',
 									differentiator: ABOVE_MAX_LENGTH_STRING,
@@ -587,7 +558,6 @@ describe('Material instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'material',
 					uuid: undefined,
 					name: 'Rosmersholm',
 					differentiator: '',
@@ -595,7 +565,6 @@ describe('Material instance', () => {
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -603,13 +572,11 @@ describe('Material instance', () => {
 					},
 					writingCredits: [
 						{
-							model: 'writingCredit',
 							name: '',
 							creditType: null,
 							errors: {},
 							writingEntities: [
 								{
-									model: 'company',
 									uuid: undefined,
 									name: ABOVE_MAX_LENGTH_STRING,
 									differentiator: '',
@@ -655,7 +622,6 @@ describe('Material instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'material',
 					uuid: undefined,
 					name: 'Rosmersholm',
 					differentiator: '',
@@ -663,7 +629,6 @@ describe('Material instance', () => {
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -671,13 +636,11 @@ describe('Material instance', () => {
 					},
 					writingCredits: [
 						{
-							model: 'writingCredit',
 							name: '',
 							creditType: null,
 							errors: {},
 							writingEntities: [
 								{
-									model: 'company',
 									uuid: undefined,
 									name: 'Ibsen Theatre Company',
 									differentiator: ABOVE_MAX_LENGTH_STRING,
@@ -722,7 +685,6 @@ describe('Material instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'material',
 					uuid: undefined,
 					name: 'Rosmersholm',
 					differentiator: '',
@@ -730,7 +692,6 @@ describe('Material instance', () => {
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -738,13 +699,11 @@ describe('Material instance', () => {
 					},
 					writingCredits: [
 						{
-							model: 'writingCredit',
 							name: '',
 							creditType: null,
 							errors: {},
 							writingEntities: [
 								{
-									model: 'material',
 									uuid: undefined,
 									name: ABOVE_MAX_LENGTH_STRING,
 									differentiator: '',
@@ -790,7 +749,6 @@ describe('Material instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'material',
 					uuid: undefined,
 					name: 'Rosmersholm',
 					differentiator: '',
@@ -798,7 +756,6 @@ describe('Material instance', () => {
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -806,13 +763,11 @@ describe('Material instance', () => {
 					},
 					writingCredits: [
 						{
-							model: 'writingCredit',
 							name: '',
 							creditType: null,
 							errors: {},
 							writingEntities: [
 								{
-									model: 'material',
 									uuid: undefined,
 									name: 'Rosmersholm',
 									differentiator: ABOVE_MAX_LENGTH_STRING,
@@ -859,7 +814,6 @@ describe('Material instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'material',
 					uuid: undefined,
 					name: 'Rosmersholm',
 					differentiator: '',
@@ -867,7 +821,6 @@ describe('Material instance', () => {
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -875,13 +828,11 @@ describe('Material instance', () => {
 					},
 					writingCredits: [
 						{
-							model: 'writingCredit',
 							name: '',
 							creditType: null,
 							errors: {},
 							writingEntities: [
 								{
-									model: 'person',
 									uuid: undefined,
 									name: 'Henrik Ibsen',
 									differentiator: '',
@@ -895,7 +846,6 @@ describe('Material instance', () => {
 									}
 								},
 								{
-									model: 'person',
 									uuid: undefined,
 									name: 'Henrik Ibsen',
 									differentiator: '',
@@ -943,7 +893,6 @@ describe('Material instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'material',
 					uuid: undefined,
 					name: 'Rosmersholm',
 					differentiator: '',
@@ -951,7 +900,6 @@ describe('Material instance', () => {
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -959,13 +907,11 @@ describe('Material instance', () => {
 					},
 					writingCredits: [
 						{
-							model: 'writingCredit',
 							name: '',
 							creditType: null,
 							errors: {},
 							writingEntities: [
 								{
-									model: 'material',
 									uuid: undefined,
 									name: 'Rosmersholm',
 									differentiator: '',
@@ -1008,7 +954,6 @@ describe('Material instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'material',
 					uuid: undefined,
 					name: 'Rosmersholm',
 					differentiator: '',
@@ -1016,7 +961,6 @@ describe('Material instance', () => {
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -1025,7 +969,6 @@ describe('Material instance', () => {
 					writingCredits: [],
 					characterGroups: [
 						{
-							model: 'characterGroup',
 							name: ABOVE_MAX_LENGTH_STRING,
 							errors: {
 								name: [
@@ -1064,7 +1007,6 @@ describe('Material instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'material',
 					uuid: undefined,
 					name: 'Rosmersholm',
 					differentiator: '',
@@ -1072,7 +1014,6 @@ describe('Material instance', () => {
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -1081,7 +1022,6 @@ describe('Material instance', () => {
 					writingCredits: [],
 					characterGroups: [
 						{
-							model: 'characterGroup',
 							name: 'Rosmersholm residents',
 							errors: {
 								name: [
@@ -1091,7 +1031,6 @@ describe('Material instance', () => {
 							characters: []
 						},
 						{
-							model: 'characterGroup',
 							name: 'Rosmersholm residents',
 							errors: {
 								name: [
@@ -1131,7 +1070,6 @@ describe('Material instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'material',
 					uuid: undefined,
 					name: 'Rosmersholm',
 					differentiator: '',
@@ -1139,7 +1077,6 @@ describe('Material instance', () => {
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -1148,12 +1085,10 @@ describe('Material instance', () => {
 					writingCredits: [],
 					characterGroups: [
 						{
-							model: 'characterGroup',
 							name: '',
 							errors: {},
 							characters: [
 								{
-									model: 'character',
 									uuid: undefined,
 									name: ABOVE_MAX_LENGTH_STRING,
 									underlyingName: '',
@@ -1199,7 +1134,6 @@ describe('Material instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'material',
 					uuid: undefined,
 					name: 'Rosmersholm',
 					differentiator: '',
@@ -1207,7 +1141,6 @@ describe('Material instance', () => {
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -1216,12 +1149,10 @@ describe('Material instance', () => {
 					writingCredits: [],
 					characterGroups: [
 						{
-							model: 'characterGroup',
 							name: '',
 							errors: {},
 							characters: [
 								{
-									model: 'character',
 									uuid: undefined,
 									name: 'Johannes Rosmer',
 									underlyingName: ABOVE_MAX_LENGTH_STRING,
@@ -1267,7 +1198,6 @@ describe('Material instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'material',
 					uuid: undefined,
 					name: 'Rosmersholm',
 					differentiator: '',
@@ -1275,7 +1205,6 @@ describe('Material instance', () => {
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -1284,12 +1213,10 @@ describe('Material instance', () => {
 					writingCredits: [],
 					characterGroups: [
 						{
-							model: 'characterGroup',
 							name: '',
 							errors: {},
 							characters: [
 								{
-									model: 'character',
 									uuid: undefined,
 									name: 'Johannes Rosmer',
 									underlyingName: '',
@@ -1335,7 +1262,6 @@ describe('Material instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'material',
 					uuid: undefined,
 					name: 'Rosmersholm',
 					differentiator: '',
@@ -1343,7 +1269,6 @@ describe('Material instance', () => {
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -1352,12 +1277,10 @@ describe('Material instance', () => {
 					writingCredits: [],
 					characterGroups: [
 						{
-							model: 'characterGroup',
 							name: '',
 							errors: {},
 							characters: [
 								{
-									model: 'character',
 									uuid: undefined,
 									name: 'Johannes Rosmer',
 									underlyingName: '',
@@ -1403,7 +1326,6 @@ describe('Material instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'material',
 					uuid: undefined,
 					name: 'Rosmersholm',
 					differentiator: '',
@@ -1411,7 +1333,6 @@ describe('Material instance', () => {
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -1420,12 +1341,10 @@ describe('Material instance', () => {
 					writingCredits: [],
 					characterGroups: [
 						{
-							model: 'characterGroup',
 							name: '',
 							errors: {},
 							characters: [
 								{
-									model: 'character',
 									uuid: undefined,
 									name: 'Johannes Rosmer',
 									underlyingName: 'Johannes Rosmer',
@@ -1476,7 +1395,6 @@ describe('Material instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'material',
 					uuid: undefined,
 					name: 'Rosmersholm',
 					differentiator: '',
@@ -1484,7 +1402,6 @@ describe('Material instance', () => {
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -1493,12 +1410,10 @@ describe('Material instance', () => {
 					writingCredits: [],
 					characterGroups: [
 						{
-							model: 'characterGroup',
 							name: '',
 							errors: {},
 							characters: [
 								{
-									model: 'character',
 									uuid: undefined,
 									name: 'Johannes Rosmer',
 									underlyingName: '',
@@ -1520,7 +1435,6 @@ describe('Material instance', () => {
 									}
 								},
 								{
-									model: 'character',
 									uuid: undefined,
 									name: 'Rebecca West',
 									underlyingName: '',
@@ -1529,7 +1443,6 @@ describe('Material instance', () => {
 									errors: {}
 								},
 								{
-									model: 'character',
 									uuid: undefined,
 									name: 'Johannes Rosmer',
 									underlyingName: '',
@@ -1580,7 +1493,6 @@ describe('Material instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'material',
 					uuid: undefined,
 					name: 'Rosmersholm',
 					differentiator: '',
@@ -1595,7 +1507,6 @@ describe('Material instance', () => {
 						]
 					},
 					originalVersionMaterial: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -1643,7 +1554,6 @@ describe('Material instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'material',
 					uuid: undefined,
 					name: 'Rosmersholm',
 					differentiator: '',
@@ -1658,7 +1568,6 @@ describe('Material instance', () => {
 						]
 					},
 					originalVersionMaterial: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -1667,12 +1576,10 @@ describe('Material instance', () => {
 					writingCredits: [],
 					characterGroups: [
 						{
-							model: 'characterGroup',
 							name: '',
 							errors: {},
 							characters: [
 								{
-									model: 'character',
 									uuid: undefined,
 									name: ABOVE_MAX_LENGTH_STRING,
 									underlyingName: '',

--- a/test-int/instance-validation-failures/person.test.js
+++ b/test-int/instance-validation-failures/person.test.js
@@ -34,7 +34,6 @@ describe('Person instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'person',
 					uuid: undefined,
 					name: '',
 					differentiator: '',
@@ -61,7 +60,6 @@ describe('Person instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'person',
 					uuid: undefined,
 					name: ABOVE_MAX_LENGTH_STRING,
 					differentiator: '',
@@ -88,7 +86,6 @@ describe('Person instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'person',
 					uuid: undefined,
 					name: 'Helen Mirren',
 					differentiator: ABOVE_MAX_LENGTH_STRING,
@@ -125,7 +122,6 @@ describe('Person instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'person',
 					uuid: undefined,
 					name: 'Helen Mirren',
 					differentiator: '',

--- a/test-int/instance-validation-failures/production.test.js
+++ b/test-int/instance-validation-failures/production.test.js
@@ -38,7 +38,6 @@ describe('Production instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'production',
 					uuid: undefined,
 					name: '',
 					hasErrors: true,
@@ -48,14 +47,12 @@ describe('Production instance', () => {
 						]
 					},
 					material: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
 						errors: {}
 					},
 					theatre: {
-						model: 'theatre',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -84,7 +81,6 @@ describe('Production instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'production',
 					uuid: undefined,
 					name: ABOVE_MAX_LENGTH_STRING,
 					hasErrors: true,
@@ -94,14 +90,12 @@ describe('Production instance', () => {
 						]
 					},
 					material: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
 						errors: {}
 					},
 					theatre: {
-						model: 'theatre',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -133,13 +127,11 @@ describe('Production instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'production',
 					uuid: undefined,
 					name: 'Hamlet',
 					hasErrors: true,
 					errors: {},
 					material: {
-						model: 'material',
 						uuid: undefined,
 						name: ABOVE_MAX_LENGTH_STRING,
 						differentiator: '',
@@ -150,7 +142,6 @@ describe('Production instance', () => {
 						}
 					},
 					theatre: {
-						model: 'theatre',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -183,13 +174,11 @@ describe('Production instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'production',
 					uuid: undefined,
 					name: 'Hamlet',
 					hasErrors: true,
 					errors: {},
 					material: {
-						model: 'material',
 						uuid: undefined,
 						name: 'Hamlet',
 						differentiator: ABOVE_MAX_LENGTH_STRING,
@@ -200,7 +189,6 @@ describe('Production instance', () => {
 						}
 					},
 					theatre: {
-						model: 'theatre',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -232,20 +220,17 @@ describe('Production instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'production',
 					uuid: undefined,
 					name: 'Hamlet',
 					hasErrors: true,
 					errors: {},
 					material: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
 						errors: {}
 					},
 					theatre: {
-						model: 'theatre',
 						uuid: undefined,
 						name: ABOVE_MAX_LENGTH_STRING,
 						differentiator: '',
@@ -282,20 +267,17 @@ describe('Production instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'production',
 					uuid: undefined,
 					name: 'Hamlet',
 					hasErrors: true,
 					errors: {},
 					material: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
 						errors: {}
 					},
 					theatre: {
-						model: 'theatre',
 						uuid: undefined,
 						name: 'National Theatre',
 						differentiator: ABOVE_MAX_LENGTH_STRING,
@@ -334,20 +316,17 @@ describe('Production instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'production',
 					uuid: undefined,
 					name: 'Hamlet',
 					hasErrors: true,
 					errors: {},
 					material: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
 						errors: {}
 					},
 					theatre: {
-						model: 'theatre',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -355,7 +334,6 @@ describe('Production instance', () => {
 					},
 					cast: [
 						{
-							model: 'person',
 							uuid: undefined,
 							name: ABOVE_MAX_LENGTH_STRING,
 							differentiator: '',
@@ -396,20 +374,17 @@ describe('Production instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'production',
 					uuid: undefined,
 					name: 'Hamlet',
 					hasErrors: true,
 					errors: {},
 					material: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
 						errors: {}
 					},
 					theatre: {
-						model: 'theatre',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -417,7 +392,6 @@ describe('Production instance', () => {
 					},
 					cast: [
 						{
-							model: 'person',
 							uuid: undefined,
 							name: 'Rory Kinnear',
 							differentiator: ABOVE_MAX_LENGTH_STRING,
@@ -462,20 +436,17 @@ describe('Production instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'production',
 					uuid: undefined,
 					name: 'Hamlet',
 					hasErrors: true,
 					errors: {},
 					material: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
 						errors: {}
 					},
 					theatre: {
-						model: 'theatre',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -483,7 +454,6 @@ describe('Production instance', () => {
 					},
 					cast: [
 						{
-							model: 'person',
 							uuid: undefined,
 							name: 'Rory Kinnear',
 							differentiator: '',
@@ -498,7 +468,6 @@ describe('Production instance', () => {
 							roles: []
 						},
 						{
-							model: 'person',
 							uuid: undefined,
 							name: 'Clare Higgins',
 							differentiator: '',
@@ -506,7 +475,6 @@ describe('Production instance', () => {
 							roles: []
 						},
 						{
-							model: 'person',
 							uuid: undefined,
 							name: 'Rory Kinnear',
 							differentiator: '',
@@ -553,20 +521,17 @@ describe('Production instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'production',
 					uuid: undefined,
 					name: 'Hamlet',
 					hasErrors: true,
 					errors: {},
 					material: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
 						errors: {}
 					},
 					theatre: {
-						model: 'theatre',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -574,7 +539,6 @@ describe('Production instance', () => {
 					},
 					cast: [
 						{
-							model: 'person',
 							uuid: undefined,
 							name: '',
 							differentiator: '',
@@ -585,7 +549,6 @@ describe('Production instance', () => {
 							},
 							roles: [
 								{
-									model: 'role',
 									name: 'Hamlet',
 									characterName: '',
 									characterDifferentiator: '',
@@ -628,20 +591,17 @@ describe('Production instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'production',
 					uuid: undefined,
 					name: 'Hamlet',
 					hasErrors: true,
 					errors: {},
 					material: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
 						errors: {}
 					},
 					theatre: {
-						model: 'theatre',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -649,14 +609,12 @@ describe('Production instance', () => {
 					},
 					cast: [
 						{
-							model: 'person',
 							uuid: undefined,
 							name: 'Rory Kinnear',
 							differentiator: '',
 							errors: {},
 							roles: [
 								{
-									model: 'role',
 									name: ABOVE_MAX_LENGTH_STRING,
 									characterName: '',
 									characterDifferentiator: '',
@@ -703,20 +661,17 @@ describe('Production instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'production',
 					uuid: undefined,
 					name: 'Hamlet',
 					hasErrors: true,
 					errors: {},
 					material: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
 						errors: {}
 					},
 					theatre: {
-						model: 'theatre',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -724,14 +679,12 @@ describe('Production instance', () => {
 					},
 					cast: [
 						{
-							model: 'person',
 							uuid: undefined,
 							name: 'Rory Kinnear',
 							differentiator: '',
 							errors: {},
 							roles: [
 								{
-									model: 'role',
 									name: 'Hamlet',
 									characterName: ABOVE_MAX_LENGTH_STRING,
 									characterDifferentiator: '',
@@ -779,20 +732,17 @@ describe('Production instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'production',
 					uuid: undefined,
 					name: 'Hamlet',
 					hasErrors: true,
 					errors: {},
 					material: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
 						errors: {}
 					},
 					theatre: {
-						model: 'theatre',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -800,14 +750,12 @@ describe('Production instance', () => {
 					},
 					cast: [
 						{
-							model: 'person',
 							uuid: undefined,
 							name: 'Rory Kinnear',
 							differentiator: '',
 							errors: {},
 							roles: [
 								{
-									model: 'role',
 									name: 'Hamlet',
 									characterName: '',
 									characterDifferentiator: ABOVE_MAX_LENGTH_STRING,
@@ -854,20 +802,17 @@ describe('Production instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'production',
 					uuid: undefined,
 					name: 'Hamlet',
 					hasErrors: true,
 					errors: {},
 					material: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
 						errors: {}
 					},
 					theatre: {
-						model: 'theatre',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -875,14 +820,12 @@ describe('Production instance', () => {
 					},
 					cast: [
 						{
-							model: 'person',
 							uuid: undefined,
 							name: 'Rory Kinnear',
 							differentiator: '',
 							errors: {},
 							roles: [
 								{
-									model: 'role',
 									name: 'Hamlet',
 									characterName: '',
 									characterDifferentiator: '',
@@ -929,20 +872,17 @@ describe('Production instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'production',
 					uuid: undefined,
 					name: 'Hamlet',
 					hasErrors: true,
 					errors: {},
 					material: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
 						errors: {}
 					},
 					theatre: {
-						model: 'theatre',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -950,14 +890,12 @@ describe('Production instance', () => {
 					},
 					cast: [
 						{
-							model: 'person',
 							uuid: undefined,
 							name: 'Rory Kinnear',
 							differentiator: '',
 							errors: {},
 							roles: [
 								{
-									model: 'role',
 									name: 'Hamlet',
 									characterName: 'Hamlet',
 									characterDifferentiator: '',
@@ -1009,20 +947,17 @@ describe('Production instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'production',
 					uuid: undefined,
 					name: 'Hamlet',
 					hasErrors: true,
 					errors: {},
 					material: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
 						errors: {}
 					},
 					theatre: {
-						model: 'theatre',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -1030,14 +965,12 @@ describe('Production instance', () => {
 					},
 					cast: [
 						{
-							model: 'person',
 							uuid: undefined,
 							name: 'David Calder',
 							differentiator: '',
 							errors: {},
 							roles: [
 								{
-									model: 'role',
 									name: 'Polonius',
 									characterName: '',
 									characterDifferentiator: '',
@@ -1058,7 +991,6 @@ describe('Production instance', () => {
 									}
 								},
 								{
-									model: 'role',
 									name: 'Gravedigger',
 									characterName: '',
 									characterDifferentiator: '',
@@ -1066,7 +998,6 @@ describe('Production instance', () => {
 									errors: {}
 								},
 								{
-									model: 'role',
 									name: 'Polonius',
 									characterName: '',
 									characterDifferentiator: '',
@@ -1116,20 +1047,17 @@ describe('Production instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'production',
 					uuid: undefined,
 					name: 'Hamlet',
 					hasErrors: true,
 					errors: {},
 					material: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
 						errors: {}
 					},
 					theatre: {
-						model: 'theatre',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -1138,7 +1066,6 @@ describe('Production instance', () => {
 					cast: [],
 					creativeCredits: [
 						{
-							model: 'creativeCredit',
 							name: ABOVE_MAX_LENGTH_STRING,
 							errors: {
 								name: [
@@ -1177,20 +1104,17 @@ describe('Production instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'production',
 					uuid: undefined,
 					name: 'Hamlet',
 					hasErrors: true,
 					errors: {},
 					material: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
 						errors: {}
 					},
 					theatre: {
-						model: 'theatre',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -1199,7 +1123,6 @@ describe('Production instance', () => {
 					cast: [],
 					creativeCredits: [
 						{
-							model: 'creativeCredit',
 							name: 'Sound Design',
 							errors: {
 								name: [
@@ -1209,7 +1132,6 @@ describe('Production instance', () => {
 							creativeEntities: []
 						},
 						{
-							model: 'creativeCredit',
 							name: 'Sound Design',
 							errors: {
 								name: [
@@ -1250,20 +1172,17 @@ describe('Production instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'production',
 					uuid: undefined,
 					name: 'Hamlet',
 					hasErrors: true,
 					errors: {},
 					material: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
 						errors: {}
 					},
 					theatre: {
-						model: 'theatre',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -1272,7 +1191,6 @@ describe('Production instance', () => {
 					cast: [],
 					creativeCredits: [
 						{
-							model: 'creativeCredit',
 							name: '',
 							errors: {
 								name: [
@@ -1281,7 +1199,6 @@ describe('Production instance', () => {
 							},
 							creativeEntities: [
 								{
-									model: 'person',
 									uuid: undefined,
 									name: 'Paul Groothuis',
 									differentiator: '',
@@ -1321,20 +1238,17 @@ describe('Production instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'production',
 					uuid: undefined,
 					name: 'Hamlet',
 					hasErrors: true,
 					errors: {},
 					material: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
 						errors: {}
 					},
 					theatre: {
-						model: 'theatre',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -1343,12 +1257,10 @@ describe('Production instance', () => {
 					cast: [],
 					creativeCredits: [
 						{
-							model: 'creativeCredit',
 							name: 'Sound Design',
 							errors: {},
 							creativeEntities: [
 								{
-									model: 'person',
 									uuid: undefined,
 									name: ABOVE_MAX_LENGTH_STRING,
 									differentiator: '',
@@ -1393,20 +1305,17 @@ describe('Production instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'production',
 					uuid: undefined,
 					name: 'Hamlet',
 					hasErrors: true,
 					errors: {},
 					material: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
 						errors: {}
 					},
 					theatre: {
-						model: 'theatre',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -1415,12 +1324,10 @@ describe('Production instance', () => {
 					cast: [],
 					creativeCredits: [
 						{
-							model: 'creativeCredit',
 							name: 'Sound Design',
 							errors: {},
 							creativeEntities: [
 								{
-									model: 'person',
 									uuid: undefined,
 									name: 'Paul Groothuis',
 									differentiator: ABOVE_MAX_LENGTH_STRING,
@@ -1465,20 +1372,17 @@ describe('Production instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'production',
 					uuid: undefined,
 					name: 'Hamlet',
 					hasErrors: true,
 					errors: {},
 					material: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
 						errors: {}
 					},
 					theatre: {
-						model: 'theatre',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -1487,12 +1391,10 @@ describe('Production instance', () => {
 					cast: [],
 					creativeCredits: [
 						{
-							model: 'creativeCredit',
 							name: 'Sound Design',
 							errors: {},
 							creativeEntities: [
 								{
-									model: 'company',
 									uuid: undefined,
 									name: ABOVE_MAX_LENGTH_STRING,
 									differentiator: '',
@@ -1539,20 +1441,17 @@ describe('Production instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'production',
 					uuid: undefined,
 					name: 'Hamlet',
 					hasErrors: true,
 					errors: {},
 					material: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
 						errors: {}
 					},
 					theatre: {
-						model: 'theatre',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -1561,12 +1460,10 @@ describe('Production instance', () => {
 					cast: [],
 					creativeCredits: [
 						{
-							model: 'creativeCredit',
 							name: 'Sound Design',
 							errors: {},
 							creativeEntities: [
 								{
-									model: 'company',
 									uuid: undefined,
 									name: 'Autograph',
 									differentiator: ABOVE_MAX_LENGTH_STRING,
@@ -1634,20 +1531,17 @@ describe('Production instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'production',
 					uuid: undefined,
 					name: 'Hamlet',
 					hasErrors: true,
 					errors: {},
 					material: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
 						errors: {}
 					},
 					theatre: {
-						model: 'theatre',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -1656,12 +1550,10 @@ describe('Production instance', () => {
 					cast: [],
 					creativeCredits: [
 						{
-							model: 'creativeCredit',
 							name: 'Sound Design',
 							errors: {},
 							creativeEntities: [
 								{
-									model: 'company',
 									uuid: undefined,
 									name: 'Autograph',
 									differentiator: '',
@@ -1675,7 +1567,6 @@ describe('Production instance', () => {
 									},
 									creditedMembers: [
 										{
-											model: 'person',
 											uuid: undefined,
 											name: 'Andrew Bruce',
 											differentiator: '',
@@ -1689,7 +1580,6 @@ describe('Production instance', () => {
 											}
 										},
 										{
-											model: 'person',
 											uuid: undefined,
 											name: 'Nick Lidster',
 											differentiator: '',
@@ -1698,7 +1588,6 @@ describe('Production instance', () => {
 									]
 								},
 								{
-									model: 'company',
 									uuid: undefined,
 									name: '59 Productions',
 									differentiator: '',
@@ -1706,7 +1595,6 @@ describe('Production instance', () => {
 									creditedMembers: []
 								},
 								{
-									model: 'person',
 									uuid: undefined,
 									name: 'Andrew Bruce',
 									differentiator: '',
@@ -1720,7 +1608,6 @@ describe('Production instance', () => {
 									}
 								},
 								{
-									model: 'company',
 									uuid: undefined,
 									name: 'Autograph',
 									differentiator: '',
@@ -1735,7 +1622,6 @@ describe('Production instance', () => {
 									creditedMembers: []
 								},
 								{
-									model: 'person',
 									uuid: undefined,
 									name: 'Gregory Clarke',
 									differentiator: '',
@@ -1782,20 +1668,17 @@ describe('Production instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'production',
 					uuid: undefined,
 					name: 'Hamlet',
 					hasErrors: true,
 					errors: {},
 					material: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
 						errors: {}
 					},
 					theatre: {
-						model: 'theatre',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -1804,12 +1687,10 @@ describe('Production instance', () => {
 					cast: [],
 					creativeCredits: [
 						{
-							model: 'creativeCredit',
 							name: 'Sound Design',
 							errors: {},
 							creativeEntities: [
 								{
-									model: 'company',
 									uuid: undefined,
 									name: '',
 									differentiator: '',
@@ -1820,7 +1701,6 @@ describe('Production instance', () => {
 									},
 									creditedMembers: [
 										{
-											model: 'person',
 											uuid: undefined,
 											name: 'Andrew Bruce',
 											differentiator: '',
@@ -1868,20 +1748,17 @@ describe('Production instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'production',
 					uuid: undefined,
 					name: 'Hamlet',
 					hasErrors: true,
 					errors: {},
 					material: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
 						errors: {}
 					},
 					theatre: {
-						model: 'theatre',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -1890,19 +1767,16 @@ describe('Production instance', () => {
 					cast: [],
 					creativeCredits: [
 						{
-							model: 'creativeCredit',
 							name: 'Sound Design',
 							errors: {},
 							creativeEntities: [
 								{
-									model: 'company',
 									uuid: undefined,
 									name: 'Autograph',
 									differentiator: '',
 									errors: {},
 									creditedMembers: [
 										{
-											model: 'person',
 											uuid: undefined,
 											name: ABOVE_MAX_LENGTH_STRING,
 											differentiator: '',
@@ -1955,20 +1829,17 @@ describe('Production instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'production',
 					uuid: undefined,
 					name: 'Hamlet',
 					hasErrors: true,
 					errors: {},
 					material: {
-						model: 'material',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
 						errors: {}
 					},
 					theatre: {
-						model: 'theatre',
 						uuid: undefined,
 						name: '',
 						differentiator: '',
@@ -1977,19 +1848,16 @@ describe('Production instance', () => {
 					cast: [],
 					creativeCredits: [
 						{
-							model: 'creativeCredit',
 							name: 'Sound Design',
 							errors: {},
 							creativeEntities: [
 								{
-									model: 'company',
 									uuid: undefined,
 									name: 'Autograph',
 									differentiator: '',
 									errors: {},
 									creditedMembers: [
 										{
-											model: 'person',
 											uuid: undefined,
 											name: 'Andrew Bruce',
 											differentiator: ABOVE_MAX_LENGTH_STRING,

--- a/test-int/instance-validation-failures/theatre.test.js
+++ b/test-int/instance-validation-failures/theatre.test.js
@@ -34,7 +34,6 @@ describe('Theatre instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'theatre',
 					uuid: undefined,
 					name: '',
 					differentiator: '',
@@ -62,7 +61,6 @@ describe('Theatre instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'theatre',
 					uuid: undefined,
 					name: ABOVE_MAX_LENGTH_STRING,
 					differentiator: '',
@@ -90,7 +88,6 @@ describe('Theatre instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'theatre',
 					uuid: undefined,
 					name: 'National Theatre',
 					differentiator: ABOVE_MAX_LENGTH_STRING,
@@ -127,7 +124,6 @@ describe('Theatre instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'theatre',
 					uuid: undefined,
 					name: 'National Theatre',
 					differentiator: '',
@@ -135,7 +131,6 @@ describe('Theatre instance', () => {
 					errors: {},
 					subTheatres: [
 						{
-							model: 'theatre',
 							uuid: undefined,
 							name: ABOVE_MAX_LENGTH_STRING,
 							differentiator: '',
@@ -173,7 +168,6 @@ describe('Theatre instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'theatre',
 					uuid: undefined,
 					name: 'National Theatre',
 					differentiator: '',
@@ -181,7 +175,6 @@ describe('Theatre instance', () => {
 					errors: {},
 					subTheatres: [
 						{
-							model: 'theatre',
 							uuid: undefined,
 							name: 'Olivier Theatre',
 							differentiator: ABOVE_MAX_LENGTH_STRING,
@@ -218,7 +211,6 @@ describe('Theatre instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'theatre',
 					uuid: undefined,
 					name: 'National Theatre',
 					differentiator: '',
@@ -226,7 +218,6 @@ describe('Theatre instance', () => {
 					errors: {},
 					subTheatres: [
 						{
-							model: 'theatre',
 							uuid: undefined,
 							name: 'National Theatre',
 							differentiator: '',
@@ -272,7 +263,6 @@ describe('Theatre instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'theatre',
 					uuid: undefined,
 					name: 'National Theatre',
 					differentiator: '',
@@ -280,7 +270,6 @@ describe('Theatre instance', () => {
 					errors: {},
 					subTheatres: [
 						{
-							model: 'theatre',
 							uuid: undefined,
 							name: 'Olivier Theatre',
 							differentiator: '',
@@ -294,14 +283,12 @@ describe('Theatre instance', () => {
 							}
 						},
 						{
-							model: 'theatre',
 							uuid: undefined,
 							name: 'Lyttelton Theatre',
 							differentiator: '',
 							errors: {}
 						},
 						{
-							model: 'theatre',
 							uuid: undefined,
 							name: 'Olivier Theatre',
 							differentiator: '',
@@ -342,7 +329,6 @@ describe('Theatre instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'theatre',
 					uuid: undefined,
 					name: 'National Theatre',
 					differentiator: '',
@@ -392,7 +378,6 @@ describe('Theatre instance', () => {
 				const result = await instance.create();
 
 				const expectedResponseBody = {
-					model: 'theatre',
 					uuid: undefined,
 					name: 'National Theatre',
 					differentiator: '',
@@ -407,7 +392,6 @@ describe('Theatre instance', () => {
 					},
 					subTheatres: [
 						{
-							model: 'theatre',
 							uuid: undefined,
 							name: ABOVE_MAX_LENGTH_STRING,
 							differentiator: '',

--- a/test-unit/src/lib/get-duplicate-entity-info.test.js
+++ b/test-unit/src/lib/get-duplicate-entity-info.test.js
@@ -4,6 +4,7 @@ import {
 	getDuplicateEntities,
 	isEntityInArray
 } from '../../../src/lib/get-duplicate-entity-info';
+import applyModelGetter from '../../test-helpers/apply-model-getter';
 
 describe('Get Duplicate Info module', () => {
 
@@ -14,44 +15,24 @@ describe('Get Duplicate Info module', () => {
 			it('returns an array of unique duplicates', () => {
 
 				const arrayOfEntities = [
-					{
-						model: 'person',
-						name: 'Nicholas Hytner',
-						differentiator: ''
-					},
-					{
-						model: 'person',
-						name: 'Vicki Mortimer',
-						differentiator: ''
-					},
-					{
-						model: 'person',
-						name: 'Nicholas Hytner',
-						differentiator: ''
-					},
-					{
-						model: 'person',
-						name: 'Jon Clark',
-						differentiator: ''
-					},
-					{
-						model: 'person',
-						name: 'Nicholas Hytner',
-						differentiator: ''
-					}
+					applyModelGetter({ name: 'Nicholas Hytner', differentiator: '' }, 'person'),
+					applyModelGetter({ name: 'Vicki Mortimer', differentiator: '' }, 'person'),
+					applyModelGetter({ name: 'Nicholas Hytner', differentiator: '' }, 'person'),
+					applyModelGetter({ name: 'Jon Clark', differentiator: '' }, 'person'),
+					applyModelGetter({ name: 'Nicholas Hytner', differentiator: '' }, 'person')
 				];
 
 				const result = getDuplicateEntities(arrayOfEntities);
 
 				const expectedResult = [
 					{
-						model: 'person',
 						name: 'Nicholas Hytner',
 						differentiator: ''
 					}
 				];
 
 				expect(result).to.deep.equal(expectedResult);
+				expect(result[0].model).to.equal('person');
 
 			});
 
@@ -62,46 +43,41 @@ describe('Get Duplicate Info module', () => {
 			it('returns an array of unique duplicates', () => {
 
 				const arrayOfEntities = [
-					{
-						model: 'company',
+					applyModelGetter({
 						name: 'Mesmer',
 						differentiator: ''
-					},
-					{
-						model: 'company',
+					}, 'company'),
+					applyModelGetter({
 						name: '59 Productions',
 						differentiator: '',
 						creditedMembers: [
-							{
-								model: 'person',
+							applyModelGetter({
 								name: 'Leo Warner',
 								differentiator: ''
-							},
-							{
-								model: 'person',
+							}, 'person'),
+							applyModelGetter({
 								name: 'Leo Warner',
 								differentiator: ''
-							}
+							}, 'person')
 						]
-					},
-					{
-						model: 'person',
+					}, 'company'),
+					applyModelGetter({
 						name: 'Akhila Krishnan',
 						differentiator: ''
-					}
+					}, 'person')
 				];
 
 				const result = getDuplicateEntities(arrayOfEntities);
 
 				const expectedResult = [
 					{
-						model: 'person',
 						name: 'Leo Warner',
 						differentiator: ''
 					}
 				];
 
 				expect(result).to.deep.equal(expectedResult);
+				expect(result[0].model).to.equal('person');
 
 			});
 
@@ -112,46 +88,41 @@ describe('Get Duplicate Info module', () => {
 			it('returns an array of unique duplicates', () => {
 
 				const arrayOfEntities = [
-					{
-						model: 'person',
+					applyModelGetter({
 						name: 'Dick Straker',
 						differentiator: ''
-					},
-					{
-						model: 'company',
+					}, 'person'),
+					applyModelGetter({
 						name: 'Mesmer',
 						differentiator: '',
 						creditedMembers: [
-							{
-								model: 'person',
+							applyModelGetter({
 								name: 'Dick Straker',
 								differentiator: ''
-							},
-							{
-								model: 'person',
+							}, 'person'),
+							applyModelGetter({
 								name: 'Mark Grimmer',
 								differentiator: ''
-							}
+							}, 'person')
 						]
-					},
-					{
-						model: 'person',
+					}, 'company'),
+					applyModelGetter({
 						name: 'Akhila Krishnan',
 						differentiator: ''
-					}
+					}, 'person')
 				];
 
 				const result = getDuplicateEntities(arrayOfEntities);
 
 				const expectedResult = [
 					{
-						model: 'person',
 						name: 'Dick Straker',
 						differentiator: ''
 					}
 				];
 
 				expect(result).to.deep.equal(expectedResult);
+				expect(result[0].model).to.equal('person');
 
 			});
 
@@ -162,63 +133,55 @@ describe('Get Duplicate Info module', () => {
 			it('returns an array of unique duplicates', () => {
 
 				const arrayOfEntities = [
-					{
-						model: 'person',
+					applyModelGetter({
 						name: 'Nina Dunn',
 						differentiator: ''
-					},
-					{
-						model: 'company',
+					}, 'person'),
+					applyModelGetter({
 						name: '59 Productions',
 						differentiator: '',
 						creditedMembers: [
-							{
-								model: 'person',
+							applyModelGetter({
 								name: 'Leo Warner',
 								differentiator: ''
-							},
-							{
-								model: 'person',
+							}, 'person'),
+							applyModelGetter({
 								name: 'Ian William Galloway',
 								differentiator: ''
-							}
+							}, 'person')
 						]
-					},
-					{
-						model: 'company',
+					}, 'company'),
+					applyModelGetter({
 						name: 'Mesmer',
 						differentiator: '',
 						creditedMembers: [
-							{
-								model: 'person',
+							applyModelGetter({
 								name: 'Ian William Galloway',
 								differentiator: ''
-							},
-							{
-								model: 'person',
+							}, 'person'),
+							applyModelGetter({
 								name: 'John O\'Connell',
 								differentiator: ''
-							}
+							}, 'person')
 						]
-					},
-					{
-						model: 'person',
+					}, 'company'),
+					applyModelGetter({
 						name: 'Akhila Krishnan',
 						differentiator: ''
-					}
+					}, 'person')
 				];
 
 				const result = getDuplicateEntities(arrayOfEntities);
 
 				const expectedResult = [
 					{
-						model: 'person',
 						name: 'Ian William Galloway',
 						differentiator: ''
 					}
 				];
 
 				expect(result).to.deep.equal(expectedResult);
+				expect(result[0].model).to.equal('person');
 
 			});
 
@@ -229,83 +192,72 @@ describe('Get Duplicate Info module', () => {
 			it('returns an array of unique duplicates', () => {
 
 				const arrayOfEntities = [
-					{
-						model: 'person',
+					applyModelGetter({
 						name: 'Mark Grimmer',
 						differentiator: ''
-					},
-					{
-						model: 'company',
+					}, 'person'),
+					applyModelGetter({
 						name: '59 Productions',
 						differentiator: '',
 						creditedMembers: [
-							{
-								model: 'person',
+							applyModelGetter({
 								name: 'Leo Warner',
 								differentiator: ''
-							},
-							{
-								model: 'person',
+							}, 'person'),
+							applyModelGetter({
 								name: 'Mark Grimmer',
 								differentiator: ''
-							},
-							{
-								model: 'person',
+							}, 'person'),
+							applyModelGetter({
 								name: 'Ian William Galloway',
 								differentiator: ''
-							}
+							}, 'person')
 						]
-					},
-					{
-						model: 'company',
+					}, 'company'),
+					applyModelGetter({
 						name: 'Mesmer',
 						differentiator: '',
 						creditedMembers: [
-							{
-								model: 'person',
+							applyModelGetter({
 								name: 'Ian William Galloway',
 								differentiator: ''
-							},
-							{
-								model: 'person',
+							}, 'person'),
+							applyModelGetter({
 								name: 'John O\'Connell',
 								differentiator: ''
-							},
-							{
-								model: 'person',
+							}, 'person'),
+							applyModelGetter({
 								name: 'Ian William Galloway',
 								differentiator: ''
-							}
+							}, 'person')
 						]
-					},
-					{
-						model: 'person',
+					}, 'company'),
+					applyModelGetter({
 						name: 'Mark Grimmer',
 						differentiator: ''
-					},
-					{
-						model: 'person',
+					}, 'person'),
+					applyModelGetter({
 						name: 'Akhila Krishnan',
 						differentiator: ''
-					}
+					}, 'person')
 				];
 
 				const result = getDuplicateEntities(arrayOfEntities);
 
 				const expectedResult = [
 					{
-						model: 'person',
 						name: 'Mark Grimmer',
 						differentiator: ''
 					},
 					{
-						model: 'person',
 						name: 'Ian William Galloway',
 						differentiator: ''
 					}
 				];
 
 				expect(result).to.deep.equal(expectedResult);
+				expect(result[0].model).to.equal('person');
+				expect(result[1].model).to.equal('person');
 
 			});
 
@@ -316,60 +268,50 @@ describe('Get Duplicate Info module', () => {
 			it('ignores entities with empty string name values', () => {
 
 				const arrayOfEntities = [
-					{
-						model: 'person',
+					applyModelGetter({
 						name: '',
 						differentiator: ''
-					},
-					{
-						model: 'company',
+					}, 'person'),
+					applyModelGetter({
 						name: '',
 						differentiator: ''
-					},
-					{
-						model: 'company',
+					}, 'company'),
+					applyModelGetter({
 						name: '59 Productions',
 						differentiator: '',
 						creditedMembers: [
-							{
-								model: 'person',
+							applyModelGetter({
 								name: 'Leo Warner',
 								differentiator: ''
-							},
-							{
-								model: 'person',
+							}, 'person'),
+							applyModelGetter({
 								name: '',
 								differentiator: ''
-							}
+							}, 'person')
 						]
-					},
-					{
-						model: 'company',
+					}, 'company'),
+					applyModelGetter({
 						name: '',
 						differentiator: ''
-					},
-					{
-						model: 'company',
+					}, 'company'),
+					applyModelGetter({
 						name: 'Mesmer',
 						differentiator: '',
 						creditedMembers: [
-							{
-								model: 'person',
+							applyModelGetter({
 								name: '',
 								differentiator: ''
-							},
-							{
-								model: 'person',
+							}, 'person'),
+							applyModelGetter({
 								name: 'John O\'Connell',
 								differentiator: ''
-							}
+							}, 'person')
 						]
-					},
-					{
-						model: 'person',
+					}, 'company'),
+					applyModelGetter({
 						name: 'Akhila Krishnan',
 						differentiator: ''
-					}
+					}, 'person')
 				];
 
 				const result = getDuplicateEntities(arrayOfEntities);
@@ -390,12 +332,12 @@ describe('Get Duplicate Info module', () => {
 
 			it('returns true', () => {
 
-				const entity = { model: 'person', name: 'Ian McKellen', differentiator: '' };
+				const entity = applyModelGetter({ name: 'Ian McKellen', differentiator: '' }, 'person');
 
 				const array = [
-					{ model: 'person', name: 'Patrick Stewart', differentiator: '' },
-					{ model: 'person', name: 'Ian McKellen', differentiator: '' },
-					{ model: 'person', name: 'Chiwetel Ejiofor', differentiator: '' }
+					applyModelGetter({ name: 'Patrick Stewart', differentiator: '' }, 'person'),
+					applyModelGetter({ name: 'Ian McKellen', differentiator: '' }, 'person'),
+					applyModelGetter({ name: 'Chiwetel Ejiofor', differentiator: '' }, 'person')
 				];
 
 				const result = isEntityInArray(entity, array);
@@ -410,13 +352,13 @@ describe('Get Duplicate Info module', () => {
 
 			it('returns false', () => {
 
-				const entity = { model: 'person', name: 'Ian McKellen', differentiator: '' };
+				const entity = applyModelGetter({ name: 'Ian McKellen', differentiator: '' }, 'person');
 
 				const array = [
-					{ model: 'person', name: 'Patrick Stewart', differentiator: '' },
-					{ model: 'company', name: 'Ian Mckellen', differentiator: '' },
-					{ model: 'person', name: 'Ian Mckellen', differentiator: '1' },
-					{ model: 'person', name: 'Chiwetel Ejiofor', differentiator: '' }
+					applyModelGetter({ name: 'Patrick Stewart', differentiator: '' }, 'person'),
+					applyModelGetter({ name: 'Ian McKellen', differentiator: '' }, 'company'),
+					applyModelGetter({ name: 'Ian McKellen', differentiator: '1' }, 'person'),
+					applyModelGetter({ name: 'Chiwetel Ejiofor', differentiator: '' }, 'person')
 				];
 
 				const result = isEntityInArray(entity, array);

--- a/test-unit/src/lib/get-duplicate-indices.test.js
+++ b/test-unit/src/lib/get-duplicate-indices.test.js
@@ -7,6 +7,7 @@ import {
 	getDuplicateNameIndices,
 	getDuplicateRoleIndices
 } from '../../../src/lib/get-duplicate-indices';
+import applyModelGetter from '../../test-helpers/apply-model-getter';
 
 describe('Get Duplicate Indices module', () => {
 
@@ -155,24 +156,24 @@ describe('Get Duplicate Indices module', () => {
 
 				const result = getDuplicateEntityIndices(
 					[
-						{ model: '', name: 'Foo', differentiator: '' },
-						{ model: '', name: 'Foo', differentiator: '1' },
-						{ model: '', name: 'Foo', differentiator: '2' },
-						{ model: 'company', name: 'Foo', differentiator: '' },
-						{ model: 'company', name: 'Foo', differentiator: '1' },
-						{ model: 'company', name: 'Foo', differentiator: '2' },
-						{ model: 'material', name: 'Foo', differentiator: '' },
-						{ model: 'material', name: 'Foo', differentiator: '1' },
-						{ model: 'material', name: 'Foo', differentiator: '2' },
-						{ model: '', name: 'Bar', differentiator: '' },
-						{ model: '', name: 'Bar', differentiator: '1' },
-						{ model: '', name: 'Bar', differentiator: '2' },
-						{ model: 'company', name: 'Bar', differentiator: '' },
-						{ model: 'company', name: 'Bar', differentiator: '1' },
-						{ model: 'company', name: 'Bar', differentiator: '2' },
-						{ model: 'material', name: 'Bar', differentiator: '' },
-						{ model: 'material', name: 'Bar', differentiator: '1' },
-						{ model: 'material', name: 'Bar', differentiator: '2' }
+						applyModelGetter({ name: 'Foo', differentiator: '' }, ''),
+						applyModelGetter({ name: 'Foo', differentiator: '1' }, ''),
+						applyModelGetter({ name: 'Foo', differentiator: '2' }, ''),
+						applyModelGetter({ name: 'Foo', differentiator: '' }, 'company'),
+						applyModelGetter({ name: 'Foo', differentiator: '1' }, 'company'),
+						applyModelGetter({ name: 'Foo', differentiator: '2' }, 'company'),
+						applyModelGetter({ name: 'Foo', differentiator: '' }, 'material'),
+						applyModelGetter({ name: 'Foo', differentiator: '1' }, 'material'),
+						applyModelGetter({ name: 'Foo', differentiator: '2' }, 'material'),
+						applyModelGetter({ name: 'Bar', differentiator: '' }, ''),
+						applyModelGetter({ name: 'Bar', differentiator: '1' }, ''),
+						applyModelGetter({ name: 'Bar', differentiator: '2' }, ''),
+						applyModelGetter({ name: 'Bar', differentiator: '' }, 'company'),
+						applyModelGetter({ name: 'Bar', differentiator: '1' }, 'company'),
+						applyModelGetter({ name: 'Bar', differentiator: '2' }, 'company'),
+						applyModelGetter({ name: 'Bar', differentiator: '' }, 'material'),
+						applyModelGetter({ name: 'Bar', differentiator: '1' }, 'material'),
+						applyModelGetter({ name: 'Bar', differentiator: '2' }, 'material')
 					]
 				);
 
@@ -188,15 +189,15 @@ describe('Get Duplicate Indices module', () => {
 
 				const result = getDuplicateEntityIndices(
 					[
-						{ model: '', name: 'Foo', differentiator: '1' },
-						{ model: 'material', name: 'Bar', differentiator: '1' },
-						{ model: 'company', name: 'Bar', differentiator: '1' },
-						{ model: '', name: '', differentiator: '1' },
-						{ model: '', name: 'Baz', differentiator: '1' },
-						{ model: '', name: 'Foo', differentiator: '1' },
-						{ model: 'material', name: 'Bar', differentiator: '1' },
-						{ model: '', name: '', differentiator: '1' },
-						{ model: '', name: 'Qux', differentiator: '1' }
+						applyModelGetter({ name: 'Foo', differentiator: '1' }, ''),
+						applyModelGetter({ name: 'Bar', differentiator: '1' }, 'material'),
+						applyModelGetter({ name: 'Bar', differentiator: '1' }, 'company'),
+						applyModelGetter({ name: '', differentiator: '1' }, ''),
+						applyModelGetter({ name: 'Baz', differentiator: '1' }, ''),
+						applyModelGetter({ name: 'Foo', differentiator: '1' }, ''),
+						applyModelGetter({ name: 'Bar', differentiator: '1' }, 'material'),
+						applyModelGetter({ name: '', differentiator: '1' }, ''),
+						applyModelGetter({ name: 'Qux', differentiator: '1' }, '')
 					]
 				);
 

--- a/test-unit/src/lib/prepare-as-params.test.js
+++ b/test-unit/src/lib/prepare-as-params.test.js
@@ -4,6 +4,7 @@ import neo4j from 'neo4j-driver';
 import { v4 as uuid } from 'uuid';
 
 import { prepareAsParams } from '../../../src/lib/prepare-as-params';
+import applyModelGetter from '../../test-helpers/apply-model-getter';
 
 describe('Prepare As Params module', () => {
 
@@ -135,6 +136,14 @@ describe('Prepare As Params module', () => {
 
 		});
 
+		it('will add model property with value from model getter method', () => {
+
+			const instance = applyModelGetter({ foo: '' });
+			const result = prepareAsParams(instance);
+			expect(result.model).to.equal('base');
+
+		});
+
 	});
 
 	context('nested level properties', () => {
@@ -196,6 +205,14 @@ describe('Prepare As Params module', () => {
 			expect(stubs.uuid.calledOnce).to.be.true;
 			expect(stubs.neo4jInt.notCalled).to.be.true;
 			expect(result.theatre).not.to.have.property('position');
+
+		});
+
+		it('will add model property with value from model getter method', () => {
+
+			const instance = { theatre: applyModelGetter({ foo: '' }) };
+			const result = prepareAsParams(instance);
+			expect(result.theatre.model).to.equal('base');
 
 		});
 
@@ -265,6 +282,14 @@ describe('Prepare As Params module', () => {
 
 			});
 
+			it('will add model property with value from model getter method', () => {
+
+				const instance = { cast: [applyModelGetter({ foo: '' })] };
+				const result = prepareAsParams(instance);
+				expect(result.cast[0].model).to.equal('base');
+
+			});
+
 		});
 
 		context('array contains more than a single item', () => {
@@ -281,6 +306,14 @@ describe('Prepare As Params module', () => {
 				expect(result.cast[0].position).to.equal(0);
 				expect(result.cast[1]).to.have.property('position');
 				expect(result.cast[1].position).to.equal(1);
+
+			});
+
+			it('will add model property with value from model getter method', () => {
+
+				const instance = { cast: [applyModelGetter({ foo: '' }), applyModelGetter({ foo: '' })] };
+				const result = prepareAsParams(instance);
+				expect(result.cast[0].model).to.equal('base');
 
 			});
 
@@ -363,12 +396,12 @@ describe('Prepare As Params module', () => {
 				.onCall(3).returns('dddddddd-dddd-dddd-dddd-dddddddddddd');
 			const instance = {
 				characters: [
-					{ model: 'character', uuid: '', name: 'Foo', underlyingName: '', differentiator: '', qualifier: 'younger' },
-					{ model: 'character', uuid: '', name: 'Bar', underlyingName: '', differentiator: '1', qualifier: 'younger' },
-					{ model: 'character', uuid: '', name: 'Baz', underlyingName: '', differentiator: '', qualifier: '' },
-					{ model: 'character', uuid: '', name: 'Foo', underlyingName: '', differentiator: '', qualifier: 'older' },
-					{ model: 'character', uuid: '', name: 'Bar', underlyingName: '', differentiator: '1', qualifier: 'older' },
-					{ model: 'character', uuid: '', name: 'Baz', underlyingName: '', differentiator: '1', qualifier: '' }
+					applyModelGetter({ uuid: '', name: 'Foo', underlyingName: '', differentiator: '', qualifier: 'younger' }),
+					applyModelGetter({ uuid: '', name: 'Bar', underlyingName: '', differentiator: '1', qualifier: 'younger' }),
+					applyModelGetter({ uuid: '', name: 'Baz', underlyingName: '', differentiator: '', qualifier: '' }),
+					applyModelGetter({ uuid: '', name: 'Foo', underlyingName: '', differentiator: '', qualifier: 'older' }),
+					applyModelGetter({ uuid: '', name: 'Bar', underlyingName: '', differentiator: '1', qualifier: 'older' }),
+					applyModelGetter({ uuid: '', name: 'Baz', underlyingName: '', differentiator: '1', qualifier: '' })
 				]
 			};
 			const result = prepareAsParams(instance);
@@ -446,6 +479,14 @@ describe('Prepare As Params module', () => {
 
 			});
 
+			it('will add model property with value from model getter method', () => {
+
+				const instance = { production: { cast: [applyModelGetter({ foo: '' })] } };
+				const result = prepareAsParams(instance);
+				expect(result.production.cast[0].model).to.equal('base');
+
+			});
+
 		});
 
 		context('array contains more than a single item', () => {
@@ -462,6 +503,14 @@ describe('Prepare As Params module', () => {
 				expect(result.production.cast[0].position).to.equal(0);
 				expect(result.production.cast[1]).to.have.property('position');
 				expect(result.production.cast[1].position).to.equal(1);
+
+			});
+
+			it('will add model property with value from model getter method', () => {
+
+				const instance = { production: { cast: [applyModelGetter({ foo: '' }), applyModelGetter({ foo: '' })] } };
+				const result = prepareAsParams(instance);
+				expect(result.production.cast[0].model).to.equal('base');
 
 			});
 
@@ -546,12 +595,12 @@ describe('Prepare As Params module', () => {
 			const instance = {
 				production: {
 					cast: [
-						{ model: 'person', uuid: '', name: 'Foo', differentiator: '' },
-						{ model: 'person', uuid: '', name: 'Bar', differentiator: '1' },
-						{ model: 'person', uuid: '', name: 'Baz', differentiator: '' },
-						{ model: 'person', uuid: '', name: 'Foo', differentiator: '' },
-						{ model: 'person', uuid: '', name: 'Bar', differentiator: '1' },
-						{ model: 'person', uuid: '', name: 'Baz', differentiator: '1' }
+						applyModelGetter({ uuid: '', name: 'Foo', differentiator: '' }),
+						applyModelGetter({ uuid: '', name: 'Bar', differentiator: '1' }),
+						applyModelGetter({ uuid: '', name: 'Baz', differentiator: '' }),
+						applyModelGetter({ uuid: '', name: 'Foo', differentiator: '' }),
+						applyModelGetter({ uuid: '', name: 'Bar', differentiator: '1' }),
+						applyModelGetter({ uuid: '', name: 'Baz', differentiator: '1' })
 					]
 				}
 			};
@@ -631,6 +680,14 @@ describe('Prepare As Params module', () => {
 
 			});
 
+			it('will add model property with value from model getter method', () => {
+
+				const instance = { cast: [{ roles: [applyModelGetter({ foo: '' })] }] };
+				const result = prepareAsParams(instance);
+				expect(result.cast[0].roles[0].model).to.equal('base');
+
+			});
+
 		});
 
 		context('array contains more than a single item', () => {
@@ -648,6 +705,14 @@ describe('Prepare As Params module', () => {
 				expect(result.cast[0].roles[0].position).to.equal(0);
 				expect(result.cast[0].roles[1]).to.have.property('position');
 				expect(result.cast[0].roles[1].position).to.equal(1);
+
+			});
+
+			it('will add model property with value from model getter method', () => {
+
+				const instance = { cast: [{ roles: [applyModelGetter({ foo: '' }), applyModelGetter({ foo: '' })] }] };
+				const result = prepareAsParams(instance);
+				expect(result.cast[0].roles[0].model).to.equal('base');
 
 			});
 
@@ -740,12 +805,12 @@ describe('Prepare As Params module', () => {
 				characterGroups: [
 					{
 						characters: [
-							{ model: 'character', uuid: '', name: 'Foo', underlyingName: '', differentiator: '', qualifier: 'younger' },
-							{ model: 'character', uuid: '', name: 'Bar', underlyingName: '', differentiator: '1', qualifier: 'younger' },
-							{ model: 'character', uuid: '', name: 'Baz', underlyingName: '', differentiator: '', qualifier: '' },
-							{ model: 'character', uuid: '', name: 'Foo', underlyingName: '', differentiator: '', qualifier: 'older' },
-							{ model: 'character', uuid: '', name: 'Bar', underlyingName: '', differentiator: '1', qualifier: 'older' },
-							{ model: 'character', uuid: '', name: 'Baz', underlyingName: '', differentiator: '1', qualifier: '' }
+							applyModelGetter({ uuid: '', name: 'Foo', underlyingName: '', differentiator: '', qualifier: 'younger' }),
+							applyModelGetter({ uuid: '', name: 'Bar', underlyingName: '', differentiator: '1', qualifier: 'younger' }),
+							applyModelGetter({ uuid: '', name: 'Baz', underlyingName: '', differentiator: '', qualifier: '' }),
+							applyModelGetter({ uuid: '', name: 'Foo', underlyingName: '', differentiator: '', qualifier: 'older' }),
+							applyModelGetter({ uuid: '', name: 'Bar', underlyingName: '', differentiator: '1', qualifier: 'older' }),
+							applyModelGetter({ uuid: '', name: 'Baz', underlyingName: '', differentiator: '1', qualifier: '' })
 						]
 					}
 				]
@@ -771,21 +836,19 @@ describe('Prepare As Params module', () => {
 			const instance = {
 				characterGroups: [
 					{
-						model: 'characterGroup',
 						name: 'Montagues',
 						characters: [
-							{ model: 'character', uuid: '', name: 'Foo', underlyingName: '', differentiator: '', qualifier: '' },
-							{ model: 'character', uuid: '', name: 'Bar', underlyingName: '', differentiator: '', qualifier: '' },
-							{ model: 'character', uuid: '', name: 'Baz', underlyingName: '', differentiator: '', qualifier: '' }
+							applyModelGetter({ uuid: '', name: 'Foo', underlyingName: '', differentiator: '', qualifier: '' }),
+							applyModelGetter({ uuid: '', name: 'Bar', underlyingName: '', differentiator: '', qualifier: '' }),
+							applyModelGetter({ uuid: '', name: 'Baz', underlyingName: '', differentiator: '', qualifier: '' })
 						]
 					},
 					{
-						model: 'characterGroup',
 						name: 'Capulets',
 						characters: [
-							{ model: 'character', uuid: '', name: 'Foo', underlyingName: '', differentiator: '', qualifier: '' },
-							{ model: 'character', uuid: '', name: 'Bar', underlyingName: '', differentiator: '', qualifier: '' },
-							{ model: 'character', uuid: '', name: 'Baz', underlyingName: '', differentiator: '1', qualifier: '' }
+							applyModelGetter({ uuid: '', name: 'Foo', underlyingName: '', differentiator: '', qualifier: '' }),
+							applyModelGetter({ uuid: '', name: 'Bar', underlyingName: '', differentiator: '', qualifier: '' }),
+							applyModelGetter({ uuid: '', name: 'Baz', underlyingName: '', differentiator: '1', qualifier: '' })
 						]
 					}
 				]

--- a/test-unit/src/models/CreativeCredit.test.js
+++ b/test-unit/src/models/CreativeCredit.test.js
@@ -125,12 +125,9 @@ describe('CreativeCredit model', () => {
 				]
 			};
 			const instance = createInstance(props);
-			instance.creativeEntities[0].model = 'person';
 			instance.creativeEntities[0].name = 'Paul Arditti';
-			instance.creativeEntities[1].model = 'company';
 			instance.creativeEntities[1].name = 'Autograph';
 			instance.creativeEntities[1].creditedMembers = [createStubInstance(Person)];
-			instance.creativeEntities[1].creditedMembers[0].model = 'person';
 			instance.creativeEntities[1].creditedMembers[0].name = 'Andrew Bruce';
 			spy(instance, 'validateName');
 			spy(instance, 'validateUniquenessInGroup');

--- a/test-unit/src/models/WritingCredit.test.js
+++ b/test-unit/src/models/WritingCredit.test.js
@@ -179,7 +179,6 @@ describe('WritingCredit model', () => {
 				]
 			};
 			const instance = createInstance(props);
-			instance.writingEntities[2].model = 'material';
 			instance.writingEntities[2].name = 'A Midsummer Night\'s Dream';
 			instance.writingEntities[2].differentiator = '1';
 			spy(instance, 'validateName');

--- a/test-unit/test-helpers/apply-model-getter.js
+++ b/test-unit/test-helpers/apply-model-getter.js
@@ -1,0 +1,7 @@
+export default (object, model = 'base') => {
+
+	return Object.defineProperty(object, 'model', {
+		get: () => model
+	});
+
+};


### PR DESCRIPTION
JavaScript getters allow a value to be called from a class instance without having to set it in the `constructor` upon instantiation.

This comes with the added benefit that the value is immutable, which makes perfect sense for class instance `model` values, as these should never change.

### References:
- [MDN Web Docs: getter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get)
- [MDN Web Docs: JSON.stringify()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON()_behavior)
- [MDN Web Docs: Object.defineProperty()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty)
- [Stack Overflow: JSON stringify ES6 class property with getter/setter](https://stackoverflow.com/questions/42107492/json-stringify-es6-class-property-with-getter-setter)
- [Stack Overflow: How to mock/replace getter function of object with Jest?](https://stackoverflow.com/questions/43697455/how-to-mock-replace-getter-function-of-object-with-jest#answer-43744255)