### PR TITLE
Modify instance validation failures integration test duplicate checks

### DIFF
--- a/test-int/instance-validation-failures/material.test.js
+++ b/test-int/instance-validation-failures/material.test.js
@@ -802,7 +802,14 @@ describe('Material instance', () => {
 									name: 'Henrik Ibsen'
 								},
 								{
+									name: 'Foo'
+								},
+								{
 									name: 'Henrik Ibsen'
+								},
+								{
+									model: 'company',
+									name: 'Foo'
 								}
 							]
 						}
@@ -847,6 +854,12 @@ describe('Material instance', () => {
 								},
 								{
 									uuid: undefined,
+									name: 'Foo',
+									differentiator: '',
+									errors: {}
+								},
+								{
+									uuid: undefined,
 									name: 'Henrik Ibsen',
 									differentiator: '',
 									errors: {
@@ -857,6 +870,12 @@ describe('Material instance', () => {
 											'This item has been duplicated within the group'
 										]
 									}
+								},
+								{
+									uuid: undefined,
+									name: 'Foo',
+									differentiator: '',
+									errors: {}
 								}
 							]
 						}
@@ -865,6 +884,8 @@ describe('Material instance', () => {
 				};
 
 				expect(result).to.deep.equal(expectedResponseBody);
+				expect(result.writingCredits[0].writingEntities[1].model).to.equal('person');
+				expect(result.writingCredits[0].writingEntities[3].model).to.equal('company');
 
 			});
 
@@ -1380,10 +1401,15 @@ describe('Material instance', () => {
 									name: 'Johannes Rosmer'
 								},
 								{
-									name: 'Rebecca West'
+									name: 'Rebecca West',
+									underlyingName: 'Becca West'
 								},
 								{
 									name: 'Johannes Rosmer'
+								},
+								{
+									name: 'Ms Rebecca West',
+									underlyingName: 'Rebecca West'
 								}
 							]
 						}
@@ -1437,7 +1463,7 @@ describe('Material instance', () => {
 								{
 									uuid: undefined,
 									name: 'Rebecca West',
-									underlyingName: '',
+									underlyingName: 'Becca West',
 									differentiator: '',
 									qualifier: '',
 									errors: {}
@@ -1462,6 +1488,14 @@ describe('Material instance', () => {
 											'This item has been duplicated within the group'
 										]
 									}
+								},
+								{
+									uuid: undefined,
+									name: 'Ms Rebecca West',
+									underlyingName: 'Rebecca West',
+									differentiator: '',
+									qualifier: '',
+									errors: {}
 								}
 							]
 						}

--- a/test-int/instance-validation-failures/production.test.js
+++ b/test-int/instance-validation-failures/production.test.js
@@ -423,10 +423,15 @@ describe('Production instance', () => {
 							name: 'Rory Kinnear'
 						},
 						{
-							name: 'Clare Higgins'
+							name: 'Clare Higgins',
+							differentiator: '1'
 						},
 						{
 							name: 'Rory Kinnear'
+						},
+						{
+							name: 'Clare Higgins',
+							differentiator: '2'
 						}
 					]
 				};
@@ -470,7 +475,7 @@ describe('Production instance', () => {
 						{
 							uuid: undefined,
 							name: 'Clare Higgins',
-							differentiator: '',
+							differentiator: '1',
 							errors: {},
 							roles: []
 						},
@@ -486,6 +491,13 @@ describe('Production instance', () => {
 									'This item has been duplicated within the group'
 								]
 							},
+							roles: []
+						},
+						{
+							uuid: undefined,
+							name: 'Clare Higgins',
+							differentiator: '2',
+							errors: {},
 							roles: []
 						}
 					],
@@ -932,10 +944,15 @@ describe('Production instance', () => {
 									name: 'Polonius'
 								},
 								{
-									name: 'Gravedigger'
+									name: 'Gravedigger',
+									characterDifferentiator: '1'
 								},
 								{
 									name: 'Polonius'
+								},
+								{
+									name: 'Gravedigger',
+									characterDifferentiator: '2'
 								}
 							]
 						}
@@ -993,7 +1010,7 @@ describe('Production instance', () => {
 								{
 									name: 'Gravedigger',
 									characterName: '',
-									characterDifferentiator: '',
+									characterDifferentiator: '1',
 									qualifier: '',
 									errors: {}
 								},
@@ -1016,6 +1033,13 @@ describe('Production instance', () => {
 											'This item has been duplicated within the group'
 										]
 									}
+								},
+								{
+									name: 'Gravedigger',
+									characterName: '',
+									characterDifferentiator: '2',
+									qualifier: '',
+									errors: {}
 								}
 							]
 						}
@@ -1503,13 +1527,9 @@ describe('Production instance', () => {
 											name: 'Andrew Bruce'
 										},
 										{
-											name: 'Nick Lidster'
+											name: 'Foo'
 										}
 									]
-								},
-								{
-									model: 'company',
-									name: '59 Productions'
 								},
 								{
 									name: 'Andrew Bruce'
@@ -1519,7 +1539,8 @@ describe('Production instance', () => {
 									name: 'Autograph'
 								},
 								{
-									name: 'Gregory Clarke'
+									model: 'company',
+									name: 'Foo'
 								}
 							]
 						}
@@ -1581,18 +1602,11 @@ describe('Production instance', () => {
 										},
 										{
 											uuid: undefined,
-											name: 'Nick Lidster',
+											name: 'Foo',
 											differentiator: '',
 											errors: {}
 										}
 									]
-								},
-								{
-									uuid: undefined,
-									name: '59 Productions',
-									differentiator: '',
-									errors: {},
-									creditedMembers: []
 								},
 								{
 									uuid: undefined,
@@ -1623,9 +1637,10 @@ describe('Production instance', () => {
 								},
 								{
 									uuid: undefined,
-									name: 'Gregory Clarke',
+									name: 'Foo',
 									differentiator: '',
-									errors: {}
+									errors: {},
+									creditedMembers: []
 								}
 							]
 						}
@@ -1633,6 +1648,8 @@ describe('Production instance', () => {
 				};
 
 				expect(result).to.deep.equal(expectedResponseBody);
+				expect(result.creativeCredits[0].creativeEntities[0].creditedMembers[1].model).to.equal('person');
+				expect(result.creativeCredits[0].creativeEntities[3].model).to.equal('company');
 
 			});
 

--- a/test-int/instance-validation-failures/theatre.test.js
+++ b/test-int/instance-validation-failures/theatre.test.js
@@ -250,10 +250,15 @@ describe('Theatre instance', () => {
 							name: 'Olivier Theatre'
 						},
 						{
-							name: 'Lyttelton Theatre'
+							name: 'Lyttelton Theatre',
+							differentiator: '1'
 						},
 						{
 							name: 'Olivier Theatre'
+						},
+						{
+							name: 'Lyttelton Theatre',
+							differentiator: '2'
 						}
 					]
 				};
@@ -285,7 +290,7 @@ describe('Theatre instance', () => {
 						{
 							uuid: undefined,
 							name: 'Lyttelton Theatre',
-							differentiator: '',
+							differentiator: '1',
 							errors: {}
 						},
 						{
@@ -300,6 +305,12 @@ describe('Theatre instance', () => {
 									'This item has been duplicated within the group'
 								]
 							}
+						},
+						{
+							uuid: undefined,
+							name: 'Lyttelton Theatre',
+							differentiator: '2',
+							errors: {}
 						}
 					]
 				};


### PR DESCRIPTION
This PR modifies the `instance-validation-failures` integration tests so that they can catch non-duplicate instances that would be deemed duplicates (and cause an error) if the wrong function from the `get-duplicate-indices.js` module were applied.

Such false errors have previously happened and were fixed by this PR: https://github.com/andygout/theatrebase-api/pull/369.

These tests will prevent regressions of such false errors.