### PR TITLE
Fix entity multiple writing credits for same material

### DIFF
--- a/db-seeding/seeds/materials/death-on-the-nile-novel.json
+++ b/db-seeding/seeds/materials/death-on-the-nile-novel.json
@@ -1,0 +1,13 @@
+{
+	"name": "Death on the Nile",
+	"format": "novel",
+	"writingCredits": [
+		{
+			"writingEntities": [
+				{
+					"name": "Agatha Christie"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/materials/murder-on-the-nile-play.json
+++ b/db-seeding/seeds/materials/murder-on-the-nile-play.json
@@ -1,0 +1,64 @@
+{
+	"name": "Murder on the Nile",
+	"format": "play",
+	"writingCredits": [
+		{
+			"writingEntities": [
+				{
+					"name": "Agatha Christie"
+				}
+			]
+		},
+		{
+			"name": "based on",
+			"writingEntities": [
+				{
+					"model": "material",
+					"name": "Death on the Nile"
+				}
+			]
+		}
+	],
+	"characterGroups": [
+		{
+			"characters": [
+				{
+					"name": "Beadsellers"
+				},
+				{
+					"name": "Steward"
+				},
+				{
+					"name": "Helen Ffoliot-ffoulkes"
+				},
+				{
+					"name": "Christina Grant"
+				},
+				{
+					"name": "Kay Ridgeway-Mostyn"
+				},
+				{
+					"name": "Simon Mostyn"
+				},
+				{
+					"name": "Louise de Vallois"
+				},
+				{
+					"name": "Dr Bessner"
+				},
+				{
+					"name": "Canon Ambrose Pennefather"
+				},
+				{
+					"name": "Jacqueline de Severac"
+				},
+				{
+					"name": "William Smith"
+				},
+				{
+					"name": "McNaught"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/productions/murder-on-the-nile.json
+++ b/db-seeding/seeds/productions/murder-on-the-nile.json
@@ -1,0 +1,136 @@
+{
+	"name": "Murder on the Nile",
+	"material": {
+		"name": "Murder on the Nile"
+	},
+	"theatre": {
+		"name": "Richmond Theatre"
+	},
+	"cast": [
+		{
+			"name": "Denis Lill",
+			"roles": [
+				{
+					"name": "Canon Ambrose Pennefather"
+				}
+			]
+		},
+		{
+			"name": "Jennifer Bryden",
+			"roles": [
+				{
+					"name": "Christina Grant"
+				}
+			]
+		},
+		{
+			"name": "Mark Wynter",
+			"roles": [
+				{
+					"name": "Dr Bessner"
+				}
+			]
+		},
+		{
+			"name": "Sydney Smith",
+			"roles": [
+				{
+					"name": "Harun",
+					"characterName": "Steward"
+				}
+			]
+		},
+		{
+			"name": "Chloe Newsome",
+			"roles": [
+				{
+					"name": "Jacqueline de Severac"
+				}
+			]
+		},
+		{
+			"name": "Susie Amy",
+			"roles": [
+				{
+					"name": "Kay Mostyn",
+					"characterName": "Kay Ridgeway-Mostyn"
+				}
+			]
+		},
+		{
+			"name": "Vanessa Morley",
+			"roles": [
+				{
+					"name": "Louise de Vallois"
+				}
+			]
+		},
+		{
+			"name": "Kate O'Mara",
+			"roles": [
+				{
+					"name": "Miss Ffoliot-ffoulkes",
+					"characterName": "Helen Ffoliot-ffoulkes"
+				}
+			]
+		},
+		{
+			"name": "Hambi Pappas",
+			"roles": [
+				{
+					"name": "Musa"
+				}
+			]
+		},
+		{
+			"name": "Ben Nealon",
+			"roles": [
+				{
+					"name": "Simon Mostyn"
+				}
+			]
+		},
+		{
+			"name": "Max Hutchinson",
+			"roles": [
+				{
+					"name": "William Smith"
+				}
+			]
+		}
+	],
+	"creativeCredits": [
+		{
+			"name": "Director",
+			"creativeEntities": [
+				{
+					"name": "Joe Harmston"
+				}
+			]
+		},
+		{
+			"name": "Designer",
+			"creativeEntities": [
+				{
+					"name": "Simon Scullion"
+				}
+			]
+		},
+		{
+			"name": "Lighting Designer",
+			"creativeEntities": [
+				{
+					"name": "Mike Roberston"
+				}
+			]
+		},
+		{
+			"name": "Sound Designer",
+			"creativeEntities": [
+				{
+					"name": "Matthew Bugg"
+				}
+			]
+		}
+	]
+}

--- a/src/neo4j/cypher-queries/company.js
+++ b/src/neo4j/cypher-queries/company.js
@@ -3,7 +3,7 @@ const getShowQuery = () => `
 
 	OPTIONAL MATCH (company)<-[:WRITTEN_BY|USES_SOURCE_MATERIAL*1..2]-(material:Material)
 
-	WITH company, COLLECT(material) AS materials
+	WITH company, COLLECT(DISTINCT(material)) AS materials
 
 	UNWIND (CASE materials WHEN [] THEN [null] ELSE materials END) AS material
 

--- a/src/neo4j/cypher-queries/person.js
+++ b/src/neo4j/cypher-queries/person.js
@@ -3,7 +3,7 @@ const getShowQuery = () => `
 
 	OPTIONAL MATCH (person)<-[:WRITTEN_BY|USES_SOURCE_MATERIAL*1..2]-(material:Material)
 
-	WITH person, COLLECT(material) AS materials
+	WITH person, COLLECT(DISTINCT(material)) AS materials
 
 	UNWIND (CASE materials WHEN [] THEN [null] ELSE materials END) AS material
 

--- a/test-e2e/model-interaction/material-multi-versions-multi-wri-groups.test.js
+++ b/test-e2e/model-interaction/material-multi-versions-multi-wri-groups.test.js
@@ -614,41 +614,6 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 				},
 				{
 					model: 'material',
-					uuid: PEER_GYNT_SUBSEQUENT_VERSION_1_MATERIAL_UUID,
-					name: 'Peer Gynt',
-					format: 'play',
-					writingCredits: [
-						{
-							model: 'writingCredit',
-							name: 'by',
-							writingEntities: [
-								{
-									model: 'person',
-									uuid: null,
-									name: 'Henrik Ibsen'
-								},
-								{
-									model: 'company',
-									uuid: IBSEN_THEATRE_COMPANY_UUID,
-									name: 'Ibsen Theatre Company'
-								}
-							]
-						},
-						{
-							model: 'writingCredit',
-							name: 'version by',
-							writingEntities: [
-								{
-									model: 'person',
-									uuid: FRANK_MCGUINNESS_PERSON_UUID,
-									name: 'Frank McGuinness'
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'material',
 					uuid: PEER_GYNT_SUBSEQUENT_VERSION_2_MATERIAL_UUID,
 					name: 'Peer Gynt',
 					format: 'play',
@@ -698,6 +663,41 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 									model: 'person',
 									uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
 									name: 'Baltasar Kormákur'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'material',
+					uuid: PEER_GYNT_SUBSEQUENT_VERSION_1_MATERIAL_UUID,
+					name: 'Peer Gynt',
+					format: 'play',
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: null,
+									name: 'Henrik Ibsen'
+								},
+								{
+									model: 'company',
+									uuid: IBSEN_THEATRE_COMPANY_UUID,
+									name: 'Ibsen Theatre Company'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'version by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: FRANK_MCGUINNESS_PERSON_UUID,
+									name: 'Frank McGuinness'
 								}
 							]
 						}
@@ -962,41 +962,6 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 				},
 				{
 					model: 'material',
-					uuid: PEER_GYNT_SUBSEQUENT_VERSION_1_MATERIAL_UUID,
-					name: 'Peer Gynt',
-					format: 'play',
-					writingCredits: [
-						{
-							model: 'writingCredit',
-							name: 'by',
-							writingEntities: [
-								{
-									model: 'person',
-									uuid: HENRIK_IBSEN_PERSON_UUID,
-									name: 'Henrik Ibsen'
-								},
-								{
-									model: 'company',
-									uuid: null,
-									name: 'Ibsen Theatre Company'
-								}
-							]
-						},
-						{
-							model: 'writingCredit',
-							name: 'version by',
-							writingEntities: [
-								{
-									model: 'person',
-									uuid: FRANK_MCGUINNESS_PERSON_UUID,
-									name: 'Frank McGuinness'
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'material',
 					uuid: PEER_GYNT_SUBSEQUENT_VERSION_2_MATERIAL_UUID,
 					name: 'Peer Gynt',
 					format: 'play',
@@ -1046,6 +1011,41 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 									model: 'person',
 									uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
 									name: 'Baltasar Kormákur'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'material',
+					uuid: PEER_GYNT_SUBSEQUENT_VERSION_1_MATERIAL_UUID,
+					name: 'Peer Gynt',
+					format: 'play',
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: HENRIK_IBSEN_PERSON_UUID,
+									name: 'Henrik Ibsen'
+								},
+								{
+									model: 'company',
+									uuid: null,
+									name: 'Ibsen Theatre Company'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'version by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: FRANK_MCGUINNESS_PERSON_UUID,
+									name: 'Frank McGuinness'
 								}
 							]
 						}

--- a/test-e2e/model-interaction/material-with-source-material.test.js
+++ b/test-e2e/model-interaction/material-with-source-material.test.js
@@ -24,17 +24,22 @@ describe('Materials with source material', () => {
 	const STEVEN_BERKOFF_PERSON_UUID = '39';
 	const EAST_PRODUCTIONS_COMPANY_UUID = '40';
 	const IAGO_CHARACTER_UUID = '43';
-	const A_MIDSUMMER_NIGHTS_DREAM_NOVELLO_THEATRE_PRODUCTION_UUID = '44';
-	const NOVELLO_THEATRE_UUID = '46';
-	const THE_DONKEY_SHOW_HANOVER_GRAND_PRODUCTION_UUID = '47';
-	const HANOVER_GRAND_THEATRE_UUID = '49';
-	const THE_INDIAN_BOY_ROYAL_SHAKESPEARE_THEATRE_PRODUCTION_UUID = '50';
-	const ROYAL_SHAKESPEARE_THEATRE_UUID = '52';
-	const SHAKESPEARES_VILLAINS_THEATRE_ROYAL_HAYMARKET_PRODUCTION_UUID = '53';
+	const A_MOORISH_CAPTAIN_MATERIAL_UUID = '48';
+	const OTHELLO_MATERIAL_UUID = '58';
+	const A_MIDSUMMER_NIGHTS_DREAM_NOVELLO_THEATRE_PRODUCTION_UUID = '64';
+	const NOVELLO_THEATRE_UUID = '66';
+	const THE_DONKEY_SHOW_HANOVER_GRAND_PRODUCTION_UUID = '67';
+	const HANOVER_GRAND_THEATRE_UUID = '69';
+	const THE_INDIAN_BOY_ROYAL_SHAKESPEARE_THEATRE_PRODUCTION_UUID = '70';
+	const ROYAL_SHAKESPEARE_THEATRE_UUID = '72';
+	const SHAKESPEARES_VILLAINS_THEATRE_ROYAL_HAYMARKET_PRODUCTION_UUID = '73';
+	const OTHELLO_DONMAR_WAREHOUSE_PRODUCTION_UUID = '76';
 
 	let aMidsummerNightsDreamMaterial;
 	let theIndianBoyMaterial;
 	let shakespearesVillainsMaterial;
+	let aMoorishCaptainMaterial;
+	let othelloMaterial;
 	let williamShakespearePerson;
 	let ronaMunroPerson;
 	let stevenBerkoffPerson;
@@ -43,6 +48,7 @@ describe('Materials with source material', () => {
 	let eastProductionsCompany;
 	let theIndianBoyRoyalShakespeareTheatreProduction;
 	let shakespearesVillainsTheatreRoyalHaymarketProduction;
+	let othelloDonmarWarehouseProduction;
 	let theIndianBoyCharacter;
 	let iagoCharacter;
 
@@ -190,6 +196,67 @@ describe('Materials with source material', () => {
 			});
 
 		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'A Moorish Captain',
+				format: 'tale',
+				writingCredits: [
+					{
+						writingEntities: [
+							// Contrivance for purposes of test.
+							{
+								model: 'person',
+								name: 'William Shakespeare'
+							},
+							{
+								model: 'company',
+								name: 'The King\'s Men'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Othello',
+				format: 'play',
+				writingCredits: [
+					{
+						writingEntities: [
+							{
+								model: 'person',
+								name: 'William Shakespeare'
+							},
+							{
+								model: 'company',
+								name: 'The King\'s Men'
+							}
+						]
+					},
+					{
+						name: 'based on',
+						writingEntities: [
+							{
+								model: 'material',
+								name: 'A Moorish Captain'
+							}
+						]
+					}
+				],
+				characterGroups: [
+					{
+						characters: [
+							{
+								name: 'Iago'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
 			.post('/productions')
 			.send({
 				name: 'A Midsummer Night\'s Dream',
@@ -237,6 +304,18 @@ describe('Materials with source material', () => {
 				}
 			});
 
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Othello',
+				material: {
+					name: 'Othello'
+				},
+				theatre: {
+					name: 'Donmar Warehouse'
+				}
+			});
+
 		aMidsummerNightsDreamMaterial = await chai.request(app)
 			.get(`/materials/${A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID}`);
 
@@ -245,6 +324,12 @@ describe('Materials with source material', () => {
 
 		shakespearesVillainsMaterial = await chai.request(app)
 			.get(`/materials/${SHAKESPEARES_VILLAINS_MATERIAL_UUID}`);
+
+		aMoorishCaptainMaterial = await chai.request(app)
+			.get(`/materials/${A_MOORISH_CAPTAIN_MATERIAL_UUID}`);
+
+		othelloMaterial = await chai.request(app)
+			.get(`/materials/${OTHELLO_MATERIAL_UUID}`);
 
 		williamShakespearePerson = await chai.request(app)
 			.get(`/people/${WILLIAM_SHAKESPEARE_PERSON_UUID}`);
@@ -269,6 +354,9 @@ describe('Materials with source material', () => {
 
 		shakespearesVillainsTheatreRoyalHaymarketProduction = await chai.request(app)
 			.get(`/productions/${SHAKESPEARES_VILLAINS_THEATRE_ROYAL_HAYMARKET_PRODUCTION_UUID}`);
+
+		othelloDonmarWarehouseProduction = await chai.request(app)
+			.get(`/productions/${OTHELLO_DONMAR_WAREHOUSE_PRODUCTION_UUID}`);
 
 		theIndianBoyCharacter = await chai.request(app)
 			.get(`/characters/${THE_INDIAN_BOY_CHARACTER_UUID}`);
@@ -570,11 +658,195 @@ describe('Materials with source material', () => {
 
 	});
 
+	describe('A Moorish Captain (material)', () => {
+
+		it('includes writers of this material and its source material grouped by their respective credits', () => {
+
+			const expectedSourcingMaterials = [
+				{
+					model: 'material',
+					uuid: OTHELLO_MATERIAL_UUID,
+					name: 'Othello',
+					format: 'play',
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+									name: 'William Shakespeare'
+								},
+								{
+									model: 'company',
+									uuid: THE_KINGS_MEN_COMPANY_UUID,
+									name: 'The King\'s Men'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'based on',
+							writingEntities: [
+								{
+									model: 'material',
+									uuid: null,
+									name: 'A Moorish Captain',
+									format: 'tale',
+									sourceMaterialWritingCredits: [
+										{
+											model: 'writingCredit',
+											name: 'by',
+											writingEntities: [
+												{
+													model: 'person',
+													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+													name: 'William Shakespeare'
+												},
+												{
+													model: 'company',
+													uuid: THE_KINGS_MEN_COMPANY_UUID,
+													name: 'The King\'s Men'
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { sourcingMaterials } = aMoorishCaptainMaterial.body;
+
+			expect(sourcingMaterials).to.deep.equal(expectedSourcingMaterials);
+
+		});
+
+	});
+
+	describe('Othello (material)', () => {
+
+		it('includes writers of this material and its source material grouped by their respective credits', () => {
+
+			const expectedWritingCredits = [
+				{
+					model: 'writingCredit',
+					name: 'by',
+					writingEntities: [
+						{
+							model: 'person',
+							uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+							name: 'William Shakespeare'
+						},
+						{
+							model: 'company',
+							uuid: THE_KINGS_MEN_COMPANY_UUID,
+							name: 'The King\'s Men'
+						}
+					]
+				},
+				{
+					model: 'writingCredit',
+					name: 'based on',
+					writingEntities: [
+						{
+							model: 'material',
+							uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
+							name: 'A Moorish Captain',
+							format: 'tale',
+							sourceMaterialWritingCredits: [
+								{
+									model: 'writingCredit',
+									name: 'by',
+									writingEntities: [
+										{
+											model: 'person',
+											uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+											name: 'William Shakespeare'
+										},
+										{
+											model: 'company',
+											uuid: THE_KINGS_MEN_COMPANY_UUID,
+											name: 'The King\'s Men'
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { writingCredits } = othelloMaterial.body;
+
+			expect(writingCredits).to.deep.equal(expectedWritingCredits);
+
+		});
+
+	});
+
 	describe('William Shakespeare (person)', () => {
 
 		it('includes materials that used their work as source material (both specific and non-specific), with corresponding writers', () => {
 
 			const expectedSourcingMaterials = [
+				{
+					model: 'material',
+					uuid: OTHELLO_MATERIAL_UUID,
+					name: 'Othello',
+					format: 'play',
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: null,
+									name: 'William Shakespeare'
+								},
+								{
+									model: 'company',
+									uuid: THE_KINGS_MEN_COMPANY_UUID,
+									name: 'The King\'s Men'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'based on',
+							writingEntities: [
+								{
+									model: 'material',
+									uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
+									name: 'A Moorish Captain',
+									format: 'tale',
+									sourceMaterialWritingCredits: [
+										{
+											model: 'writingCredit',
+											name: 'by',
+											writingEntities: [
+												{
+													model: 'person',
+													uuid: null,
+													name: 'William Shakespeare'
+												},
+												{
+													model: 'company',
+													uuid: THE_KINGS_MEN_COMPANY_UUID,
+													name: 'The King\'s Men'
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
 				{
 					model: 'material',
 					uuid: SHAKESPEARES_VILLAINS_MATERIAL_UUID,
@@ -862,6 +1134,60 @@ describe('Materials with source material', () => {
 		it('includes materials that used their work as source material (both specific and non-specific), with corresponding writers', () => {
 
 			const expectedSourcingMaterials = [
+				{
+					model: 'material',
+					uuid: OTHELLO_MATERIAL_UUID,
+					name: 'Othello',
+					format: 'play',
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+									name: 'William Shakespeare'
+								},
+								{
+									model: 'company',
+									uuid: null,
+									name: 'The King\'s Men'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'based on',
+							writingEntities: [
+								{
+									model: 'material',
+									uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
+									name: 'A Moorish Captain',
+									format: 'tale',
+									sourceMaterialWritingCredits: [
+										{
+											model: 'writingCredit',
+											name: 'by',
+											writingEntities: [
+												{
+													model: 'person',
+													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+													name: 'William Shakespeare'
+												},
+												{
+													model: 'company',
+													uuid: null,
+													name: 'The King\'s Men'
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
 				{
 					model: 'material',
 					uuid: SHAKESPEARES_VILLAINS_MATERIAL_UUID,
@@ -1264,6 +1590,73 @@ describe('Materials with source material', () => {
 
 	});
 
+	describe('Othello at Donmar Warehouse (production)', () => {
+
+		it('includes in its material data the writers of the material and its source material', () => {
+
+			const expectedMaterial = {
+				model: 'material',
+				uuid: OTHELLO_MATERIAL_UUID,
+				name: 'Othello',
+				format: 'play',
+				writingCredits: [
+					{
+						model: 'writingCredit',
+						name: 'by',
+						writingEntities: [
+							{
+								model: 'person',
+								uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+								name: 'William Shakespeare'
+							},
+							{
+								model: 'company',
+								uuid: THE_KINGS_MEN_COMPANY_UUID,
+								name: 'The King\'s Men'
+							}
+						]
+					},
+					{
+						model: 'writingCredit',
+						name: 'based on',
+						writingEntities: [
+							{
+								model: 'material',
+								uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
+								name: 'A Moorish Captain',
+								format: 'tale',
+								sourceMaterialWritingCredits: [
+									{
+										model: 'writingCredit',
+										name: 'by',
+										writingEntities: [
+											{
+												model: 'person',
+												uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+												name: 'William Shakespeare'
+											},
+											{
+												model: 'company',
+												uuid: THE_KINGS_MEN_COMPANY_UUID,
+												name: 'The King\'s Men'
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			};
+
+			const { material } = othelloDonmarWarehouseProduction.body;
+
+			expect(material).to.deep.equal(expectedMaterial);
+
+		});
+
+	});
+
 	describe('The Indian Boy (character)', () => {
 
 		it('includes in its material data the writers of the material and its source material', () => {
@@ -1339,6 +1732,61 @@ describe('Materials with source material', () => {
 		it('includes in its material data the writers of the material and its source material', () => {
 
 			const expectedMaterials = [
+				{
+					model: 'material',
+					uuid: OTHELLO_MATERIAL_UUID,
+					name: 'Othello',
+					format: 'play',
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+									name: 'William Shakespeare'
+								},
+								{
+									model: 'company',
+									uuid: THE_KINGS_MEN_COMPANY_UUID,
+									name: 'The King\'s Men'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'based on',
+							writingEntities: [
+								{
+									model: 'material',
+									uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
+									name: 'A Moorish Captain',
+									format: 'tale',
+									sourceMaterialWritingCredits: [
+										{
+											model: 'writingCredit',
+											name: 'by',
+											writingEntities: [
+												{
+													model: 'person',
+													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+													name: 'William Shakespeare'
+												},
+												{
+													model: 'company',
+													uuid: THE_KINGS_MEN_COMPANY_UUID,
+													name: 'The King\'s Men'
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					],
+					depictions: []
+				},
 				{
 					model: 'material',
 					uuid: SHAKESPEARES_VILLAINS_MATERIAL_UUID,
@@ -1417,6 +1865,84 @@ describe('Materials with source material', () => {
 									model: 'company',
 									uuid: THE_KINGS_MEN_COMPANY_UUID,
 									name: 'The King\'s Men'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'material',
+					uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
+					name: 'A Moorish Captain',
+					format: 'tale',
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+									name: 'William Shakespeare'
+								},
+								{
+									model: 'company',
+									uuid: THE_KINGS_MEN_COMPANY_UUID,
+									name: 'The King\'s Men'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'material',
+					uuid: OTHELLO_MATERIAL_UUID,
+					name: 'Othello',
+					format: 'play',
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+									name: 'William Shakespeare'
+								},
+								{
+									model: 'company',
+									uuid: THE_KINGS_MEN_COMPANY_UUID,
+									name: 'The King\'s Men'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'based on',
+							writingEntities: [
+								{
+									model: 'material',
+									uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
+									name: 'A Moorish Captain',
+									format: 'tale',
+									sourceMaterialWritingCredits: [
+										{
+											model: 'writingCredit',
+											name: 'by',
+											writingEntities: [
+												{
+													model: 'person',
+													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+													name: 'William Shakespeare'
+												},
+												{
+													model: 'company',
+													uuid: THE_KINGS_MEN_COMPANY_UUID,
+													name: 'The King\'s Men'
+												}
+											]
+										}
+									]
 								}
 							]
 						}


### PR DESCRIPTION
This PR fixes a bug that appears on the person and company pages in the scenario of a person or company having:
- a direct writing credit for a given material
- a source material writing credit for the same material

It also adds end-to-end tests to prevent regressions, as well as database seeds to include an example of the above (the play Murder on the Nile by Agatha Christie, which is based on Death on the Nile - the novel also written by Agatha Christie).

This change to the Cypher query has also affect the order of materials in person/company credits, so the `material-multi-versions-multi-wri-groups` end-to-end tests have also needed to be revised to accommodate this change (these will become stable once there is a secondary ordering clause such as date written).

---

#### Before:
![before](https://user-images.githubusercontent.com/10484515/112755719-e8b84e00-8fd9-11eb-9991-b3dfa3317948.png)

---

#### After:
![after](https://user-images.githubusercontent.com/10484515/112755722-ebb33e80-8fd9-11eb-9514-6bf77df9288a.png)