### PR TITLE
Fix entity duplicate materials in writing credits where multiple direct credits exist

### DIFF
--- a/src/neo4j/cypher-queries/company.js
+++ b/src/neo4j/cypher-queries/company.js
@@ -20,8 +20,9 @@ const getShowQuery = () => `
 
 		WITH
 			company,
-			writerRel,
 			material,
+			writerRel.creditType AS creditType,
+			CASE writerRel WHEN NULL THEN false ELSE true END AS hasDirectCredit,
 			CASE subsequentVersionRel WHEN NULL THEN false ELSE true END AS isSubsequentVersion,
 			CASE sourcingMaterialRel WHEN NULL THEN false ELSE true END AS isSourcingMaterial,
 			writingEntityRel,
@@ -32,8 +33,9 @@ const getShowQuery = () => `
 
 		WITH
 			company,
-			writerRel,
 			material,
+			creditType,
+			hasDirectCredit,
 			isSubsequentVersion,
 			isSourcingMaterial,
 			writingEntityRel,
@@ -53,7 +55,15 @@ const getShowQuery = () => `
 				END
 			) AS sourceMaterialWriters
 
-		WITH company, writerRel, material, isSubsequentVersion, isSourcingMaterial, writingEntityRel, writingEntity,
+		WITH
+			company,
+			material,
+			creditType,
+			hasDirectCredit,
+			isSubsequentVersion,
+			isSourcingMaterial,
+			writingEntityRel,
+			writingEntity,
 			COLLECT(
 				CASE SIZE(sourceMaterialWriters) WHEN 0
 					THEN null
@@ -68,8 +78,9 @@ const getShowQuery = () => `
 
 		WITH
 			company,
-			writerRel,
 			material,
+			creditType,
+			hasDirectCredit,
 			isSubsequentVersion,
 			isSourcingMaterial,
 			writingEntityRel.credit AS writingCreditName,
@@ -89,7 +100,7 @@ const getShowQuery = () => `
 				ELSE writingEntity { .model, .uuid, .name }
 			END] AS writingEntities
 
-		WITH company, writerRel, material, isSubsequentVersion, isSourcingMaterial,
+		WITH company, material, creditType, hasDirectCredit, isSubsequentVersion, isSourcingMaterial,
 			COLLECT(
 				CASE SIZE(writingEntities) WHEN 0
 					THEN null
@@ -112,8 +123,8 @@ const getShowQuery = () => `
 						.name,
 						.format,
 						writingCredits: writingCredits,
-						creditType: writerRel.creditType,
-						hasDirectCredit: CASE writerRel WHEN NULL THEN false ELSE true END,
+						creditType: creditType,
+						hasDirectCredit: hasDirectCredit,
 						isSubsequentVersion: isSubsequentVersion,
 						isSourcingMaterial: isSourcingMaterial
 					}

--- a/src/neo4j/cypher-queries/person.js
+++ b/src/neo4j/cypher-queries/person.js
@@ -20,8 +20,9 @@ const getShowQuery = () => `
 
 		WITH
 			person,
-			writerRel,
 			material,
+			writerRel.creditType AS creditType,
+			CASE writerRel WHEN NULL THEN false ELSE true END AS hasDirectCredit,
 			CASE subsequentVersionRel WHEN NULL THEN false ELSE true END AS isSubsequentVersion,
 			CASE sourcingMaterialRel WHEN NULL THEN false ELSE true END AS isSourcingMaterial,
 			writingEntityRel,
@@ -32,8 +33,9 @@ const getShowQuery = () => `
 
 		WITH
 			person,
-			writerRel,
 			material,
+			creditType,
+			hasDirectCredit,
 			isSubsequentVersion,
 			isSourcingMaterial,
 			writingEntityRel,
@@ -53,7 +55,15 @@ const getShowQuery = () => `
 				END
 			) AS sourceMaterialWriters
 
-		WITH person, writerRel, material, isSubsequentVersion, isSourcingMaterial, writingEntityRel, writingEntity,
+		WITH
+			person,
+			material,
+			creditType,
+			hasDirectCredit,
+			isSubsequentVersion,
+			isSourcingMaterial,
+			writingEntityRel,
+			writingEntity,
 			COLLECT(
 				CASE SIZE(sourceMaterialWriters) WHEN 0
 					THEN null
@@ -68,8 +78,9 @@ const getShowQuery = () => `
 
 		WITH
 			person,
-			writerRel,
 			material,
+			creditType,
+			hasDirectCredit,
 			isSubsequentVersion,
 			isSourcingMaterial,
 			writingEntityRel.credit AS writingCreditName,
@@ -89,7 +100,7 @@ const getShowQuery = () => `
 				ELSE writingEntity { .model, .uuid, .name }
 			END] AS writingEntities
 
-		WITH person, writerRel, material, isSubsequentVersion, isSourcingMaterial,
+		WITH person, material, creditType, hasDirectCredit, isSubsequentVersion, isSourcingMaterial,
 			COLLECT(
 				CASE SIZE(writingEntities) WHEN 0
 					THEN null
@@ -112,8 +123,8 @@ const getShowQuery = () => `
 						.name,
 						.format,
 						writingCredits: writingCredits,
-						creditType: writerRel.creditType,
-						hasDirectCredit: CASE writerRel WHEN NULL THEN false ELSE true END,
+						creditType: creditType,
+						hasDirectCredit: hasDirectCredit,
 						isSubsequentVersion: isSubsequentVersion,
 						isSourcingMaterial: isSourcingMaterial
 					}

--- a/test-e2e/model-interaction/material-with-multiple-credited-entities.test.js
+++ b/test-e2e/model-interaction/material-with-multiple-credited-entities.test.js
@@ -1,0 +1,237 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import { createSandbox } from 'sinon';
+import { v4 as uuid } from 'uuid';
+
+import app from '../../src/app';
+import purgeDatabase from '../test-helpers/neo4j/purge-database';
+
+describe('Materials with entities credited multiple times', () => {
+
+	chai.use(chaiHttp);
+
+	const MATERIAL_UUID = '4';
+	const PERSON_UUID = '6';
+	const COMPANY_UUID = '7';
+
+	let material;
+	let person;
+	let company;
+
+	const sandbox = createSandbox();
+
+	before(async () => {
+
+		let uuidCallCount = 0;
+
+		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+
+		await purgeDatabase();
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Material name',
+				format: 'play',
+				writingCredits: [
+					{
+						writingEntities: [
+							{
+								name: 'Person #1'
+							},
+							{
+								model: 'company',
+								name: 'Company #1'
+							}
+						]
+					},
+					{
+						name: 'additional material by',
+						writingEntities: [
+							{
+								name: 'Person #1'
+							},
+							{
+								model: 'company',
+								name: 'Company #1'
+							}
+						]
+					}
+				]
+			});
+
+		material = await chai.request(app)
+			.get(`/materials/${MATERIAL_UUID}`);
+
+		person = await chai.request(app)
+			.get(`/people/${PERSON_UUID}`);
+
+		company = await chai.request(app)
+			.get(`/companies/${COMPANY_UUID}`);
+
+	});
+
+	after(() => {
+
+		sandbox.restore();
+
+	});
+
+	describe('Material', () => {
+
+		it('includes writers of this material grouped by their respective credits', () => {
+
+			const expectedWritingCredits = [
+				{
+					model: 'writingCredit',
+					name: 'by',
+					writingEntities: [
+						{
+							model: 'person',
+							uuid: PERSON_UUID,
+							name: 'Person #1'
+						},
+						{
+							model: 'company',
+							uuid: COMPANY_UUID,
+							name: 'Company #1'
+						}
+					]
+				},
+				{
+					model: 'writingCredit',
+					name: 'additional material by',
+					writingEntities: [
+						{
+							model: 'person',
+							uuid: PERSON_UUID,
+							name: 'Person #1'
+						},
+						{
+							model: 'company',
+							uuid: COMPANY_UUID,
+							name: 'Company #1'
+						}
+					]
+				}
+			];
+
+			const { writingCredits } = material.body;
+
+			expect(writingCredits).to.deep.equal(expectedWritingCredits);
+
+		});
+
+	});
+
+	describe('Person', () => {
+
+		it('includes materials they have written (in which their uuid is nullified), with corresponding writers', () => {
+
+			const expectedMaterials = [
+				{
+					model: 'material',
+					uuid: MATERIAL_UUID,
+					name: 'Material name',
+					format: 'play',
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: null,
+									name: 'Person #1'
+								},
+								{
+									model: 'company',
+									uuid: COMPANY_UUID,
+									name: 'Company #1'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'additional material by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: null,
+									name: 'Person #1'
+								},
+								{
+									model: 'company',
+									uuid: COMPANY_UUID,
+									name: 'Company #1'
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { materials } = person.body;
+
+			expect(materials).to.deep.equal(expectedMaterials);
+
+		});
+
+	});
+
+	describe('Company', () => {
+
+		it('includes materials they have written (in which their uuid is nullified), with corresponding writers', () => {
+
+			const expectedMaterials = [
+				{
+					model: 'material',
+					uuid: MATERIAL_UUID,
+					name: 'Material name',
+					format: 'play',
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: PERSON_UUID,
+									name: 'Person #1'
+								},
+								{
+									model: 'company',
+									uuid: null,
+									name: 'Company #1'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'additional material by',
+							writingEntities: [
+								{
+									model: 'person',
+									uuid: PERSON_UUID,
+									name: 'Person #1'
+								},
+								{
+									model: 'company',
+									uuid: null,
+									name: 'Company #1'
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { materials } = company.body;
+
+			expect(materials).to.deep.equal(expectedMaterials);
+
+		});
+
+	});
+
+});


### PR DESCRIPTION
This PR fixes the person and company Cypher show queries for when such an entity has two direct credits (i.e. not credited via a specific source material) to the same material.

Admittedly this is an unlikely occurrence but the result of this change means that the Cypher query is written in a more logical way: the result of the `writerRel` being carried through (via `WITH`) and was still present as part of the materials when they were collected, meant that duplicate materials were still kept separate if multiple distinct credits for the same piece of material existed.

Now that `writerRel` is not carried through, it allows the materials to be consolidated and de-duplicated when they are `COLLECT`ed as `materials`.

---

#### Before:
![before](https://user-images.githubusercontent.com/10484515/112857939-49628c00-90a9-11eb-93b9-23b71d69773b.png)

---

#### After:
![after](https://user-images.githubusercontent.com/10484515/112857946-4bc4e600-90a9-11eb-9360-81e63f08fd79.png)