### PR TITLE
Fix person + company Cypher show query error

### DIFF
--- a/src/neo4j/cypher-queries/company.js
+++ b/src/neo4j/cypher-queries/company.js
@@ -7,7 +7,7 @@ const getShowQuery = () => `
 
 	UNWIND (CASE materials WHEN [] THEN [null] ELSE materials END) AS material
 
-		OPTIONAL MATCH (company)<-[writerRel:WRITTEN_BY]-(material:Material)
+		OPTIONAL MATCH (company)<-[writerRel:WRITTEN_BY]-(material)
 
 		OPTIONAL MATCH (company)<-[:WRITTEN_BY]-(:Material)<-[subsequentVersionRel:SUBSEQUENT_VERSION_OF]-(material)
 

--- a/src/neo4j/cypher-queries/person.js
+++ b/src/neo4j/cypher-queries/person.js
@@ -7,7 +7,7 @@ const getShowQuery = () => `
 
 	UNWIND (CASE materials WHEN [] THEN [null] ELSE materials END) AS material
 
-		OPTIONAL MATCH (person)<-[writerRel:WRITTEN_BY]-(material:Material)
+		OPTIONAL MATCH (person)<-[writerRel:WRITTEN_BY]-(material)
 
 		OPTIONAL MATCH (person)<-[:WRITTEN_BY]-(:Material)<-[subsequentVersionRel:SUBSEQUENT_VERSION_OF]-(material)
 


### PR DESCRIPTION
This PR fixes a bug which can be replicated via the these steps:

Clear Neo4j database:
`MATCH (n) DETACH DELETE n RETURN 'done'`

Add a single person node:
`CREATE (p:Person { uuid: 'c771ad24-24ca-4002-ab8f-17719e4c32dc', name: 'John Doe' }) RETURN p`

Set params to use the person's uuid value:
`:params { uuid: 'c771ad24-24ca-4002-ab8f-17719e4c32dc' }`

The person show query will then fail with this error:
```
ERROR Neo.DatabaseError.Statement.ExecutionFailed
Tried overwriting already taken variable name '  material@246' as LongSlot(1,false,Node) (was: RefSlot(1,true,Any))
```

The same error occurs if the same steps are done for a company rather than a person.

My initial investigation into this issue is detailed in [my comment](https://github.com/neo4j/neo4j/issues/12441#issuecomment-810494380) in this [GitHub issue](https://github.com/neo4j/neo4j/issues/12441).

It transpired that the `:Material` label as removed in this PR is unnecessary because all the `material` items in the `materials` array were originally matched on the basis of having that label, and furthermore it causes the above error.

Removing the label fixes the error.

### References:
- [GitHub - neo4j/neo4j: Execution of complex query fails using the slotted runtime](https://github.com/neo4j/neo4j/issues/12441)