### PR TITLE
Rename writingEntities -> entities

### DIFF
--- a/db-seeding/seeds/materials/3-winters.json
+++ b/db-seeding/seeds/materials/3-winters.json
@@ -3,7 +3,7 @@
 	"format": "play",
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Tena Štivičić"
 				}

--- a/db-seeding/seeds/materials/a-midsummer-nights-dream.json
+++ b/db-seeding/seeds/materials/a-midsummer-nights-dream.json
@@ -3,7 +3,7 @@
 	"format": "play",
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "William Shakespeare"
 				}

--- a/db-seeding/seeds/materials/coriolanus.json
+++ b/db-seeding/seeds/materials/coriolanus.json
@@ -3,7 +3,7 @@
 	"format": "play",
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "William Shakespeare"
 				}

--- a/db-seeding/seeds/materials/death-on-the-nile-novel.json
+++ b/db-seeding/seeds/materials/death-on-the-nile-novel.json
@@ -3,7 +3,7 @@
 	"format": "novel",
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Agatha Christie"
 				}

--- a/db-seeding/seeds/materials/hamlet.json
+++ b/db-seeding/seeds/materials/hamlet.json
@@ -3,7 +3,7 @@
 	"format": "play",
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "William Shakespeare"
 				}

--- a/db-seeding/seeds/materials/happy-days.json
+++ b/db-seeding/seeds/materials/happy-days.json
@@ -3,7 +3,7 @@
 	"format": "play",
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Samuel Beckett"
 				}

--- a/db-seeding/seeds/materials/henry-iv-part-1.json
+++ b/db-seeding/seeds/materials/henry-iv-part-1.json
@@ -3,7 +3,7 @@
 	"format": "play",
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "William Shakespeare"
 				}

--- a/db-seeding/seeds/materials/henry-iv-part-2.json
+++ b/db-seeding/seeds/materials/henry-iv-part-2.json
@@ -3,7 +3,7 @@
 	"format": "play",
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "William Shakespeare"
 				}

--- a/db-seeding/seeds/materials/henry-v.json
+++ b/db-seeding/seeds/materials/henry-v.json
@@ -3,7 +3,7 @@
 	"format": "play",
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "William Shakespeare"
 				}

--- a/db-seeding/seeds/materials/julius-caesar.json
+++ b/db-seeding/seeds/materials/julius-caesar.json
@@ -3,7 +3,7 @@
 	"format": "play",
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "William Shakespeare"
 				}

--- a/db-seeding/seeds/materials/little-eyolf.json
+++ b/db-seeding/seeds/materials/little-eyolf.json
@@ -3,7 +3,7 @@
 	"format": "play",
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Henrik Ibsen"
 				}

--- a/db-seeding/seeds/materials/miss-julie-original-version.json
+++ b/db-seeding/seeds/materials/miss-julie-original-version.json
@@ -3,7 +3,7 @@
 	"format": "play",
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "August Strindberg"
 				}

--- a/db-seeding/seeds/materials/miss-julie-subsequent-version-1.json
+++ b/db-seeding/seeds/materials/miss-julie-subsequent-version-1.json
@@ -6,7 +6,7 @@
 	},
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Patrick Marber"
 				}
@@ -14,7 +14,7 @@
 		},
 		{
 			"name": "after",
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "August Strindberg"
 				}

--- a/db-seeding/seeds/materials/miss-julie-subsequent-version-2.json
+++ b/db-seeding/seeds/materials/miss-julie-subsequent-version-2.json
@@ -6,7 +6,7 @@
 	},
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Polly Stenham"
 				}
@@ -14,7 +14,7 @@
 		},
 		{
 			"name": "after",
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "August Strindberg"
 				}

--- a/db-seeding/seeds/materials/mrs-affleck.json
+++ b/db-seeding/seeds/materials/mrs-affleck.json
@@ -3,7 +3,7 @@
 	"format": "play",
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Samuel Adamson"
 				}
@@ -11,7 +11,7 @@
 		},
 		{
 			"name": "from",
-			"writingEntities": [
+			"entities": [
 				{
 					"model": "material",
 					"name": "Little Eyolf"

--- a/db-seeding/seeds/materials/murder-on-the-nile-play.json
+++ b/db-seeding/seeds/materials/murder-on-the-nile-play.json
@@ -3,7 +3,7 @@
 	"format": "play",
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Agatha Christie"
 				}
@@ -11,7 +11,7 @@
 		},
 		{
 			"name": "based on",
-			"writingEntities": [
+			"entities": [
 				{
 					"model": "material",
 					"name": "Death on the Nile"

--- a/db-seeding/seeds/materials/peer-gynt-original-version.json
+++ b/db-seeding/seeds/materials/peer-gynt-original-version.json
@@ -4,7 +4,7 @@
 	"format": "play",
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Henrik Ibsen"
 				}

--- a/db-seeding/seeds/materials/peer-gynt-subsequent-version-1.json
+++ b/db-seeding/seeds/materials/peer-gynt-subsequent-version-1.json
@@ -8,7 +8,7 @@
 	},
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Henrik Ibsen"
 				}
@@ -16,7 +16,7 @@
 		},
 		{
 			"name": "version by",
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Frank McGuiness"
 				}

--- a/db-seeding/seeds/materials/peer-gynt-subsequent-version-2.json
+++ b/db-seeding/seeds/materials/peer-gynt-subsequent-version-2.json
@@ -8,7 +8,7 @@
 	},
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Henrik Ibsen"
 				}
@@ -16,7 +16,7 @@
 		},
 		{
 			"name": "translated by",
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Gerry Bamman"
 				},
@@ -27,7 +27,7 @@
 		},
 		{
 			"name": "adapted by",
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Baltasar Kormákur"
 				}

--- a/db-seeding/seeds/materials/rock-n-roll.json
+++ b/db-seeding/seeds/materials/rock-n-roll.json
@@ -3,7 +3,7 @@
 	"format": "play",
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Tom Stoppard"
 				}

--- a/db-seeding/seeds/materials/rope.json
+++ b/db-seeding/seeds/materials/rope.json
@@ -3,7 +3,7 @@
 	"format": "play",
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Patrick Hamilton"
 				}

--- a/db-seeding/seeds/materials/shakespeares-villains.json
+++ b/db-seeding/seeds/materials/shakespeares-villains.json
@@ -3,7 +3,7 @@
 	"format": "play",
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Steven Berkoff"
 				}
@@ -12,7 +12,7 @@
 		{
 			"name": "based on works by",
 			"creditType": "NON_SPECIFIC_SOURCE_MATERIAL",
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "William Shakespeare"
 				}

--- a/db-seeding/seeds/materials/the-b-file.json
+++ b/db-seeding/seeds/materials/the-b-file.json
@@ -3,7 +3,7 @@
 	"format": "play",
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Deborah Levy"
 				}

--- a/db-seeding/seeds/materials/the-dark-philosophers.json
+++ b/db-seeding/seeds/materials/the-dark-philosophers.json
@@ -4,7 +4,7 @@
 	"writingCredits": [
 		{
 			"name": "adapted by",
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Carl Grose"
 				},
@@ -17,7 +17,7 @@
 		{
 			"name": "based on the life and stories of",
 			"creditType": "NON_SPECIFIC_SOURCE_MATERIAL",
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Gwyn Thomas"
 				}

--- a/db-seeding/seeds/materials/the-dumb-waiter.json
+++ b/db-seeding/seeds/materials/the-dumb-waiter.json
@@ -3,7 +3,7 @@
 	"format": "play",
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Harold Pinter"
 				}

--- a/db-seeding/seeds/materials/the-girl-on-the-train-film.json
+++ b/db-seeding/seeds/materials/the-girl-on-the-train-film.json
@@ -4,7 +4,7 @@
 	"format": "film",
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"model": "company",
 					"name": "Dreamworks"

--- a/db-seeding/seeds/materials/the-girl-on-the-train-novel.json
+++ b/db-seeding/seeds/materials/the-girl-on-the-train-novel.json
@@ -4,7 +4,7 @@
 	"format": "novel",
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Paula Hawkins"
 				}

--- a/db-seeding/seeds/materials/the-girl-on-the-train-play.json
+++ b/db-seeding/seeds/materials/the-girl-on-the-train-play.json
@@ -5,7 +5,7 @@
 	"writingCredits": [
 		{
 			"name": "based on",
-			"writingEntities": [
+			"entities": [
 				{
 					"model": "material",
 					"name": "The Girl on the Train",
@@ -20,7 +20,7 @@
 		},
 		{
 			"name": "adapted by",
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Rachel Wagstaff"
 				},

--- a/db-seeding/seeds/materials/the-indian-boy.json
+++ b/db-seeding/seeds/materials/the-indian-boy.json
@@ -3,7 +3,7 @@
 	"format": "play",
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Rona Munro"
 				}
@@ -11,7 +11,7 @@
 		},
 		{
 			"name": "inspired by",
-			"writingEntities": [
+			"entities": [
 				{
 					"model": "material",
 					"name": "A Midsummer Night's Dream"

--- a/db-seeding/seeds/materials/the-ladykillers-1-screenplay.json
+++ b/db-seeding/seeds/materials/the-ladykillers-1-screenplay.json
@@ -4,7 +4,7 @@
 	"format": "motion picture screenplay",
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "William Rose"
 				}

--- a/db-seeding/seeds/materials/the-ladykillers-2-play.json
+++ b/db-seeding/seeds/materials/the-ladykillers-2-play.json
@@ -4,7 +4,7 @@
 	"format": "play",
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Graham Linehan"
 				}
@@ -12,7 +12,7 @@
 		},
 		{
 			"name": "from",
-			"writingEntities": [
+			"entities": [
 				{
 					"model": "material",
 					"name": "The Ladykillers",
@@ -23,7 +23,7 @@
 		{
 			"name": "by special arrangement with",
 			"creditType": "RIGHTS_GRANTOR",
-			"writingEntities": [
+			"entities": [
 				{
 					"model": "company",
 					"name": "StudioCanal"

--- a/db-seeding/seeds/materials/the-seagull-original-version.json
+++ b/db-seeding/seeds/materials/the-seagull-original-version.json
@@ -4,7 +4,7 @@
 	"format": "play",
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Anton Chekhov"
 				}

--- a/db-seeding/seeds/materials/the-seagull-subsequent-version.json
+++ b/db-seeding/seeds/materials/the-seagull-subsequent-version.json
@@ -8,7 +8,7 @@
 	},
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Anton Chekhov"
 				}
@@ -16,7 +16,7 @@
 		},
 		{
 			"name": "version by",
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "John Donnelly"
 				}

--- a/db-seeding/seeds/materials/three-sisters-original-version.json
+++ b/db-seeding/seeds/materials/three-sisters-original-version.json
@@ -4,7 +4,7 @@
 	"format": "play",
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Anton Chekhov"
 				}

--- a/db-seeding/seeds/materials/three-sisters-subsequent-version-1.json
+++ b/db-seeding/seeds/materials/three-sisters-subsequent-version-1.json
@@ -8,7 +8,7 @@
 	},
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Anton Chekhov"
 				}
@@ -16,7 +16,7 @@
 		},
 		{
 			"name": "version by",
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Benedict Andrews"
 				}

--- a/db-seeding/seeds/materials/three-sisters-subsequent-version-2.json
+++ b/db-seeding/seeds/materials/three-sisters-subsequent-version-2.json
@@ -8,7 +8,7 @@
 	},
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Inua Ellams"
 				}
@@ -16,7 +16,7 @@
 		},
 		{
 			"name": "after",
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Anton Chekhov"
 				}

--- a/db-seeding/seeds/materials/titus-andronicus.json
+++ b/db-seeding/seeds/materials/titus-andronicus.json
@@ -3,7 +3,7 @@
 	"format": "play",
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "William Shakespeare"
 				}

--- a/db-seeding/seeds/materials/true-west.json
+++ b/db-seeding/seeds/materials/true-west.json
@@ -3,7 +3,7 @@
 	"format": "play",
 	"writingCredits": [
 		{
-			"writingEntities": [
+			"entities": [
 				{
 					"name": "Sam Shepard"
 				}

--- a/src/controllers/model-seed-props/material.js
+++ b/src/controllers/model-seed-props/material.js
@@ -1,7 +1,7 @@
 export default {
 	writingCredits: [
 		{
-			writingEntities: [
+			entities: [
 				{}
 			]
 		}

--- a/src/lib/prepare-as-params.js
+++ b/src/lib/prepare-as-params.js
@@ -21,7 +21,7 @@ export const prepareAsParams = instance => {
 		|| EMPTY_NAME_EXCEPTION_KEYS.includes(key);
 
 	const isNotWritingCreditWithoutNamedEntity = key => item =>
-		key !== WRITING_CREDITS || item.writingEntities.some(entity => !!entity.name);
+		key !== WRITING_CREDITS || item.entities.some(entity => !!entity.name);
 
 	const isNotCharacterGroupWithoutNamedCharacter = key => item =>
 		key !== CHARACTER_GROUPS || item.characters.some(character => !!character.name);

--- a/src/models/WritingCredit.js
+++ b/src/models/WritingCredit.js
@@ -9,19 +9,19 @@ export default class WritingCredit extends Base {
 
 		super(props);
 
-		const { creditType, writingEntities } = props;
+		const { creditType, entities } = props;
 
 		this.creditType = CREDIT_TYPES[creditType] || null;
 
-		this.writingEntities = writingEntities
-			? writingEntities.map(writingEntity => {
-				switch (writingEntity.model) {
+		this.entities = entities
+			? entities.map(entity => {
+				switch (entity.model) {
 					case 'company':
-						return new Company(writingEntity);
+						return new Company(entity);
 					case 'material':
-						return new Material({ ...writingEntity, isAssociation: true });
+						return new Material({ ...entity, isAssociation: true });
 					default:
-						return new Person(writingEntity);
+						return new Person(entity);
 				}
 			})
 			: [];
@@ -40,19 +40,19 @@ export default class WritingCredit extends Base {
 
 		this.validateUniquenessInGroup({ isDuplicate: opts.isDuplicate });
 
-		const duplicateWritingEntityIndices = getDuplicateEntityIndices(this.writingEntities);
+		const duplicateWritingEntityIndices = getDuplicateEntityIndices(this.entities);
 
-		this.writingEntities.forEach((writingEntity, index) => {
+		this.entities.forEach((entity, index) => {
 
-			writingEntity.validateName({ isRequired: false });
+			entity.validateName({ isRequired: false });
 
-			writingEntity.validateDifferentiator();
+			entity.validateDifferentiator();
 
-			writingEntity.validateUniquenessInGroup({ isDuplicate: duplicateWritingEntityIndices.includes(index) });
+			entity.validateUniquenessInGroup({ isDuplicate: duplicateWritingEntityIndices.includes(index) });
 
-			if (writingEntity.model === 'material') {
+			if (entity.model === 'material') {
 
-				writingEntity.validateNoAssociationWithSelf(opts.subject.name, opts.subject.differentiator);
+				entity.validateNoAssociationWithSelf(opts.subject.name, opts.subject.differentiator);
 
 			}
 

--- a/src/neo4j/cypher-queries/character.js
+++ b/src/neo4j/cypher-queries/character.js
@@ -3,17 +3,17 @@ const getShowQuery = () => `
 
 	OPTIONAL MATCH (character)<-[materialRel:INCLUDES_CHARACTER]-(material:Material)
 
-	OPTIONAL MATCH (material)-[writingEntityRel:WRITTEN_BY|USES_SOURCE_MATERIAL]->(writingEntity)
-		WHERE writingEntity:Person OR writingEntity:Company OR writingEntity:Material
+	OPTIONAL MATCH (material)-[entityRel:WRITTEN_BY|USES_SOURCE_MATERIAL]->(entity)
+		WHERE entity:Person OR entity:Company OR entity:Material
 
-	OPTIONAL MATCH (writingEntity:Material)-[sourceMaterialWriterRel:WRITTEN_BY]->(sourceMaterialWriter)
+	OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:WRITTEN_BY]->(sourceMaterialWriter)
 
 	WITH
 		character,
 		materialRel,
 		material,
-		writingEntityRel,
-		writingEntity,
+		entityRel,
+		entity,
 		sourceMaterialWriterRel,
 		sourceMaterialWriter
 		ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriterRel.entityPosition
@@ -22,8 +22,8 @@ const getShowQuery = () => `
 		character,
 		materialRel,
 		material,
-		writingEntityRel,
-		writingEntity,
+		entityRel,
+		entity,
 		sourceMaterialWriterRel.credit AS sourceMaterialWritingCreditName,
 		COLLECT(
 			CASE sourceMaterialWriter WHEN NULL
@@ -32,44 +32,44 @@ const getShowQuery = () => `
 			END
 		) AS sourceMaterialWriters
 
-	WITH character, materialRel, material, writingEntityRel, writingEntity,
+	WITH character, materialRel, material, entityRel, entity,
 		COLLECT(
 			CASE SIZE(sourceMaterialWriters) WHEN 0
 				THEN null
 				ELSE {
 					model: 'writingCredit',
 					name: COALESCE(sourceMaterialWritingCreditName, 'by'),
-					writingEntities: sourceMaterialWriters
+					entities: sourceMaterialWriters
 				}
 			END
 		) AS sourceMaterialWritingCredits
-		ORDER BY writingEntityRel.creditPosition, writingEntityRel.entityPosition
+		ORDER BY entityRel.creditPosition, entityRel.entityPosition
 
-	WITH character, materialRel, material, writingEntityRel.credit AS writingCreditName,
-		[writingEntity IN COLLECT(
-			CASE writingEntity WHEN NULL
+	WITH character, materialRel, material, entityRel.credit AS writingCreditName,
+		[entity IN COLLECT(
+			CASE entity WHEN NULL
 				THEN null
-				ELSE writingEntity {
-					model: TOLOWER(HEAD(LABELS(writingEntity))),
+				ELSE entity {
+					model: TOLOWER(HEAD(LABELS(entity))),
 					.uuid,
 					.name,
 					.format,
 					sourceMaterialWritingCredits: sourceMaterialWritingCredits
 				}
 			END
-		) | CASE writingEntity.model WHEN 'material'
-			THEN writingEntity
-			ELSE writingEntity { .model, .uuid, .name }
-		END] AS writingEntities
+		) | CASE entity.model WHEN 'material'
+			THEN entity
+			ELSE entity { .model, .uuid, .name }
+		END] AS entities
 
 	WITH character, materialRel, material,
 		COLLECT(
-			CASE SIZE(writingEntities) WHEN 0
+			CASE SIZE(entities) WHEN 0
 				THEN null
 				ELSE {
 					model: 'writingCredit',
 					name: COALESCE(writingCreditName, 'by'),
-					writingEntities: writingEntities
+					entities: entities
 				}
 			END
 		) AS writingCredits

--- a/src/neo4j/cypher-queries/person.js
+++ b/src/neo4j/cypher-queries/person.js
@@ -13,10 +13,10 @@ const getShowQuery = () => `
 
 		OPTIONAL MATCH (person)<-[:WRITTEN_BY]-(:Material)<-[sourcingMaterialRel:USES_SOURCE_MATERIAL]-(material)
 
-		OPTIONAL MATCH (material)-[writingEntityRel:WRITTEN_BY|USES_SOURCE_MATERIAL]->(writingEntity)
-			WHERE writingEntity:Person OR writingEntity:Company OR writingEntity:Material
+		OPTIONAL MATCH (material)-[entityRel:WRITTEN_BY|USES_SOURCE_MATERIAL]->(entity)
+			WHERE entity:Person OR entity:Company OR entity:Material
 
-		OPTIONAL MATCH (writingEntity:Material)-[sourceMaterialWriterRel:WRITTEN_BY]->(sourceMaterialWriter)
+		OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:WRITTEN_BY]->(sourceMaterialWriter)
 
 		WITH
 			person,
@@ -25,8 +25,8 @@ const getShowQuery = () => `
 			CASE writerRel WHEN NULL THEN false ELSE true END AS hasDirectCredit,
 			CASE subsequentVersionRel WHEN NULL THEN false ELSE true END AS isSubsequentVersion,
 			CASE sourcingMaterialRel WHEN NULL THEN false ELSE true END AS isSourcingMaterial,
-			writingEntityRel,
-			writingEntity,
+			entityRel,
+			entity,
 			sourceMaterialWriterRel,
 			sourceMaterialWriter
 			ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriterRel.entityPosition
@@ -38,8 +38,8 @@ const getShowQuery = () => `
 			hasDirectCredit,
 			isSubsequentVersion,
 			isSourcingMaterial,
-			writingEntityRel,
-			writingEntity,
+			entityRel,
+			entity,
 			sourceMaterialWriterRel.credit AS sourceMaterialWritingCreditName,
 			COLLECT(
 				CASE sourceMaterialWriter WHEN NULL
@@ -62,19 +62,19 @@ const getShowQuery = () => `
 			hasDirectCredit,
 			isSubsequentVersion,
 			isSourcingMaterial,
-			writingEntityRel,
-			writingEntity,
+			entityRel,
+			entity,
 			COLLECT(
 				CASE SIZE(sourceMaterialWriters) WHEN 0
 					THEN null
 					ELSE {
 						model: 'writingCredit',
 						name: COALESCE(sourceMaterialWritingCreditName, 'by'),
-						writingEntities: sourceMaterialWriters
+						entities: sourceMaterialWriters
 					}
 				END
 			) AS sourceMaterialWritingCredits
-			ORDER BY writingEntityRel.creditPosition, writingEntityRel.entityPosition
+			ORDER BY entityRel.creditPosition, entityRel.entityPosition
 
 		WITH
 			person,
@@ -83,31 +83,31 @@ const getShowQuery = () => `
 			hasDirectCredit,
 			isSubsequentVersion,
 			isSourcingMaterial,
-			writingEntityRel.credit AS writingCreditName,
-			[writingEntity IN COLLECT(
-				CASE writingEntity WHEN NULL
+			entityRel.credit AS writingCreditName,
+			[entity IN COLLECT(
+				CASE entity WHEN NULL
 					THEN null
-					ELSE writingEntity {
-						model: TOLOWER(HEAD(LABELS(writingEntity))),
-						uuid: CASE writingEntity.uuid WHEN person.uuid THEN null ELSE writingEntity.uuid END,
+					ELSE entity {
+						model: TOLOWER(HEAD(LABELS(entity))),
+						uuid: CASE entity.uuid WHEN person.uuid THEN null ELSE entity.uuid END,
 						.name,
 						.format,
 						sourceMaterialWritingCredits: sourceMaterialWritingCredits
 					}
 				END
-			) | CASE writingEntity.model WHEN 'material'
-				THEN writingEntity
-				ELSE writingEntity { .model, .uuid, .name }
-			END] AS writingEntities
+			) | CASE entity.model WHEN 'material'
+				THEN entity
+				ELSE entity { .model, .uuid, .name }
+			END] AS entities
 
 		WITH person, material, creditType, hasDirectCredit, isSubsequentVersion, isSourcingMaterial,
 			COLLECT(
-				CASE SIZE(writingEntities) WHEN 0
+				CASE SIZE(entities) WHEN 0
 					THEN null
 					ELSE {
 						model: 'writingCredit',
 						name: COALESCE(writingCreditName, 'by'),
-						writingEntities: writingEntities
+						entities: entities
 					}
 				END
 			) AS writingCredits

--- a/test-e2e/crud/materials-api.test.js
+++ b/test-e2e/crud/materials-api.test.js
@@ -38,7 +38,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 						name: '',
 						creditType: null,
 						errors: {},
-						writingEntities: [
+						entities: [
 							{
 								model: 'person',
 								name: '',
@@ -121,7 +121,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 						name: '',
 						creditType: null,
 						errors: {},
-						writingEntities: [
+						entities: [
 							{
 								model: 'person',
 								name: '',
@@ -180,7 +180,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 						name: '',
 						creditType: null,
 						errors: {},
-						writingEntities: [
+						entities: [
 							{
 								model: 'person',
 								name: '',
@@ -243,7 +243,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 						name: '',
 						creditType: null,
 						errors: {},
-						writingEntities: [
+						entities: [
 							{
 								model: 'person',
 								name: '',
@@ -387,7 +387,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 					writingCredits: [
 						{
 							name: '',
-							writingEntities: [
+							entities: [
 								{
 									name: 'Henrik Ibsen',
 									differentiator: '1'
@@ -402,7 +402,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 						},
 						{
 							name: 'version by',
-							writingEntities: [
+							entities: [
 								{
 									name: 'David Eldridge',
 									differentiator: '1'
@@ -412,7 +412,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 						// Contrivance for purposes of test.
 						{
 							name: 'based on',
-							writingEntities: [
+							entities: [
 								{
 									model: 'material',
 									name: 'John Gabriel Borkman',
@@ -467,7 +467,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 						name: '',
 						creditType: null,
 						errors: {},
-						writingEntities: [
+						entities: [
 							{
 								model: 'person',
 								name: 'Henrik Ibsen',
@@ -493,7 +493,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 						name: 'version by',
 						creditType: null,
 						errors: {},
-						writingEntities: [
+						entities: [
 							{
 								model: 'person',
 								name: 'David Eldridge',
@@ -513,7 +513,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 						name: 'based on',
 						creditType: null,
 						errors: {},
-						writingEntities: [
+						entities: [
 							{
 								model: 'material',
 								name: 'John Gabriel Borkman',
@@ -533,7 +533,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 						name: '',
 						creditType: null,
 						errors: {},
-						writingEntities: [
+						entities: [
 							{
 								model: 'person',
 								name: '',
@@ -631,7 +631,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 					{
 						model: 'writingCredit',
 						name: 'by',
-						writingEntities: [
+						entities: [
 							{
 								model: 'person',
 								uuid: HENRIK_IBSEN_PERSON_UUID,
@@ -647,7 +647,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 					{
 						model: 'writingCredit',
 						name: 'version by',
-						writingEntities: [
+						entities: [
 							{
 								model: 'person',
 								uuid: DAVID_ELDRIDGE_PERSON_UUID,
@@ -658,7 +658,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 					{
 						model: 'writingCredit',
 						name: 'based on',
-						writingEntities: [
+						entities: [
 							{
 								model: 'material',
 								uuid: JOHN_GABRIEL_BORKMAN_SOURCE_MATERIAL_MATERIAL_UUID,
@@ -729,7 +729,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 						name: '',
 						creditType: null,
 						errors: {},
-						writingEntities: [
+						entities: [
 							{
 								model: 'person',
 								name: 'Henrik Ibsen',
@@ -755,7 +755,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 						name: 'version by',
 						creditType: null,
 						errors: {},
-						writingEntities: [
+						entities: [
 							{
 								model: 'person',
 								name: 'David Eldridge',
@@ -775,7 +775,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 						name: 'based on',
 						creditType: null,
 						errors: {},
-						writingEntities: [
+						entities: [
 							{
 								model: 'material',
 								name: 'John Gabriel Borkman',
@@ -795,7 +795,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 						name: '',
 						creditType: null,
 						errors: {},
-						writingEntities: [
+						entities: [
 							{
 								model: 'person',
 								name: '',
@@ -885,7 +885,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 					writingCredits: [
 						{
 							name: '',
-							writingEntities: [
+							entities: [
 								{
 									name: 'Anton Chekhov',
 									differentiator: '1'
@@ -900,7 +900,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 						},
 						{
 							name: 'adaptation by',
-							writingEntities: [
+							entities: [
 								{
 									name: 'Benedict Andrews',
 									differentiator: '1'
@@ -910,7 +910,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 						// Contrivance for purposes of test.
 						{
 							name: 'based on',
-							writingEntities: [
+							entities: [
 								{
 									model: 'material',
 									name: 'Three Sisters',
@@ -965,7 +965,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 						name: '',
 						creditType: null,
 						errors: {},
-						writingEntities: [
+						entities: [
 							{
 								model: 'person',
 								name: 'Anton Chekhov',
@@ -991,7 +991,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 						name: 'adaptation by',
 						creditType: null,
 						errors: {},
-						writingEntities: [
+						entities: [
 							{
 								model: 'person',
 								name: 'Benedict Andrews',
@@ -1011,7 +1011,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 						name: 'based on',
 						creditType: null,
 						errors: {},
-						writingEntities: [
+						entities: [
 							{
 								model: 'material',
 								name: 'Three Sisters',
@@ -1031,7 +1031,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 						name: '',
 						creditType: null,
 						errors: {},
-						writingEntities: [
+						entities: [
 							{
 								model: 'person',
 								name: '',
@@ -1129,7 +1129,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 					{
 						model: 'writingCredit',
 						name: 'by',
-						writingEntities: [
+						entities: [
 							{
 								model: 'person',
 								uuid: ANTON_CHEKHOV_PERSON_UUID,
@@ -1145,7 +1145,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 					{
 						model: 'writingCredit',
 						name: 'adaptation by',
-						writingEntities: [
+						entities: [
 							{
 								model: 'person',
 								uuid: BENEDICT_ANDREWS_PERSON_UUID,
@@ -1156,7 +1156,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 					{
 						model: 'writingCredit',
 						name: 'based on',
-						writingEntities: [
+						entities: [
 							{
 								model: 'material',
 								uuid: THREE_SISTERS_SOURCE_MATERIAL_MATERIAL_UUID,
@@ -1233,7 +1233,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 						name: '',
 						creditType: null,
 						errors: {},
-						writingEntities: [
+						entities: [
 							{
 								model: 'person',
 								name: '',

--- a/test-e2e/model-interaction/material-multi-versions-multi-wri-groups.test.js
+++ b/test-e2e/model-interaction/material-multi-versions-multi-wri-groups.test.js
@@ -52,7 +52,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 				format: 'play',
 				writingCredits: [
 					{
-						writingEntities: [
+						entities: [
 							{
 								name: 'Henrik Ibsen'
 							},
@@ -87,7 +87,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 				},
 				writingCredits: [
 					{
-						writingEntities: [
+						entities: [
 							{
 								name: 'Henrik Ibsen'
 							},
@@ -100,7 +100,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 					},
 					{
 						name: 'version by',
-						writingEntities: [
+						entities: [
 							{
 								name: 'Frank McGuinness'
 							}
@@ -130,7 +130,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 				},
 				writingCredits: [
 					{
-						writingEntities: [
+						entities: [
 							{
 								name: 'Henrik Ibsen'
 							},
@@ -143,7 +143,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 					},
 					{
 						name: 'translated by',
-						writingEntities: [
+						entities: [
 							{
 								name: 'Gerry Bamman'
 							},
@@ -159,7 +159,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 					},
 					{
 						name: 'adapted by',
-						writingEntities: [
+						entities: [
 							{
 								name: 'Baltasar Kormákur'
 							}
@@ -185,7 +185,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 				format: 'play',
 				writingCredits: [
 					{
-						writingEntities: [
+						entities: [
 							{
 								name: 'Henrik Ibsen'
 							},
@@ -212,7 +212,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 				},
 				writingCredits: [
 					{
-						writingEntities: [
+						entities: [
 							{
 								name: 'Henrik Ibsen'
 							},
@@ -225,7 +225,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 					},
 					{
 						name: 'translated by',
-						writingEntities: [
+						entities: [
 							{
 								name: 'Gerry Bamman'
 							},
@@ -241,7 +241,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 					},
 					{
 						name: 'adapted by',
-						writingEntities: [
+						entities: [
 							{
 								name: 'Baltasar Kormákur'
 							}
@@ -309,7 +309,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'translated by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: GERRY_BAMMAN_PERSON_UUID,
@@ -330,7 +330,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'adapted by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
@@ -349,7 +349,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'version by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: FRANK_MCGUINNESS_PERSON_UUID,
@@ -373,7 +373,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 				{
 					model: 'writingCredit',
 					name: 'by',
-					writingEntities: [
+					entities: [
 						{
 							model: 'person',
 							uuid: HENRIK_IBSEN_PERSON_UUID,
@@ -409,7 +409,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 					{
 						model: 'writingCredit',
 						name: 'by',
-						writingEntities: [
+						entities: [
 							{
 								model: 'person',
 								uuid: HENRIK_IBSEN_PERSON_UUID,
@@ -437,7 +437,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 				{
 					model: 'writingCredit',
 					name: 'by',
-					writingEntities: [
+					entities: [
 						{
 							model: 'person',
 							uuid: HENRIK_IBSEN_PERSON_UUID,
@@ -453,7 +453,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 				{
 					model: 'writingCredit',
 					name: 'translated by',
-					writingEntities: [
+					entities: [
 						{
 							model: 'person',
 							uuid: GERRY_BAMMAN_PERSON_UUID,
@@ -474,7 +474,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 				{
 					model: 'writingCredit',
 					name: 'adapted by',
-					writingEntities: [
+					entities: [
 						{
 							model: 'person',
 							uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
@@ -506,7 +506,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: null,
@@ -530,7 +530,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: null,
@@ -565,7 +565,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: null,
@@ -581,7 +581,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'translated by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: GERRY_BAMMAN_PERSON_UUID,
@@ -602,7 +602,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'adapted by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
@@ -621,7 +621,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: null,
@@ -637,7 +637,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'translated by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: GERRY_BAMMAN_PERSON_UUID,
@@ -658,7 +658,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'adapted by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
@@ -677,7 +677,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: null,
@@ -693,7 +693,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'version by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: FRANK_MCGUINNESS_PERSON_UUID,
@@ -727,7 +727,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
@@ -743,7 +743,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'translated by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: null,
@@ -764,7 +764,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'adapted by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
@@ -783,7 +783,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
@@ -799,7 +799,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'translated by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: null,
@@ -820,7 +820,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'adapted by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
@@ -854,7 +854,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
@@ -878,7 +878,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
@@ -913,7 +913,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
@@ -929,7 +929,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'translated by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: GERRY_BAMMAN_PERSON_UUID,
@@ -950,7 +950,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'adapted by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
@@ -969,7 +969,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
@@ -985,7 +985,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'translated by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: GERRY_BAMMAN_PERSON_UUID,
@@ -1006,7 +1006,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'adapted by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
@@ -1025,7 +1025,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
@@ -1041,7 +1041,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'version by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: FRANK_MCGUINNESS_PERSON_UUID,
@@ -1075,7 +1075,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
@@ -1091,7 +1091,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'translated by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: GERRY_BAMMAN_PERSON_UUID,
@@ -1112,7 +1112,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'adapted by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
@@ -1131,7 +1131,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
@@ -1147,7 +1147,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'translated by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: GERRY_BAMMAN_PERSON_UUID,
@@ -1168,7 +1168,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'adapted by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
@@ -1201,7 +1201,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 					{
 						model: 'writingCredit',
 						name: 'by',
-						writingEntities: [
+						entities: [
 							{
 								model: 'person',
 								uuid: HENRIK_IBSEN_PERSON_UUID,
@@ -1217,7 +1217,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 					{
 						model: 'writingCredit',
 						name: 'translated by',
-						writingEntities: [
+						entities: [
 							{
 								model: 'person',
 								uuid: GERRY_BAMMAN_PERSON_UUID,
@@ -1238,7 +1238,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 					{
 						model: 'writingCredit',
 						name: 'adapted by',
-						writingEntities: [
+						entities: [
 							{
 								model: 'person',
 								uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
@@ -1271,7 +1271,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
@@ -1287,7 +1287,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'translated by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: GERRY_BAMMAN_PERSON_UUID,
@@ -1308,7 +1308,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'adapted by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
@@ -1328,7 +1328,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
@@ -1344,7 +1344,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'version by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: FRANK_MCGUINNESS_PERSON_UUID,
@@ -1364,7 +1364,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
@@ -1407,7 +1407,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
@@ -1431,7 +1431,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
@@ -1447,7 +1447,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'translated by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: GERRY_BAMMAN_PERSON_UUID,
@@ -1468,7 +1468,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'adapted by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
@@ -1487,7 +1487,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
@@ -1511,7 +1511,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
@@ -1527,7 +1527,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'version by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: FRANK_MCGUINNESS_PERSON_UUID,
@@ -1546,7 +1546,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: HENRIK_IBSEN_PERSON_UUID,
@@ -1562,7 +1562,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'translated by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: GERRY_BAMMAN_PERSON_UUID,
@@ -1583,7 +1583,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'adapted by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: BALTASAR_KORMÁKUR_PERSON_UUID,

--- a/test-e2e/model-interaction/material-with-multiple-credited-entities.test.js
+++ b/test-e2e/model-interaction/material-with-multiple-credited-entities.test.js
@@ -35,7 +35,7 @@ describe('Materials with entities credited multiple times', () => {
 				format: 'play',
 				writingCredits: [
 					{
-						writingEntities: [
+						entities: [
 							{
 								name: 'Person #1'
 							},
@@ -47,7 +47,7 @@ describe('Materials with entities credited multiple times', () => {
 					},
 					{
 						name: 'additional material by',
-						writingEntities: [
+						entities: [
 							{
 								name: 'Person #1'
 							},
@@ -85,7 +85,7 @@ describe('Materials with entities credited multiple times', () => {
 				{
 					model: 'writingCredit',
 					name: 'by',
-					writingEntities: [
+					entities: [
 						{
 							model: 'person',
 							uuid: PERSON_UUID,
@@ -101,7 +101,7 @@ describe('Materials with entities credited multiple times', () => {
 				{
 					model: 'writingCredit',
 					name: 'additional material by',
-					writingEntities: [
+					entities: [
 						{
 							model: 'person',
 							uuid: PERSON_UUID,
@@ -138,7 +138,7 @@ describe('Materials with entities credited multiple times', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: null,
@@ -154,7 +154,7 @@ describe('Materials with entities credited multiple times', () => {
 						{
 							model: 'writingCredit',
 							name: 'additional material by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: null,
@@ -193,7 +193,7 @@ describe('Materials with entities credited multiple times', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: PERSON_UUID,
@@ -209,7 +209,7 @@ describe('Materials with entities credited multiple times', () => {
 						{
 							model: 'writingCredit',
 							name: 'additional material by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: PERSON_UUID,

--- a/test-e2e/model-interaction/material-with-rights-grantor.test.js
+++ b/test-e2e/model-interaction/material-with-rights-grantor.test.js
@@ -38,7 +38,7 @@ describe('Materials with rights grantor credits', () => {
 				format: 'motion picture screenplay',
 				writingCredits: [
 					{
-						writingEntities: [
+						entities: [
 							{
 								name: 'William Rose'
 							}
@@ -55,7 +55,7 @@ describe('Materials with rights grantor credits', () => {
 				format: 'play',
 				writingCredits: [
 					{
-						writingEntities: [
+						entities: [
 							{
 								name: 'Graham Linehan'
 							}
@@ -63,7 +63,7 @@ describe('Materials with rights grantor credits', () => {
 					},
 					{
 						name: 'from',
-						writingEntities: [
+						entities: [
 							{
 								model: 'material',
 								name: 'The Ladykillers',
@@ -74,7 +74,7 @@ describe('Materials with rights grantor credits', () => {
 					{
 						name: 'by special arrangement with',
 						creditType: 'RIGHTS_GRANTOR',
-						writingEntities: [
+						entities: [
 							{
 								model: 'company',
 								name: 'StudioCanal'
@@ -116,7 +116,7 @@ describe('Materials with rights grantor credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: GRAHAM_LINEHAN_PERSON_UUID,
@@ -127,7 +127,7 @@ describe('Materials with rights grantor credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'from',
-							writingEntities: [
+							entities: [
 								{
 									model: 'material',
 									uuid: THE_LADYKILLERS_SCREENPLAY_MATERIAL_UUID,
@@ -137,7 +137,7 @@ describe('Materials with rights grantor credits', () => {
 										{
 											model: 'writingCredit',
 											name: 'by',
-											writingEntities: [
+											entities: [
 												{
 													model: 'person',
 													uuid: WILLIAM_ROSE_PERSON_UUID,
@@ -152,7 +152,7 @@ describe('Materials with rights grantor credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'by special arrangement with',
-							writingEntities: [
+							entities: [
 								{
 									model: 'company',
 									uuid: null,
@@ -191,7 +191,7 @@ describe('Materials with rights grantor credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: GRAHAM_LINEHAN_PERSON_UUID,
@@ -202,7 +202,7 @@ describe('Materials with rights grantor credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'from',
-							writingEntities: [
+							entities: [
 								{
 									model: 'material',
 									uuid: THE_LADYKILLERS_SCREENPLAY_MATERIAL_UUID,
@@ -212,7 +212,7 @@ describe('Materials with rights grantor credits', () => {
 										{
 											model: 'writingCredit',
 											name: 'by',
-											writingEntities: [
+											entities: [
 												{
 													model: 'person',
 													uuid: WILLIAM_ROSE_PERSON_UUID,
@@ -227,7 +227,7 @@ describe('Materials with rights grantor credits', () => {
 						{
 							model: 'writingCredit',
 							name: 'by special arrangement with',
-							writingEntities: [
+							entities: [
 								{
 									model: 'company',
 									uuid: STUDIOCANAL_COMPANY_UUID,

--- a/test-e2e/model-interaction/material-with-source-material.test.js
+++ b/test-e2e/model-interaction/material-with-source-material.test.js
@@ -69,7 +69,7 @@ describe('Materials with source material', () => {
 				format: 'play',
 				writingCredits: [
 					{
-						writingEntities: [
+						entities: [
 							{
 								name: 'William Shakespeare'
 							},
@@ -91,7 +91,7 @@ describe('Materials with source material', () => {
 				writingCredits: [
 					{
 						name: 'book by',
-						writingEntities: [
+						entities: [
 							{
 								name: 'Diane Paulus'
 							},
@@ -102,7 +102,7 @@ describe('Materials with source material', () => {
 					},
 					{
 						name: 'based on',
-						writingEntities: [
+						entities: [
 							{
 								model: 'material',
 								name: 'A Midsummer Night\'s Dream'
@@ -119,7 +119,7 @@ describe('Materials with source material', () => {
 				format: 'play',
 				writingCredits: [
 					{
-						writingEntities: [
+						entities: [
 							{
 								name: 'Rona Munro'
 							},
@@ -132,7 +132,7 @@ describe('Materials with source material', () => {
 					},
 					{
 						name: 'inspired by',
-						writingEntities: [
+						entities: [
 							{
 								model: 'material',
 								name: 'A Midsummer Night\'s Dream'
@@ -158,7 +158,7 @@ describe('Materials with source material', () => {
 				format: 'play',
 				writingCredits: [
 					{
-						writingEntities: [
+						entities: [
 							{
 								name: 'Steven Berkoff'
 							},
@@ -172,7 +172,7 @@ describe('Materials with source material', () => {
 					{
 						name: 'based on works by',
 						creditType: 'NON_SPECIFIC_SOURCE_MATERIAL',
-						writingEntities: [
+						entities: [
 							{
 								name: 'William Shakespeare'
 							},
@@ -202,7 +202,7 @@ describe('Materials with source material', () => {
 				format: 'tale',
 				writingCredits: [
 					{
-						writingEntities: [
+						entities: [
 							// Contrivance for purposes of test.
 							{
 								model: 'person',
@@ -224,7 +224,7 @@ describe('Materials with source material', () => {
 				format: 'play',
 				writingCredits: [
 					{
-						writingEntities: [
+						entities: [
 							{
 								model: 'person',
 								name: 'William Shakespeare'
@@ -237,7 +237,7 @@ describe('Materials with source material', () => {
 					},
 					{
 						name: 'based on',
-						writingEntities: [
+						entities: [
 							{
 								model: 'material',
 								name: 'A Moorish Captain'
@@ -386,7 +386,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'book by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: DIANE_PAULUS_PERSON_UUID,
@@ -402,7 +402,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'based on',
-							writingEntities: [
+							entities: [
 								{
 									model: 'material',
 									uuid: null,
@@ -412,7 +412,7 @@ describe('Materials with source material', () => {
 										{
 											model: 'writingCredit',
 											name: 'by',
-											writingEntities: [
+											entities: [
 												{
 													model: 'person',
 													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
@@ -440,7 +440,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: RONA_MUNRO_PERSON_UUID,
@@ -456,7 +456,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'inspired by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'material',
 									uuid: null,
@@ -466,7 +466,7 @@ describe('Materials with source material', () => {
 										{
 											model: 'writingCredit',
 											name: 'by',
-											writingEntities: [
+											entities: [
 												{
 													model: 'person',
 													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
@@ -558,7 +558,7 @@ describe('Materials with source material', () => {
 				{
 					model: 'writingCredit',
 					name: 'by',
-					writingEntities: [
+					entities: [
 						{
 							model: 'person',
 							uuid: RONA_MUNRO_PERSON_UUID,
@@ -574,7 +574,7 @@ describe('Materials with source material', () => {
 				{
 					model: 'writingCredit',
 					name: 'inspired by',
-					writingEntities: [
+					entities: [
 						{
 							model: 'material',
 							uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
@@ -584,7 +584,7 @@ describe('Materials with source material', () => {
 								{
 									model: 'writingCredit',
 									name: 'by',
-									writingEntities: [
+									entities: [
 										{
 											model: 'person',
 											uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
@@ -619,7 +619,7 @@ describe('Materials with source material', () => {
 				{
 					model: 'writingCredit',
 					name: 'by',
-					writingEntities: [
+					entities: [
 						{
 							model: 'person',
 							uuid: STEVEN_BERKOFF_PERSON_UUID,
@@ -635,7 +635,7 @@ describe('Materials with source material', () => {
 				{
 					model: 'writingCredit',
 					name: 'based on works by',
-					writingEntities: [
+					entities: [
 						{
 							model: 'person',
 							uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
@@ -672,7 +672,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
@@ -688,7 +688,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'based on',
-							writingEntities: [
+							entities: [
 								{
 									model: 'material',
 									uuid: null,
@@ -698,7 +698,7 @@ describe('Materials with source material', () => {
 										{
 											model: 'writingCredit',
 											name: 'by',
-											writingEntities: [
+											entities: [
 												{
 													model: 'person',
 													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
@@ -735,7 +735,7 @@ describe('Materials with source material', () => {
 				{
 					model: 'writingCredit',
 					name: 'by',
-					writingEntities: [
+					entities: [
 						{
 							model: 'person',
 							uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
@@ -751,7 +751,7 @@ describe('Materials with source material', () => {
 				{
 					model: 'writingCredit',
 					name: 'based on',
-					writingEntities: [
+					entities: [
 						{
 							model: 'material',
 							uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
@@ -761,7 +761,7 @@ describe('Materials with source material', () => {
 								{
 									model: 'writingCredit',
 									name: 'by',
-									writingEntities: [
+									entities: [
 										{
 											model: 'person',
 											uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
@@ -802,7 +802,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: null,
@@ -818,7 +818,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'based on',
-							writingEntities: [
+							entities: [
 								{
 									model: 'material',
 									uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
@@ -828,7 +828,7 @@ describe('Materials with source material', () => {
 										{
 											model: 'writingCredit',
 											name: 'by',
-											writingEntities: [
+											entities: [
 												{
 													model: 'person',
 													uuid: null,
@@ -856,7 +856,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: STEVEN_BERKOFF_PERSON_UUID,
@@ -872,7 +872,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'based on works by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: null,
@@ -896,7 +896,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'book by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: DIANE_PAULUS_PERSON_UUID,
@@ -912,7 +912,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'based on',
-							writingEntities: [
+							entities: [
 								{
 									model: 'material',
 									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
@@ -922,7 +922,7 @@ describe('Materials with source material', () => {
 										{
 											model: 'writingCredit',
 											name: 'by',
-											writingEntities: [
+											entities: [
 												{
 													model: 'person',
 													uuid: null,
@@ -950,7 +950,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: RONA_MUNRO_PERSON_UUID,
@@ -966,7 +966,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'inspired by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'material',
 									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
@@ -976,7 +976,7 @@ describe('Materials with source material', () => {
 										{
 											model: 'writingCredit',
 											name: 'by',
-											writingEntities: [
+											entities: [
 												{
 													model: 'person',
 													uuid: null,
@@ -1019,7 +1019,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: null,
@@ -1035,7 +1035,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'inspired by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'material',
 									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
@@ -1045,7 +1045,7 @@ describe('Materials with source material', () => {
 										{
 											model: 'writingCredit',
 											name: 'by',
-											writingEntities: [
+											entities: [
 												{
 													model: 'person',
 													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
@@ -1088,7 +1088,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: null,
@@ -1104,7 +1104,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'based on works by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
@@ -1143,7 +1143,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
@@ -1159,7 +1159,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'based on',
-							writingEntities: [
+							entities: [
 								{
 									model: 'material',
 									uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
@@ -1169,7 +1169,7 @@ describe('Materials with source material', () => {
 										{
 											model: 'writingCredit',
 											name: 'by',
-											writingEntities: [
+											entities: [
 												{
 													model: 'person',
 													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
@@ -1197,7 +1197,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: STEVEN_BERKOFF_PERSON_UUID,
@@ -1213,7 +1213,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'based on works by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
@@ -1237,7 +1237,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'book by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: DIANE_PAULUS_PERSON_UUID,
@@ -1253,7 +1253,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'based on',
-							writingEntities: [
+							entities: [
 								{
 									model: 'material',
 									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
@@ -1263,7 +1263,7 @@ describe('Materials with source material', () => {
 										{
 											model: 'writingCredit',
 											name: 'by',
-											writingEntities: [
+											entities: [
 												{
 													model: 'person',
 													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
@@ -1291,7 +1291,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: RONA_MUNRO_PERSON_UUID,
@@ -1307,7 +1307,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'inspired by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'material',
 									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
@@ -1317,7 +1317,7 @@ describe('Materials with source material', () => {
 										{
 											model: 'writingCredit',
 											name: 'by',
-											writingEntities: [
+											entities: [
 												{
 													model: 'person',
 													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
@@ -1360,7 +1360,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: RONA_MUNRO_PERSON_UUID,
@@ -1376,7 +1376,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'inspired by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'material',
 									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
@@ -1386,7 +1386,7 @@ describe('Materials with source material', () => {
 										{
 											model: 'writingCredit',
 											name: 'by',
-											writingEntities: [
+											entities: [
 												{
 													model: 'person',
 													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
@@ -1429,7 +1429,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: STEVEN_BERKOFF_PERSON_UUID,
@@ -1445,7 +1445,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'based on works by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
@@ -1483,7 +1483,7 @@ describe('Materials with source material', () => {
 					{
 						model: 'writingCredit',
 						name: 'by',
-						writingEntities: [
+						entities: [
 							{
 								model: 'person',
 								uuid: RONA_MUNRO_PERSON_UUID,
@@ -1499,7 +1499,7 @@ describe('Materials with source material', () => {
 					{
 						model: 'writingCredit',
 						name: 'inspired by',
-						writingEntities: [
+						entities: [
 							{
 								model: 'material',
 								uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
@@ -1509,7 +1509,7 @@ describe('Materials with source material', () => {
 									{
 										model: 'writingCredit',
 										name: 'by',
-										writingEntities: [
+										entities: [
 											{
 												model: 'person',
 												uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
@@ -1550,7 +1550,7 @@ describe('Materials with source material', () => {
 					{
 						model: 'writingCredit',
 						name: 'by',
-						writingEntities: [
+						entities: [
 							{
 								model: 'person',
 								uuid: STEVEN_BERKOFF_PERSON_UUID,
@@ -1566,7 +1566,7 @@ describe('Materials with source material', () => {
 					{
 						model: 'writingCredit',
 						name: 'based on works by',
-						writingEntities: [
+						entities: [
 							{
 								model: 'person',
 								uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
@@ -1603,7 +1603,7 @@ describe('Materials with source material', () => {
 					{
 						model: 'writingCredit',
 						name: 'by',
-						writingEntities: [
+						entities: [
 							{
 								model: 'person',
 								uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
@@ -1619,7 +1619,7 @@ describe('Materials with source material', () => {
 					{
 						model: 'writingCredit',
 						name: 'based on',
-						writingEntities: [
+						entities: [
 							{
 								model: 'material',
 								uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
@@ -1629,7 +1629,7 @@ describe('Materials with source material', () => {
 									{
 										model: 'writingCredit',
 										name: 'by',
-										writingEntities: [
+										entities: [
 											{
 												model: 'person',
 												uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
@@ -1671,7 +1671,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: RONA_MUNRO_PERSON_UUID,
@@ -1687,7 +1687,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'inspired by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'material',
 									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
@@ -1697,7 +1697,7 @@ describe('Materials with source material', () => {
 										{
 											model: 'writingCredit',
 											name: 'by',
-											writingEntities: [
+											entities: [
 												{
 													model: 'person',
 													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
@@ -1741,7 +1741,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
@@ -1757,7 +1757,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'based on',
-							writingEntities: [
+							entities: [
 								{
 									model: 'material',
 									uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
@@ -1767,7 +1767,7 @@ describe('Materials with source material', () => {
 										{
 											model: 'writingCredit',
 											name: 'by',
-											writingEntities: [
+											entities: [
 												{
 													model: 'person',
 													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
@@ -1796,7 +1796,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: STEVEN_BERKOFF_PERSON_UUID,
@@ -1812,7 +1812,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'based on works by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
@@ -1855,7 +1855,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
@@ -1879,7 +1879,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
@@ -1903,7 +1903,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
@@ -1919,7 +1919,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'based on',
-							writingEntities: [
+							entities: [
 								{
 									model: 'material',
 									uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
@@ -1929,7 +1929,7 @@ describe('Materials with source material', () => {
 										{
 											model: 'writingCredit',
 											name: 'by',
-											writingEntities: [
+											entities: [
 												{
 													model: 'person',
 													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
@@ -1957,7 +1957,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: STEVEN_BERKOFF_PERSON_UUID,
@@ -1973,7 +1973,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'based on works by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
@@ -1997,7 +1997,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'book by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: DIANE_PAULUS_PERSON_UUID,
@@ -2013,7 +2013,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'based on',
-							writingEntities: [
+							entities: [
 								{
 									model: 'material',
 									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
@@ -2023,7 +2023,7 @@ describe('Materials with source material', () => {
 										{
 											model: 'writingCredit',
 											name: 'by',
-											writingEntities: [
+											entities: [
 												{
 													model: 'person',
 													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
@@ -2051,7 +2051,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'person',
 									uuid: RONA_MUNRO_PERSON_UUID,
@@ -2067,7 +2067,7 @@ describe('Materials with source material', () => {
 						{
 							model: 'writingCredit',
 							name: 'inspired by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'material',
 									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
@@ -2077,7 +2077,7 @@ describe('Materials with source material', () => {
 										{
 											model: 'writingCredit',
 											name: 'by',
-											writingEntities: [
+											entities: [
 												{
 													model: 'person',
 													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,

--- a/test-e2e/model-interaction/wri-groups-grouping.test.js
+++ b/test-e2e/model-interaction/wri-groups-grouping.test.js
@@ -34,7 +34,7 @@ describe('Nameless writer groups grouping', () => {
 				format: 'play',
 				writingCredits: [
 					{
-						writingEntities: [
+						entities: [
 							{
 								name: 'Person #1'
 							}
@@ -42,14 +42,14 @@ describe('Nameless writer groups grouping', () => {
 					},
 					{
 						name: 'version by',
-						writingEntities: [
+						entities: [
 							{
 								name: 'Person #2'
 							}
 						]
 					},
 					{
-						writingEntities: [
+						entities: [
 							{
 								name: 'Person #3'
 							}
@@ -77,7 +77,7 @@ describe('Nameless writer groups grouping', () => {
 				{
 					model: 'writingCredit',
 					name: 'by',
-					writingEntities: [
+					entities: [
 						{
 							model: 'person',
 							uuid: PERSON_1_UUID,
@@ -93,7 +93,7 @@ describe('Nameless writer groups grouping', () => {
 				{
 					model: 'writingCredit',
 					name: 'version by',
-					writingEntities: [
+					entities: [
 						{
 							model: 'person',
 							uuid: PERSON_2_UUID,

--- a/test-e2e/uniqueness-in-db/materials-api.test.js
+++ b/test-e2e/uniqueness-in-db/materials-api.test.js
@@ -64,7 +64,7 @@ describe('Uniqueness in database: Materials API', () => {
 						name: '',
 						creditType: null,
 						errors: {},
-						writingEntities: [
+						entities: [
 							{
 								model: 'person',
 								name: '',
@@ -169,7 +169,7 @@ describe('Uniqueness in database: Materials API', () => {
 						name: '',
 						creditType: null,
 						errors: {},
-						writingEntities: [
+						entities: [
 							{
 								model: 'person',
 								name: '',
@@ -276,7 +276,7 @@ describe('Uniqueness in database: Materials API', () => {
 						name: '',
 						creditType: null,
 						errors: {},
-						writingEntities: [
+						entities: [
 							{
 								model: 'person',
 								name: '',
@@ -340,7 +340,7 @@ describe('Uniqueness in database: Materials API', () => {
 						name: '',
 						creditType: null,
 						errors: {},
-						writingEntities: [
+						entities: [
 							{
 								model: 'person',
 								name: '',
@@ -551,7 +551,7 @@ describe('Uniqueness in database: Materials API', () => {
 					name: 'Dot',
 					writingCredits: [
 						{
-							writingEntities: [
+							entities: [
 								{
 									name: 'Kate Ryan'
 								}
@@ -561,7 +561,7 @@ describe('Uniqueness in database: Materials API', () => {
 				});
 
 			expect(response).to.have.status(200);
-			expect(response.body.writingCredits[0].writingEntities[0]).to.deep.equal(expectedPersonKateRyan1);
+			expect(response.body.writingCredits[0].entities[0]).to.deep.equal(expectedPersonKateRyan1);
 			expect(await countNodesWithLabel('Person')).to.equal(1);
 
 		});
@@ -576,7 +576,7 @@ describe('Uniqueness in database: Materials API', () => {
 					name: 'Dot',
 					writingCredits: [
 						{
-							writingEntities: [
+							entities: [
 								{
 									name: 'Kate Ryan',
 									differentiator: '1'
@@ -587,7 +587,7 @@ describe('Uniqueness in database: Materials API', () => {
 				});
 
 			expect(response).to.have.status(200);
-			expect(response.body.writingCredits[0].writingEntities[0]).to.deep.equal(expectedPersonKateRyan2);
+			expect(response.body.writingCredits[0].entities[0]).to.deep.equal(expectedPersonKateRyan2);
 			expect(await countNodesWithLabel('Person')).to.equal(2);
 
 		});
@@ -602,7 +602,7 @@ describe('Uniqueness in database: Materials API', () => {
 					name: 'Dot',
 					writingCredits: [
 						{
-							writingEntities: [
+							entities: [
 								{
 									name: 'Kate Ryan'
 								}
@@ -612,7 +612,7 @@ describe('Uniqueness in database: Materials API', () => {
 				});
 
 			expect(response).to.have.status(200);
-			expect(response.body.writingCredits[0].writingEntities[0]).to.deep.equal(expectedPersonKateRyan1);
+			expect(response.body.writingCredits[0].entities[0]).to.deep.equal(expectedPersonKateRyan1);
 			expect(await countNodesWithLabel('Person')).to.equal(2);
 
 		});
@@ -627,7 +627,7 @@ describe('Uniqueness in database: Materials API', () => {
 					name: 'Dot',
 					writingCredits: [
 						{
-							writingEntities: [
+							entities: [
 								{
 									name: 'Kate Ryan',
 									differentiator: '1'
@@ -638,7 +638,7 @@ describe('Uniqueness in database: Materials API', () => {
 				});
 
 			expect(response).to.have.status(200);
-			expect(response.body.writingCredits[0].writingEntities[0]).to.deep.equal(expectedPersonKateRyan2);
+			expect(response.body.writingCredits[0].entities[0]).to.deep.equal(expectedPersonKateRyan2);
 			expect(await countNodesWithLabel('Person')).to.equal(2);
 
 		});
@@ -695,7 +695,7 @@ describe('Uniqueness in database: Materials API', () => {
 					name: 'Untitled',
 					writingCredits: [
 						{
-							writingEntities: [
+							entities: [
 								{
 									model: 'company',
 									name: 'Gate Theatre Company'
@@ -706,7 +706,7 @@ describe('Uniqueness in database: Materials API', () => {
 				});
 
 			expect(response).to.have.status(200);
-			expect(response.body.writingCredits[0].writingEntities[0]).to.deep.equal(expectedCompanyGateTheatreCompany1);
+			expect(response.body.writingCredits[0].entities[0]).to.deep.equal(expectedCompanyGateTheatreCompany1);
 			expect(await countNodesWithLabel('Company')).to.equal(1);
 
 		});
@@ -721,7 +721,7 @@ describe('Uniqueness in database: Materials API', () => {
 					name: 'Untitled',
 					writingCredits: [
 						{
-							writingEntities: [
+							entities: [
 								{
 									model: 'company',
 									name: 'Gate Theatre Company',
@@ -733,7 +733,7 @@ describe('Uniqueness in database: Materials API', () => {
 				});
 
 			expect(response).to.have.status(200);
-			expect(response.body.writingCredits[0].writingEntities[0]).to.deep.equal(expectedCompanyGateTheatreCompany2);
+			expect(response.body.writingCredits[0].entities[0]).to.deep.equal(expectedCompanyGateTheatreCompany2);
 			expect(await countNodesWithLabel('Company')).to.equal(2);
 
 		});
@@ -748,7 +748,7 @@ describe('Uniqueness in database: Materials API', () => {
 					name: 'Untitled',
 					writingCredits: [
 						{
-							writingEntities: [
+							entities: [
 								{
 									model: 'company',
 									name: 'Gate Theatre Company'
@@ -759,7 +759,7 @@ describe('Uniqueness in database: Materials API', () => {
 				});
 
 			expect(response).to.have.status(200);
-			expect(response.body.writingCredits[0].writingEntities[0]).to.deep.equal(expectedCompanyGateTheatreCompany1);
+			expect(response.body.writingCredits[0].entities[0]).to.deep.equal(expectedCompanyGateTheatreCompany1);
 			expect(await countNodesWithLabel('Company')).to.equal(2);
 
 		});
@@ -774,7 +774,7 @@ describe('Uniqueness in database: Materials API', () => {
 					name: 'Untitled',
 					writingCredits: [
 						{
-							writingEntities: [
+							entities: [
 								{
 									model: 'company',
 									name: 'Gate Theatre Company',
@@ -786,7 +786,7 @@ describe('Uniqueness in database: Materials API', () => {
 				});
 
 			expect(response).to.have.status(200);
-			expect(response.body.writingCredits[0].writingEntities[0]).to.deep.equal(expectedCompanyGateTheatreCompany2);
+			expect(response.body.writingCredits[0].entities[0]).to.deep.equal(expectedCompanyGateTheatreCompany2);
 			expect(await countNodesWithLabel('Company')).to.equal(2);
 
 		});
@@ -844,7 +844,7 @@ describe('Uniqueness in database: Materials API', () => {
 					writingCredits: [
 						{
 							name: 'inspired by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'material',
 									name: 'A Midsummer Night\'s Dream'
@@ -855,7 +855,7 @@ describe('Uniqueness in database: Materials API', () => {
 				});
 
 			expect(response).to.have.status(200);
-			expect(response.body.writingCredits[0].writingEntities[0]).to.deep.equal(expectedMaterialAMidsummerNightsDream1);
+			expect(response.body.writingCredits[0].entities[0]).to.deep.equal(expectedMaterialAMidsummerNightsDream1);
 			expect(await countNodesWithLabel('Material')).to.equal(2);
 
 		});
@@ -871,7 +871,7 @@ describe('Uniqueness in database: Materials API', () => {
 					writingCredits: [
 						{
 							name: 'inspired by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'material',
 									name: 'A Midsummer Night\'s Dream',
@@ -883,7 +883,7 @@ describe('Uniqueness in database: Materials API', () => {
 				});
 
 			expect(response).to.have.status(200);
-			expect(response.body.writingCredits[0].writingEntities[0]).to.deep.equal(expectedMaterialAMidsummerNightsDream2);
+			expect(response.body.writingCredits[0].entities[0]).to.deep.equal(expectedMaterialAMidsummerNightsDream2);
 			expect(await countNodesWithLabel('Material')).to.equal(3);
 
 		});
@@ -899,7 +899,7 @@ describe('Uniqueness in database: Materials API', () => {
 					writingCredits: [
 						{
 							name: 'inspired by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'material',
 									name: 'A Midsummer Night\'s Dream'
@@ -910,7 +910,7 @@ describe('Uniqueness in database: Materials API', () => {
 				});
 
 			expect(response).to.have.status(200);
-			expect(response.body.writingCredits[0].writingEntities[0]).to.deep.equal(expectedMaterialAMidsummerNightsDream1);
+			expect(response.body.writingCredits[0].entities[0]).to.deep.equal(expectedMaterialAMidsummerNightsDream1);
 			expect(await countNodesWithLabel('Material')).to.equal(3);
 
 		});
@@ -926,7 +926,7 @@ describe('Uniqueness in database: Materials API', () => {
 					writingCredits: [
 						{
 							name: 'inspired by',
-							writingEntities: [
+							entities: [
 								{
 									model: 'material',
 									name: 'A Midsummer Night\'s Dream',
@@ -938,7 +938,7 @@ describe('Uniqueness in database: Materials API', () => {
 				});
 
 			expect(response).to.have.status(200);
-			expect(response.body.writingCredits[0].writingEntities[0]).to.deep.equal(expectedMaterialAMidsummerNightsDream2);
+			expect(response.body.writingCredits[0].entities[0]).to.deep.equal(expectedMaterialAMidsummerNightsDream2);
 			expect(await countNodesWithLabel('Material')).to.equal(3);
 
 		});

--- a/test-int/instance-validation-failures/material.test.js
+++ b/test-int/instance-validation-failures/material.test.js
@@ -334,7 +334,7 @@ describe('Material instance', () => {
 									'Value is too long'
 								]
 							},
-							writingEntities: []
+							entities: []
 						}
 					],
 					characterGroups: []
@@ -388,7 +388,7 @@ describe('Material instance', () => {
 									'This item has been duplicated within the group'
 								]
 							},
-							writingEntities: []
+							entities: []
 						},
 						{
 							name: 'version by',
@@ -398,7 +398,7 @@ describe('Material instance', () => {
 									'This item has been duplicated within the group'
 								]
 							},
-							writingEntities: []
+							entities: []
 						}
 					],
 					characterGroups: []
@@ -418,7 +418,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					writingCredits: [
 						{
-							writingEntities: [
+							entities: [
 								{
 									name: ABOVE_MAX_LENGTH_STRING
 								}
@@ -449,7 +449,7 @@ describe('Material instance', () => {
 							name: '',
 							creditType: null,
 							errors: {},
-							writingEntities: [
+							entities: [
 								{
 									uuid: undefined,
 									name: ABOVE_MAX_LENGTH_STRING,
@@ -480,7 +480,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					writingCredits: [
 						{
-							writingEntities: [
+							entities: [
 								{
 									name: 'Henrik Ibsen',
 									differentiator: ABOVE_MAX_LENGTH_STRING
@@ -512,7 +512,7 @@ describe('Material instance', () => {
 							name: '',
 							creditType: null,
 							errors: {},
-							writingEntities: [
+							entities: [
 								{
 									uuid: undefined,
 									name: 'Henrik Ibsen',
@@ -543,7 +543,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					writingCredits: [
 						{
-							writingEntities: [
+							entities: [
 								{
 									model: 'company',
 									name: ABOVE_MAX_LENGTH_STRING
@@ -575,7 +575,7 @@ describe('Material instance', () => {
 							name: '',
 							creditType: null,
 							errors: {},
-							writingEntities: [
+							entities: [
 								{
 									uuid: undefined,
 									name: ABOVE_MAX_LENGTH_STRING,
@@ -606,7 +606,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					writingCredits: [
 						{
-							writingEntities: [
+							entities: [
 								{
 									model: 'company',
 									name: 'Ibsen Theatre Company',
@@ -639,7 +639,7 @@ describe('Material instance', () => {
 							name: '',
 							creditType: null,
 							errors: {},
-							writingEntities: [
+							entities: [
 								{
 									uuid: undefined,
 									name: 'Ibsen Theatre Company',
@@ -670,7 +670,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					writingCredits: [
 						{
-							writingEntities: [
+							entities: [
 								{
 									model: 'material',
 									name: ABOVE_MAX_LENGTH_STRING
@@ -702,7 +702,7 @@ describe('Material instance', () => {
 							name: '',
 							creditType: null,
 							errors: {},
-							writingEntities: [
+							entities: [
 								{
 									uuid: undefined,
 									name: ABOVE_MAX_LENGTH_STRING,
@@ -733,7 +733,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					writingCredits: [
 						{
-							writingEntities: [
+							entities: [
 								{
 									model: 'material',
 									name: 'Rosmersholm',
@@ -766,7 +766,7 @@ describe('Material instance', () => {
 							name: '',
 							creditType: null,
 							errors: {},
-							writingEntities: [
+							entities: [
 								{
 									uuid: undefined,
 									name: 'Rosmersholm',
@@ -789,7 +789,7 @@ describe('Material instance', () => {
 
 		});
 
-		context('duplicate writingEntities', () => {
+		context('duplicate entities', () => {
 
 			it('assigns appropriate error', async () => {
 
@@ -797,7 +797,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					writingCredits: [
 						{
-							writingEntities: [
+							entities: [
 								{
 									name: 'Henrik Ibsen'
 								},
@@ -838,7 +838,7 @@ describe('Material instance', () => {
 							name: '',
 							creditType: null,
 							errors: {},
-							writingEntities: [
+							entities: [
 								{
 									uuid: undefined,
 									name: 'Henrik Ibsen',
@@ -884,8 +884,8 @@ describe('Material instance', () => {
 				};
 
 				expect(result).to.deep.equal(expectedResponseBody);
-				expect(result.writingCredits[0].writingEntities[1].model).to.equal('person');
-				expect(result.writingCredits[0].writingEntities[3].model).to.equal('company');
+				expect(result.writingCredits[0].entities[1].model).to.equal('person');
+				expect(result.writingCredits[0].entities[3].model).to.equal('company');
 
 			});
 
@@ -899,7 +899,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					writingCredits: [
 						{
-							writingEntities: [
+							entities: [
 								{
 									model: 'material',
 									name: 'Rosmersholm'
@@ -931,7 +931,7 @@ describe('Material instance', () => {
 							name: '',
 							creditType: null,
 							errors: {},
-							writingEntities: [
+							entities: [
 								{
 									uuid: undefined,
 									name: 'Rosmersholm',

--- a/test-unit/src/lib/prepare-as-params.test.js
+++ b/test-unit/src/lib/prepare-as-params.test.js
@@ -341,7 +341,7 @@ describe('Prepare As Params module', () => {
 
 				const instance = {
 					writingCredits: [
-						{ name: '', writingEntities: [{ name: 'Henrik Ibsen' }] }
+						{ name: '', entities: [{ name: 'Henrik Ibsen' }] }
 					],
 					characterGroups: [
 						{ name: '', characters: [{ name: 'Malene' }] }
@@ -359,13 +359,13 @@ describe('Prepare As Params module', () => {
 
 			});
 
-			it('filters out objects that do not have any non-empty string name writingEntities/characters', () => {
+			it('filters out objects that do not have any non-empty string name entities/characters', () => {
 
 				const instance = {
 					writingCredits: [
-						{ name: '', writingEntities: [{ name: '' }] },
-						{ name: 'version by', writingEntities: [{ name: 'David Eldridge' }] },
-						{ name: 'translation by', writingEntities: [{ name: '' }] }
+						{ name: '', entities: [{ name: '' }] },
+						{ name: 'version by', entities: [{ name: 'David Eldridge' }] },
+						{ name: 'translation by', entities: [{ name: '' }] }
 					],
 					characterGroups: [
 						{ name: '', characters: [{ name: '' }] },
@@ -539,7 +539,7 @@ describe('Prepare As Params module', () => {
 				const instance = {
 					material: {
 						writingCredits: [
-							{ name: '', writingEntities: [{ name: 'Henrik Ibsen' }] }
+							{ name: '', entities: [{ name: 'Henrik Ibsen' }] }
 						],
 						characterGroups: [
 							{ name: '', characters: [{ name: 'Malene' }] }
@@ -558,14 +558,14 @@ describe('Prepare As Params module', () => {
 
 			});
 
-			it('filters out objects that do not have any non-empty string name writingEntities/characters', () => {
+			it('filters out objects that do not have any non-empty string name entities/characters', () => {
 
 				const instance = {
 					material: {
 						writingCredits: [
-							{ name: '', writingEntities: [{ name: '' }] },
-							{ name: 'version by', writingEntities: [{ name: 'David Eldridge' }] },
-							{ name: 'translation by', writingEntities: [{ name: '' }] }
+							{ name: '', entities: [{ name: '' }] },
+							{ name: 'version by', entities: [{ name: 'David Eldridge' }] },
+							{ name: 'translation by', entities: [{ name: '' }] }
 						],
 						characterGroups: [
 							{ name: '', characters: [{ name: '' }] },
@@ -742,7 +742,7 @@ describe('Prepare As Params module', () => {
 					materials: [
 						{
 							writingCredits: [
-								{ name: '', writingEntities: [{ name: 'Henrik Ibsen' }] }
+								{ name: '', entities: [{ name: 'Henrik Ibsen' }] }
 							],
 							characterGroups: [
 								{ name: '', characters: [{ name: 'Malene' }] }
@@ -762,15 +762,15 @@ describe('Prepare As Params module', () => {
 
 			});
 
-			it('filters out objects that do not have any non-empty string name writingEntities/characters', () => {
+			it('filters out objects that do not have any non-empty string name entities/characters', () => {
 
 				const instance = {
 					materials: [
 						{
 							writingCredits: [
-								{ name: '', writingEntities: [{ name: '' }] },
-								{ name: 'version by', writingEntities: [{ name: 'David Eldridge' }] },
-								{ name: 'translation by', writingEntities: [{ name: '' }] }
+								{ name: '', entities: [{ name: '' }] },
+								{ name: 'version by', entities: [{ name: 'David Eldridge' }] },
+								{ name: 'translation by', entities: [{ name: '' }] }
 							],
 							characterGroups: [
 								{ name: '', characters: [{ name: '' }] },

--- a/test-unit/src/models/WritingCredit.test.js
+++ b/test-unit/src/models/WritingCredit.test.js
@@ -91,12 +91,12 @@ describe('WritingCredit model', () => {
 
 		});
 
-		describe('writingEntities property', () => {
+		describe('entities property', () => {
 
 			it('assigns empty array if absent from props', () => {
 
 				const instance = createInstance({ name: 'version by' });
-				expect(instance.writingEntities).to.deep.equal([]);
+				expect(instance.entities).to.deep.equal([]);
 
 			});
 
@@ -104,7 +104,7 @@ describe('WritingCredit model', () => {
 
 				const props = {
 					name: 'version by',
-					writingEntities: [
+					entities: [
 						{
 							name: 'David Eldridge'
 						},
@@ -141,16 +141,16 @@ describe('WritingCredit model', () => {
 					]
 				};
 				const instance = createInstance(props);
-				expect(instance.writingEntities.length).to.equal(9);
-				expect(instance.writingEntities[0] instanceof Person).to.be.true;
-				expect(instance.writingEntities[1] instanceof Company).to.be.true;
-				expect(instance.writingEntities[2] instanceof Material).to.be.true;
-				expect(instance.writingEntities[3] instanceof Person).to.be.true;
-				expect(instance.writingEntities[4] instanceof Company).to.be.true;
-				expect(instance.writingEntities[5] instanceof Material).to.be.true;
-				expect(instance.writingEntities[6] instanceof Person).to.be.true;
-				expect(instance.writingEntities[7] instanceof Company).to.be.true;
-				expect(instance.writingEntities[8] instanceof Material).to.be.true;
+				expect(instance.entities.length).to.equal(9);
+				expect(instance.entities[0] instanceof Person).to.be.true;
+				expect(instance.entities[1] instanceof Company).to.be.true;
+				expect(instance.entities[2] instanceof Material).to.be.true;
+				expect(instance.entities[3] instanceof Person).to.be.true;
+				expect(instance.entities[4] instanceof Company).to.be.true;
+				expect(instance.entities[5] instanceof Material).to.be.true;
+				expect(instance.entities[6] instanceof Person).to.be.true;
+				expect(instance.entities[7] instanceof Company).to.be.true;
+				expect(instance.entities[8] instanceof Material).to.be.true;
 
 			});
 
@@ -164,7 +164,7 @@ describe('WritingCredit model', () => {
 
 			const props = {
 				name: 'version by',
-				writingEntities: [
+				entities: [
 					{
 						name: 'David Eldridge'
 					},
@@ -179,8 +179,8 @@ describe('WritingCredit model', () => {
 				]
 			};
 			const instance = createInstance(props);
-			instance.writingEntities[2].name = 'A Midsummer Night\'s Dream';
-			instance.writingEntities[2].differentiator = '1';
+			instance.entities[2].name = 'A Midsummer Night\'s Dream';
+			instance.entities[2].differentiator = '1';
 			spy(instance, 'validateName');
 			spy(instance, 'validateUniquenessInGroup');
 			instance.runInputValidations(
@@ -190,51 +190,51 @@ describe('WritingCredit model', () => {
 				instance.validateName,
 				instance.validateUniquenessInGroup,
 				stubs.getDuplicateIndicesModule.getDuplicateEntityIndices,
-				instance.writingEntities[0].validateName,
-				instance.writingEntities[0].validateDifferentiator,
-				instance.writingEntities[0].validateUniquenessInGroup,
-				instance.writingEntities[1].validateName,
-				instance.writingEntities[1].validateDifferentiator,
-				instance.writingEntities[1].validateUniquenessInGroup,
-				instance.writingEntities[2].validateName,
-				instance.writingEntities[2].validateDifferentiator,
-				instance.writingEntities[2].validateUniquenessInGroup,
-				instance.writingEntities[2].validateNoAssociationWithSelf
+				instance.entities[0].validateName,
+				instance.entities[0].validateDifferentiator,
+				instance.entities[0].validateUniquenessInGroup,
+				instance.entities[1].validateName,
+				instance.entities[1].validateDifferentiator,
+				instance.entities[1].validateUniquenessInGroup,
+				instance.entities[2].validateName,
+				instance.entities[2].validateDifferentiator,
+				instance.entities[2].validateUniquenessInGroup,
+				instance.entities[2].validateNoAssociationWithSelf
 			);
 			expect(instance.validateName.calledOnce).to.be.true;
 			expect(instance.validateName.calledWithExactly({ isRequired: false })).to.be.true;
 			expect(stubs.getDuplicateIndicesModule.getDuplicateEntityIndices.calledOnce).to.be.true;
 			expect(stubs.getDuplicateIndicesModule.getDuplicateEntityIndices.calledWithExactly(
-				instance.writingEntities
+				instance.entities
 			)).to.be.true;
-			expect(instance.writingEntities[0].validateName.calledOnce).to.be.true;
-			expect(instance.writingEntities[0].validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.writingEntities[0].validateDifferentiator.calledOnce).to.be.true;
-			expect(instance.writingEntities[0].validateDifferentiator.calledWithExactly()).to.be.true;
-			expect(instance.writingEntities[0].validateUniquenessInGroup.calledOnce).to.be.true;
-			expect(instance.writingEntities[0].validateUniquenessInGroup.calledWithExactly(
+			expect(instance.entities[0].validateName.calledOnce).to.be.true;
+			expect(instance.entities[0].validateName.calledWithExactly({ isRequired: false })).to.be.true;
+			expect(instance.entities[0].validateDifferentiator.calledOnce).to.be.true;
+			expect(instance.entities[0].validateDifferentiator.calledWithExactly()).to.be.true;
+			expect(instance.entities[0].validateUniquenessInGroup.calledOnce).to.be.true;
+			expect(instance.entities[0].validateUniquenessInGroup.calledWithExactly(
 				{ isDuplicate: false }
 			)).to.be.true;
-			expect(instance.writingEntities[0].validateNoAssociationWithSelf.notCalled).to.be.true;
-			expect(instance.writingEntities[1].validateName.calledOnce).to.be.true;
-			expect(instance.writingEntities[1].validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.writingEntities[1].validateDifferentiator.calledOnce).to.be.true;
-			expect(instance.writingEntities[1].validateDifferentiator.calledWithExactly()).to.be.true;
-			expect(instance.writingEntities[1].validateUniquenessInGroup.calledOnce).to.be.true;
-			expect(instance.writingEntities[1].validateUniquenessInGroup.calledWithExactly(
+			expect(instance.entities[0].validateNoAssociationWithSelf.notCalled).to.be.true;
+			expect(instance.entities[1].validateName.calledOnce).to.be.true;
+			expect(instance.entities[1].validateName.calledWithExactly({ isRequired: false })).to.be.true;
+			expect(instance.entities[1].validateDifferentiator.calledOnce).to.be.true;
+			expect(instance.entities[1].validateDifferentiator.calledWithExactly()).to.be.true;
+			expect(instance.entities[1].validateUniquenessInGroup.calledOnce).to.be.true;
+			expect(instance.entities[1].validateUniquenessInGroup.calledWithExactly(
 				{ isDuplicate: false }
 			)).to.be.true;
-			expect(instance.writingEntities[1].validateNoAssociationWithSelf.notCalled).to.be.true;
-			expect(instance.writingEntities[2].validateName.calledOnce).to.be.true;
-			expect(instance.writingEntities[2].validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.writingEntities[2].validateDifferentiator.calledOnce).to.be.true;
-			expect(instance.writingEntities[2].validateDifferentiator.calledWithExactly()).to.be.true;
-			expect(instance.writingEntities[2].validateUniquenessInGroup.calledOnce).to.be.true;
-			expect(instance.writingEntities[2].validateUniquenessInGroup.calledWithExactly(
+			expect(instance.entities[1].validateNoAssociationWithSelf.notCalled).to.be.true;
+			expect(instance.entities[2].validateName.calledOnce).to.be.true;
+			expect(instance.entities[2].validateName.calledWithExactly({ isRequired: false })).to.be.true;
+			expect(instance.entities[2].validateDifferentiator.calledOnce).to.be.true;
+			expect(instance.entities[2].validateDifferentiator.calledWithExactly()).to.be.true;
+			expect(instance.entities[2].validateUniquenessInGroup.calledOnce).to.be.true;
+			expect(instance.entities[2].validateUniquenessInGroup.calledWithExactly(
 				{ isDuplicate: false }
 			)).to.be.true;
-			expect(instance.writingEntities[2].validateNoAssociationWithSelf.calledOnce).to.be.true;
-			expect(instance.writingEntities[2].validateNoAssociationWithSelf.calledWithExactly(
+			expect(instance.entities[2].validateNoAssociationWithSelf.calledOnce).to.be.true;
+			expect(instance.entities[2].validateNoAssociationWithSelf.calledWithExactly(
 				'The Indian Boy', '1'
 			)).to.be.true;
 

--- a/test-unit/src/neo4j/convert-neo4j-records-to-objects.test.js
+++ b/test-unit/src/neo4j/convert-neo4j-records-to-objects.test.js
@@ -41,7 +41,7 @@ describe('Convert Neo4j Records To Objects module', () => {
 							{
 								name: 'by',
 								model: 'writingCredit',
-								writingEntities: [
+								entities: [
 									{
 										name: 'Tena Štivičić',
 										model: 'person',
@@ -65,7 +65,7 @@ describe('Convert Neo4j Records To Objects module', () => {
 					{
 						name: 'by',
 						model: 'writingCredit',
-						writingEntities: [
+						entities: [
 							{
 								name: 'Tena Štivičić',
 								model: 'person',

--- a/test-unit/src/neo4j/cypher-queries/material.test.js
+++ b/test-unit/src/neo4j/cypher-queries/material.test.js
@@ -35,12 +35,12 @@ describe('Cypher Queries Material module', () => {
 
 				WITH material
 
-				UNWIND (CASE $writingCredits WHEN [] THEN [{ writingEntities: [] }] ELSE $writingCredits END) AS writingCredit
+				UNWIND (CASE $writingCredits WHEN [] THEN [{ entities: [] }] ELSE $writingCredits END) AS writingCredit
 
 					UNWIND
-						CASE SIZE([entity IN writingCredit.writingEntities WHERE entity.model = 'person']) WHEN 0
+						CASE SIZE([entity IN writingCredit.entities WHERE entity.model = 'person']) WHEN 0
 							THEN [null]
-							ELSE [entity IN writingCredit.writingEntities WHERE entity.model = 'person']
+							ELSE [entity IN writingCredit.entities WHERE entity.model = 'person']
 						END AS writingPersonParam
 
 						OPTIONAL MATCH (existingWritingPerson:Person { name: writingPersonParam.name })
@@ -67,9 +67,9 @@ describe('Cypher Queries Material module', () => {
 					WITH DISTINCT material, writingCredit
 
 					UNWIND
-						CASE SIZE([entity IN writingCredit.writingEntities WHERE entity.model = 'company']) WHEN 0
+						CASE SIZE([entity IN writingCredit.entities WHERE entity.model = 'company']) WHEN 0
 							THEN [null]
-							ELSE [entity IN writingCredit.writingEntities WHERE entity.model = 'company']
+							ELSE [entity IN writingCredit.entities WHERE entity.model = 'company']
 						END AS writingCompanyParam
 
 						OPTIONAL MATCH (existingWritingCompany:Company { name: writingCompanyParam.name })
@@ -99,9 +99,9 @@ describe('Cypher Queries Material module', () => {
 					WITH DISTINCT material, writingCredit
 
 					UNWIND
-						CASE SIZE([entity IN writingCredit.writingEntities WHERE entity.model = 'material']) WHEN 0
+						CASE SIZE([entity IN writingCredit.entities WHERE entity.model = 'material']) WHEN 0
 							THEN [null]
-							ELSE [entity IN writingCredit.writingEntities WHERE entity.model = 'material']
+							ELSE [entity IN writingCredit.entities WHERE entity.model = 'material']
 						END AS sourceMaterialParam
 
 						OPTIONAL MATCH (existingSourceMaterial:Material { name: sourceMaterialParam.name })
@@ -169,36 +169,36 @@ describe('Cypher Queries Material module', () => {
 
 				OPTIONAL MATCH (material)-[:SUBSEQUENT_VERSION_OF]->(originalVersionMaterial:Material)
 
-				OPTIONAL MATCH (material)-[writingEntityRel:WRITTEN_BY|USES_SOURCE_MATERIAL]->(writingEntity)
-					WHERE writingEntity:Person OR writingEntity:Company OR writingEntity:Material
+				OPTIONAL MATCH (material)-[entityRel:WRITTEN_BY|USES_SOURCE_MATERIAL]->(entity)
+					WHERE entity:Person OR entity:Company OR entity:Material
 
-				WITH material, originalVersionMaterial, writingEntityRel, writingEntity
-					ORDER BY writingEntityRel.creditPosition, writingEntityRel.entityPosition
+				WITH material, originalVersionMaterial, entityRel, entity
+					ORDER BY entityRel.creditPosition, entityRel.entityPosition
 
 				WITH
 					material,
 					originalVersionMaterial,
-					writingEntityRel.credit AS writingCreditName,
-					writingEntityRel.creditType AS writingCreditType,
+					entityRel.credit AS writingCreditName,
+					entityRel.creditType AS writingCreditType,
 					COLLECT(
-						CASE writingEntity WHEN NULL
+						CASE entity WHEN NULL
 							THEN null
-							ELSE writingEntity { model: TOLOWER(HEAD(LABELS(writingEntity))), .name, .differentiator }
+							ELSE entity { model: TOLOWER(HEAD(LABELS(entity))), .name, .differentiator }
 						END
-					) + [{}] AS writingEntities
+					) + [{}] AS entities
 
 				WITH material, originalVersionMaterial,
 					COLLECT(
-						CASE WHEN writingCreditName IS NULL AND SIZE(writingEntities) = 1
+						CASE WHEN writingCreditName IS NULL AND SIZE(entities) = 1
 							THEN null
 							ELSE {
 								model: 'writingCredit',
 								name: writingCreditName,
 								creditType: writingCreditType,
-								writingEntities: writingEntities
+								entities: entities
 							}
 						END
-					) + [{ writingEntities: [{}] }] AS writingCredits
+					) + [{ entities: [{}] }] AS writingCredits
 
 				OPTIONAL MATCH (material)-[characterRel:INCLUDES_CHARACTER]->(character:Character)
 
@@ -256,8 +256,8 @@ describe('Cypher Queries Material module', () => {
 
 				WITH DISTINCT material
 
-				OPTIONAL MATCH (material)-[writerRel:WRITTEN_BY]->(writingEntity)
-					WHERE writingEntity:Person OR writingEntity:Company
+				OPTIONAL MATCH (material)-[writerRel:WRITTEN_BY]->(entity)
+					WHERE entity:Person OR entity:Company
 
 				DELETE writerRel
 
@@ -302,12 +302,12 @@ describe('Cypher Queries Material module', () => {
 
 				WITH material
 
-				UNWIND (CASE $writingCredits WHEN [] THEN [{ writingEntities: [] }] ELSE $writingCredits END) AS writingCredit
+				UNWIND (CASE $writingCredits WHEN [] THEN [{ entities: [] }] ELSE $writingCredits END) AS writingCredit
 
 					UNWIND
-						CASE SIZE([entity IN writingCredit.writingEntities WHERE entity.model = 'person']) WHEN 0
+						CASE SIZE([entity IN writingCredit.entities WHERE entity.model = 'person']) WHEN 0
 							THEN [null]
-							ELSE [entity IN writingCredit.writingEntities WHERE entity.model = 'person']
+							ELSE [entity IN writingCredit.entities WHERE entity.model = 'person']
 						END AS writingPersonParam
 
 						OPTIONAL MATCH (existingWritingPerson:Person { name: writingPersonParam.name })
@@ -334,9 +334,9 @@ describe('Cypher Queries Material module', () => {
 					WITH DISTINCT material, writingCredit
 
 					UNWIND
-						CASE SIZE([entity IN writingCredit.writingEntities WHERE entity.model = 'company']) WHEN 0
+						CASE SIZE([entity IN writingCredit.entities WHERE entity.model = 'company']) WHEN 0
 							THEN [null]
-							ELSE [entity IN writingCredit.writingEntities WHERE entity.model = 'company']
+							ELSE [entity IN writingCredit.entities WHERE entity.model = 'company']
 						END AS writingCompanyParam
 
 						OPTIONAL MATCH (existingWritingCompany:Company { name: writingCompanyParam.name })
@@ -366,9 +366,9 @@ describe('Cypher Queries Material module', () => {
 					WITH DISTINCT material, writingCredit
 
 					UNWIND
-						CASE SIZE([entity IN writingCredit.writingEntities WHERE entity.model = 'material']) WHEN 0
+						CASE SIZE([entity IN writingCredit.entities WHERE entity.model = 'material']) WHEN 0
 							THEN [null]
-							ELSE [entity IN writingCredit.writingEntities WHERE entity.model = 'material']
+							ELSE [entity IN writingCredit.entities WHERE entity.model = 'material']
 						END AS sourceMaterialParam
 
 						OPTIONAL MATCH (existingSourceMaterial:Material { name: sourceMaterialParam.name })
@@ -436,36 +436,36 @@ describe('Cypher Queries Material module', () => {
 
 				OPTIONAL MATCH (material)-[:SUBSEQUENT_VERSION_OF]->(originalVersionMaterial:Material)
 
-				OPTIONAL MATCH (material)-[writingEntityRel:WRITTEN_BY|USES_SOURCE_MATERIAL]->(writingEntity)
-					WHERE writingEntity:Person OR writingEntity:Company OR writingEntity:Material
+				OPTIONAL MATCH (material)-[entityRel:WRITTEN_BY|USES_SOURCE_MATERIAL]->(entity)
+					WHERE entity:Person OR entity:Company OR entity:Material
 
-				WITH material, originalVersionMaterial, writingEntityRel, writingEntity
-					ORDER BY writingEntityRel.creditPosition, writingEntityRel.entityPosition
+				WITH material, originalVersionMaterial, entityRel, entity
+					ORDER BY entityRel.creditPosition, entityRel.entityPosition
 
 				WITH
 					material,
 					originalVersionMaterial,
-					writingEntityRel.credit AS writingCreditName,
-					writingEntityRel.creditType AS writingCreditType,
+					entityRel.credit AS writingCreditName,
+					entityRel.creditType AS writingCreditType,
 					COLLECT(
-						CASE writingEntity WHEN NULL
+						CASE entity WHEN NULL
 							THEN null
-							ELSE writingEntity { model: TOLOWER(HEAD(LABELS(writingEntity))), .name, .differentiator }
+							ELSE entity { model: TOLOWER(HEAD(LABELS(entity))), .name, .differentiator }
 						END
-					) + [{}] AS writingEntities
+					) + [{}] AS entities
 
 				WITH material, originalVersionMaterial,
 					COLLECT(
-						CASE WHEN writingCreditName IS NULL AND SIZE(writingEntities) = 1
+						CASE WHEN writingCreditName IS NULL AND SIZE(entities) = 1
 							THEN null
 							ELSE {
 								model: 'writingCredit',
 								name: writingCreditName,
 								creditType: writingCreditType,
-								writingEntities: writingEntities
+								entities: entities
 							}
 						END
-					) + [{ writingEntities: [{}] }] AS writingCredits
+					) + [{ entities: [{}] }] AS writingCredits
 
 				OPTIONAL MATCH (material)-[characterRel:INCLUDES_CHARACTER]->(character:Character)
 


### PR DESCRIPTION
In this PR https://github.com/andygout/theatrebase-api/pull/387, `creativeEntities` and `crewEntities` were both renamed to simply `entities`.

This PR renames `writingEntities` to `entities` in order to keep the naming consistent.