### PR TITLE
Rename sourceMaterialWritingCredits -> writingCredits

### DIFF
--- a/src/neo4j/cypher-queries/character.js
+++ b/src/neo4j/cypher-queries/character.js
@@ -54,7 +54,7 @@ const getShowQuery = () => `
 					.uuid,
 					.name,
 					.format,
-					sourceMaterialWritingCredits: sourceMaterialWritingCredits
+					writingCredits: sourceMaterialWritingCredits
 				}
 			END
 		) | CASE entity.model WHEN 'material'

--- a/src/neo4j/cypher-queries/company.js
+++ b/src/neo4j/cypher-queries/company.js
@@ -92,7 +92,7 @@ const getShowQuery = () => `
 						uuid: CASE entity.uuid WHEN company.uuid THEN null ELSE entity.uuid END,
 						.name,
 						.format,
-						sourceMaterialWritingCredits: sourceMaterialWritingCredits
+						writingCredits: sourceMaterialWritingCredits
 					}
 				END
 			) | CASE entity.model WHEN 'material'

--- a/src/neo4j/cypher-queries/material.js
+++ b/src/neo4j/cypher-queries/material.js
@@ -376,7 +376,7 @@ const getShowQuery = () => `
 						uuid: CASE entity.uuid WHEN material.uuid THEN null ELSE entity.uuid END,
 						.name,
 						.format,
-						sourceMaterialWritingCredits: sourceMaterialWritingCredits
+						writingCredits: sourceMaterialWritingCredits
 					}
 				END
 			) | CASE entity.model WHEN 'material'
@@ -603,7 +603,7 @@ const getListQuery = () => `
 					.uuid,
 					.name,
 					.format,
-					sourceMaterialWritingCredits: sourceMaterialWritingCredits
+					writingCredits: sourceMaterialWritingCredits
 				}
 			END
 		) | CASE entity.model WHEN 'material'

--- a/src/neo4j/cypher-queries/person.js
+++ b/src/neo4j/cypher-queries/person.js
@@ -92,7 +92,7 @@ const getShowQuery = () => `
 						uuid: CASE entity.uuid WHEN person.uuid THEN null ELSE entity.uuid END,
 						.name,
 						.format,
-						sourceMaterialWritingCredits: sourceMaterialWritingCredits
+						writingCredits: sourceMaterialWritingCredits
 					}
 				END
 			) | CASE entity.model WHEN 'material'

--- a/src/neo4j/cypher-queries/production.js
+++ b/src/neo4j/cypher-queries/production.js
@@ -530,7 +530,7 @@ const getShowQuery = () => `
 					.uuid,
 					.name,
 					.format,
-					sourceMaterialWritingCredits: sourceMaterialWritingCredits
+					writingCredits: sourceMaterialWritingCredits
 				}
 			END
 		) | CASE entity.model WHEN 'material'

--- a/test-e2e/crud/materials-api.test.js
+++ b/test-e2e/crud/materials-api.test.js
@@ -664,7 +664,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 								uuid: JOHN_GABRIEL_BORKMAN_SOURCE_MATERIAL_MATERIAL_UUID,
 								name: 'John Gabriel Borkman',
 								format: null,
-								sourceMaterialWritingCredits: []
+								writingCredits: []
 							}
 						]
 					}
@@ -1162,7 +1162,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 								uuid: THREE_SISTERS_SOURCE_MATERIAL_MATERIAL_UUID,
 								name: 'Three Sisters',
 								format: null,
-								sourceMaterialWritingCredits: []
+								writingCredits: []
 							}
 						]
 					}

--- a/test-e2e/model-interaction/material-with-rights-grantor.test.js
+++ b/test-e2e/model-interaction/material-with-rights-grantor.test.js
@@ -133,7 +133,7 @@ describe('Materials with rights grantor credits', () => {
 									uuid: THE_LADYKILLERS_SCREENPLAY_MATERIAL_UUID,
 									name: 'The Ladykillers',
 									format: 'motion picture screenplay',
-									sourceMaterialWritingCredits: [
+									writingCredits: [
 										{
 											model: 'writingCredit',
 											name: 'by',
@@ -208,7 +208,7 @@ describe('Materials with rights grantor credits', () => {
 									uuid: THE_LADYKILLERS_SCREENPLAY_MATERIAL_UUID,
 									name: 'The Ladykillers',
 									format: 'motion picture screenplay',
-									sourceMaterialWritingCredits: [
+									writingCredits: [
 										{
 											model: 'writingCredit',
 											name: 'by',

--- a/test-e2e/model-interaction/material-with-source-material.test.js
+++ b/test-e2e/model-interaction/material-with-source-material.test.js
@@ -408,7 +408,7 @@ describe('Materials with source material', () => {
 									uuid: null,
 									name: 'A Midsummer Night\'s Dream',
 									format: 'play',
-									sourceMaterialWritingCredits: [
+									writingCredits: [
 										{
 											model: 'writingCredit',
 											name: 'by',
@@ -462,7 +462,7 @@ describe('Materials with source material', () => {
 									uuid: null,
 									name: 'A Midsummer Night\'s Dream',
 									format: 'play',
-									sourceMaterialWritingCredits: [
+									writingCredits: [
 										{
 											model: 'writingCredit',
 											name: 'by',
@@ -580,7 +580,7 @@ describe('Materials with source material', () => {
 							uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
 							name: 'A Midsummer Night\'s Dream',
 							format: 'play',
-							sourceMaterialWritingCredits: [
+							writingCredits: [
 								{
 									model: 'writingCredit',
 									name: 'by',
@@ -694,7 +694,7 @@ describe('Materials with source material', () => {
 									uuid: null,
 									name: 'A Moorish Captain',
 									format: 'tale',
-									sourceMaterialWritingCredits: [
+									writingCredits: [
 										{
 											model: 'writingCredit',
 											name: 'by',
@@ -757,7 +757,7 @@ describe('Materials with source material', () => {
 							uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
 							name: 'A Moorish Captain',
 							format: 'tale',
-							sourceMaterialWritingCredits: [
+							writingCredits: [
 								{
 									model: 'writingCredit',
 									name: 'by',
@@ -824,7 +824,7 @@ describe('Materials with source material', () => {
 									uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
 									name: 'A Moorish Captain',
 									format: 'tale',
-									sourceMaterialWritingCredits: [
+									writingCredits: [
 										{
 											model: 'writingCredit',
 											name: 'by',
@@ -918,7 +918,7 @@ describe('Materials with source material', () => {
 									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
 									name: 'A Midsummer Night\'s Dream',
 									format: 'play',
-									sourceMaterialWritingCredits: [
+									writingCredits: [
 										{
 											model: 'writingCredit',
 											name: 'by',
@@ -972,7 +972,7 @@ describe('Materials with source material', () => {
 									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
 									name: 'A Midsummer Night\'s Dream',
 									format: 'play',
-									sourceMaterialWritingCredits: [
+									writingCredits: [
 										{
 											model: 'writingCredit',
 											name: 'by',
@@ -1041,7 +1041,7 @@ describe('Materials with source material', () => {
 									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
 									name: 'A Midsummer Night\'s Dream',
 									format: 'play',
-									sourceMaterialWritingCredits: [
+									writingCredits: [
 										{
 											model: 'writingCredit',
 											name: 'by',
@@ -1165,7 +1165,7 @@ describe('Materials with source material', () => {
 									uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
 									name: 'A Moorish Captain',
 									format: 'tale',
-									sourceMaterialWritingCredits: [
+									writingCredits: [
 										{
 											model: 'writingCredit',
 											name: 'by',
@@ -1259,7 +1259,7 @@ describe('Materials with source material', () => {
 									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
 									name: 'A Midsummer Night\'s Dream',
 									format: 'play',
-									sourceMaterialWritingCredits: [
+									writingCredits: [
 										{
 											model: 'writingCredit',
 											name: 'by',
@@ -1313,7 +1313,7 @@ describe('Materials with source material', () => {
 									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
 									name: 'A Midsummer Night\'s Dream',
 									format: 'play',
-									sourceMaterialWritingCredits: [
+									writingCredits: [
 										{
 											model: 'writingCredit',
 											name: 'by',
@@ -1382,7 +1382,7 @@ describe('Materials with source material', () => {
 									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
 									name: 'A Midsummer Night\'s Dream',
 									format: 'play',
-									sourceMaterialWritingCredits: [
+									writingCredits: [
 										{
 											model: 'writingCredit',
 											name: 'by',
@@ -1505,7 +1505,7 @@ describe('Materials with source material', () => {
 								uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
 								name: 'A Midsummer Night\'s Dream',
 								format: 'play',
-								sourceMaterialWritingCredits: [
+								writingCredits: [
 									{
 										model: 'writingCredit',
 										name: 'by',
@@ -1625,7 +1625,7 @@ describe('Materials with source material', () => {
 								uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
 								name: 'A Moorish Captain',
 								format: 'tale',
-								sourceMaterialWritingCredits: [
+								writingCredits: [
 									{
 										model: 'writingCredit',
 										name: 'by',
@@ -1693,7 +1693,7 @@ describe('Materials with source material', () => {
 									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
 									name: 'A Midsummer Night\'s Dream',
 									format: 'play',
-									sourceMaterialWritingCredits: [
+									writingCredits: [
 										{
 											model: 'writingCredit',
 											name: 'by',
@@ -1763,7 +1763,7 @@ describe('Materials with source material', () => {
 									uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
 									name: 'A Moorish Captain',
 									format: 'tale',
-									sourceMaterialWritingCredits: [
+									writingCredits: [
 										{
 											model: 'writingCredit',
 											name: 'by',
@@ -1925,7 +1925,7 @@ describe('Materials with source material', () => {
 									uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
 									name: 'A Moorish Captain',
 									format: 'tale',
-									sourceMaterialWritingCredits: [
+									writingCredits: [
 										{
 											model: 'writingCredit',
 											name: 'by',
@@ -2019,7 +2019,7 @@ describe('Materials with source material', () => {
 									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
 									name: 'A Midsummer Night\'s Dream',
 									format: 'play',
-									sourceMaterialWritingCredits: [
+									writingCredits: [
 										{
 											model: 'writingCredit',
 											name: 'by',
@@ -2073,7 +2073,7 @@ describe('Materials with source material', () => {
 									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
 									name: 'A Midsummer Night\'s Dream',
 									format: 'play',
-									sourceMaterialWritingCredits: [
+									writingCredits: [
 										{
 											model: 'writingCredit',
 											name: 'by',


### PR DESCRIPTION
When looking at a material instance object that has source material, the `sourceMaterialWritingCredits` property is within the context of the source material itself and so makes more sense to be named `writingCredits`.

E.g. The Indian Boy has source material of A Midsummer Night's Dream: the `sourceMaterialWritingCredits` property of A Midsummer Night's Dream suggests that its value is the writing credits for the source material of A Midsummer Night's Dream (of which there is none) rather than the writing credits of A Midsummer Night's Dream.

Changing it to `writingCredits` makes clear that the value is the writing credits for A Midsummer Night's Dream, i.e. "by William Shakespeare".

```diff
{
	model: 'material',
	uuid: THE_INDIAN_BOY_MATERIAL_UUID,
	name: 'The Indian Boy',
	format: 'play',
	writingCredits: [
		{
			model: 'writingCredit',
			name: 'by',
			entities: [
				{
					model: 'person',
					uuid: RONA_MUNRO_PERSON_UUID,
					name: 'Rona Munro'
				}
			]
		},
		{
			model: 'writingCredit',
			name: 'inspired by',
			entities: [
				{
					model: 'material',
					uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
					name: 'A Midsummer Night\'s Dream',
					format: 'play',
-					sourceMaterialWritingCredits: [
+					writingCredits: [
						{
							model: 'writingCredit',
							name: 'by',
							entities: [
								{
									model: 'person',
									uuid: null,
									name: 'William Shakespeare'
								}
							]
						}
					]
				}
			]
		}
	]
}
```

N.B. Though A Midsummer Night's Dream is not a translation or adaptation of an earlier work, various sources such as Ovid's Metamorphoses and Chaucer's "The Knight's Tale" served as inspiration. According to John Twyning, the play's plot of four lovers undergoing a trial in the woods was intended as a "riff" on Der Busant, a Middle High German poem (ref: https://en.wikipedia.org/wiki/A_Midsummer_Night%27s_Dream#Sources).