### PR TITLE
Rename Neo4j relationships

### DIFF
--- a/src/neo4j/cypher-queries/character.js
+++ b/src/neo4j/cypher-queries/character.js
@@ -1,12 +1,12 @@
 const getShowQuery = () => `
 	MATCH (character:Character { uuid: $uuid })
 
-	OPTIONAL MATCH (character)<-[materialRel:INCLUDES_CHARACTER]-(material:Material)
+	OPTIONAL MATCH (character)<-[materialRel:HAS_CHARACTER]-(material:Material)
 
-	OPTIONAL MATCH (material)-[entityRel:WRITTEN_BY|USES_SOURCE_MATERIAL]->(entity)
+	OPTIONAL MATCH (material)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity)
 		WHERE entity:Person OR entity:Company OR entity:Material
 
-	OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:WRITTEN_BY]->(sourceMaterialWriter)
+	OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->(sourceMaterialWriter)
 
 	WITH
 		character,
@@ -99,7 +99,7 @@ const getShowQuery = () => `
 			END
 		) AS materials
 
-	OPTIONAL MATCH (character)<-[variantNamedDepiction:INCLUDES_CHARACTER]-(:Material)
+	OPTIONAL MATCH (character)<-[variantNamedDepiction:HAS_CHARACTER]-(:Material)
 		WHERE EXISTS(variantNamedDepiction.displayName)
 
 	WITH character, materials, variantNamedDepiction
@@ -107,7 +107,7 @@ const getShowQuery = () => `
 
 	WITH character, materials, COLLECT(DISTINCT(variantNamedDepiction.displayName)) AS variantNamedDepictions
 
-	OPTIONAL MATCH (character)<-[depictionForVariantNamedPortrayal:INCLUDES_CHARACTER]-(:Material)
+	OPTIONAL MATCH (character)<-[depictionForVariantNamedPortrayal:HAS_CHARACTER]-(:Material)
 		<-[:PRODUCTION_OF]-(:Production)-[variantNamedPortrayal:HAS_CAST_MEMBER]->(:Person)
 		WHERE
 			character.name <> variantNamedPortrayal.roleName AND
@@ -122,7 +122,7 @@ const getShowQuery = () => `
 	WITH character, variantNamedDepictions, materials,
 		COLLECT(DISTINCT(variantNamedPortrayal.roleName)) AS variantNamedPortrayals
 
-	OPTIONAL MATCH (character)<-[characterDepiction:INCLUDES_CHARACTER]-(materialForProduction:Material)
+	OPTIONAL MATCH (character)<-[characterDepiction:HAS_CHARACTER]-(materialForProduction:Material)
 		<-[productionRel:PRODUCTION_OF]-(production:Production)-[role:HAS_CAST_MEMBER]->(person:Person)
 		WHERE
 			(
@@ -142,7 +142,7 @@ const getShowQuery = () => `
 			)
 
 	OPTIONAL MATCH (person)<-[otherRole]-(production)-[productionRel]->
-		(materialForProduction)-[otherCharacterDepiction:INCLUDES_CHARACTER]->(otherCharacter:Character)
+		(materialForProduction)-[otherCharacterDepiction:HAS_CHARACTER]->(otherCharacter:Character)
 		WHERE
 			(
 				otherCharacter.name IN [otherRole.roleName, otherRole.characterName] OR
@@ -155,7 +155,7 @@ const getShowQuery = () => `
 
 	OPTIONAL MATCH (production)-[:PLAYS_AT]->(theatre:Theatre)
 
-	OPTIONAL MATCH (theatre)<-[:INCLUDES_SUB_THEATRE]-(surTheatre:Theatre)
+	OPTIONAL MATCH (theatre)<-[:HAS_SUB_THEATRE]-(surTheatre:Theatre)
 
 	WITH
 		character,

--- a/src/neo4j/cypher-queries/material.js
+++ b/src/neo4j/cypher-queries/material.js
@@ -13,7 +13,7 @@ const getCreateUpdateQuery = action => {
 
 			WITH DISTINCT material
 
-			OPTIONAL MATCH (material)-[writerRel:WRITTEN_BY]->(entity)
+			OPTIONAL MATCH (material)-[writerRel:HAS_WRITING_ENTITY]->(entity)
 				WHERE entity:Person OR entity:Company
 
 			DELETE writerRel
@@ -26,7 +26,7 @@ const getCreateUpdateQuery = action => {
 
 			WITH DISTINCT material
 
-			OPTIONAL MATCH (material)-[characterRel:INCLUDES_CHARACTER]->(:Character)
+			OPTIONAL MATCH (material)-[characterRel:HAS_CHARACTER]->(:Character)
 
 			DELETE characterRel
 
@@ -85,7 +85,7 @@ const getCreateUpdateQuery = action => {
 						ON CREATE SET writingPerson.differentiator = writingPersonParam.differentiator
 
 					CREATE (material)-
-						[:WRITTEN_BY {
+						[:HAS_WRITING_ENTITY {
 							creditPosition: writingCredit.position,
 							entityPosition: writingPersonParam.position,
 							credit: writingCredit.name,
@@ -117,7 +117,7 @@ const getCreateUpdateQuery = action => {
 						ON CREATE SET writingCompany.differentiator = writingCompanyParam.differentiator
 
 					CREATE (material)-
-						[:WRITTEN_BY {
+						[:HAS_WRITING_ENTITY {
 							creditPosition: writingCredit.position,
 							entityPosition: writingCompanyParam.position,
 							credit: writingCredit.name,
@@ -180,7 +180,7 @@ const getCreateUpdateQuery = action => {
 						ON CREATE SET character.differentiator = characterParam.differentiator
 
 					CREATE (material)-
-						[:INCLUDES_CHARACTER {
+						[:HAS_CHARACTER {
 							groupPosition: characterGroup.position,
 							characterPosition: characterParam.position,
 							displayName: CASE characterParam.underlyingName WHEN NULL
@@ -206,7 +206,7 @@ const getEditQuery = () => `
 
 	OPTIONAL MATCH (material)-[:SUBSEQUENT_VERSION_OF]->(originalVersionMaterial:Material)
 
-	OPTIONAL MATCH (material)-[entityRel:WRITTEN_BY|USES_SOURCE_MATERIAL]->(entity)
+	OPTIONAL MATCH (material)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity)
 		WHERE entity:Person OR entity:Company OR entity:Material
 
 	WITH material, originalVersionMaterial, entityRel, entity
@@ -237,7 +237,7 @@ const getEditQuery = () => `
 			END
 		) + [{ entities: [{}] }] AS writingCredits
 
-	OPTIONAL MATCH (material)-[characterRel:INCLUDES_CHARACTER]->(character:Character)
+	OPTIONAL MATCH (material)-[characterRel:HAS_CHARACTER]->(character:Character)
 
 	WITH material, originalVersionMaterial, writingCredits, characterRel, character
 		ORDER BY characterRel.groupPosition, characterRel.characterPosition
@@ -296,12 +296,12 @@ const getShowQuery = () => `
 
 		OPTIONAL MATCH (relatedMaterial)-[sourcingMaterialRel:USES_SOURCE_MATERIAL]->(material)
 
-		OPTIONAL MATCH (relatedMaterial)-[entityRel:WRITTEN_BY|USES_SOURCE_MATERIAL]->(entity)
+		OPTIONAL MATCH (relatedMaterial)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity)
 			WHERE entity:Person OR entity:Company OR entity:Material
 
-		OPTIONAL MATCH (entity)<-[originalVersionWritingEntityRel:WRITTEN_BY|USES_SOURCE_MATERIAL]-(material)
+		OPTIONAL MATCH (entity)<-[originalVersionWritingEntityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]-(material)
 
-		OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:WRITTEN_BY]->(sourceMaterialWriter)
+		OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->(sourceMaterialWriter)
 
 		WITH
 			material,
@@ -433,7 +433,7 @@ const getShowQuery = () => `
 				relatedMaterial { .model, .uuid, .name, .format, .writingCredits }
 			] AS sourcingMaterials
 
-	OPTIONAL MATCH (material)-[characterRel:INCLUDES_CHARACTER]->(character:Character)
+	OPTIONAL MATCH (material)-[characterRel:HAS_CHARACTER]->(character:Character)
 
 	WITH
 		material,
@@ -493,7 +493,7 @@ const getShowQuery = () => `
 
 		OPTIONAL MATCH (production)-[:PLAYS_AT]->(theatre:Theatre)
 
-		OPTIONAL MATCH (theatre)<-[:INCLUDES_SUB_THEATRE]-(surTheatre:Theatre)
+		OPTIONAL MATCH (theatre)<-[:HAS_SUB_THEATRE]-(surTheatre:Theatre)
 
 		OPTIONAL MATCH (material)<-[:USES_SOURCE_MATERIAL]-(:Material)<-[sourcingMaterialRel:PRODUCTION_OF]-(production)
 
@@ -565,10 +565,10 @@ const getShowQuery = () => `
 const getListQuery = () => `
 	MATCH (material:Material)
 
-	OPTIONAL MATCH (material)-[entityRel:WRITTEN_BY|USES_SOURCE_MATERIAL]->(entity)
+	OPTIONAL MATCH (material)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity)
 		WHERE entity:Person OR entity:Company OR entity:Material
 
-	OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:WRITTEN_BY]->(sourceMaterialWriter)
+	OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->(sourceMaterialWriter)
 
 	WITH material, entityRel, entity, sourceMaterialWriterRel, sourceMaterialWriter
 		ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriterRel.entityPosition

--- a/src/neo4j/cypher-queries/production.js
+++ b/src/neo4j/cypher-queries/production.js
@@ -109,7 +109,7 @@ const getCreateUpdateQuery = action => {
 						ON CREATE SET creativePerson.differentiator = creativePersonParam.differentiator
 
 					CREATE (production)-
-						[:HAS_CREATIVE_TEAM_MEMBER {
+						[:HAS_CREATIVE_ENTITY {
 							creditPosition: creativeCredit.position,
 							entityPosition: creativePersonParam.position,
 							credit: creativeCredit.name
@@ -140,7 +140,7 @@ const getCreateUpdateQuery = action => {
 						ON CREATE SET creativeCompany.differentiator = creativeCompanyParam.differentiator
 
 					CREATE (production)-
-						[:HAS_CREATIVE_TEAM_MEMBER {
+						[:HAS_CREATIVE_ENTITY {
 							creditPosition: creativeCredit.position,
 							entityPosition: creativeCompanyParam.position,
 							credit: creativeCredit.name
@@ -160,7 +160,7 @@ const getCreateUpdateQuery = action => {
 							(creativeCompanyParam.differentiator IS NULL AND creditedCompany.differentiator IS NULL) OR
 							creativeCompanyParam.differentiator = creditedCompany.differentiator
 
-					OPTIONAL MATCH (creditedCompany)<-[creativeCompanyRel:HAS_CREATIVE_TEAM_MEMBER]-(production)
+					OPTIONAL MATCH (creditedCompany)<-[creativeCompanyRel:HAS_CREATIVE_ENTITY]-(production)
 						WHERE
 							creativeCredit.position IS NULL OR
 							creativeCredit.position = creativeCompanyRel.creditPosition
@@ -182,7 +182,7 @@ const getCreateUpdateQuery = action => {
 							ON CREATE SET creditedMember.differentiator = creditedMemberParam.differentiator
 
 						CREATE (production)-
-							[:HAS_CREATIVE_TEAM_MEMBER {
+							[:HAS_CREATIVE_ENTITY {
 								creditPosition: creativeCredit.position,
 								memberPosition: creditedMemberParam.position,
 								creditedCompanyUuid: creditedCompany.uuid
@@ -218,7 +218,7 @@ const getCreateUpdateQuery = action => {
 						ON CREATE SET crewPerson.differentiator = crewPersonParam.differentiator
 
 					CREATE (production)-
-						[:HAS_CREW_MEMBER {
+						[:HAS_CREW_ENTITY {
 							creditPosition: crewCredit.position,
 							entityPosition: crewPersonParam.position,
 							credit: crewCredit.name
@@ -249,7 +249,7 @@ const getCreateUpdateQuery = action => {
 						ON CREATE SET crewCompany.differentiator = crewCompanyParam.differentiator
 
 					CREATE (production)-
-						[:HAS_CREW_MEMBER {
+						[:HAS_CREW_ENTITY {
 							creditPosition: crewCredit.position,
 							entityPosition: crewCompanyParam.position,
 							credit: crewCredit.name
@@ -269,7 +269,7 @@ const getCreateUpdateQuery = action => {
 							(crewCompanyParam.differentiator IS NULL AND creditedCompany.differentiator IS NULL) OR
 							crewCompanyParam.differentiator = creditedCompany.differentiator
 
-					OPTIONAL MATCH (creditedCompany)<-[crewCompanyRel:HAS_CREW_MEMBER]-(production)
+					OPTIONAL MATCH (creditedCompany)<-[crewCompanyRel:HAS_CREW_ENTITY]-(production)
 						WHERE
 							crewCredit.position IS NULL OR
 							crewCredit.position = crewCompanyRel.creditPosition
@@ -291,7 +291,7 @@ const getCreateUpdateQuery = action => {
 							ON CREATE SET creditedMember.differentiator = creditedMemberParam.differentiator
 
 						CREATE (production)-
-							[:HAS_CREW_MEMBER {
+							[:HAS_CREW_ENTITY {
 								creditPosition: crewCredit.position,
 								memberPosition: creditedMemberParam.position,
 								creditedCompanyUuid: creditedCompany.uuid
@@ -343,7 +343,7 @@ const getEditQuery = () => `
 			END
 		) + [{ roles: [{}] }] AS cast
 
-	OPTIONAL MATCH (production)-[creativeEntityRel:HAS_CREATIVE_TEAM_MEMBER]->(creativeEntity)
+	OPTIONAL MATCH (production)-[creativeEntityRel:HAS_CREATIVE_ENTITY]->(creativeEntity)
 		WHERE
 			(creativeEntity:Person AND creativeEntityRel.creditedCompanyUuid IS NULL) OR
 			creativeEntity:Company
@@ -360,7 +360,7 @@ const getEditQuery = () => `
 
 		UNWIND (COALESCE(creativeEntity.creditedMemberUuids, [null])) AS creditedMemberUuid
 
-			OPTIONAL MATCH (production)-[creditedMemberRel:HAS_CREATIVE_TEAM_MEMBER]->
+			OPTIONAL MATCH (production)-[creditedMemberRel:HAS_CREATIVE_ENTITY]->
 				(creditedMember:Person { uuid: creditedMemberUuid })
 				WHERE
 					creativeEntityRel.creditPosition IS NULL OR
@@ -398,7 +398,7 @@ const getEditQuery = () => `
 			END
 		) + [{ entities: [{}] }] AS creativeCredits
 
-	OPTIONAL MATCH (production)-[crewEntityRel:HAS_CREW_MEMBER]->(crewEntity)
+	OPTIONAL MATCH (production)-[crewEntityRel:HAS_CREW_ENTITY]->(crewEntity)
 		WHERE
 			(crewEntity:Person AND crewEntityRel.creditedCompanyUuid IS NULL) OR
 			crewEntity:Company
@@ -415,7 +415,7 @@ const getEditQuery = () => `
 
 		UNWIND (COALESCE(crewEntity.creditedMemberUuids, [null])) AS creditedMemberUuid
 
-			OPTIONAL MATCH (production)-[creditedMemberRel:HAS_CREW_MEMBER]->
+			OPTIONAL MATCH (production)-[creditedMemberRel:HAS_CREW_ENTITY]->
 				(creditedMember:Person { uuid: creditedMemberUuid })
 				WHERE
 					crewEntityRel.creditPosition IS NULL OR
@@ -468,7 +468,7 @@ const getShowQuery = () => `
 
 	OPTIONAL MATCH (production)-[:PLAYS_AT]->(theatre:Theatre)
 
-	OPTIONAL MATCH (theatre)<-[:INCLUDES_SUB_THEATRE]-(surTheatre:Theatre)
+	OPTIONAL MATCH (theatre)<-[:HAS_SUB_THEATRE]-(surTheatre:Theatre)
 
 	WITH production,
 		CASE theatre WHEN NULL
@@ -486,10 +486,10 @@ const getShowQuery = () => `
 
 	OPTIONAL MATCH (production)-[materialRel:PRODUCTION_OF]->(material:Material)
 
-	OPTIONAL MATCH (material)-[entityRel:WRITTEN_BY|USES_SOURCE_MATERIAL]->(entity)
+	OPTIONAL MATCH (material)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity)
 		WHERE entity:Person OR entity:Company OR entity:Material
 
-	OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:WRITTEN_BY]->(sourceMaterialWriter)
+	OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->(sourceMaterialWriter)
 
 	WITH production, theatre, material, entityRel, entity, sourceMaterialWriterRel, sourceMaterialWriter
 		ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriterRel.entityPosition
@@ -553,7 +553,7 @@ const getShowQuery = () => `
 	OPTIONAL MATCH (production)-[role:HAS_CAST_MEMBER]->(castMember:Person)
 
 	OPTIONAL MATCH (castMember)<-[role]-(production)-[materialRel]->
-		(material)-[characterRel:INCLUDES_CHARACTER]->(character:Character)
+		(material)-[characterRel:HAS_CHARACTER]->(character:Character)
 		WHERE
 			(
 				role.roleName IN [character.name, characterRel.displayName] OR
@@ -584,7 +584,7 @@ const getShowQuery = () => `
 			END
 		) AS cast
 
-	OPTIONAL MATCH (production)-[creativeEntityRel:HAS_CREATIVE_TEAM_MEMBER]->(creativeEntity)
+	OPTIONAL MATCH (production)-[creativeEntityRel:HAS_CREATIVE_ENTITY]->(creativeEntity)
 		WHERE
 			(creativeEntity:Person AND creativeEntityRel.creditedCompanyUuid IS NULL) OR
 			creativeEntity:Company
@@ -601,7 +601,7 @@ const getShowQuery = () => `
 
 		UNWIND (COALESCE(creativeEntity.creditedMemberUuids, [null])) AS creditedMemberUuid
 
-			OPTIONAL MATCH (production)-[creditedMemberRel:HAS_CREATIVE_TEAM_MEMBER]->
+			OPTIONAL MATCH (production)-[creditedMemberRel:HAS_CREATIVE_ENTITY]->
 				(creditedMember:Person { uuid: creditedMemberUuid })
 				WHERE
 					creativeEntityRel.creditPosition IS NULL OR
@@ -639,7 +639,7 @@ const getShowQuery = () => `
 			END
 		) AS creativeCredits
 
-	OPTIONAL MATCH (production)-[crewEntityRel:HAS_CREW_MEMBER]->(crewEntity)
+	OPTIONAL MATCH (production)-[crewEntityRel:HAS_CREW_ENTITY]->(crewEntity)
 		WHERE
 			(crewEntity:Person AND crewEntityRel.creditedCompanyUuid IS NULL) OR
 			crewEntity:Company
@@ -656,7 +656,7 @@ const getShowQuery = () => `
 
 		UNWIND (COALESCE(crewEntity.creditedMemberUuids, [null])) AS creditedMemberUuid
 
-			OPTIONAL MATCH (production)-[creditedMemberRel:HAS_CREW_MEMBER]->
+			OPTIONAL MATCH (production)-[creditedMemberRel:HAS_CREW_ENTITY]->
 				(creditedMember:Person { uuid: creditedMemberUuid })
 				WHERE
 					crewEntityRel.creditPosition IS NULL OR
@@ -707,7 +707,7 @@ const getListQuery = () => `
 
 	OPTIONAL MATCH (production)-[:PLAYS_AT]->(theatre:Theatre)
 
-	OPTIONAL MATCH (theatre)<-[:INCLUDES_SUB_THEATRE]-(surTheatre:Theatre)
+	OPTIONAL MATCH (theatre)<-[:HAS_SUB_THEATRE]-(surTheatre:Theatre)
 
 	RETURN
 		'production' AS model,

--- a/src/neo4j/cypher-queries/theatre.js
+++ b/src/neo4j/cypher-queries/theatre.js
@@ -5,7 +5,7 @@ const getCreateUpdateQuery = action => {
 		update: `
 			MATCH (theatre:Theatre { uuid: $uuid })
 
-			OPTIONAL MATCH (theatre)-[relationship:INCLUDES_SUB_THEATRE]->(:Theatre)
+			OPTIONAL MATCH (theatre)-[relationship:HAS_SUB_THEATRE]->(:Theatre)
 
 			DELETE relationship
 
@@ -36,7 +36,7 @@ const getCreateUpdateQuery = action => {
 				})
 					ON CREATE SET subTheatre.differentiator = subTheatreParam.differentiator
 
-				CREATE (theatre)-[:INCLUDES_SUB_THEATRE { position: subTheatreParam.position }]->(subTheatre)
+				CREATE (theatre)-[:HAS_SUB_THEATRE { position: subTheatreParam.position }]->(subTheatre)
 			)
 
 		WITH DISTINCT theatre
@@ -51,7 +51,7 @@ const getCreateQuery = () => getCreateUpdateQuery('create');
 const getEditQuery = () => `
 	MATCH (theatre:Theatre { uuid: $uuid })
 
-	OPTIONAL MATCH (theatre)-[subTheatreRel:INCLUDES_SUB_THEATRE]->(subTheatre:Theatre)
+	OPTIONAL MATCH (theatre)-[subTheatreRel:HAS_SUB_THEATRE]->(subTheatre:Theatre)
 
 	WITH theatre, subTheatreRel, subTheatre
 		ORDER BY subTheatreRel.position
@@ -74,7 +74,7 @@ const getUpdateQuery = () => getCreateUpdateQuery('update');
 const getShowQuery = () => `
 	MATCH (theatre:Theatre { uuid: $uuid })
 
-	OPTIONAL MATCH (surTheatre:Theatre)-[:INCLUDES_SUB_THEATRE]->(theatre)
+	OPTIONAL MATCH (surTheatre:Theatre)-[:HAS_SUB_THEATRE]->(theatre)
 
 	WITH theatre,
 		CASE surTheatre WHEN NULL
@@ -82,7 +82,7 @@ const getShowQuery = () => `
 			ELSE surTheatre { model: 'theatre', .uuid, .name }
 		END AS surTheatre
 
-	OPTIONAL MATCH (theatre)-[subTheatreRel:INCLUDES_SUB_THEATRE]->(subTheatre:Theatre)
+	OPTIONAL MATCH (theatre)-[subTheatreRel:HAS_SUB_THEATRE]->(subTheatre:Theatre)
 
 	WITH theatre, surTheatre, subTheatre
 		ORDER BY subTheatreRel.position
@@ -96,7 +96,7 @@ const getShowQuery = () => `
 		) AS subTheatres
 
 	OPTIONAL MATCH path=
-		(theatre)-[:INCLUDES_SUB_THEATRE*0..1]->(subTheatreForProduction:Theatre)<-[:PLAYS_AT]-(production:Production)
+		(theatre)-[:HAS_SUB_THEATRE*0..1]->(subTheatreForProduction:Theatre)<-[:PLAYS_AT]-(production:Production)
 
 	WITH
 		theatre,
@@ -132,9 +132,9 @@ const getShowQuery = () => `
 
 const getListQuery = () => `
 	MATCH (theatre:Theatre)
-		WHERE NOT (:Theatre)-[:INCLUDES_SUB_THEATRE]->(theatre)
+		WHERE NOT (:Theatre)-[:HAS_SUB_THEATRE]->(theatre)
 
-	OPTIONAL MATCH (theatre)-[subTheatreRel:INCLUDES_SUB_THEATRE]->(subTheatre:Theatre)
+	OPTIONAL MATCH (theatre)-[subTheatreRel:HAS_SUB_THEATRE]->(subTheatre:Theatre)
 
 	WITH theatre, subTheatre
 		ORDER BY subTheatreRel.position

--- a/test-e2e/instance-validation-failures/characters-api.test.js
+++ b/test-e2e/instance-validation-failures/characters-api.test.js
@@ -227,7 +227,7 @@ describe('Instance validation failures: Characters API', () => {
 				sourceUuid: TWELFTH_NIGHT_MATERIAL_UUID,
 				destinationLabel: 'Character',
 				destinationUuid: VIOLA_CHARACTER_UUID,
-				relationshipName: 'INCLUDES_CHARACTER'
+				relationshipName: 'HAS_CHARACTER'
 			});
 
 		});

--- a/test-unit/src/neo4j/cypher-queries/material.test.js
+++ b/test-unit/src/neo4j/cypher-queries/material.test.js
@@ -56,7 +56,7 @@ describe('Cypher Queries Material module', () => {
 								ON CREATE SET writingPerson.differentiator = writingPersonParam.differentiator
 
 							CREATE (material)-
-								[:WRITTEN_BY {
+								[:HAS_WRITING_ENTITY {
 									creditPosition: writingCredit.position,
 									entityPosition: writingPersonParam.position,
 									credit: writingCredit.name,
@@ -88,7 +88,7 @@ describe('Cypher Queries Material module', () => {
 								ON CREATE SET writingCompany.differentiator = writingCompanyParam.differentiator
 
 							CREATE (material)-
-								[:WRITTEN_BY {
+								[:HAS_WRITING_ENTITY {
 									creditPosition: writingCredit.position,
 									entityPosition: writingCompanyParam.position,
 									credit: writingCredit.name,
@@ -151,7 +151,7 @@ describe('Cypher Queries Material module', () => {
 								ON CREATE SET character.differentiator = characterParam.differentiator
 
 							CREATE (material)-
-								[:INCLUDES_CHARACTER {
+								[:HAS_CHARACTER {
 									groupPosition: characterGroup.position,
 									characterPosition: characterParam.position,
 									displayName: CASE characterParam.underlyingName WHEN NULL
@@ -169,7 +169,7 @@ describe('Cypher Queries Material module', () => {
 
 				OPTIONAL MATCH (material)-[:SUBSEQUENT_VERSION_OF]->(originalVersionMaterial:Material)
 
-				OPTIONAL MATCH (material)-[entityRel:WRITTEN_BY|USES_SOURCE_MATERIAL]->(entity)
+				OPTIONAL MATCH (material)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity)
 					WHERE entity:Person OR entity:Company OR entity:Material
 
 				WITH material, originalVersionMaterial, entityRel, entity
@@ -200,7 +200,7 @@ describe('Cypher Queries Material module', () => {
 						END
 					) + [{ entities: [{}] }] AS writingCredits
 
-				OPTIONAL MATCH (material)-[characterRel:INCLUDES_CHARACTER]->(character:Character)
+				OPTIONAL MATCH (material)-[characterRel:HAS_CHARACTER]->(character:Character)
 
 				WITH material, originalVersionMaterial, writingCredits, characterRel, character
 					ORDER BY characterRel.groupPosition, characterRel.characterPosition
@@ -256,7 +256,7 @@ describe('Cypher Queries Material module', () => {
 
 				WITH DISTINCT material
 
-				OPTIONAL MATCH (material)-[writerRel:WRITTEN_BY]->(entity)
+				OPTIONAL MATCH (material)-[writerRel:HAS_WRITING_ENTITY]->(entity)
 					WHERE entity:Person OR entity:Company
 
 				DELETE writerRel
@@ -269,7 +269,7 @@ describe('Cypher Queries Material module', () => {
 
 				WITH DISTINCT material
 
-				OPTIONAL MATCH (material)-[characterRel:INCLUDES_CHARACTER]->(:Character)
+				OPTIONAL MATCH (material)-[characterRel:HAS_CHARACTER]->(:Character)
 
 				DELETE characterRel
 
@@ -323,7 +323,7 @@ describe('Cypher Queries Material module', () => {
 								ON CREATE SET writingPerson.differentiator = writingPersonParam.differentiator
 
 							CREATE (material)-
-								[:WRITTEN_BY {
+								[:HAS_WRITING_ENTITY {
 									creditPosition: writingCredit.position,
 									entityPosition: writingPersonParam.position,
 									credit: writingCredit.name,
@@ -355,7 +355,7 @@ describe('Cypher Queries Material module', () => {
 								ON CREATE SET writingCompany.differentiator = writingCompanyParam.differentiator
 
 							CREATE (material)-
-								[:WRITTEN_BY {
+								[:HAS_WRITING_ENTITY {
 									creditPosition: writingCredit.position,
 									entityPosition: writingCompanyParam.position,
 									credit: writingCredit.name,
@@ -418,7 +418,7 @@ describe('Cypher Queries Material module', () => {
 								ON CREATE SET character.differentiator = characterParam.differentiator
 
 							CREATE (material)-
-								[:INCLUDES_CHARACTER {
+								[:HAS_CHARACTER {
 									groupPosition: characterGroup.position,
 									characterPosition: characterParam.position,
 									displayName: CASE characterParam.underlyingName WHEN NULL
@@ -436,7 +436,7 @@ describe('Cypher Queries Material module', () => {
 
 				OPTIONAL MATCH (material)-[:SUBSEQUENT_VERSION_OF]->(originalVersionMaterial:Material)
 
-				OPTIONAL MATCH (material)-[entityRel:WRITTEN_BY|USES_SOURCE_MATERIAL]->(entity)
+				OPTIONAL MATCH (material)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity)
 					WHERE entity:Person OR entity:Company OR entity:Material
 
 				WITH material, originalVersionMaterial, entityRel, entity
@@ -467,7 +467,7 @@ describe('Cypher Queries Material module', () => {
 						END
 					) + [{ entities: [{}] }] AS writingCredits
 
-				OPTIONAL MATCH (material)-[characterRel:INCLUDES_CHARACTER]->(character:Character)
+				OPTIONAL MATCH (material)-[characterRel:HAS_CHARACTER]->(character:Character)
 
 				WITH material, originalVersionMaterial, writingCredits, characterRel, character
 					ORDER BY characterRel.groupPosition, characterRel.characterPosition

--- a/test-unit/src/neo4j/cypher-queries/production.test.js
+++ b/test-unit/src/neo4j/cypher-queries/production.test.js
@@ -102,7 +102,7 @@ describe('Cypher Queries Production module', () => {
 								ON CREATE SET creativePerson.differentiator = creativePersonParam.differentiator
 
 							CREATE (production)-
-								[:HAS_CREATIVE_TEAM_MEMBER {
+								[:HAS_CREATIVE_ENTITY {
 									creditPosition: creativeCredit.position,
 									entityPosition: creativePersonParam.position,
 									credit: creativeCredit.name
@@ -133,7 +133,7 @@ describe('Cypher Queries Production module', () => {
 								ON CREATE SET creativeCompany.differentiator = creativeCompanyParam.differentiator
 
 							CREATE (production)-
-								[:HAS_CREATIVE_TEAM_MEMBER {
+								[:HAS_CREATIVE_ENTITY {
 									creditPosition: creativeCredit.position,
 									entityPosition: creativeCompanyParam.position,
 									credit: creativeCredit.name
@@ -153,7 +153,7 @@ describe('Cypher Queries Production module', () => {
 									(creativeCompanyParam.differentiator IS NULL AND creditedCompany.differentiator IS NULL) OR
 									creativeCompanyParam.differentiator = creditedCompany.differentiator
 
-							OPTIONAL MATCH (creditedCompany)<-[creativeCompanyRel:HAS_CREATIVE_TEAM_MEMBER]-(production)
+							OPTIONAL MATCH (creditedCompany)<-[creativeCompanyRel:HAS_CREATIVE_ENTITY]-(production)
 								WHERE
 									creativeCredit.position IS NULL OR
 									creativeCredit.position = creativeCompanyRel.creditPosition
@@ -175,7 +175,7 @@ describe('Cypher Queries Production module', () => {
 									ON CREATE SET creditedMember.differentiator = creditedMemberParam.differentiator
 
 								CREATE (production)-
-									[:HAS_CREATIVE_TEAM_MEMBER {
+									[:HAS_CREATIVE_ENTITY {
 										creditPosition: creativeCredit.position,
 										memberPosition: creditedMemberParam.position,
 										creditedCompanyUuid: creditedCompany.uuid
@@ -211,7 +211,7 @@ describe('Cypher Queries Production module', () => {
 								ON CREATE SET crewPerson.differentiator = crewPersonParam.differentiator
 
 							CREATE (production)-
-								[:HAS_CREW_MEMBER {
+								[:HAS_CREW_ENTITY {
 									creditPosition: crewCredit.position,
 									entityPosition: crewPersonParam.position,
 									credit: crewCredit.name
@@ -242,7 +242,7 @@ describe('Cypher Queries Production module', () => {
 								ON CREATE SET crewCompany.differentiator = crewCompanyParam.differentiator
 
 							CREATE (production)-
-								[:HAS_CREW_MEMBER {
+								[:HAS_CREW_ENTITY {
 									creditPosition: crewCredit.position,
 									entityPosition: crewCompanyParam.position,
 									credit: crewCredit.name
@@ -262,7 +262,7 @@ describe('Cypher Queries Production module', () => {
 									(crewCompanyParam.differentiator IS NULL AND creditedCompany.differentiator IS NULL) OR
 									crewCompanyParam.differentiator = creditedCompany.differentiator
 
-							OPTIONAL MATCH (creditedCompany)<-[crewCompanyRel:HAS_CREW_MEMBER]-(production)
+							OPTIONAL MATCH (creditedCompany)<-[crewCompanyRel:HAS_CREW_ENTITY]-(production)
 								WHERE
 									crewCredit.position IS NULL OR
 									crewCredit.position = crewCompanyRel.creditPosition
@@ -284,7 +284,7 @@ describe('Cypher Queries Production module', () => {
 									ON CREATE SET creditedMember.differentiator = creditedMemberParam.differentiator
 
 								CREATE (production)-
-									[:HAS_CREW_MEMBER {
+									[:HAS_CREW_ENTITY {
 										creditPosition: crewCredit.position,
 										memberPosition: creditedMemberParam.position,
 										creditedCompanyUuid: creditedCompany.uuid
@@ -328,7 +328,7 @@ describe('Cypher Queries Production module', () => {
 						END
 					) + [{ roles: [{}] }] AS cast
 
-				OPTIONAL MATCH (production)-[creativeEntityRel:HAS_CREATIVE_TEAM_MEMBER]->(creativeEntity)
+				OPTIONAL MATCH (production)-[creativeEntityRel:HAS_CREATIVE_ENTITY]->(creativeEntity)
 					WHERE
 						(creativeEntity:Person AND creativeEntityRel.creditedCompanyUuid IS NULL) OR
 						creativeEntity:Company
@@ -345,7 +345,7 @@ describe('Cypher Queries Production module', () => {
 
 					UNWIND (COALESCE(creativeEntity.creditedMemberUuids, [null])) AS creditedMemberUuid
 
-						OPTIONAL MATCH (production)-[creditedMemberRel:HAS_CREATIVE_TEAM_MEMBER]->
+						OPTIONAL MATCH (production)-[creditedMemberRel:HAS_CREATIVE_ENTITY]->
 							(creditedMember:Person { uuid: creditedMemberUuid })
 							WHERE
 								creativeEntityRel.creditPosition IS NULL OR
@@ -383,7 +383,7 @@ describe('Cypher Queries Production module', () => {
 						END
 					) + [{ entities: [{}] }] AS creativeCredits
 
-				OPTIONAL MATCH (production)-[crewEntityRel:HAS_CREW_MEMBER]->(crewEntity)
+				OPTIONAL MATCH (production)-[crewEntityRel:HAS_CREW_ENTITY]->(crewEntity)
 					WHERE
 						(crewEntity:Person AND crewEntityRel.creditedCompanyUuid IS NULL) OR
 						crewEntity:Company
@@ -400,7 +400,7 @@ describe('Cypher Queries Production module', () => {
 
 					UNWIND (COALESCE(crewEntity.creditedMemberUuids, [null])) AS creditedMemberUuid
 
-						OPTIONAL MATCH (production)-[creditedMemberRel:HAS_CREW_MEMBER]->
+						OPTIONAL MATCH (production)-[creditedMemberRel:HAS_CREW_ENTITY]->
 							(creditedMember:Person { uuid: creditedMemberUuid })
 							WHERE
 								crewEntityRel.creditPosition IS NULL OR
@@ -557,7 +557,7 @@ describe('Cypher Queries Production module', () => {
 								ON CREATE SET creativePerson.differentiator = creativePersonParam.differentiator
 
 							CREATE (production)-
-								[:HAS_CREATIVE_TEAM_MEMBER {
+								[:HAS_CREATIVE_ENTITY {
 									creditPosition: creativeCredit.position,
 									entityPosition: creativePersonParam.position,
 									credit: creativeCredit.name
@@ -588,7 +588,7 @@ describe('Cypher Queries Production module', () => {
 								ON CREATE SET creativeCompany.differentiator = creativeCompanyParam.differentiator
 
 							CREATE (production)-
-								[:HAS_CREATIVE_TEAM_MEMBER {
+								[:HAS_CREATIVE_ENTITY {
 									creditPosition: creativeCredit.position,
 									entityPosition: creativeCompanyParam.position,
 									credit: creativeCredit.name
@@ -608,7 +608,7 @@ describe('Cypher Queries Production module', () => {
 									(creativeCompanyParam.differentiator IS NULL AND creditedCompany.differentiator IS NULL) OR
 									creativeCompanyParam.differentiator = creditedCompany.differentiator
 
-							OPTIONAL MATCH (creditedCompany)<-[creativeCompanyRel:HAS_CREATIVE_TEAM_MEMBER]-(production)
+							OPTIONAL MATCH (creditedCompany)<-[creativeCompanyRel:HAS_CREATIVE_ENTITY]-(production)
 								WHERE
 									creativeCredit.position IS NULL OR
 									creativeCredit.position = creativeCompanyRel.creditPosition
@@ -630,7 +630,7 @@ describe('Cypher Queries Production module', () => {
 									ON CREATE SET creditedMember.differentiator = creditedMemberParam.differentiator
 
 								CREATE (production)-
-									[:HAS_CREATIVE_TEAM_MEMBER {
+									[:HAS_CREATIVE_ENTITY {
 										creditPosition: creativeCredit.position,
 										memberPosition: creditedMemberParam.position,
 										creditedCompanyUuid: creditedCompany.uuid
@@ -666,7 +666,7 @@ describe('Cypher Queries Production module', () => {
 								ON CREATE SET crewPerson.differentiator = crewPersonParam.differentiator
 
 							CREATE (production)-
-								[:HAS_CREW_MEMBER {
+								[:HAS_CREW_ENTITY {
 									creditPosition: crewCredit.position,
 									entityPosition: crewPersonParam.position,
 									credit: crewCredit.name
@@ -697,7 +697,7 @@ describe('Cypher Queries Production module', () => {
 								ON CREATE SET crewCompany.differentiator = crewCompanyParam.differentiator
 
 							CREATE (production)-
-								[:HAS_CREW_MEMBER {
+								[:HAS_CREW_ENTITY {
 									creditPosition: crewCredit.position,
 									entityPosition: crewCompanyParam.position,
 									credit: crewCredit.name
@@ -717,7 +717,7 @@ describe('Cypher Queries Production module', () => {
 									(crewCompanyParam.differentiator IS NULL AND creditedCompany.differentiator IS NULL) OR
 									crewCompanyParam.differentiator = creditedCompany.differentiator
 
-							OPTIONAL MATCH (creditedCompany)<-[crewCompanyRel:HAS_CREW_MEMBER]-(production)
+							OPTIONAL MATCH (creditedCompany)<-[crewCompanyRel:HAS_CREW_ENTITY]-(production)
 								WHERE
 									crewCredit.position IS NULL OR
 									crewCredit.position = crewCompanyRel.creditPosition
@@ -739,7 +739,7 @@ describe('Cypher Queries Production module', () => {
 									ON CREATE SET creditedMember.differentiator = creditedMemberParam.differentiator
 
 								CREATE (production)-
-									[:HAS_CREW_MEMBER {
+									[:HAS_CREW_ENTITY {
 										creditPosition: crewCredit.position,
 										memberPosition: creditedMemberParam.position,
 										creditedCompanyUuid: creditedCompany.uuid
@@ -783,7 +783,7 @@ describe('Cypher Queries Production module', () => {
 						END
 					) + [{ roles: [{}] }] AS cast
 
-				OPTIONAL MATCH (production)-[creativeEntityRel:HAS_CREATIVE_TEAM_MEMBER]->(creativeEntity)
+				OPTIONAL MATCH (production)-[creativeEntityRel:HAS_CREATIVE_ENTITY]->(creativeEntity)
 					WHERE
 						(creativeEntity:Person AND creativeEntityRel.creditedCompanyUuid IS NULL) OR
 						creativeEntity:Company
@@ -800,7 +800,7 @@ describe('Cypher Queries Production module', () => {
 
 					UNWIND (COALESCE(creativeEntity.creditedMemberUuids, [null])) AS creditedMemberUuid
 
-						OPTIONAL MATCH (production)-[creditedMemberRel:HAS_CREATIVE_TEAM_MEMBER]->
+						OPTIONAL MATCH (production)-[creditedMemberRel:HAS_CREATIVE_ENTITY]->
 							(creditedMember:Person { uuid: creditedMemberUuid })
 							WHERE
 								creativeEntityRel.creditPosition IS NULL OR
@@ -838,7 +838,7 @@ describe('Cypher Queries Production module', () => {
 						END
 					) + [{ entities: [{}] }] AS creativeCredits
 
-				OPTIONAL MATCH (production)-[crewEntityRel:HAS_CREW_MEMBER]->(crewEntity)
+				OPTIONAL MATCH (production)-[crewEntityRel:HAS_CREW_ENTITY]->(crewEntity)
 					WHERE
 						(crewEntity:Person AND crewEntityRel.creditedCompanyUuid IS NULL) OR
 						crewEntity:Company
@@ -855,7 +855,7 @@ describe('Cypher Queries Production module', () => {
 
 					UNWIND (COALESCE(crewEntity.creditedMemberUuids, [null])) AS creditedMemberUuid
 
-						OPTIONAL MATCH (production)-[creditedMemberRel:HAS_CREW_MEMBER]->
+						OPTIONAL MATCH (production)-[creditedMemberRel:HAS_CREW_ENTITY]->
 							(creditedMember:Person { uuid: creditedMemberUuid })
 							WHERE
 								crewEntityRel.creditPosition IS NULL OR

--- a/test-unit/src/neo4j/cypher-queries/theatre.test.js
+++ b/test-unit/src/neo4j/cypher-queries/theatre.test.js
@@ -29,14 +29,14 @@ describe('Cypher Queries Theatre module', () => {
 						})
 							ON CREATE SET subTheatre.differentiator = subTheatreParam.differentiator
 
-						CREATE (theatre)-[:INCLUDES_SUB_THEATRE { position: subTheatreParam.position }]->(subTheatre)
+						CREATE (theatre)-[:HAS_SUB_THEATRE { position: subTheatreParam.position }]->(subTheatre)
 					)
 
 				WITH DISTINCT theatre
 
 				MATCH (theatre:Theatre { uuid: $uuid })
 
-				OPTIONAL MATCH (theatre)-[subTheatreRel:INCLUDES_SUB_THEATRE]->(subTheatre:Theatre)
+				OPTIONAL MATCH (theatre)-[subTheatreRel:HAS_SUB_THEATRE]->(subTheatre:Theatre)
 
 				WITH theatre, subTheatreRel, subTheatre
 					ORDER BY subTheatreRel.position
@@ -66,7 +66,7 @@ describe('Cypher Queries Theatre module', () => {
 			expect(removeExcessWhitespace(result)).to.equal(removeExcessWhitespace(`
 				MATCH (theatre:Theatre { uuid: $uuid })
 
-				OPTIONAL MATCH (theatre)-[relationship:INCLUDES_SUB_THEATRE]->(:Theatre)
+				OPTIONAL MATCH (theatre)-[relationship:HAS_SUB_THEATRE]->(:Theatre)
 
 				DELETE relationship
 
@@ -92,14 +92,14 @@ describe('Cypher Queries Theatre module', () => {
 						})
 							ON CREATE SET subTheatre.differentiator = subTheatreParam.differentiator
 
-						CREATE (theatre)-[:INCLUDES_SUB_THEATRE { position: subTheatreParam.position }]->(subTheatre)
+						CREATE (theatre)-[:HAS_SUB_THEATRE { position: subTheatreParam.position }]->(subTheatre)
 					)
 
 				WITH DISTINCT theatre
 
 				MATCH (theatre:Theatre { uuid: $uuid })
 
-				OPTIONAL MATCH (theatre)-[subTheatreRel:INCLUDES_SUB_THEATRE]->(subTheatre:Theatre)
+				OPTIONAL MATCH (theatre)-[subTheatreRel:HAS_SUB_THEATRE]->(subTheatre:Theatre)
 
 				WITH theatre, subTheatreRel, subTheatre
 					ORDER BY subTheatreRel.position


### PR DESCRIPTION
This PR renames Neo4j relationships for consistency and to shorten them where possible:

- `:WRITTEN_BY` -> `:HAS_WRITING_ENTITY`: for consistency and to accommodate instances where the associated entity has not technically written the material, e.g. translation, non-specific source material.
- `:HAS_CREATIVE_TEAM_MEMBER` -> `:HAS_CREATIVE_ENTITY` : for consistency and to shorten the name.
- `:HAS_CREW_MEMBER` -> `:HAS_CREW_ENTITY`: for consistency.
- `:INCLUDES_CHARACTER` -> `:HAS_CHARACTER`: to shorten the name (the change of words barely alters meaning).
- `:INCLUDES_SUB_THEATRE` -> `:HAS_SUB_THEATRE`: to shorten the name (the change of words barely alters meaning).

N.B. `:HAS_CREW_MEMBER` has not been changed to `:HAS_CREW_ENTITY` because it currently only connects productions to people, who seem more naturally referred to as cast members; `:HAS_{type}_ENTITY` feels like a better fit when the entity can be either a person or a company.