### PR TITLE
Order productions by start date

### DIFF
--- a/src/neo4j/cypher-queries/character.js
+++ b/src/neo4j/cypher-queries/character.js
@@ -203,7 +203,7 @@ const getShowQuery = () => `
 			qualifier: role.qualifier,
 			otherRoles: otherRoles
 		}) AS performers
-		ORDER BY production.name, theatre.name
+		ORDER BY production.startDate DESC, production.name, theatre.name
 
 	RETURN
 		'character' AS model,

--- a/src/neo4j/cypher-queries/company.js
+++ b/src/neo4j/cypher-queries/company.js
@@ -215,7 +215,7 @@ const getShowQuery = () => `
 			creditedMembers: creditedMembers,
 			coCreditedEntities: coCreditedEntities
 		}) AS producerCredits
-		ORDER BY production.name, theatre.name
+		ORDER BY production.startDate DESC, production.name, theatre.name
 
 	WITH company, materials,
 		COLLECT(
@@ -335,7 +335,7 @@ const getShowQuery = () => `
 			creditedMembers: creditedMembers,
 			coCreditedEntities: coCreditedEntities
 		}) AS creativeCredits
-		ORDER BY production.name, theatre.name
+		ORDER BY production.startDate DESC, production.name, theatre.name
 
 	WITH company, materials, producerProductions,
 		COLLECT(
@@ -457,7 +457,7 @@ const getShowQuery = () => `
 			creditedMembers: creditedMembers,
 			coCreditedEntities: coCreditedEntities
 		}) AS crewCredits
-		ORDER BY production.name, theatre.name
+		ORDER BY production.startDate DESC, production.name, theatre.name
 
 	RETURN
 		'company' AS model,

--- a/src/neo4j/cypher-queries/material.js
+++ b/src/neo4j/cypher-queries/material.js
@@ -508,7 +508,7 @@ const getShowQuery = () => `
 			theatre,
 			surTheatre,
 			CASE sourcingMaterialRel WHEN NULL THEN false ELSE true END AS usesSourcingMaterial
-			ORDER BY production.name, theatre.name
+			ORDER BY production.startDate DESC, production.name, theatre.name
 
 		WITH
 			material,

--- a/src/neo4j/cypher-queries/person.js
+++ b/src/neo4j/cypher-queries/person.js
@@ -255,7 +255,7 @@ const getShowQuery = () => `
 			creditedEmployerCompany: creditedEmployerCompany,
 			coCreditedEntities: coCreditedEntities
 		}) AS producerCredits
-		ORDER BY production.name, theatre.name
+		ORDER BY production.startDate DESC, production.name, theatre.name
 
 	WITH person, materials,
 		COLLECT(
@@ -308,7 +308,7 @@ const getShowQuery = () => `
 				ELSE role { model: 'character', uuid: character.uuid, name: role.roleName, .qualifier }
 			END
 		) AS roles
-		ORDER BY production.name, theatre.name
+		ORDER BY production.startDate DESC, production.name, theatre.name
 
 	WITH person, materials, producerProductions,
 		COLLECT(
@@ -482,7 +482,7 @@ const getShowQuery = () => `
 			creditedEmployerCompany: creditedEmployerCompany,
 			coCreditedEntities: coCreditedEntities
 		}) AS creativeCredits
-		ORDER BY production.name, theatre.name
+		ORDER BY production.startDate DESC, production.name, theatre.name
 
 	WITH person, materials, producerProductions, castMemberProductions,
 		COLLECT(
@@ -670,7 +670,7 @@ const getShowQuery = () => `
 			creditedEmployerCompany: creditedEmployerCompany,
 			coCreditedEntities: coCreditedEntities
 		}) AS crewCredits
-		ORDER BY production.name, theatre.name
+		ORDER BY production.startDate DESC, production.name, theatre.name
 
 	RETURN
 		'person' AS model,

--- a/src/neo4j/cypher-queries/production.js
+++ b/src/neo4j/cypher-queries/production.js
@@ -1003,7 +1003,7 @@ const getListQuery = () => `
 			}
 		END AS theatre
 
-	ORDER BY production.name, theatre.name
+	ORDER BY production.startDate DESC, production.name, theatre.name
 
 	LIMIT 100
 `;

--- a/src/neo4j/cypher-queries/theatre.js
+++ b/src/neo4j/cypher-queries/theatre.js
@@ -105,7 +105,7 @@ const getShowQuery = () => `
 		subTheatreForProduction,
 		LENGTH(path) AS theatreToProductionPathLength,
 		production
-		ORDER BY production.name
+		ORDER BY production.startDate DESC, production.name
 
 	RETURN
 		'theatre' AS model,

--- a/test-e2e/model-interaction/cast-member-with-multi-prods.test.js
+++ b/test-e2e/model-interaction/cast-member-with-multi-prods.test.js
@@ -138,33 +138,6 @@ describe('Cast member with multiple production credits', () => {
 			const expectedCastMemberProductions = [
 				{
 					model: 'production',
-					uuid: CITY_OF_ANGELS_PRINCE_OF_WALES_PRODUCTION_UUID,
-					name: 'City of Angels',
-					startDate: '1993-03-19',
-					endDate: '1993-11-18',
-					theatre: {
-						model: 'theatre',
-						uuid: PRINCE_OF_WALES_THEATRE_UUID,
-						name: 'Prince of Wales Theatre',
-						surTheatre: null
-					},
-					roles: [
-						{
-							model: 'character',
-							uuid: null,
-							name: 'Alaura Kingsley',
-							qualifier: null
-						},
-						{
-							model: 'character',
-							uuid: null,
-							name: 'Carla Haywood',
-							qualifier: null
-						}
-					]
-				},
-				{
-					model: 'production',
 					uuid: ENRON_CHICHESTER_FESTIVAL_PRODUCTION_UUID,
 					name: 'Enron',
 					startDate: '2009-07-11',
@@ -192,6 +165,33 @@ describe('Cast member with multiple production credits', () => {
 							model: 'character',
 							uuid: null,
 							name: 'Irene Gant',
+							qualifier: null
+						}
+					]
+				},
+				{
+					model: 'production',
+					uuid: CITY_OF_ANGELS_PRINCE_OF_WALES_PRODUCTION_UUID,
+					name: 'City of Angels',
+					startDate: '1993-03-19',
+					endDate: '1993-11-18',
+					theatre: {
+						model: 'theatre',
+						uuid: PRINCE_OF_WALES_THEATRE_UUID,
+						name: 'Prince of Wales Theatre',
+						surTheatre: null
+					},
+					roles: [
+						{
+							model: 'character',
+							uuid: null,
+							name: 'Alaura Kingsley',
+							qualifier: null
+						},
+						{
+							model: 'character',
+							uuid: null,
+							name: 'Carla Haywood',
 							qualifier: null
 						}
 					]

--- a/test-e2e/model-interaction/char-in-multi-prods-of-multi-materials.test.js
+++ b/test-e2e/model-interaction/char-in-multi-prods-of-multi-materials.test.js
@@ -384,33 +384,10 @@ describe('Character in multiple productions of multiple materials', () => {
 			const expectedProductions = [
 				{
 					model: 'production',
-					uuid: HENRY_IV_PART_1_NATIONAL_PRODUCTION_UUID,
-					name: 'Henry IV: Part 1',
-					startDate: '2005-04-16',
-					endDate: '2005-08-31',
-					theatre: {
-						model: 'theatre',
-						uuid: NATIONAL_THEATRE_UUID,
-						name: 'National Theatre',
-						surTheatre: null
-					},
-					performers: [
-						{
-							model: 'person',
-							uuid: MICHAEL_GAMBON_PERSON_UUID,
-							name: 'Michael Gambon',
-							roleName: 'Sir John Falstaff',
-							qualifier: null,
-							otherRoles: []
-						}
-					]
-				},
-				{
-					model: 'production',
-					uuid: HENRY_IV_PART_1_GLOBE_PRODUCTION_UUID,
-					name: 'Henry IV: Part 1',
-					startDate: '2010-06-06',
-					endDate: '2010-10-02',
+					uuid: THE_MERRY_WIVES_OF_WINDSOR_GLOBE_PRODUCTION_UUID,
+					name: 'The Merry Wives of Windsor',
+					startDate: '2019-05-17',
+					endDate: '2019-10-12',
 					theatre: {
 						model: 'theatre',
 						uuid: SHAKESPEARES_GLOBE_THEATRE_UUID,
@@ -422,52 +399,6 @@ describe('Character in multiple productions of multiple materials', () => {
 							model: 'person',
 							uuid: ROGER_ALLAM_PERSON_UUID,
 							name: 'Roger Allam',
-							roleName: 'Sir John Falstaff',
-							qualifier: null,
-							otherRoles: []
-						}
-					]
-				},
-				{
-					model: 'production',
-					uuid: HENRY_IV_PART_1_SWAN_PRODUCTION_UUID,
-					name: 'Henry IV: Part 1',
-					startDate: '2000-04-12',
-					endDate: '2000-06-15',
-					theatre: {
-						model: 'theatre',
-						uuid: SWAN_THEATRE_UUID,
-						name: 'Swan Theatre',
-						surTheatre: null
-					},
-					performers: [
-						{
-							model: 'person',
-							uuid: RICHARD_CORDERY_PERSON_UUID,
-							name: 'Richard Cordery',
-							roleName: 'Sir John Falstaff',
-							qualifier: null,
-							otherRoles: []
-						}
-					]
-				},
-				{
-					model: 'production',
-					uuid: HENRY_IV_PART_2_NATIONAL_PRODUCTION_UUID,
-					name: 'Henry IV: Part 2',
-					startDate: '2005-04-26',
-					endDate: '2005-08-31',
-					theatre: {
-						model: 'theatre',
-						uuid: NATIONAL_THEATRE_UUID,
-						name: 'National Theatre',
-						surTheatre: null
-					},
-					performers: [
-						{
-							model: 'person',
-							uuid: MICHAEL_GAMBON_PERSON_UUID,
-							name: 'Michael Gambon',
 							roleName: 'Sir John Falstaff',
 							qualifier: null,
 							otherRoles: []
@@ -499,21 +430,21 @@ describe('Character in multiple productions of multiple materials', () => {
 				},
 				{
 					model: 'production',
-					uuid: HENRY_IV_PART_2_SWAN_PRODUCTION_UUID,
-					name: 'Henry IV: Part 2',
-					startDate: '2000-06-22',
-					endDate: '2000-09-15',
+					uuid: HENRY_IV_PART_1_GLOBE_PRODUCTION_UUID,
+					name: 'Henry IV: Part 1',
+					startDate: '2010-06-06',
+					endDate: '2010-10-02',
 					theatre: {
 						model: 'theatre',
-						uuid: SWAN_THEATRE_UUID,
-						name: 'Swan Theatre',
+						uuid: SHAKESPEARES_GLOBE_THEATRE_UUID,
+						name: 'Shakespeare\'s Globe',
 						surTheatre: null
 					},
 					performers: [
 						{
 							model: 'person',
-							uuid: RICHARD_CORDERY_PERSON_UUID,
-							name: 'Richard Cordery',
+							uuid: ROGER_ALLAM_PERSON_UUID,
+							name: 'Roger Allam',
 							roleName: 'Sir John Falstaff',
 							qualifier: null,
 							otherRoles: []
@@ -545,21 +476,44 @@ describe('Character in multiple productions of multiple materials', () => {
 				},
 				{
 					model: 'production',
-					uuid: THE_MERRY_WIVES_OF_WINDSOR_GLOBE_PRODUCTION_UUID,
-					name: 'The Merry Wives of Windsor',
-					startDate: '2019-05-17',
-					endDate: '2019-10-12',
+					uuid: HENRY_IV_PART_2_NATIONAL_PRODUCTION_UUID,
+					name: 'Henry IV: Part 2',
+					startDate: '2005-04-26',
+					endDate: '2005-08-31',
 					theatre: {
 						model: 'theatre',
-						uuid: SHAKESPEARES_GLOBE_THEATRE_UUID,
-						name: 'Shakespeare\'s Globe',
+						uuid: NATIONAL_THEATRE_UUID,
+						name: 'National Theatre',
 						surTheatre: null
 					},
 					performers: [
 						{
 							model: 'person',
-							uuid: ROGER_ALLAM_PERSON_UUID,
-							name: 'Roger Allam',
+							uuid: MICHAEL_GAMBON_PERSON_UUID,
+							name: 'Michael Gambon',
+							roleName: 'Sir John Falstaff',
+							qualifier: null,
+							otherRoles: []
+						}
+					]
+				},
+				{
+					model: 'production',
+					uuid: HENRY_IV_PART_1_NATIONAL_PRODUCTION_UUID,
+					name: 'Henry IV: Part 1',
+					startDate: '2005-04-16',
+					endDate: '2005-08-31',
+					theatre: {
+						model: 'theatre',
+						uuid: NATIONAL_THEATRE_UUID,
+						name: 'National Theatre',
+						surTheatre: null
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: MICHAEL_GAMBON_PERSON_UUID,
+							name: 'Michael Gambon',
 							roleName: 'Sir John Falstaff',
 							qualifier: null,
 							otherRoles: []
@@ -572,6 +526,52 @@ describe('Character in multiple productions of multiple materials', () => {
 					name: 'The Merry Wives of Windsor',
 					startDate: '2002-10-24',
 					endDate: '2003-01-25',
+					theatre: {
+						model: 'theatre',
+						uuid: SWAN_THEATRE_UUID,
+						name: 'Swan Theatre',
+						surTheatre: null
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: RICHARD_CORDERY_PERSON_UUID,
+							name: 'Richard Cordery',
+							roleName: 'Sir John Falstaff',
+							qualifier: null,
+							otherRoles: []
+						}
+					]
+				},
+				{
+					model: 'production',
+					uuid: HENRY_IV_PART_2_SWAN_PRODUCTION_UUID,
+					name: 'Henry IV: Part 2',
+					startDate: '2000-06-22',
+					endDate: '2000-09-15',
+					theatre: {
+						model: 'theatre',
+						uuid: SWAN_THEATRE_UUID,
+						name: 'Swan Theatre',
+						surTheatre: null
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: RICHARD_CORDERY_PERSON_UUID,
+							name: 'Richard Cordery',
+							roleName: 'Sir John Falstaff',
+							qualifier: null,
+							otherRoles: []
+						}
+					]
+				},
+				{
+					model: 'production',
+					uuid: HENRY_IV_PART_1_SWAN_PRODUCTION_UUID,
+					name: 'Henry IV: Part 1',
+					startDate: '2000-04-12',
+					endDate: '2000-06-15',
 					theatre: {
 						model: 'theatre',
 						uuid: SWAN_THEATRE_UUID,

--- a/test-e2e/model-interaction/char-with-variant-depiction-portrayal-names.test.js
+++ b/test-e2e/model-interaction/char-with-variant-depiction-portrayal-names.test.js
@@ -528,28 +528,58 @@ describe('Character with variant depiction and portrayal names', () => {
 			const expectedProductions = [
 				{
 					model: 'production',
-					uuid: HENRY_IV_PART_1_NATIONAL_PRODUCTION_UUID,
-					name: 'Henry IV, Part 1',
-					startDate: '2005-04-16',
-					endDate: '2005-08-31',
+					uuid: HENRY_V_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
+					name: 'Henry V',
+					startDate: '2015-09-12',
+					endDate: '2015-10-25',
 					theatre: {
 						model: 'theatre',
-						uuid: NATIONAL_THEATRE_UUID,
-						name: 'National Theatre',
+						uuid: ROYAL_SHAKESPEARE_THEATRE_UUID,
+						name: 'Royal Shakespeare Theatre',
 						surTheatre: null
 					},
 					performers: [
 						{
 							model: 'person',
-							uuid: MATTHEW_MACFADYEN_PERSON_UUID,
-							name: 'Matthew Macfadyen',
-							roleName: 'Prince Hal',
+							uuid: ALEX_HASSELL_PERSON_UUID,
+							name: 'Alex Hassell',
+							roleName: 'Henry V',
 							qualifier: null,
 							otherRoles: [
 								{
 									model: 'character',
-									uuid: MESSENGER_CHARACTER_UUID,
-									name: 'Messenger',
+									uuid: SOLDIER_CHARACTER_UUID,
+									name: 'Soldier',
+									qualifier: null
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'production',
+					uuid: HENRY_IV_PART_2_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
+					name: 'Henry IV, Part 2',
+					startDate: '2014-03-28',
+					endDate: '2014-09-06',
+					theatre: {
+						model: 'theatre',
+						uuid: ROYAL_SHAKESPEARE_THEATRE_UUID,
+						name: 'Royal Shakespeare Theatre',
+						surTheatre: null
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: ALEX_HASSELL_PERSON_UUID,
+							name: 'Alex Hassell',
+							roleName: 'Hal',
+							qualifier: null,
+							otherRoles: [
+								{
+									model: 'character',
+									uuid: ATTENDANT_CHARACTER_UUID,
+									name: 'Attendant',
 									qualifier: null
 								}
 							]
@@ -618,28 +648,28 @@ describe('Character with variant depiction and portrayal names', () => {
 				},
 				{
 					model: 'production',
-					uuid: HENRY_IV_PART_2_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
-					name: 'Henry IV, Part 2',
-					startDate: '2014-03-28',
-					endDate: '2014-09-06',
+					uuid: HENRY_IV_PART_1_NATIONAL_PRODUCTION_UUID,
+					name: 'Henry IV, Part 1',
+					startDate: '2005-04-16',
+					endDate: '2005-08-31',
 					theatre: {
 						model: 'theatre',
-						uuid: ROYAL_SHAKESPEARE_THEATRE_UUID,
-						name: 'Royal Shakespeare Theatre',
+						uuid: NATIONAL_THEATRE_UUID,
+						name: 'National Theatre',
 						surTheatre: null
 					},
 					performers: [
 						{
 							model: 'person',
-							uuid: ALEX_HASSELL_PERSON_UUID,
-							name: 'Alex Hassell',
-							roleName: 'Hal',
+							uuid: MATTHEW_MACFADYEN_PERSON_UUID,
+							name: 'Matthew Macfadyen',
+							roleName: 'Prince Hal',
 							qualifier: null,
 							otherRoles: [
 								{
 									model: 'character',
-									uuid: ATTENDANT_CHARACTER_UUID,
-									name: 'Attendant',
+									uuid: MESSENGER_CHARACTER_UUID,
+									name: 'Messenger',
 									qualifier: null
 								}
 							]
@@ -663,36 +693,6 @@ describe('Character with variant depiction and portrayal names', () => {
 							model: 'person',
 							uuid: ADRIAN_LESTER_PERSON_UUID,
 							name: 'Adrian Lester',
-							roleName: 'Henry V',
-							qualifier: null,
-							otherRoles: [
-								{
-									model: 'character',
-									uuid: SOLDIER_CHARACTER_UUID,
-									name: 'Soldier',
-									qualifier: null
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'production',
-					uuid: HENRY_V_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
-					name: 'Henry V',
-					startDate: '2015-09-12',
-					endDate: '2015-10-25',
-					theatre: {
-						model: 'theatre',
-						uuid: ROYAL_SHAKESPEARE_THEATRE_UUID,
-						name: 'Royal Shakespeare Theatre',
-						surTheatre: null
-					},
-					performers: [
-						{
-							model: 'person',
-							uuid: ALEX_HASSELL_PERSON_UUID,
-							name: 'Alex Hassell',
 							roleName: 'Henry V',
 							qualifier: null,
 							otherRoles: [
@@ -723,36 +723,6 @@ describe('Character with variant depiction and portrayal names', () => {
 			const expectedProductions = [
 				{
 					model: 'production',
-					uuid: HENRY_IV_PART_1_NATIONAL_PRODUCTION_UUID,
-					name: 'Henry IV, Part 1',
-					startDate: '2005-04-16',
-					endDate: '2005-08-31',
-					theatre: {
-						model: 'theatre',
-						uuid: NATIONAL_THEATRE_UUID,
-						name: 'National Theatre',
-						surTheatre: null
-					},
-					performers: [
-						{
-							model: 'person',
-							uuid: MATTHEW_MACFADYEN_PERSON_UUID,
-							name: 'Matthew Macfadyen',
-							roleName: 'Messenger',
-							qualifier: null,
-							otherRoles: [
-								{
-									model: 'character',
-									uuid: KING_HENRY_V_CHARACTER_UUID,
-									name: 'Prince Hal',
-									qualifier: null
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'production',
 					uuid: HENRY_IV_PART_1_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
 					name: 'Henry IV, Part 1',
 					startDate: '2014-03-18',
@@ -780,6 +750,36 @@ describe('Character with variant depiction and portrayal names', () => {
 							]
 						}
 					]
+				},
+				{
+					model: 'production',
+					uuid: HENRY_IV_PART_1_NATIONAL_PRODUCTION_UUID,
+					name: 'Henry IV, Part 1',
+					startDate: '2005-04-16',
+					endDate: '2005-08-31',
+					theatre: {
+						model: 'theatre',
+						uuid: NATIONAL_THEATRE_UUID,
+						name: 'National Theatre',
+						surTheatre: null
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: MATTHEW_MACFADYEN_PERSON_UUID,
+							name: 'Matthew Macfadyen',
+							roleName: 'Messenger',
+							qualifier: null,
+							otherRoles: [
+								{
+									model: 'character',
+									uuid: KING_HENRY_V_CHARACTER_UUID,
+									name: 'Prince Hal',
+									qualifier: null
+								}
+							]
+						}
+					]
 				}
 			];
 
@@ -796,36 +796,6 @@ describe('Character with variant depiction and portrayal names', () => {
 		it('includes productions in which character was portrayed (with portrayers\' other roles using uuid of King Henry V and specific display name)', () => {
 
 			const expectedProductions = [
-				{
-					model: 'production',
-					uuid: HENRY_IV_PART_2_NATIONAL_PRODUCTION_UUID,
-					name: 'Henry IV, Part 2',
-					startDate: '2005-04-26',
-					endDate: '2005-08-31',
-					theatre: {
-						model: 'theatre',
-						uuid: NATIONAL_THEATRE_UUID,
-						name: 'National Theatre',
-						surTheatre: null
-					},
-					performers: [
-						{
-							model: 'person',
-							uuid: MATTHEW_MACFADYEN_PERSON_UUID,
-							name: 'Matthew Macfadyen',
-							roleName: 'Attendant',
-							qualifier: null,
-							otherRoles: [
-								{
-									model: 'character',
-									uuid: KING_HENRY_V_CHARACTER_UUID,
-									name: 'Hal, Prince of England',
-									qualifier: null
-								}
-							]
-						}
-					]
-				},
 				{
 					model: 'production',
 					uuid: HENRY_IV_PART_2_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
@@ -855,6 +825,36 @@ describe('Character with variant depiction and portrayal names', () => {
 							]
 						}
 					]
+				},
+				{
+					model: 'production',
+					uuid: HENRY_IV_PART_2_NATIONAL_PRODUCTION_UUID,
+					name: 'Henry IV, Part 2',
+					startDate: '2005-04-26',
+					endDate: '2005-08-31',
+					theatre: {
+						model: 'theatre',
+						uuid: NATIONAL_THEATRE_UUID,
+						name: 'National Theatre',
+						surTheatre: null
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: MATTHEW_MACFADYEN_PERSON_UUID,
+							name: 'Matthew Macfadyen',
+							roleName: 'Attendant',
+							qualifier: null,
+							otherRoles: [
+								{
+									model: 'character',
+									uuid: KING_HENRY_V_CHARACTER_UUID,
+									name: 'Hal, Prince of England',
+									qualifier: null
+								}
+							]
+						}
+					]
 				}
 			];
 
@@ -873,36 +873,6 @@ describe('Character with variant depiction and portrayal names', () => {
 			const expectedProductions = [
 				{
 					model: 'production',
-					uuid: HENRY_V_NATIONAL_PRODUCTION_UUID,
-					name: 'Henry V',
-					startDate: '2003-05-06',
-					endDate: '2003-08-20',
-					theatre: {
-						model: 'theatre',
-						uuid: NATIONAL_THEATRE_UUID,
-						name: 'National Theatre',
-						surTheatre: null
-					},
-					performers: [
-						{
-							model: 'person',
-							uuid: ADRIAN_LESTER_PERSON_UUID,
-							name: 'Adrian Lester',
-							roleName: 'Soldier',
-							qualifier: null,
-							otherRoles: [
-								{
-									model: 'character',
-									uuid: KING_HENRY_V_CHARACTER_UUID,
-									name: 'Henry V',
-									qualifier: null
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'production',
 					uuid: HENRY_V_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
 					name: 'Henry V',
 					startDate: '2015-09-12',
@@ -918,6 +888,36 @@ describe('Character with variant depiction and portrayal names', () => {
 							model: 'person',
 							uuid: ALEX_HASSELL_PERSON_UUID,
 							name: 'Alex Hassell',
+							roleName: 'Soldier',
+							qualifier: null,
+							otherRoles: [
+								{
+									model: 'character',
+									uuid: KING_HENRY_V_CHARACTER_UUID,
+									name: 'Henry V',
+									qualifier: null
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'production',
+					uuid: HENRY_V_NATIONAL_PRODUCTION_UUID,
+					name: 'Henry V',
+					startDate: '2003-05-06',
+					endDate: '2003-08-20',
+					theatre: {
+						model: 'theatre',
+						uuid: NATIONAL_THEATRE_UUID,
+						name: 'National Theatre',
+						surTheatre: null
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: ADRIAN_LESTER_PERSON_UUID,
+							name: 'Adrian Lester',
 							roleName: 'Soldier',
 							qualifier: null,
 							otherRoles: [
@@ -1329,10 +1329,10 @@ describe('Character with variant depiction and portrayal names', () => {
 			const expectedCastMemberProductions = [
 				{
 					model: 'production',
-					uuid: HENRY_IV_PART_1_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
-					name: 'Henry IV, Part 1',
-					startDate: '2014-03-18',
-					endDate: '2014-09-06',
+					uuid: HENRY_V_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
+					name: 'Henry V',
+					startDate: '2015-09-12',
+					endDate: '2015-10-25',
 					theatre: {
 						model: 'theatre',
 						uuid: ROYAL_SHAKESPEARE_THEATRE_UUID,
@@ -1343,13 +1343,13 @@ describe('Character with variant depiction and portrayal names', () => {
 						{
 							model: 'character',
 							uuid: KING_HENRY_V_CHARACTER_UUID,
-							name: 'Henry, Prince of Wales',
+							name: 'Henry V',
 							qualifier: null
 						},
 						{
 							model: 'character',
-							uuid: MESSENGER_CHARACTER_UUID,
-							name: 'Messenger',
+							uuid: SOLDIER_CHARACTER_UUID,
+							name: 'Soldier',
 							qualifier: null
 						}
 					]
@@ -1383,10 +1383,10 @@ describe('Character with variant depiction and portrayal names', () => {
 				},
 				{
 					model: 'production',
-					uuid: HENRY_V_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
-					name: 'Henry V',
-					startDate: '2015-09-12',
-					endDate: '2015-10-25',
+					uuid: HENRY_IV_PART_1_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
+					name: 'Henry IV, Part 1',
+					startDate: '2014-03-18',
+					endDate: '2014-09-06',
 					theatre: {
 						model: 'theatre',
 						uuid: ROYAL_SHAKESPEARE_THEATRE_UUID,
@@ -1397,13 +1397,13 @@ describe('Character with variant depiction and portrayal names', () => {
 						{
 							model: 'character',
 							uuid: KING_HENRY_V_CHARACTER_UUID,
-							name: 'Henry V',
+							name: 'Henry, Prince of Wales',
 							qualifier: null
 						},
 						{
 							model: 'character',
-							uuid: SOLDIER_CHARACTER_UUID,
-							name: 'Soldier',
+							uuid: MESSENGER_CHARACTER_UUID,
+							name: 'Messenger',
 							qualifier: null
 						}
 					]
@@ -1423,33 +1423,6 @@ describe('Character with variant depiction and portrayal names', () => {
 		it('includes productions of their portrayals of King Henry V under variant names (Prince Hal; Hal, Prince of England) but using its uuid value', () => {
 
 			const expectedCastMemberProductions = [
-				{
-					model: 'production',
-					uuid: HENRY_IV_PART_1_NATIONAL_PRODUCTION_UUID,
-					name: 'Henry IV, Part 1',
-					startDate: '2005-04-16',
-					endDate: '2005-08-31',
-					theatre: {
-						model: 'theatre',
-						uuid: NATIONAL_THEATRE_UUID,
-						name: 'National Theatre',
-						surTheatre: null
-					},
-					roles: [
-						{
-							model: 'character',
-							uuid: KING_HENRY_V_CHARACTER_UUID,
-							name: 'Prince Hal',
-							qualifier: null
-						},
-						{
-							model: 'character',
-							uuid: MESSENGER_CHARACTER_UUID,
-							name: 'Messenger',
-							qualifier: null
-						}
-					]
-				},
 				{
 					model: 'production',
 					uuid: HENRY_IV_PART_2_NATIONAL_PRODUCTION_UUID,
@@ -1473,6 +1446,33 @@ describe('Character with variant depiction and portrayal names', () => {
 							model: 'character',
 							uuid: ATTENDANT_CHARACTER_UUID,
 							name: 'Attendant',
+							qualifier: null
+						}
+					]
+				},
+				{
+					model: 'production',
+					uuid: HENRY_IV_PART_1_NATIONAL_PRODUCTION_UUID,
+					name: 'Henry IV, Part 1',
+					startDate: '2005-04-16',
+					endDate: '2005-08-31',
+					theatre: {
+						model: 'theatre',
+						uuid: NATIONAL_THEATRE_UUID,
+						name: 'National Theatre',
+						surTheatre: null
+					},
+					roles: [
+						{
+							model: 'character',
+							uuid: KING_HENRY_V_CHARACTER_UUID,
+							name: 'Prince Hal',
+							qualifier: null
+						},
+						{
+							model: 'character',
+							uuid: MESSENGER_CHARACTER_UUID,
+							name: 'Messenger',
 							qualifier: null
 						}
 					]

--- a/test-e2e/model-interaction/char-with-variant-names-diff-materials.test.js
+++ b/test-e2e/model-interaction/char-with-variant-names-diff-materials.test.js
@@ -367,52 +367,6 @@ describe('Character with variant names from productions of different materials',
 			const expectedProductions = [
 				{
 					model: 'production',
-					uuid: FORTINBRAS_LA_JOLLA_PRODUCTION_UUID,
-					name: 'Fortinbras',
-					startDate: '1991-06-18',
-					endDate: '1991-07-28',
-					theatre: {
-						model: 'theatre',
-						uuid: LA_JOLLA_PLAYHOUSE_THEATRE_UUID,
-						name: 'La Jolla Playhouse',
-						surTheatre: null
-					},
-					performers: [
-						{
-							model: 'person',
-							uuid: DON_REILLY_PERSON_UUID,
-							name: 'Don Reilly',
-							roleName: 'Spirit of Hamlet',
-							qualifier: null,
-							otherRoles: []
-						}
-					]
-				},
-				{
-					model: 'production',
-					uuid: HAMLET_NATIONAL_PRODUCTION_UUID,
-					name: 'Hamlet',
-					startDate: '2010-09-30',
-					endDate: '2011-01-26',
-					theatre: {
-						model: 'theatre',
-						uuid: NATIONAL_THEATRE_UUID,
-						name: 'National Theatre',
-						surTheatre: null
-					},
-					performers: [
-						{
-							model: 'person',
-							uuid: RORY_KINNEAR_PERSON_UUID,
-							name: 'Rory Kinnear',
-							roleName: 'Hamlet, Prince of Denmark',
-							qualifier: null,
-							otherRoles: []
-						}
-					]
-				},
-				{
-					model: 'production',
 					uuid: HAMLETMACHINE_TEATRO_SAN_NICOLÒ_PRODUCTION_UUID,
 					name: 'Hamletmachine',
 					startDate: '2017-07-07',
@@ -452,6 +406,52 @@ describe('Character with variant names from productions of different materials',
 							uuid: JACK_HAWKINS_PERSON_UUID,
 							name: 'Jack Hawkins',
 							roleName: 'Prince Hamlet',
+							qualifier: null,
+							otherRoles: []
+						}
+					]
+				},
+				{
+					model: 'production',
+					uuid: HAMLET_NATIONAL_PRODUCTION_UUID,
+					name: 'Hamlet',
+					startDate: '2010-09-30',
+					endDate: '2011-01-26',
+					theatre: {
+						model: 'theatre',
+						uuid: NATIONAL_THEATRE_UUID,
+						name: 'National Theatre',
+						surTheatre: null
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: RORY_KINNEAR_PERSON_UUID,
+							name: 'Rory Kinnear',
+							roleName: 'Hamlet, Prince of Denmark',
+							qualifier: null,
+							otherRoles: []
+						}
+					]
+				},
+				{
+					model: 'production',
+					uuid: FORTINBRAS_LA_JOLLA_PRODUCTION_UUID,
+					name: 'Fortinbras',
+					startDate: '1991-06-18',
+					endDate: '1991-07-28',
+					theatre: {
+						model: 'theatre',
+						uuid: LA_JOLLA_PLAYHOUSE_THEATRE_UUID,
+						name: 'La Jolla Playhouse',
+						surTheatre: null
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: DON_REILLY_PERSON_UUID,
+							name: 'Don Reilly',
+							roleName: 'Spirit of Hamlet',
 							qualifier: null,
 							otherRoles: []
 						}

--- a/test-e2e/model-interaction/char-with-variant-names-same-material.test.js
+++ b/test-e2e/model-interaction/char-with-variant-names-same-material.test.js
@@ -263,36 +263,6 @@ describe('Character with variant names from productions of the same material', (
 				},
 				{
 					model: 'production',
-					uuid: HAMLET_NOVELLO_PRODUCTION_UUID,
-					name: 'Hamlet',
-					startDate: '2008-12-03',
-					endDate: '2009-01-10',
-					theatre: {
-						model: 'theatre',
-						uuid: NOVELLO_THEATRE_UUID,
-						name: 'Novello Theatre',
-						surTheatre: null
-					},
-					performers: [
-						{
-							model: 'person',
-							uuid: PATRICK_STEWART_PERSON_UUID,
-							name: 'Patrick Stewart',
-							roleName: 'Ghost',
-							qualifier: null,
-							otherRoles: [
-								{
-									model: 'character',
-									uuid: CLAUDIUS_CHARACTER_UUID,
-									name: 'Claudius, King of Denmark',
-									qualifier: null
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'production',
 					uuid: HAMLET_WYNDHAMS_PRODUCTION_UUID,
 					name: 'Hamlet',
 					startDate: '2009-05-29',
@@ -315,6 +285,36 @@ describe('Character with variant names from productions of the same material', (
 									model: 'character',
 									uuid: FIRST_PLAYER_CHARACTER_UUID,
 									name: 'First Player',
+									qualifier: null
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'production',
+					uuid: HAMLET_NOVELLO_PRODUCTION_UUID,
+					name: 'Hamlet',
+					startDate: '2008-12-03',
+					endDate: '2009-01-10',
+					theatre: {
+						model: 'theatre',
+						uuid: NOVELLO_THEATRE_UUID,
+						name: 'Novello Theatre',
+						surTheatre: null
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: PATRICK_STEWART_PERSON_UUID,
+							name: 'Patrick Stewart',
+							roleName: 'Ghost',
+							qualifier: null,
+							otherRoles: [
+								{
+									model: 'character',
+									uuid: CLAUDIUS_CHARACTER_UUID,
+									name: 'Claudius, King of Denmark',
 									qualifier: null
 								}
 							]

--- a/test-e2e/model-interaction/material-with-multi-prods.test.js
+++ b/test-e2e/model-interaction/material-with-multi-prods.test.js
@@ -111,19 +111,6 @@ describe('Material with multiple productions', () => {
 			const expectedProductions = [
 				{
 					model: 'production',
-					uuid: TWELFTH_NIGHT_NATIONAL_PRODUCTION_UUID,
-					name: 'Twelfth Night',
-					startDate: '2011-01-11',
-					endDate: '2011-03-02',
-					theatre: {
-						model: 'theatre',
-						uuid: NATIONAL_THEATRE_UUID,
-						name: 'National Theatre',
-						surTheatre: null
-					}
-				},
-				{
-					model: 'production',
 					uuid: TWELFTH_NIGHT_GLOBE_PRODUCTION_UUID,
 					name: 'Twelfth Night',
 					startDate: '2012-09-22',
@@ -132,6 +119,19 @@ describe('Material with multiple productions', () => {
 						model: 'theatre',
 						uuid: SHAKESPEARES_GLOBE_THEATRE_UUID,
 						name: 'Shakespeare\'s Globe',
+						surTheatre: null
+					}
+				},
+				{
+					model: 'production',
+					uuid: TWELFTH_NIGHT_NATIONAL_PRODUCTION_UUID,
+					name: 'Twelfth Night',
+					startDate: '2011-01-11',
+					endDate: '2011-03-02',
+					theatre: {
+						model: 'theatre',
+						uuid: NATIONAL_THEATRE_UUID,
+						name: 'National Theatre',
 						surTheatre: null
 					}
 				},

--- a/test-e2e/model-interaction/material-with-source-material.test.js
+++ b/test-e2e/model-interaction/material-with-source-material.test.js
@@ -537,19 +537,6 @@ describe('Materials with source material', () => {
 			const expectedSourcingMaterialProductions = [
 				{
 					model: 'production',
-					uuid: THE_DONKEY_SHOW_HANOVER_GRAND_PRODUCTION_UUID,
-					name: 'The Donkey Show',
-					startDate: '2000-09-12',
-					endDate: '2002-01-02',
-					theatre: {
-						model: 'theatre',
-						uuid: HANOVER_GRAND_THEATRE_UUID,
-						name: 'Hanover Grand',
-						surTheatre: null
-					}
-				},
-				{
-					model: 'production',
 					uuid: THE_INDIAN_BOY_ROYAL_SHAKESPEARE_THEATRE_PRODUCTION_UUID,
 					name: 'The Indian Boy',
 					startDate: '2006-11-07',
@@ -558,6 +545,19 @@ describe('Materials with source material', () => {
 						model: 'theatre',
 						uuid: ROYAL_SHAKESPEARE_THEATRE_UUID,
 						name: 'Royal Shakespeare Theatre',
+						surTheatre: null
+					}
+				},
+				{
+					model: 'production',
+					uuid: THE_DONKEY_SHOW_HANOVER_GRAND_PRODUCTION_UUID,
+					name: 'The Donkey Show',
+					startDate: '2000-09-12',
+					endDate: '2002-01-02',
+					theatre: {
+						model: 'theatre',
+						uuid: HANOVER_GRAND_THEATRE_UUID,
+						name: 'Hanover Grand',
 						surTheatre: null
 					}
 				}

--- a/test-e2e/model-interaction/prods-with-creative-team.test.js
+++ b/test-e2e/model-interaction/prods-with-creative-team.test.js
@@ -885,6 +885,31 @@ describe('Productions with creative team', () => {
 			const expectedCreativeProductions = [
 				{
 					model: 'production',
+					uuid: MOTHER_COURAGE_AND_HER_CHILDREN_OLIVIER_PRODUCTION_UUID,
+					name: 'Mother Courage and Her Children',
+					startDate: '2009-09-16',
+					endDate: '2009-12-08',
+					theatre: {
+						model: 'theatre',
+						uuid: OLIVIER_THEATRE_UUID,
+						name: 'Olivier Theatre',
+						surTheatre: {
+							model: 'theatre',
+							uuid: NATIONAL_THEATRE_UUID,
+							name: 'National Theatre'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'creativeCredit',
+							name: 'Directed by',
+							creditedEmployerCompany: null,
+							coCreditedEntities: []
+						}
+					]
+				},
+				{
+					model: 'production',
 					uuid: HAPPY_DAYS_LYTTELTON_PRODUCTION_UUID,
 					name: 'Happy Days',
 					startDate: '2007-01-18',
@@ -928,7 +953,22 @@ describe('Productions with creative team', () => {
 							coCreditedEntities: []
 						}
 					]
-				},
+				}
+			];
+
+			const { creativeProductions } = deborahWarnerPerson.body;
+
+			expect(creativeProductions).to.deep.equal(expectedCreativeProductions);
+
+		});
+
+	});
+
+	describe('Nina Dunn (person)', () => {
+
+		it('includes productions for which they have a creative team credit, included co-credited entities', () => {
+
+			const expectedCreativeProductions = [
 				{
 					model: 'production',
 					uuid: MOTHER_COURAGE_AND_HER_CHILDREN_OLIVIER_PRODUCTION_UUID,
@@ -948,27 +988,68 @@ describe('Productions with creative team', () => {
 					creativeCredits: [
 						{
 							model: 'creativeCredit',
-							name: 'Directed by',
+							name: 'Video Design by',
 							creditedEmployerCompany: null,
-							coCreditedEntities: []
+							coCreditedEntities: [
+								{
+									model: 'company',
+									uuid: MESMER_COMPANY_UUID,
+									name: 'Mesmer',
+									creditedMembers: [
+										{
+											model: 'person',
+											uuid: DANIEL_DENTON_PERSON_UUID,
+											name: 'Daniel Denton'
+										},
+										{
+											model: 'person',
+											uuid: DICK_STRAKER_PERSON_UUID,
+											name: 'Dick Straker'
+										},
+										{
+											model: 'person',
+											uuid: IAN_WILLIAM_GALLOWAY_PERSON_UUID,
+											name: 'Ian William Galloway'
+										}
+									]
+								},
+								{
+									model: 'company',
+									uuid: FIFTY_NINE_PRODUCTIONS_COMPANY_UUID,
+									name: '59 Productions',
+									creditedMembers: [
+										{
+											model: 'person',
+											uuid: ANNA_JAMESON_PERSON_UUID,
+											name: 'Anna Jameson'
+										},
+										{
+											model: 'person',
+											uuid: LEO_WARNER_PERSON_UUID,
+											name: 'Leo Warner'
+										},
+										{
+											model: 'person',
+											uuid: MARK_GRIMMER_PERSON_UUID,
+											name: 'Mark Grimmer'
+										}
+									]
+								},
+								{
+									model: 'company',
+									uuid: CINELUMA_COMPANY_UUID,
+									name: 'Cineluma',
+									creditedMembers: []
+								},
+								{
+									model: 'person',
+									uuid: AKHILA_KIRSHNAN_PERSON_UUID,
+									name: 'Akhila Krishnan'
+								}
+							]
 						}
 					]
-				}
-			];
-
-			const { creativeProductions } = deborahWarnerPerson.body;
-
-			expect(creativeProductions).to.deep.equal(expectedCreativeProductions);
-
-		});
-
-	});
-
-	describe('Nina Dunn (person)', () => {
-
-		it('includes productions for which they have a creative team credit, included co-credited entities', () => {
-
-			const expectedCreativeProductions = [
+				},
 				{
 					model: 'production',
 					uuid: HAPPY_DAYS_LYTTELTON_PRODUCTION_UUID,
@@ -1135,87 +1216,6 @@ describe('Productions with creative team', () => {
 				},
 				{
 					model: 'production',
-					uuid: MOTHER_COURAGE_AND_HER_CHILDREN_OLIVIER_PRODUCTION_UUID,
-					name: 'Mother Courage and Her Children',
-					startDate: '2009-09-16',
-					endDate: '2009-12-08',
-					theatre: {
-						model: 'theatre',
-						uuid: OLIVIER_THEATRE_UUID,
-						name: 'Olivier Theatre',
-						surTheatre: {
-							model: 'theatre',
-							uuid: NATIONAL_THEATRE_UUID,
-							name: 'National Theatre'
-						}
-					},
-					creativeCredits: [
-						{
-							model: 'creativeCredit',
-							name: 'Video Design by',
-							creditedEmployerCompany: null,
-							coCreditedEntities: [
-								{
-									model: 'company',
-									uuid: MESMER_COMPANY_UUID,
-									name: 'Mesmer',
-									creditedMembers: [
-										{
-											model: 'person',
-											uuid: DANIEL_DENTON_PERSON_UUID,
-											name: 'Daniel Denton'
-										},
-										{
-											model: 'person',
-											uuid: DICK_STRAKER_PERSON_UUID,
-											name: 'Dick Straker'
-										},
-										{
-											model: 'person',
-											uuid: IAN_WILLIAM_GALLOWAY_PERSON_UUID,
-											name: 'Ian William Galloway'
-										}
-									]
-								},
-								{
-									model: 'company',
-									uuid: FIFTY_NINE_PRODUCTIONS_COMPANY_UUID,
-									name: '59 Productions',
-									creditedMembers: [
-										{
-											model: 'person',
-											uuid: ANNA_JAMESON_PERSON_UUID,
-											name: 'Anna Jameson'
-										},
-										{
-											model: 'person',
-											uuid: LEO_WARNER_PERSON_UUID,
-											name: 'Leo Warner'
-										},
-										{
-											model: 'person',
-											uuid: MARK_GRIMMER_PERSON_UUID,
-											name: 'Mark Grimmer'
-										}
-									]
-								},
-								{
-									model: 'company',
-									uuid: CINELUMA_COMPANY_UUID,
-									name: 'Cineluma',
-									creditedMembers: []
-								},
-								{
-									model: 'person',
-									uuid: AKHILA_KIRSHNAN_PERSON_UUID,
-									name: 'Akhila Krishnan'
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'production',
 					uuid: RICHARD_II_COTTESLOE_PRODUCTION_UUID,
 					name: 'Richard II',
 					startDate: '1995-05-26',
@@ -1310,6 +1310,97 @@ describe('Productions with creative team', () => {
 		it('includes productions for which they have a creative team credit, included co-credited entities', () => {
 
 			const expectedCreativeProductions = [
+				{
+					model: 'production',
+					uuid: MOTHER_COURAGE_AND_HER_CHILDREN_OLIVIER_PRODUCTION_UUID,
+					name: 'Mother Courage and Her Children',
+					startDate: '2009-09-16',
+					endDate: '2009-12-08',
+					theatre: {
+						model: 'theatre',
+						uuid: OLIVIER_THEATRE_UUID,
+						name: 'Olivier Theatre',
+						surTheatre: {
+							model: 'theatre',
+							uuid: NATIONAL_THEATRE_UUID,
+							name: 'National Theatre'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'creativeCredit',
+							name: 'Design by',
+							creditedEmployerCompany: {
+								model: 'company',
+								uuid: FIFTY_NINE_PRODUCTIONS_COMPANY_UUID,
+								name: '59 Productions',
+								coCreditedMembers: []
+							},
+							coCreditedEntities: []
+						},
+						{
+							model: 'creativeCredit',
+							name: 'Video Design by',
+							creditedEmployerCompany: {
+								model: 'company',
+								uuid: FIFTY_NINE_PRODUCTIONS_COMPANY_UUID,
+								name: '59 Productions',
+								coCreditedMembers: [
+									{
+										model: 'person',
+										uuid: ANNA_JAMESON_PERSON_UUID,
+										name: 'Anna Jameson'
+									},
+									{
+										model: 'person',
+										uuid: MARK_GRIMMER_PERSON_UUID,
+										name: 'Mark Grimmer'
+									}
+								]
+							},
+							coCreditedEntities: [
+								{
+									model: 'person',
+									uuid: NINA_DUNN_PERSON_UUID,
+									name: 'Nina Dunn'
+								},
+								{
+									model: 'company',
+									uuid: MESMER_COMPANY_UUID,
+									name: 'Mesmer',
+									creditedMembers: [
+										{
+											model: 'person',
+											uuid: DANIEL_DENTON_PERSON_UUID,
+											name: 'Daniel Denton'
+										},
+										{
+											model: 'person',
+											uuid: DICK_STRAKER_PERSON_UUID,
+											name: 'Dick Straker'
+										},
+										{
+											model: 'person',
+											uuid: IAN_WILLIAM_GALLOWAY_PERSON_UUID,
+											name: 'Ian William Galloway'
+										}
+									]
+								},
+								{
+									model: 'company',
+									uuid: CINELUMA_COMPANY_UUID,
+									name: 'Cineluma',
+									creditedMembers: []
+								},
+								{
+									model: 'person',
+									uuid: AKHILA_KIRSHNAN_PERSON_UUID,
+									name: 'Akhila Krishnan'
+								}
+							]
+						}
+					]
+				},
 				{
 					model: 'production',
 					uuid: HAPPY_DAYS_LYTTELTON_PRODUCTION_UUID,
@@ -1461,97 +1552,6 @@ describe('Productions with creative team', () => {
 									model: 'person',
 									uuid: NINA_DUNN_PERSON_UUID,
 									name: 'Nina Dunn'
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'production',
-					uuid: MOTHER_COURAGE_AND_HER_CHILDREN_OLIVIER_PRODUCTION_UUID,
-					name: 'Mother Courage and Her Children',
-					startDate: '2009-09-16',
-					endDate: '2009-12-08',
-					theatre: {
-						model: 'theatre',
-						uuid: OLIVIER_THEATRE_UUID,
-						name: 'Olivier Theatre',
-						surTheatre: {
-							model: 'theatre',
-							uuid: NATIONAL_THEATRE_UUID,
-							name: 'National Theatre'
-						}
-					},
-					creativeCredits: [
-						{
-							model: 'creativeCredit',
-							name: 'Design by',
-							creditedEmployerCompany: {
-								model: 'company',
-								uuid: FIFTY_NINE_PRODUCTIONS_COMPANY_UUID,
-								name: '59 Productions',
-								coCreditedMembers: []
-							},
-							coCreditedEntities: []
-						},
-						{
-							model: 'creativeCredit',
-							name: 'Video Design by',
-							creditedEmployerCompany: {
-								model: 'company',
-								uuid: FIFTY_NINE_PRODUCTIONS_COMPANY_UUID,
-								name: '59 Productions',
-								coCreditedMembers: [
-									{
-										model: 'person',
-										uuid: ANNA_JAMESON_PERSON_UUID,
-										name: 'Anna Jameson'
-									},
-									{
-										model: 'person',
-										uuid: MARK_GRIMMER_PERSON_UUID,
-										name: 'Mark Grimmer'
-									}
-								]
-							},
-							coCreditedEntities: [
-								{
-									model: 'person',
-									uuid: NINA_DUNN_PERSON_UUID,
-									name: 'Nina Dunn'
-								},
-								{
-									model: 'company',
-									uuid: MESMER_COMPANY_UUID,
-									name: 'Mesmer',
-									creditedMembers: [
-										{
-											model: 'person',
-											uuid: DANIEL_DENTON_PERSON_UUID,
-											name: 'Daniel Denton'
-										},
-										{
-											model: 'person',
-											uuid: DICK_STRAKER_PERSON_UUID,
-											name: 'Dick Straker'
-										},
-										{
-											model: 'person',
-											uuid: IAN_WILLIAM_GALLOWAY_PERSON_UUID,
-											name: 'Ian William Galloway'
-										}
-									]
-								},
-								{
-									model: 'company',
-									uuid: CINELUMA_COMPANY_UUID,
-									name: 'Cineluma',
-									creditedMembers: []
-								},
-								{
-									model: 'person',
-									uuid: AKHILA_KIRSHNAN_PERSON_UUID,
-									name: 'Akhila Krishnan'
 								}
 							]
 						}
@@ -1749,6 +1749,31 @@ describe('Productions with creative team', () => {
 			const expectedCreativeProductions = [
 				{
 					model: 'production',
+					uuid: MOTHER_COURAGE_AND_HER_CHILDREN_OLIVIER_PRODUCTION_UUID,
+					name: 'Mother Courage and Her Children',
+					startDate: '2009-09-16',
+					endDate: '2009-12-08',
+					theatre: {
+						model: 'theatre',
+						uuid: OLIVIER_THEATRE_UUID,
+						name: 'Olivier Theatre',
+						surTheatre: {
+							model: 'theatre',
+							uuid: NATIONAL_THEATRE_UUID,
+							name: 'National Theatre'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'creativeCredit',
+							name: 'Sound Design by',
+							creditedMembers: [],
+							coCreditedEntities: []
+						}
+					]
+				},
+				{
+					model: 'production',
 					uuid: HAPPY_DAYS_LYTTELTON_PRODUCTION_UUID,
 					name: 'Happy Days',
 					startDate: '2007-01-18',
@@ -1798,7 +1823,22 @@ describe('Productions with creative team', () => {
 							coCreditedEntities: []
 						}
 					]
-				},
+				}
+			];
+
+			const { creativeProductions } = autographCompany.body;
+
+			expect(creativeProductions).to.deep.equal(expectedCreativeProductions);
+
+		});
+
+	});
+
+	describe('Mesmer (company)', () => {
+
+		it('includes productions for which they have a creative team credit', () => {
+
+			const expectedCreativeProductions = [
 				{
 					model: 'production',
 					uuid: MOTHER_COURAGE_AND_HER_CHILDREN_OLIVIER_PRODUCTION_UUID,
@@ -1818,27 +1858,67 @@ describe('Productions with creative team', () => {
 					creativeCredits: [
 						{
 							model: 'creativeCredit',
-							name: 'Sound Design by',
-							creditedMembers: [],
-							coCreditedEntities: []
+							name: 'Video Design by',
+							creditedMembers: [
+								{
+									model: 'person',
+									uuid: DANIEL_DENTON_PERSON_UUID,
+									name: 'Daniel Denton'
+								},
+								{
+									model: 'person',
+									uuid: DICK_STRAKER_PERSON_UUID,
+									name: 'Dick Straker'
+								},
+								{
+									model: 'person',
+									uuid: IAN_WILLIAM_GALLOWAY_PERSON_UUID,
+									name: 'Ian William Galloway'
+								}
+							],
+							coCreditedEntities: [
+								{
+									model: 'person',
+									uuid: NINA_DUNN_PERSON_UUID,
+									name: 'Nina Dunn'
+								},
+								{
+									model: 'company',
+									uuid: FIFTY_NINE_PRODUCTIONS_COMPANY_UUID,
+									name: '59 Productions',
+									creditedMembers: [
+										{
+											model: 'person',
+											uuid: ANNA_JAMESON_PERSON_UUID,
+											name: 'Anna Jameson'
+										},
+										{
+											model: 'person',
+											uuid: LEO_WARNER_PERSON_UUID,
+											name: 'Leo Warner'
+										},
+										{
+											model: 'person',
+											uuid: MARK_GRIMMER_PERSON_UUID,
+											name: 'Mark Grimmer'
+										}
+									]
+								},
+								{
+									model: 'company',
+									uuid: CINELUMA_COMPANY_UUID,
+									name: 'Cineluma',
+									creditedMembers: []
+								},
+								{
+									model: 'person',
+									uuid: AKHILA_KIRSHNAN_PERSON_UUID,
+									name: 'Akhila Krishnan'
+								}
+							]
 						}
 					]
-				}
-			];
-
-			const { creativeProductions } = autographCompany.body;
-
-			expect(creativeProductions).to.deep.equal(expectedCreativeProductions);
-
-		});
-
-	});
-
-	describe('Mesmer (company)', () => {
-
-		it('includes productions for which they have a creative team credit', () => {
-
-			const expectedCreativeProductions = [
+				},
 				{
 					model: 'production',
 					uuid: HAPPY_DAYS_LYTTELTON_PRODUCTION_UUID,
@@ -1997,86 +2077,6 @@ describe('Productions with creative team', () => {
 				},
 				{
 					model: 'production',
-					uuid: MOTHER_COURAGE_AND_HER_CHILDREN_OLIVIER_PRODUCTION_UUID,
-					name: 'Mother Courage and Her Children',
-					startDate: '2009-09-16',
-					endDate: '2009-12-08',
-					theatre: {
-						model: 'theatre',
-						uuid: OLIVIER_THEATRE_UUID,
-						name: 'Olivier Theatre',
-						surTheatre: {
-							model: 'theatre',
-							uuid: NATIONAL_THEATRE_UUID,
-							name: 'National Theatre'
-						}
-					},
-					creativeCredits: [
-						{
-							model: 'creativeCredit',
-							name: 'Video Design by',
-							creditedMembers: [
-								{
-									model: 'person',
-									uuid: DANIEL_DENTON_PERSON_UUID,
-									name: 'Daniel Denton'
-								},
-								{
-									model: 'person',
-									uuid: DICK_STRAKER_PERSON_UUID,
-									name: 'Dick Straker'
-								},
-								{
-									model: 'person',
-									uuid: IAN_WILLIAM_GALLOWAY_PERSON_UUID,
-									name: 'Ian William Galloway'
-								}
-							],
-							coCreditedEntities: [
-								{
-									model: 'person',
-									uuid: NINA_DUNN_PERSON_UUID,
-									name: 'Nina Dunn'
-								},
-								{
-									model: 'company',
-									uuid: FIFTY_NINE_PRODUCTIONS_COMPANY_UUID,
-									name: '59 Productions',
-									creditedMembers: [
-										{
-											model: 'person',
-											uuid: ANNA_JAMESON_PERSON_UUID,
-											name: 'Anna Jameson'
-										},
-										{
-											model: 'person',
-											uuid: LEO_WARNER_PERSON_UUID,
-											name: 'Leo Warner'
-										},
-										{
-											model: 'person',
-											uuid: MARK_GRIMMER_PERSON_UUID,
-											name: 'Mark Grimmer'
-										}
-									]
-								},
-								{
-									model: 'company',
-									uuid: CINELUMA_COMPANY_UUID,
-									name: 'Cineluma',
-									creditedMembers: []
-								},
-								{
-									model: 'person',
-									uuid: AKHILA_KIRSHNAN_PERSON_UUID,
-									name: 'Akhila Krishnan'
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'production',
 					uuid: RICHARD_II_COTTESLOE_PRODUCTION_UUID,
 					name: 'Richard II',
 					startDate: '1995-05-26',
@@ -2170,6 +2170,98 @@ describe('Productions with creative team', () => {
 		it('includes productions for which they have a creative team credit, included co-credited entities', () => {
 
 			const expectedCreativeProductions = [
+				{
+					model: 'production',
+					uuid: MOTHER_COURAGE_AND_HER_CHILDREN_OLIVIER_PRODUCTION_UUID,
+					name: 'Mother Courage and Her Children',
+					startDate: '2009-09-16',
+					endDate: '2009-12-08',
+					theatre: {
+						model: 'theatre',
+						uuid: OLIVIER_THEATRE_UUID,
+						name: 'Olivier Theatre',
+						surTheatre: {
+							model: 'theatre',
+							uuid: NATIONAL_THEATRE_UUID,
+							name: 'National Theatre'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'creativeCredit',
+							name: 'Design by',
+							creditedMembers: [
+								{
+									model: 'person',
+									uuid: LEO_WARNER_PERSON_UUID,
+									name: 'Leo Warner'
+								}
+							],
+							coCreditedEntities: []
+						},
+						{
+							model: 'creativeCredit',
+							name: 'Video Design by',
+							creditedMembers: [
+								{
+									model: 'person',
+									uuid: ANNA_JAMESON_PERSON_UUID,
+									name: 'Anna Jameson'
+								},
+								{
+									model: 'person',
+									uuid: LEO_WARNER_PERSON_UUID,
+									name: 'Leo Warner'
+								},
+								{
+									model: 'person',
+									uuid: MARK_GRIMMER_PERSON_UUID,
+									name: 'Mark Grimmer'
+								}
+							],
+							coCreditedEntities: [
+								{
+									model: 'person',
+									uuid: NINA_DUNN_PERSON_UUID,
+									name: 'Nina Dunn'
+								},
+								{
+									model: 'company',
+									uuid: MESMER_COMPANY_UUID,
+									name: 'Mesmer',
+									creditedMembers: [
+										{
+											model: 'person',
+											uuid: DANIEL_DENTON_PERSON_UUID,
+											name: 'Daniel Denton'
+										},
+										{
+											model: 'person',
+											uuid: DICK_STRAKER_PERSON_UUID,
+											name: 'Dick Straker'
+										},
+										{
+											model: 'person',
+											uuid: IAN_WILLIAM_GALLOWAY_PERSON_UUID,
+											name: 'Ian William Galloway'
+										}
+									]
+								},
+								{
+									model: 'company',
+									uuid: CINELUMA_COMPANY_UUID,
+									name: 'Cineluma',
+									creditedMembers: []
+								},
+								{
+									model: 'person',
+									uuid: AKHILA_KIRSHNAN_PERSON_UUID,
+									name: 'Akhila Krishnan'
+								}
+							]
+						}
+					]
+				},
 				{
 					model: 'production',
 					uuid: HAPPY_DAYS_LYTTELTON_PRODUCTION_UUID,
@@ -2321,98 +2413,6 @@ describe('Productions with creative team', () => {
 									model: 'person',
 									uuid: NINA_DUNN_PERSON_UUID,
 									name: 'Nina Dunn'
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'production',
-					uuid: MOTHER_COURAGE_AND_HER_CHILDREN_OLIVIER_PRODUCTION_UUID,
-					name: 'Mother Courage and Her Children',
-					startDate: '2009-09-16',
-					endDate: '2009-12-08',
-					theatre: {
-						model: 'theatre',
-						uuid: OLIVIER_THEATRE_UUID,
-						name: 'Olivier Theatre',
-						surTheatre: {
-							model: 'theatre',
-							uuid: NATIONAL_THEATRE_UUID,
-							name: 'National Theatre'
-						}
-					},
-					creativeCredits: [
-						{
-							model: 'creativeCredit',
-							name: 'Design by',
-							creditedMembers: [
-								{
-									model: 'person',
-									uuid: LEO_WARNER_PERSON_UUID,
-									name: 'Leo Warner'
-								}
-							],
-							coCreditedEntities: []
-						},
-						{
-							model: 'creativeCredit',
-							name: 'Video Design by',
-							creditedMembers: [
-								{
-									model: 'person',
-									uuid: ANNA_JAMESON_PERSON_UUID,
-									name: 'Anna Jameson'
-								},
-								{
-									model: 'person',
-									uuid: LEO_WARNER_PERSON_UUID,
-									name: 'Leo Warner'
-								},
-								{
-									model: 'person',
-									uuid: MARK_GRIMMER_PERSON_UUID,
-									name: 'Mark Grimmer'
-								}
-							],
-							coCreditedEntities: [
-								{
-									model: 'person',
-									uuid: NINA_DUNN_PERSON_UUID,
-									name: 'Nina Dunn'
-								},
-								{
-									model: 'company',
-									uuid: MESMER_COMPANY_UUID,
-									name: 'Mesmer',
-									creditedMembers: [
-										{
-											model: 'person',
-											uuid: DANIEL_DENTON_PERSON_UUID,
-											name: 'Daniel Denton'
-										},
-										{
-											model: 'person',
-											uuid: DICK_STRAKER_PERSON_UUID,
-											name: 'Dick Straker'
-										},
-										{
-											model: 'person',
-											uuid: IAN_WILLIAM_GALLOWAY_PERSON_UUID,
-											name: 'Ian William Galloway'
-										}
-									]
-								},
-								{
-									model: 'company',
-									uuid: CINELUMA_COMPANY_UUID,
-									name: 'Cineluma',
-									creditedMembers: []
-								},
-								{
-									model: 'person',
-									uuid: AKHILA_KIRSHNAN_PERSON_UUID,
-									name: 'Akhila Krishnan'
 								}
 							]
 						}

--- a/test-e2e/model-interaction/prods-with-crew.test.js
+++ b/test-e2e/model-interaction/prods-with-crew.test.js
@@ -889,31 +889,6 @@ describe('Productions with crew', () => {
 			const expectedCrewProductions = [
 				{
 					model: 'production',
-					uuid: MUCH_ADO_ABOUT_NOTHING_OLIVIER_PRODUCTION_UUID,
-					name: 'Much Ado About Nothing',
-					startDate: '2007-12-10',
-					endDate: '2008-03-29',
-					theatre: {
-						model: 'theatre',
-						uuid: OLIVIER_THEATRE_UUID,
-						name: 'Olivier Theatre',
-						surTheatre: {
-							model: 'theatre',
-							uuid: NATIONAL_THEATRE_UUID,
-							name: 'National Theatre'
-						}
-					},
-					crewCredits: [
-						{
-							model: 'crewCredit',
-							name: 'Production Management by',
-							creditedEmployerCompany: null,
-							coCreditedEntities: []
-						}
-					]
-				},
-				{
-					model: 'production',
 					uuid: PHÈDRE_LYTTELTON_PRODUCTION_UUID,
 					name: 'Phèdre',
 					startDate: '2009-06-04',
@@ -957,22 +932,7 @@ describe('Productions with crew', () => {
 							coCreditedEntities: []
 						}
 					]
-				}
-			];
-
-			const { crewProductions } = tariqHussainPerson.body;
-
-			expect(crewProductions).to.deep.equal(expectedCrewProductions);
-
-		});
-
-	});
-
-	describe('Cass Kirchner (person)', () => {
-
-		it('includes productions for which they have a crew credit, included co-credited entities', () => {
-
-			const expectedCrewProductions = [
+				},
 				{
 					model: 'production',
 					uuid: MUCH_ADO_ABOUT_NOTHING_OLIVIER_PRODUCTION_UUID,
@@ -992,68 +952,27 @@ describe('Productions with crew', () => {
 					crewCredits: [
 						{
 							model: 'crewCredit',
-							name: 'Stage Management by',
+							name: 'Production Management by',
 							creditedEmployerCompany: null,
-							coCreditedEntities: [
-								{
-									model: 'company',
-									uuid: CREW_DEPUTIES_LTD_COMPANY_UUID,
-									name: 'Crew Deputies Ltd',
-									creditedMembers: [
-										{
-											model: 'person',
-											uuid: TAMARA_ALBACHARI_PERSON_UUID,
-											name: 'Tamara Albachari'
-										},
-										{
-											model: 'person',
-											uuid: BENJAMIN_DONOGHUE_PERSON_UUID,
-											name: 'Benjamin Donoghue'
-										},
-										{
-											model: 'person',
-											uuid: NIK_HAFFENDEN_PERSON_UUID,
-											name: 'Nik Haffenden'
-										}
-									]
-								},
-								{
-									model: 'company',
-									uuid: CREW_ASSISTANTS_LTD_COMPANY_UUID,
-									name: 'Crew Assistants Ltd',
-									creditedMembers: [
-										{
-											model: 'person',
-											uuid: PETER_GREGORY_PERSON_UUID,
-											name: 'Peter Gregory'
-										},
-										{
-											model: 'person',
-											uuid: SARA_GUNTER_PERSON_UUID,
-											name: 'Sara Gunter'
-										},
-										{
-											model: 'person',
-											uuid: JULIA_WICKHAM_PERSON_UUID,
-											name: 'Julia Wickham'
-										}
-									]
-								},
-								{
-									model: 'company',
-									uuid: THEATRICAL_PRODUCTION_SERVICES_LTD_COMPANY_UUID,
-									name: 'Theatrical Production Services Ltd',
-									creditedMembers: []
-								},
-								{
-									model: 'person',
-									uuid: PRAD_PANKHANI_PERSON_UUID,
-									name: 'Prad Pankhani'
-								}
-							]
+							coCreditedEntities: []
 						}
 					]
-				},
+				}
+			];
+
+			const { crewProductions } = tariqHussainPerson.body;
+
+			expect(crewProductions).to.deep.equal(expectedCrewProductions);
+
+		});
+
+	});
+
+	describe('Cass Kirchner (person)', () => {
+
+		it('includes productions for which they have a crew credit, included co-credited entities', () => {
+
+			const expectedCrewProductions = [
 				{
 					model: 'production',
 					uuid: PAINS_OF_YOUTH_COTTESLOE_PRODUCTION_UUID,
@@ -1298,22 +1217,7 @@ describe('Productions with crew', () => {
 							]
 						}
 					]
-				}
-			];
-
-			const { crewProductions } = cassKirchnerPerson.body;
-
-			expect(crewProductions).to.deep.equal(expectedCrewProductions);
-
-		});
-
-	});
-
-	describe('Sara Gunter (person)', () => {
-
-		it('includes productions for which they have a crew credit, included co-credited entities', () => {
-
-			const expectedCrewProductions = [
+				},
 				{
 					model: 'production',
 					uuid: MUCH_ADO_ABOUT_NOTHING_OLIVIER_PRODUCTION_UUID,
@@ -1333,41 +1237,9 @@ describe('Productions with crew', () => {
 					crewCredits: [
 						{
 							model: 'crewCredit',
-							name: 'Rigging Supervision by',
-							creditedEmployerCompany: {
-								model: 'company',
-								uuid: CREW_ASSISTANTS_LTD_COMPANY_UUID,
-								name: 'Crew Assistants Ltd',
-								coCreditedMembers: []
-							},
-							coCreditedEntities: []
-						},
-						{
-							model: 'crewCredit',
 							name: 'Stage Management by',
-							creditedEmployerCompany: {
-								model: 'company',
-								uuid: CREW_ASSISTANTS_LTD_COMPANY_UUID,
-								name: 'Crew Assistants Ltd',
-								coCreditedMembers: [
-									{
-										model: 'person',
-										uuid: PETER_GREGORY_PERSON_UUID,
-										name: 'Peter Gregory'
-									},
-									{
-										model: 'person',
-										uuid: JULIA_WICKHAM_PERSON_UUID,
-										name: 'Julia Wickham'
-									}
-								]
-							},
+							creditedEmployerCompany: null,
 							coCreditedEntities: [
-								{
-									model: 'person',
-									uuid: CASS_KIRCHNER_PERSON_UUID,
-									name: 'Cass Kirchner'
-								},
 								{
 									model: 'company',
 									uuid: CREW_DEPUTIES_LTD_COMPANY_UUID,
@@ -1392,6 +1264,28 @@ describe('Productions with crew', () => {
 								},
 								{
 									model: 'company',
+									uuid: CREW_ASSISTANTS_LTD_COMPANY_UUID,
+									name: 'Crew Assistants Ltd',
+									creditedMembers: [
+										{
+											model: 'person',
+											uuid: PETER_GREGORY_PERSON_UUID,
+											name: 'Peter Gregory'
+										},
+										{
+											model: 'person',
+											uuid: SARA_GUNTER_PERSON_UUID,
+											name: 'Sara Gunter'
+										},
+										{
+											model: 'person',
+											uuid: JULIA_WICKHAM_PERSON_UUID,
+											name: 'Julia Wickham'
+										}
+									]
+								},
+								{
+									model: 'company',
 									uuid: THEATRICAL_PRODUCTION_SERVICES_LTD_COMPANY_UUID,
 									name: 'Theatrical Production Services Ltd',
 									creditedMembers: []
@@ -1404,7 +1298,22 @@ describe('Productions with crew', () => {
 							]
 						}
 					]
-				},
+				}
+			];
+
+			const { crewProductions } = cassKirchnerPerson.body;
+
+			expect(crewProductions).to.deep.equal(expectedCrewProductions);
+
+		});
+
+	});
+
+	describe('Sara Gunter (person)', () => {
+
+		it('includes productions for which they have a crew credit, included co-credited entities', () => {
+
+			const expectedCrewProductions = [
 				{
 					model: 'production',
 					uuid: PAINS_OF_YOUTH_COTTESLOE_PRODUCTION_UUID,
@@ -1640,6 +1549,97 @@ describe('Productions with crew', () => {
 							]
 						}
 					]
+				},
+				{
+					model: 'production',
+					uuid: MUCH_ADO_ABOUT_NOTHING_OLIVIER_PRODUCTION_UUID,
+					name: 'Much Ado About Nothing',
+					startDate: '2007-12-10',
+					endDate: '2008-03-29',
+					theatre: {
+						model: 'theatre',
+						uuid: OLIVIER_THEATRE_UUID,
+						name: 'Olivier Theatre',
+						surTheatre: {
+							model: 'theatre',
+							uuid: NATIONAL_THEATRE_UUID,
+							name: 'National Theatre'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'crewCredit',
+							name: 'Rigging Supervision by',
+							creditedEmployerCompany: {
+								model: 'company',
+								uuid: CREW_ASSISTANTS_LTD_COMPANY_UUID,
+								name: 'Crew Assistants Ltd',
+								coCreditedMembers: []
+							},
+							coCreditedEntities: []
+						},
+						{
+							model: 'crewCredit',
+							name: 'Stage Management by',
+							creditedEmployerCompany: {
+								model: 'company',
+								uuid: CREW_ASSISTANTS_LTD_COMPANY_UUID,
+								name: 'Crew Assistants Ltd',
+								coCreditedMembers: [
+									{
+										model: 'person',
+										uuid: PETER_GREGORY_PERSON_UUID,
+										name: 'Peter Gregory'
+									},
+									{
+										model: 'person',
+										uuid: JULIA_WICKHAM_PERSON_UUID,
+										name: 'Julia Wickham'
+									}
+								]
+							},
+							coCreditedEntities: [
+								{
+									model: 'person',
+									uuid: CASS_KIRCHNER_PERSON_UUID,
+									name: 'Cass Kirchner'
+								},
+								{
+									model: 'company',
+									uuid: CREW_DEPUTIES_LTD_COMPANY_UUID,
+									name: 'Crew Deputies Ltd',
+									creditedMembers: [
+										{
+											model: 'person',
+											uuid: TAMARA_ALBACHARI_PERSON_UUID,
+											name: 'Tamara Albachari'
+										},
+										{
+											model: 'person',
+											uuid: BENJAMIN_DONOGHUE_PERSON_UUID,
+											name: 'Benjamin Donoghue'
+										},
+										{
+											model: 'person',
+											uuid: NIK_HAFFENDEN_PERSON_UUID,
+											name: 'Nik Haffenden'
+										}
+									]
+								},
+								{
+									model: 'company',
+									uuid: THEATRICAL_PRODUCTION_SERVICES_LTD_COMPANY_UUID,
+									name: 'Theatrical Production Services Ltd',
+									creditedMembers: []
+								},
+								{
+									model: 'person',
+									uuid: PRAD_PANKHANI_PERSON_UUID,
+									name: 'Prad Pankhani'
+								}
+							]
+						}
+					]
 				}
 			];
 
@@ -1753,31 +1753,6 @@ describe('Productions with crew', () => {
 			const expectedCrewProductions = [
 				{
 					model: 'production',
-					uuid: MUCH_ADO_ABOUT_NOTHING_OLIVIER_PRODUCTION_UUID,
-					name: 'Much Ado About Nothing',
-					startDate: '2007-12-10',
-					endDate: '2008-03-29',
-					theatre: {
-						model: 'theatre',
-						uuid: OLIVIER_THEATRE_UUID,
-						name: 'Olivier Theatre',
-						surTheatre: {
-							model: 'theatre',
-							uuid: NATIONAL_THEATRE_UUID,
-							name: 'National Theatre'
-						}
-					},
-					crewCredits: [
-						{
-							model: 'crewCredit',
-							name: 'Sound Operation by',
-							creditedMembers: [],
-							coCreditedEntities: []
-						}
-					]
-				},
-				{
-					model: 'production',
 					uuid: PHÈDRE_LYTTELTON_PRODUCTION_UUID,
 					name: 'Phèdre',
 					startDate: '2009-06-04',
@@ -1827,22 +1802,7 @@ describe('Productions with crew', () => {
 							coCreditedEntities: []
 						}
 					]
-				}
-			];
-
-			const { crewProductions } = stagecraftLtdCompany.body;
-
-			expect(crewProductions).to.deep.equal(expectedCrewProductions);
-
-		});
-
-	});
-
-	describe('Crew Deputies Ltd (company)', () => {
-
-		it('includes productions for which they have a crew credit', () => {
-
-			const expectedCrewProductions = [
+				},
 				{
 					model: 'production',
 					uuid: MUCH_ADO_ABOUT_NOTHING_OLIVIER_PRODUCTION_UUID,
@@ -1862,67 +1822,27 @@ describe('Productions with crew', () => {
 					crewCredits: [
 						{
 							model: 'crewCredit',
-							name: 'Stage Management by',
-							creditedMembers: [
-								{
-									model: 'person',
-									uuid: TAMARA_ALBACHARI_PERSON_UUID,
-									name: 'Tamara Albachari'
-								},
-								{
-									model: 'person',
-									uuid: BENJAMIN_DONOGHUE_PERSON_UUID,
-									name: 'Benjamin Donoghue'
-								},
-								{
-									model: 'person',
-									uuid: NIK_HAFFENDEN_PERSON_UUID,
-									name: 'Nik Haffenden'
-								}
-							],
-							coCreditedEntities: [
-								{
-									model: 'person',
-									uuid: CASS_KIRCHNER_PERSON_UUID,
-									name: 'Cass Kirchner'
-								},
-								{
-									model: 'company',
-									uuid: CREW_ASSISTANTS_LTD_COMPANY_UUID,
-									name: 'Crew Assistants Ltd',
-									creditedMembers: [
-										{
-											model: 'person',
-											uuid: PETER_GREGORY_PERSON_UUID,
-											name: 'Peter Gregory'
-										},
-										{
-											model: 'person',
-											uuid: SARA_GUNTER_PERSON_UUID,
-											name: 'Sara Gunter'
-										},
-										{
-											model: 'person',
-											uuid: JULIA_WICKHAM_PERSON_UUID,
-											name: 'Julia Wickham'
-										}
-									]
-								},
-								{
-									model: 'company',
-									uuid: THEATRICAL_PRODUCTION_SERVICES_LTD_COMPANY_UUID,
-									name: 'Theatrical Production Services Ltd',
-									creditedMembers: []
-								},
-								{
-									model: 'person',
-									uuid: PRAD_PANKHANI_PERSON_UUID,
-									name: 'Prad Pankhani'
-								}
-							]
+							name: 'Sound Operation by',
+							creditedMembers: [],
+							coCreditedEntities: []
 						}
 					]
-				},
+				}
+			];
+
+			const { crewProductions } = stagecraftLtdCompany.body;
+
+			expect(crewProductions).to.deep.equal(expectedCrewProductions);
+
+		});
+
+	});
+
+	describe('Crew Deputies Ltd (company)', () => {
+
+		it('includes productions for which they have a crew credit', () => {
+
+			const expectedCrewProductions = [
 				{
 					model: 'production',
 					uuid: PAINS_OF_YOUTH_COTTESLOE_PRODUCTION_UUID,
@@ -2158,22 +2078,7 @@ describe('Productions with crew', () => {
 							]
 						}
 					]
-				}
-			];
-
-			const { crewProductions } = crewDeputiesLtdCompany.body;
-
-			expect(crewProductions).to.deep.equal(expectedCrewProductions);
-
-		});
-
-	});
-
-	describe('Crew Assistants Ltd (company)', () => {
-
-		it('includes productions for which they have a crew credit, included co-credited entities', () => {
-
-			const expectedCrewProductions = [
+				},
 				{
 					model: 'production',
 					uuid: MUCH_ADO_ABOUT_NOTHING_OLIVIER_PRODUCTION_UUID,
@@ -2193,34 +2098,22 @@ describe('Productions with crew', () => {
 					crewCredits: [
 						{
 							model: 'crewCredit',
-							name: 'Rigging Supervision by',
-							creditedMembers: [
-								{
-									model: 'person',
-									uuid: SARA_GUNTER_PERSON_UUID,
-									name: 'Sara Gunter'
-								}
-							],
-							coCreditedEntities: []
-						},
-						{
-							model: 'crewCredit',
 							name: 'Stage Management by',
 							creditedMembers: [
 								{
 									model: 'person',
-									uuid: PETER_GREGORY_PERSON_UUID,
-									name: 'Peter Gregory'
+									uuid: TAMARA_ALBACHARI_PERSON_UUID,
+									name: 'Tamara Albachari'
 								},
 								{
 									model: 'person',
-									uuid: SARA_GUNTER_PERSON_UUID,
-									name: 'Sara Gunter'
+									uuid: BENJAMIN_DONOGHUE_PERSON_UUID,
+									name: 'Benjamin Donoghue'
 								},
 								{
 									model: 'person',
-									uuid: JULIA_WICKHAM_PERSON_UUID,
-									name: 'Julia Wickham'
+									uuid: NIK_HAFFENDEN_PERSON_UUID,
+									name: 'Nik Haffenden'
 								}
 							],
 							coCreditedEntities: [
@@ -2231,23 +2124,23 @@ describe('Productions with crew', () => {
 								},
 								{
 									model: 'company',
-									uuid: CREW_DEPUTIES_LTD_COMPANY_UUID,
-									name: 'Crew Deputies Ltd',
+									uuid: CREW_ASSISTANTS_LTD_COMPANY_UUID,
+									name: 'Crew Assistants Ltd',
 									creditedMembers: [
 										{
 											model: 'person',
-											uuid: TAMARA_ALBACHARI_PERSON_UUID,
-											name: 'Tamara Albachari'
+											uuid: PETER_GREGORY_PERSON_UUID,
+											name: 'Peter Gregory'
 										},
 										{
 											model: 'person',
-											uuid: BENJAMIN_DONOGHUE_PERSON_UUID,
-											name: 'Benjamin Donoghue'
+											uuid: SARA_GUNTER_PERSON_UUID,
+											name: 'Sara Gunter'
 										},
 										{
 											model: 'person',
-											uuid: NIK_HAFFENDEN_PERSON_UUID,
-											name: 'Nik Haffenden'
+											uuid: JULIA_WICKHAM_PERSON_UUID,
+											name: 'Julia Wickham'
 										}
 									]
 								},
@@ -2265,7 +2158,22 @@ describe('Productions with crew', () => {
 							]
 						}
 					]
-				},
+				}
+			];
+
+			const { crewProductions } = crewDeputiesLtdCompany.body;
+
+			expect(crewProductions).to.deep.equal(expectedCrewProductions);
+
+		});
+
+	});
+
+	describe('Crew Assistants Ltd (company)', () => {
+
+		it('includes productions for which they have a crew credit, included co-credited entities', () => {
+
+			const expectedCrewProductions = [
 				{
 					model: 'production',
 					uuid: PAINS_OF_YOUTH_COTTESLOE_PRODUCTION_UUID,
@@ -2497,6 +2405,98 @@ describe('Productions with crew', () => {
 									model: 'person',
 									uuid: CASS_KIRCHNER_PERSON_UUID,
 									name: 'Cass Kirchner'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'production',
+					uuid: MUCH_ADO_ABOUT_NOTHING_OLIVIER_PRODUCTION_UUID,
+					name: 'Much Ado About Nothing',
+					startDate: '2007-12-10',
+					endDate: '2008-03-29',
+					theatre: {
+						model: 'theatre',
+						uuid: OLIVIER_THEATRE_UUID,
+						name: 'Olivier Theatre',
+						surTheatre: {
+							model: 'theatre',
+							uuid: NATIONAL_THEATRE_UUID,
+							name: 'National Theatre'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'crewCredit',
+							name: 'Rigging Supervision by',
+							creditedMembers: [
+								{
+									model: 'person',
+									uuid: SARA_GUNTER_PERSON_UUID,
+									name: 'Sara Gunter'
+								}
+							],
+							coCreditedEntities: []
+						},
+						{
+							model: 'crewCredit',
+							name: 'Stage Management by',
+							creditedMembers: [
+								{
+									model: 'person',
+									uuid: PETER_GREGORY_PERSON_UUID,
+									name: 'Peter Gregory'
+								},
+								{
+									model: 'person',
+									uuid: SARA_GUNTER_PERSON_UUID,
+									name: 'Sara Gunter'
+								},
+								{
+									model: 'person',
+									uuid: JULIA_WICKHAM_PERSON_UUID,
+									name: 'Julia Wickham'
+								}
+							],
+							coCreditedEntities: [
+								{
+									model: 'person',
+									uuid: CASS_KIRCHNER_PERSON_UUID,
+									name: 'Cass Kirchner'
+								},
+								{
+									model: 'company',
+									uuid: CREW_DEPUTIES_LTD_COMPANY_UUID,
+									name: 'Crew Deputies Ltd',
+									creditedMembers: [
+										{
+											model: 'person',
+											uuid: TAMARA_ALBACHARI_PERSON_UUID,
+											name: 'Tamara Albachari'
+										},
+										{
+											model: 'person',
+											uuid: BENJAMIN_DONOGHUE_PERSON_UUID,
+											name: 'Benjamin Donoghue'
+										},
+										{
+											model: 'person',
+											uuid: NIK_HAFFENDEN_PERSON_UUID,
+											name: 'Nik Haffenden'
+										}
+									]
+								},
+								{
+									model: 'company',
+									uuid: THEATRICAL_PRODUCTION_SERVICES_LTD_COMPANY_UUID,
+									name: 'Theatrical Production Services Ltd',
+									creditedMembers: []
+								},
+								{
+									model: 'person',
+									uuid: PRAD_PANKHANI_PERSON_UUID,
+									name: 'Prad Pankhani'
 								}
 							]
 						}

--- a/test-e2e/model-interaction/prods-with-producers.test.js
+++ b/test-e2e/model-interaction/prods-with-producers.test.js
@@ -887,20 +887,24 @@ describe('Productions with producer', () => {
 			const expectedProducerProductions = [
 				{
 					model: 'production',
-					uuid: HANGMEN_WYNDHAMS_PRODUCTION_UUID,
-					name: 'Hangmen',
-					startDate: '2015-12-01',
-					endDate: '2016-03-05',
+					uuid: WHITE_PEARL_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+					name: 'White Pearl',
+					startDate: '2019-05-10',
+					endDate: '2019-06-15',
 					theatre: {
 						model: 'theatre',
-						uuid: WYNDHAMS_THEATRE_UUID,
-						name: 'Wyndham\'s Theatre',
-						surTheatre: null
+						uuid: JERWOOD_THEATRE_DOWNSTAIRS_UUID,
+						name: 'Jerwood Theatre Downstairs',
+						surTheatre: {
+							model: 'theatre',
+							uuid: ROYAL_COURT_THEATRE_UUID,
+							name: 'Royal Court Theatre'
+						}
 					},
 					producerCredits: [
 						{
 							model: 'producerCredit',
-							name: 'Producer',
+							name: 'Producing',
 							creditedEmployerCompany: null,
 							coCreditedEntities: []
 						}
@@ -933,24 +937,20 @@ describe('Productions with producer', () => {
 				},
 				{
 					model: 'production',
-					uuid: WHITE_PEARL_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
-					name: 'White Pearl',
-					startDate: '2019-05-10',
-					endDate: '2019-06-15',
+					uuid: HANGMEN_WYNDHAMS_PRODUCTION_UUID,
+					name: 'Hangmen',
+					startDate: '2015-12-01',
+					endDate: '2016-03-05',
 					theatre: {
 						model: 'theatre',
-						uuid: JERWOOD_THEATRE_DOWNSTAIRS_UUID,
-						name: 'Jerwood Theatre Downstairs',
-						surTheatre: {
-							model: 'theatre',
-							uuid: ROYAL_COURT_THEATRE_UUID,
-							name: 'Royal Court Theatre'
-						}
+						uuid: WYNDHAMS_THEATRE_UUID,
+						name: 'Wyndham\'s Theatre',
+						surTheatre: null
 					},
 					producerCredits: [
 						{
 							model: 'producerCredit',
-							name: 'Producing',
+							name: 'Producer',
 							creditedEmployerCompany: null,
 							coCreditedEntities: []
 						}
@@ -973,91 +973,14 @@ describe('Productions with producer', () => {
 			const expectedProducerProductions = [
 				{
 					model: 'production',
-					uuid: HANGMEN_WYNDHAMS_PRODUCTION_UUID,
-					name: 'Hangmen',
-					startDate: '2015-12-01',
-					endDate: '2016-03-05',
+					uuid: WHITE_PEARL_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+					name: 'White Pearl',
+					startDate: '2019-05-10',
+					endDate: '2019-06-15',
 					theatre: {
 						model: 'theatre',
-						uuid: WYNDHAMS_THEATRE_UUID,
-						name: 'Wyndham\'s Theatre',
-						surTheatre: null
-					},
-					producerCredits: [
-						{
-							model: 'producerCredit',
-							name: 'Co-Producers',
-							creditedEmployerCompany: null,
-							coCreditedEntities: [
-								{
-									model: 'company',
-									uuid: ROYAL_COURT_THEATRE_COMPANY_UUID,
-									name: 'Royal Court Theatre',
-									creditedMembers: [
-										{
-											model: 'person',
-											uuid: VICKY_FEATHERSTONE_PERSON_UUID,
-											name: 'Vicky Featherstone'
-										},
-										{
-											model: 'person',
-											uuid: LUCY_DAVIES_PERSON_UUID,
-											name: 'Lucy Davies'
-										},
-										{
-											model: 'person',
-											uuid: OLA_INCE_PERSON_UUID,
-											name: 'Ola Ince'
-										}
-									]
-								},
-								{
-									model: 'person',
-									uuid: PAUL_ELLIOTT_PERSON_UUID,
-									name: 'Paul Elliott'
-								},
-								{
-									model: 'company',
-									uuid: OLD_VIC_PRODUCTIONS_COMPANY_UUID,
-									name: 'Old Vic Productions',
-									creditedMembers: []
-								},
-								{
-									model: 'company',
-									uuid: PLAYFUL_PRODUCTIONS_COMPANY_UUID,
-									name: 'Playful Productions',
-									creditedMembers: [
-										{
-											model: 'person',
-											uuid: MATTHEW_BYAM_SHAW_PERSON_UUID,
-											name: 'Matthew Byam Shaw'
-										},
-										{
-											model: 'person',
-											uuid: NIA_JANIS_PERSON_UUID,
-											name: 'Nia Janis'
-										},
-										{
-											model: 'person',
-											uuid: NICK_SALMON_PERSON_UUID,
-											name: 'Nick Salmon'
-										}
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'production',
-					uuid: LIGHTS_OUT_THE_SITE_PRODUCTION_UUID,
-					name: 'Lights Out',
-					startDate: '2017-05-17',
-					endDate: '2017-05-19',
-					theatre: {
-						model: 'theatre',
-						uuid: THE_SITE_THEATRE_UUID,
-						name: 'The Site',
+						uuid: JERWOOD_THEATRE_DOWNSTAIRS_UUID,
+						name: 'Jerwood Theatre Downstairs',
 						surTheatre: {
 							model: 'theatre',
 							uuid: ROYAL_COURT_THEATRE_UUID,
@@ -1067,9 +990,26 @@ describe('Productions with producer', () => {
 					producerCredits: [
 						{
 							model: 'producerCredit',
-							name: 'Co-Producing by',
+							name: 'Associate Producing',
+							creditedEmployerCompany: null,
+							coCreditedEntities: []
+						},
+						{
+							model: 'producerCredit',
+							name: 'Co-Producing',
 							creditedEmployerCompany: null,
 							coCreditedEntities: [
+								{
+									model: 'company',
+									uuid: OLD_VIC_PRODUCTIONS_COMPANY_UUID,
+									name: 'Old Vic Productions',
+									creditedMembers: []
+								},
+								{
+									model: 'person',
+									uuid: PAUL_ELLIOTT_PERSON_UUID,
+									name: 'Paul Elliott'
+								},
 								{
 									model: 'company',
 									uuid: ROYAL_COURT_THEATRE_COMPANY_UUID,
@@ -1077,13 +1017,13 @@ describe('Productions with producer', () => {
 									creditedMembers: [
 										{
 											model: 'person',
-											uuid: SAM_PRITCHARD_PERSON_UUID,
-											name: 'Sam Pritchard'
+											uuid: VICKY_FEATHERSTONE_PERSON_UUID,
+											name: 'Vicky Featherstone'
 										},
 										{
 											model: 'person',
-											uuid: VICKY_FEATHERSTONE_PERSON_UUID,
-											name: 'Vicky Featherstone'
+											uuid: HAMISH_PIRIE_PERSON_UUID,
+											name: 'Hamish Pirie'
 										},
 										{
 											model: 'person',
@@ -1099,13 +1039,13 @@ describe('Productions with producer', () => {
 									creditedMembers: [
 										{
 											model: 'person',
-											uuid: NICK_SALMON_PERSON_UUID,
-											name: 'Nick Salmon'
+											uuid: MATTHEW_BYAM_SHAW_PERSON_UUID,
+											name: 'Matthew Byam Shaw'
 										},
 										{
 											model: 'person',
-											uuid: MATTHEW_BYAM_SHAW_PERSON_UUID,
-											name: 'Matthew Byam Shaw'
+											uuid: HARRIET_ASTBURY_PERSON_UUID,
+											name: 'Harriet Astbury'
 										},
 										{
 											model: 'person',
@@ -1113,17 +1053,6 @@ describe('Productions with producer', () => {
 											name: 'Nia Janis'
 										}
 									]
-								},
-								{
-									model: 'company',
-									uuid: OLD_VIC_PRODUCTIONS_COMPANY_UUID,
-									name: 'Old Vic Productions',
-									creditedMembers: []
-								},
-								{
-									model: 'person',
-									uuid: PAUL_ELLIOTT_PERSON_UUID,
-									name: 'Paul Elliott'
 								}
 							]
 						}
@@ -1212,14 +1141,14 @@ describe('Productions with producer', () => {
 				},
 				{
 					model: 'production',
-					uuid: WHITE_PEARL_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
-					name: 'White Pearl',
-					startDate: '2019-05-10',
-					endDate: '2019-06-15',
+					uuid: LIGHTS_OUT_THE_SITE_PRODUCTION_UUID,
+					name: 'Lights Out',
+					startDate: '2017-05-17',
+					endDate: '2017-05-19',
 					theatre: {
 						model: 'theatre',
-						uuid: JERWOOD_THEATRE_DOWNSTAIRS_UUID,
-						name: 'Jerwood Theatre Downstairs',
+						uuid: THE_SITE_THEATRE_UUID,
+						name: 'The Site',
 						surTheatre: {
 							model: 'theatre',
 							uuid: ROYAL_COURT_THEATRE_UUID,
@@ -1229,26 +1158,9 @@ describe('Productions with producer', () => {
 					producerCredits: [
 						{
 							model: 'producerCredit',
-							name: 'Associate Producing',
-							creditedEmployerCompany: null,
-							coCreditedEntities: []
-						},
-						{
-							model: 'producerCredit',
-							name: 'Co-Producing',
+							name: 'Co-Producing by',
 							creditedEmployerCompany: null,
 							coCreditedEntities: [
-								{
-									model: 'company',
-									uuid: OLD_VIC_PRODUCTIONS_COMPANY_UUID,
-									name: 'Old Vic Productions',
-									creditedMembers: []
-								},
-								{
-									model: 'person',
-									uuid: PAUL_ELLIOTT_PERSON_UUID,
-									name: 'Paul Elliott'
-								},
 								{
 									model: 'company',
 									uuid: ROYAL_COURT_THEATRE_COMPANY_UUID,
@@ -1256,13 +1168,13 @@ describe('Productions with producer', () => {
 									creditedMembers: [
 										{
 											model: 'person',
-											uuid: VICKY_FEATHERSTONE_PERSON_UUID,
-											name: 'Vicky Featherstone'
+											uuid: SAM_PRITCHARD_PERSON_UUID,
+											name: 'Sam Pritchard'
 										},
 										{
 											model: 'person',
-											uuid: HAMISH_PIRIE_PERSON_UUID,
-											name: 'Hamish Pirie'
+											uuid: VICKY_FEATHERSTONE_PERSON_UUID,
+											name: 'Vicky Featherstone'
 										},
 										{
 											model: 'person',
@@ -1278,13 +1190,13 @@ describe('Productions with producer', () => {
 									creditedMembers: [
 										{
 											model: 'person',
-											uuid: MATTHEW_BYAM_SHAW_PERSON_UUID,
-											name: 'Matthew Byam Shaw'
+											uuid: NICK_SALMON_PERSON_UUID,
+											name: 'Nick Salmon'
 										},
 										{
 											model: 'person',
-											uuid: HARRIET_ASTBURY_PERSON_UUID,
-											name: 'Harriet Astbury'
+											uuid: MATTHEW_BYAM_SHAW_PERSON_UUID,
+											name: 'Matthew Byam Shaw'
 										},
 										{
 											model: 'person',
@@ -1292,26 +1204,22 @@ describe('Productions with producer', () => {
 											name: 'Nia Janis'
 										}
 									]
+								},
+								{
+									model: 'company',
+									uuid: OLD_VIC_PRODUCTIONS_COMPANY_UUID,
+									name: 'Old Vic Productions',
+									creditedMembers: []
+								},
+								{
+									model: 'person',
+									uuid: PAUL_ELLIOTT_PERSON_UUID,
+									name: 'Paul Elliott'
 								}
 							]
 						}
 					]
-				}
-			];
-
-			const { producerProductions } = ericAbrahamPerson.body;
-
-			expect(producerProductions).to.deep.equal(expectedProducerProductions);
-
-		});
-
-	});
-
-	describe('Matthew Byam Shaw (person)', () => {
-
-		it('includes productions for which they have a producer credit, included co-credited entities', () => {
-
-			const expectedProducerProductions = [
+				},
 				{
 					model: 'production',
 					uuid: HANGMEN_WYNDHAMS_PRODUCTION_UUID,
@@ -1328,23 +1236,7 @@ describe('Productions with producer', () => {
 						{
 							model: 'producerCredit',
 							name: 'Co-Producers',
-							creditedEmployerCompany: {
-								model: 'company',
-								uuid: PLAYFUL_PRODUCTIONS_COMPANY_UUID,
-								name: 'Playful Productions',
-								coCreditedMembers: [
-									{
-										model: 'person',
-										uuid: NIA_JANIS_PERSON_UUID,
-										name: 'Nia Janis'
-									},
-									{
-										model: 'person',
-										uuid: NICK_SALMON_PERSON_UUID,
-										name: 'Nick Salmon'
-									}
-								]
-							},
+							creditedEmployerCompany: null,
 							coCreditedEntities: [
 								{
 									model: 'company',
@@ -1380,24 +1272,56 @@ describe('Productions with producer', () => {
 									creditedMembers: []
 								},
 								{
-									model: 'person',
-									uuid: ERIC_ABRAHAM_PERSON_UUID,
-									name: 'Eric Abraham'
+									model: 'company',
+									uuid: PLAYFUL_PRODUCTIONS_COMPANY_UUID,
+									name: 'Playful Productions',
+									creditedMembers: [
+										{
+											model: 'person',
+											uuid: MATTHEW_BYAM_SHAW_PERSON_UUID,
+											name: 'Matthew Byam Shaw'
+										},
+										{
+											model: 'person',
+											uuid: NIA_JANIS_PERSON_UUID,
+											name: 'Nia Janis'
+										},
+										{
+											model: 'person',
+											uuid: NICK_SALMON_PERSON_UUID,
+											name: 'Nick Salmon'
+										}
+									]
 								}
 							]
 						}
 					]
-				},
+				}
+			];
+
+			const { producerProductions } = ericAbrahamPerson.body;
+
+			expect(producerProductions).to.deep.equal(expectedProducerProductions);
+
+		});
+
+	});
+
+	describe('Matthew Byam Shaw (person)', () => {
+
+		it('includes productions for which they have a producer credit, included co-credited entities', () => {
+
+			const expectedProducerProductions = [
 				{
 					model: 'production',
-					uuid: LIGHTS_OUT_THE_SITE_PRODUCTION_UUID,
-					name: 'Lights Out',
-					startDate: '2017-05-17',
-					endDate: '2017-05-19',
+					uuid: WHITE_PEARL_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+					name: 'White Pearl',
+					startDate: '2019-05-10',
+					endDate: '2019-06-15',
 					theatre: {
 						model: 'theatre',
-						uuid: THE_SITE_THEATRE_UUID,
-						name: 'The Site',
+						uuid: JERWOOD_THEATRE_DOWNSTAIRS_UUID,
+						name: 'Jerwood Theatre Downstairs',
 						surTheatre: {
 							model: 'theatre',
 							uuid: ROYAL_COURT_THEATRE_UUID,
@@ -1407,7 +1331,7 @@ describe('Productions with producer', () => {
 					producerCredits: [
 						{
 							model: 'producerCredit',
-							name: 'Co-Producing by',
+							name: 'Co-Producing',
 							creditedEmployerCompany: {
 								model: 'company',
 								uuid: PLAYFUL_PRODUCTIONS_COMPANY_UUID,
@@ -1415,8 +1339,8 @@ describe('Productions with producer', () => {
 								coCreditedMembers: [
 									{
 										model: 'person',
-										uuid: NICK_SALMON_PERSON_UUID,
-										name: 'Nick Salmon'
+										uuid: HARRIET_ASTBURY_PERSON_UUID,
+										name: 'Harriet Astbury'
 									},
 									{
 										model: 'person',
@@ -1427,33 +1351,6 @@ describe('Productions with producer', () => {
 							},
 							coCreditedEntities: [
 								{
-									model: 'person',
-									uuid: ERIC_ABRAHAM_PERSON_UUID,
-									name: 'Eric Abraham'
-								},
-								{
-									model: 'company',
-									uuid: ROYAL_COURT_THEATRE_COMPANY_UUID,
-									name: 'Royal Court Theatre',
-									creditedMembers: [
-										{
-											model: 'person',
-											uuid: SAM_PRITCHARD_PERSON_UUID,
-											name: 'Sam Pritchard'
-										},
-										{
-											model: 'person',
-											uuid: VICKY_FEATHERSTONE_PERSON_UUID,
-											name: 'Vicky Featherstone'
-										},
-										{
-											model: 'person',
-											uuid: LUCY_DAVIES_PERSON_UUID,
-											name: 'Lucy Davies'
-										}
-									]
-								},
-								{
 									model: 'company',
 									uuid: OLD_VIC_PRODUCTIONS_COMPANY_UUID,
 									name: 'Old Vic Productions',
@@ -1463,6 +1360,33 @@ describe('Productions with producer', () => {
 									model: 'person',
 									uuid: PAUL_ELLIOTT_PERSON_UUID,
 									name: 'Paul Elliott'
+								},
+								{
+									model: 'company',
+									uuid: ROYAL_COURT_THEATRE_COMPANY_UUID,
+									name: 'Royal Court Theatre',
+									creditedMembers: [
+										{
+											model: 'person',
+											uuid: VICKY_FEATHERSTONE_PERSON_UUID,
+											name: 'Vicky Featherstone'
+										},
+										{
+											model: 'person',
+											uuid: HAMISH_PIRIE_PERSON_UUID,
+											name: 'Hamish Pirie'
+										},
+										{
+											model: 'person',
+											uuid: LUCY_DAVIES_PERSON_UUID,
+											name: 'Lucy Davies'
+										}
+									]
+								},
+								{
+									model: 'person',
+									uuid: ERIC_ABRAHAM_PERSON_UUID,
+									name: 'Eric Abraham'
 								}
 							]
 						}
@@ -1561,14 +1485,14 @@ describe('Productions with producer', () => {
 				},
 				{
 					model: 'production',
-					uuid: WHITE_PEARL_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
-					name: 'White Pearl',
-					startDate: '2019-05-10',
-					endDate: '2019-06-15',
+					uuid: LIGHTS_OUT_THE_SITE_PRODUCTION_UUID,
+					name: 'Lights Out',
+					startDate: '2017-05-17',
+					endDate: '2017-05-19',
 					theatre: {
 						model: 'theatre',
-						uuid: JERWOOD_THEATRE_DOWNSTAIRS_UUID,
-						name: 'Jerwood Theatre Downstairs',
+						uuid: THE_SITE_THEATRE_UUID,
+						name: 'The Site',
 						surTheatre: {
 							model: 'theatre',
 							uuid: ROYAL_COURT_THEATRE_UUID,
@@ -1578,7 +1502,7 @@ describe('Productions with producer', () => {
 					producerCredits: [
 						{
 							model: 'producerCredit',
-							name: 'Co-Producing',
+							name: 'Co-Producing by',
 							creditedEmployerCompany: {
 								model: 'company',
 								uuid: PLAYFUL_PRODUCTIONS_COMPANY_UUID,
@@ -1586,8 +1510,8 @@ describe('Productions with producer', () => {
 								coCreditedMembers: [
 									{
 										model: 'person',
-										uuid: HARRIET_ASTBURY_PERSON_UUID,
-										name: 'Harriet Astbury'
+										uuid: NICK_SALMON_PERSON_UUID,
+										name: 'Nick Salmon'
 									},
 									{
 										model: 'person',
@@ -1598,6 +1522,33 @@ describe('Productions with producer', () => {
 							},
 							coCreditedEntities: [
 								{
+									model: 'person',
+									uuid: ERIC_ABRAHAM_PERSON_UUID,
+									name: 'Eric Abraham'
+								},
+								{
+									model: 'company',
+									uuid: ROYAL_COURT_THEATRE_COMPANY_UUID,
+									name: 'Royal Court Theatre',
+									creditedMembers: [
+										{
+											model: 'person',
+											uuid: SAM_PRITCHARD_PERSON_UUID,
+											name: 'Sam Pritchard'
+										},
+										{
+											model: 'person',
+											uuid: VICKY_FEATHERSTONE_PERSON_UUID,
+											name: 'Vicky Featherstone'
+										},
+										{
+											model: 'person',
+											uuid: LUCY_DAVIES_PERSON_UUID,
+											name: 'Lucy Davies'
+										}
+									]
+								},
+								{
 									model: 'company',
 									uuid: OLD_VIC_PRODUCTIONS_COMPANY_UUID,
 									name: 'Old Vic Productions',
@@ -1607,7 +1558,45 @@ describe('Productions with producer', () => {
 									model: 'person',
 									uuid: PAUL_ELLIOTT_PERSON_UUID,
 									name: 'Paul Elliott'
-								},
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'production',
+					uuid: HANGMEN_WYNDHAMS_PRODUCTION_UUID,
+					name: 'Hangmen',
+					startDate: '2015-12-01',
+					endDate: '2016-03-05',
+					theatre: {
+						model: 'theatre',
+						uuid: WYNDHAMS_THEATRE_UUID,
+						name: 'Wyndham\'s Theatre',
+						surTheatre: null
+					},
+					producerCredits: [
+						{
+							model: 'producerCredit',
+							name: 'Co-Producers',
+							creditedEmployerCompany: {
+								model: 'company',
+								uuid: PLAYFUL_PRODUCTIONS_COMPANY_UUID,
+								name: 'Playful Productions',
+								coCreditedMembers: [
+									{
+										model: 'person',
+										uuid: NIA_JANIS_PERSON_UUID,
+										name: 'Nia Janis'
+									},
+									{
+										model: 'person',
+										uuid: NICK_SALMON_PERSON_UUID,
+										name: 'Nick Salmon'
+									}
+								]
+							},
+							coCreditedEntities: [
 								{
 									model: 'company',
 									uuid: ROYAL_COURT_THEATRE_COMPANY_UUID,
@@ -1620,15 +1609,26 @@ describe('Productions with producer', () => {
 										},
 										{
 											model: 'person',
-											uuid: HAMISH_PIRIE_PERSON_UUID,
-											name: 'Hamish Pirie'
+											uuid: LUCY_DAVIES_PERSON_UUID,
+											name: 'Lucy Davies'
 										},
 										{
 											model: 'person',
-											uuid: LUCY_DAVIES_PERSON_UUID,
-											name: 'Lucy Davies'
+											uuid: OLA_INCE_PERSON_UUID,
+											name: 'Ola Ince'
 										}
 									]
+								},
+								{
+									model: 'person',
+									uuid: PAUL_ELLIOTT_PERSON_UUID,
+									name: 'Paul Elliott'
+								},
+								{
+									model: 'company',
+									uuid: OLD_VIC_PRODUCTIONS_COMPANY_UUID,
+									name: 'Old Vic Productions',
+									creditedMembers: []
 								},
 								{
 									model: 'person',
@@ -1751,26 +1751,24 @@ describe('Productions with producer', () => {
 			const expectedProducerProductions = [
 				{
 					model: 'production',
-					uuid: HANGMEN_WYNDHAMS_PRODUCTION_UUID,
-					name: 'Hangmen',
-					startDate: '2015-12-01',
-					endDate: '2016-03-05',
+					uuid: WHITE_PEARL_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+					name: 'White Pearl',
+					startDate: '2019-05-10',
+					endDate: '2019-06-15',
 					theatre: {
 						model: 'theatre',
-						uuid: WYNDHAMS_THEATRE_UUID,
-						name: 'Wyndham\'s Theatre',
-						surTheatre: null
+						uuid: JERWOOD_THEATRE_DOWNSTAIRS_UUID,
+						name: 'Jerwood Theatre Downstairs',
+						surTheatre: {
+							model: 'theatre',
+							uuid: ROYAL_COURT_THEATRE_UUID,
+							name: 'Royal Court Theatre'
+						}
 					},
 					producerCredits: [
 						{
 							model: 'producerCredit',
-							name: 'Associate Producer',
-							creditedMembers: [],
-							coCreditedEntities: []
-						},
-						{
-							model: 'producerCredit',
-							name: 'Executive Producer',
+							name: 'Executive Producing',
 							creditedMembers: [],
 							coCreditedEntities: []
 						}
@@ -1803,24 +1801,26 @@ describe('Productions with producer', () => {
 				},
 				{
 					model: 'production',
-					uuid: WHITE_PEARL_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
-					name: 'White Pearl',
-					startDate: '2019-05-10',
-					endDate: '2019-06-15',
+					uuid: HANGMEN_WYNDHAMS_PRODUCTION_UUID,
+					name: 'Hangmen',
+					startDate: '2015-12-01',
+					endDate: '2016-03-05',
 					theatre: {
 						model: 'theatre',
-						uuid: JERWOOD_THEATRE_DOWNSTAIRS_UUID,
-						name: 'Jerwood Theatre Downstairs',
-						surTheatre: {
-							model: 'theatre',
-							uuid: ROYAL_COURT_THEATRE_UUID,
-							name: 'Royal Court Theatre'
-						}
+						uuid: WYNDHAMS_THEATRE_UUID,
+						name: 'Wyndham\'s Theatre',
+						surTheatre: null
 					},
 					producerCredits: [
 						{
 							model: 'producerCredit',
-							name: 'Executive Producing',
+							name: 'Associate Producer',
+							creditedMembers: [],
+							coCreditedEntities: []
+						},
+						{
+							model: 'producerCredit',
+							name: 'Executive Producer',
 							creditedMembers: [],
 							coCreditedEntities: []
 						}
@@ -1843,90 +1843,14 @@ describe('Productions with producer', () => {
 			const expectedProducerProductions = [
 				{
 					model: 'production',
-					uuid: HANGMEN_WYNDHAMS_PRODUCTION_UUID,
-					name: 'Hangmen',
-					startDate: '2015-12-01',
-					endDate: '2016-03-05',
+					uuid: WHITE_PEARL_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+					name: 'White Pearl',
+					startDate: '2019-05-10',
+					endDate: '2019-06-15',
 					theatre: {
 						model: 'theatre',
-						uuid: WYNDHAMS_THEATRE_UUID,
-						name: 'Wyndham\'s Theatre',
-						surTheatre: null
-					},
-					producerCredits: [
-						{
-							model: 'producerCredit',
-							name: 'Co-Producers',
-							creditedMembers: [
-								{
-									model: 'person',
-									uuid: VICKY_FEATHERSTONE_PERSON_UUID,
-									name: 'Vicky Featherstone'
-								},
-								{
-									model: 'person',
-									uuid: LUCY_DAVIES_PERSON_UUID,
-									name: 'Lucy Davies'
-								},
-								{
-									model: 'person',
-									uuid: OLA_INCE_PERSON_UUID,
-									name: 'Ola Ince'
-								}
-							],
-							coCreditedEntities: [
-								{
-									model: 'person',
-									uuid: PAUL_ELLIOTT_PERSON_UUID,
-									name: 'Paul Elliott'
-								},
-								{
-									model: 'company',
-									uuid: OLD_VIC_PRODUCTIONS_COMPANY_UUID,
-									name: 'Old Vic Productions',
-									creditedMembers: []
-								},
-								{
-									model: 'company',
-									uuid: PLAYFUL_PRODUCTIONS_COMPANY_UUID,
-									name: 'Playful Productions',
-									creditedMembers: [
-										{
-											model: 'person',
-											uuid: MATTHEW_BYAM_SHAW_PERSON_UUID,
-											name: 'Matthew Byam Shaw'
-										},
-										{
-											model: 'person',
-											uuid: NIA_JANIS_PERSON_UUID,
-											name: 'Nia Janis'
-										},
-										{
-											model: 'person',
-											uuid: NICK_SALMON_PERSON_UUID,
-											name: 'Nick Salmon'
-										}
-									]
-								},
-								{
-									model: 'person',
-									uuid: ERIC_ABRAHAM_PERSON_UUID,
-									name: 'Eric Abraham'
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'production',
-					uuid: LIGHTS_OUT_THE_SITE_PRODUCTION_UUID,
-					name: 'Lights Out',
-					startDate: '2017-05-17',
-					endDate: '2017-05-19',
-					theatre: {
-						model: 'theatre',
-						uuid: THE_SITE_THEATRE_UUID,
-						name: 'The Site',
+						uuid: JERWOOD_THEATRE_DOWNSTAIRS_UUID,
+						name: 'Jerwood Theatre Downstairs',
 						surTheatre: {
 							model: 'theatre',
 							uuid: ROYAL_COURT_THEATRE_UUID,
@@ -1936,17 +1860,17 @@ describe('Productions with producer', () => {
 					producerCredits: [
 						{
 							model: 'producerCredit',
-							name: 'Co-Producing by',
+							name: 'Co-Producing',
 							creditedMembers: [
-								{
-									model: 'person',
-									uuid: SAM_PRITCHARD_PERSON_UUID,
-									name: 'Sam Pritchard'
-								},
 								{
 									model: 'person',
 									uuid: VICKY_FEATHERSTONE_PERSON_UUID,
 									name: 'Vicky Featherstone'
+								},
+								{
+									model: 'person',
+									uuid: HAMISH_PIRIE_PERSON_UUID,
+									name: 'Hamish Pirie'
 								},
 								{
 									model: 'person',
@@ -1955,6 +1879,17 @@ describe('Productions with producer', () => {
 								}
 							],
 							coCreditedEntities: [
+								{
+									model: 'company',
+									uuid: OLD_VIC_PRODUCTIONS_COMPANY_UUID,
+									name: 'Old Vic Productions',
+									creditedMembers: []
+								},
+								{
+									model: 'person',
+									uuid: PAUL_ELLIOTT_PERSON_UUID,
+									name: 'Paul Elliott'
+								},
 								{
 									model: 'person',
 									uuid: ERIC_ABRAHAM_PERSON_UUID,
@@ -1967,13 +1902,13 @@ describe('Productions with producer', () => {
 									creditedMembers: [
 										{
 											model: 'person',
-											uuid: NICK_SALMON_PERSON_UUID,
-											name: 'Nick Salmon'
+											uuid: MATTHEW_BYAM_SHAW_PERSON_UUID,
+											name: 'Matthew Byam Shaw'
 										},
 										{
 											model: 'person',
-											uuid: MATTHEW_BYAM_SHAW_PERSON_UUID,
-											name: 'Matthew Byam Shaw'
+											uuid: HARRIET_ASTBURY_PERSON_UUID,
+											name: 'Harriet Astbury'
 										},
 										{
 											model: 'person',
@@ -1981,17 +1916,6 @@ describe('Productions with producer', () => {
 											name: 'Nia Janis'
 										}
 									]
-								},
-								{
-									model: 'company',
-									uuid: OLD_VIC_PRODUCTIONS_COMPANY_UUID,
-									name: 'Old Vic Productions',
-									creditedMembers: []
-								},
-								{
-									model: 'person',
-									uuid: PAUL_ELLIOTT_PERSON_UUID,
-									name: 'Paul Elliott'
 								}
 							]
 						}
@@ -2079,14 +2003,14 @@ describe('Productions with producer', () => {
 				},
 				{
 					model: 'production',
-					uuid: WHITE_PEARL_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
-					name: 'White Pearl',
-					startDate: '2019-05-10',
-					endDate: '2019-06-15',
+					uuid: LIGHTS_OUT_THE_SITE_PRODUCTION_UUID,
+					name: 'Lights Out',
+					startDate: '2017-05-17',
+					endDate: '2017-05-19',
 					theatre: {
 						model: 'theatre',
-						uuid: JERWOOD_THEATRE_DOWNSTAIRS_UUID,
-						name: 'Jerwood Theatre Downstairs',
+						uuid: THE_SITE_THEATRE_UUID,
+						name: 'The Site',
 						surTheatre: {
 							model: 'theatre',
 							uuid: ROYAL_COURT_THEATRE_UUID,
@@ -2096,17 +2020,17 @@ describe('Productions with producer', () => {
 					producerCredits: [
 						{
 							model: 'producerCredit',
-							name: 'Co-Producing',
+							name: 'Co-Producing by',
 							creditedMembers: [
+								{
+									model: 'person',
+									uuid: SAM_PRITCHARD_PERSON_UUID,
+									name: 'Sam Pritchard'
+								},
 								{
 									model: 'person',
 									uuid: VICKY_FEATHERSTONE_PERSON_UUID,
 									name: 'Vicky Featherstone'
-								},
-								{
-									model: 'person',
-									uuid: HAMISH_PIRIE_PERSON_UUID,
-									name: 'Hamish Pirie'
 								},
 								{
 									model: 'person',
@@ -2115,6 +2039,33 @@ describe('Productions with producer', () => {
 								}
 							],
 							coCreditedEntities: [
+								{
+									model: 'person',
+									uuid: ERIC_ABRAHAM_PERSON_UUID,
+									name: 'Eric Abraham'
+								},
+								{
+									model: 'company',
+									uuid: PLAYFUL_PRODUCTIONS_COMPANY_UUID,
+									name: 'Playful Productions',
+									creditedMembers: [
+										{
+											model: 'person',
+											uuid: NICK_SALMON_PERSON_UUID,
+											name: 'Nick Salmon'
+										},
+										{
+											model: 'person',
+											uuid: MATTHEW_BYAM_SHAW_PERSON_UUID,
+											name: 'Matthew Byam Shaw'
+										},
+										{
+											model: 'person',
+											uuid: NIA_JANIS_PERSON_UUID,
+											name: 'Nia Janis'
+										}
+									]
+								},
 								{
 									model: 'company',
 									uuid: OLD_VIC_PRODUCTIONS_COMPANY_UUID,
@@ -2125,11 +2076,55 @@ describe('Productions with producer', () => {
 									model: 'person',
 									uuid: PAUL_ELLIOTT_PERSON_UUID,
 									name: 'Paul Elliott'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'production',
+					uuid: HANGMEN_WYNDHAMS_PRODUCTION_UUID,
+					name: 'Hangmen',
+					startDate: '2015-12-01',
+					endDate: '2016-03-05',
+					theatre: {
+						model: 'theatre',
+						uuid: WYNDHAMS_THEATRE_UUID,
+						name: 'Wyndham\'s Theatre',
+						surTheatre: null
+					},
+					producerCredits: [
+						{
+							model: 'producerCredit',
+							name: 'Co-Producers',
+							creditedMembers: [
+								{
+									model: 'person',
+									uuid: VICKY_FEATHERSTONE_PERSON_UUID,
+									name: 'Vicky Featherstone'
 								},
 								{
 									model: 'person',
-									uuid: ERIC_ABRAHAM_PERSON_UUID,
-									name: 'Eric Abraham'
+									uuid: LUCY_DAVIES_PERSON_UUID,
+									name: 'Lucy Davies'
+								},
+								{
+									model: 'person',
+									uuid: OLA_INCE_PERSON_UUID,
+									name: 'Ola Ince'
+								}
+							],
+							coCreditedEntities: [
+								{
+									model: 'person',
+									uuid: PAUL_ELLIOTT_PERSON_UUID,
+									name: 'Paul Elliott'
+								},
+								{
+									model: 'company',
+									uuid: OLD_VIC_PRODUCTIONS_COMPANY_UUID,
+									name: 'Old Vic Productions',
+									creditedMembers: []
 								},
 								{
 									model: 'company',
@@ -2143,15 +2138,20 @@ describe('Productions with producer', () => {
 										},
 										{
 											model: 'person',
-											uuid: HARRIET_ASTBURY_PERSON_UUID,
-											name: 'Harriet Astbury'
+											uuid: NIA_JANIS_PERSON_UUID,
+											name: 'Nia Janis'
 										},
 										{
 											model: 'person',
-											uuid: NIA_JANIS_PERSON_UUID,
-											name: 'Nia Janis'
+											uuid: NICK_SALMON_PERSON_UUID,
+											name: 'Nick Salmon'
 										}
 									]
+								},
+								{
+									model: 'person',
+									uuid: ERIC_ABRAHAM_PERSON_UUID,
+									name: 'Eric Abraham'
 								}
 							]
 						}
@@ -2174,90 +2174,14 @@ describe('Productions with producer', () => {
 			const expectedProducerProductions = [
 				{
 					model: 'production',
-					uuid: HANGMEN_WYNDHAMS_PRODUCTION_UUID,
-					name: 'Hangmen',
-					startDate: '2015-12-01',
-					endDate: '2016-03-05',
+					uuid: WHITE_PEARL_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+					name: 'White Pearl',
+					startDate: '2019-05-10',
+					endDate: '2019-06-15',
 					theatre: {
 						model: 'theatre',
-						uuid: WYNDHAMS_THEATRE_UUID,
-						name: 'Wyndham\'s Theatre',
-						surTheatre: null
-					},
-					producerCredits: [
-						{
-							model: 'producerCredit',
-							name: 'Co-Producers',
-							creditedMembers: [
-								{
-									model: 'person',
-									uuid: MATTHEW_BYAM_SHAW_PERSON_UUID,
-									name: 'Matthew Byam Shaw'
-								},
-								{
-									model: 'person',
-									uuid: NIA_JANIS_PERSON_UUID,
-									name: 'Nia Janis'
-								},
-								{
-									model: 'person',
-									uuid: NICK_SALMON_PERSON_UUID,
-									name: 'Nick Salmon'
-								}
-							],
-							coCreditedEntities: [
-								{
-									model: 'company',
-									uuid: ROYAL_COURT_THEATRE_COMPANY_UUID,
-									name: 'Royal Court Theatre',
-									creditedMembers: [
-										{
-											model: 'person',
-											uuid: VICKY_FEATHERSTONE_PERSON_UUID,
-											name: 'Vicky Featherstone'
-										},
-										{
-											model: 'person',
-											uuid: LUCY_DAVIES_PERSON_UUID,
-											name: 'Lucy Davies'
-										},
-										{
-											model: 'person',
-											uuid: OLA_INCE_PERSON_UUID,
-											name: 'Ola Ince'
-										}
-									]
-								},
-								{
-									model: 'person',
-									uuid: PAUL_ELLIOTT_PERSON_UUID,
-									name: 'Paul Elliott'
-								},
-								{
-									model: 'company',
-									uuid: OLD_VIC_PRODUCTIONS_COMPANY_UUID,
-									name: 'Old Vic Productions',
-									creditedMembers: []
-								},
-								{
-									model: 'person',
-									uuid: ERIC_ABRAHAM_PERSON_UUID,
-									name: 'Eric Abraham'
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'production',
-					uuid: LIGHTS_OUT_THE_SITE_PRODUCTION_UUID,
-					name: 'Lights Out',
-					startDate: '2017-05-17',
-					endDate: '2017-05-19',
-					theatre: {
-						model: 'theatre',
-						uuid: THE_SITE_THEATRE_UUID,
-						name: 'The Site',
+						uuid: JERWOOD_THEATRE_DOWNSTAIRS_UUID,
+						name: 'Jerwood Theatre Downstairs',
 						surTheatre: {
 							model: 'theatre',
 							uuid: ROYAL_COURT_THEATRE_UUID,
@@ -2267,17 +2191,17 @@ describe('Productions with producer', () => {
 					producerCredits: [
 						{
 							model: 'producerCredit',
-							name: 'Co-Producing by',
+							name: 'Co-Producing',
 							creditedMembers: [
-								{
-									model: 'person',
-									uuid: NICK_SALMON_PERSON_UUID,
-									name: 'Nick Salmon'
-								},
 								{
 									model: 'person',
 									uuid: MATTHEW_BYAM_SHAW_PERSON_UUID,
 									name: 'Matthew Byam Shaw'
+								},
+								{
+									model: 'person',
+									uuid: HARRIET_ASTBURY_PERSON_UUID,
+									name: 'Harriet Astbury'
 								},
 								{
 									model: 'person',
@@ -2286,33 +2210,6 @@ describe('Productions with producer', () => {
 								}
 							],
 							coCreditedEntities: [
-								{
-									model: 'person',
-									uuid: ERIC_ABRAHAM_PERSON_UUID,
-									name: 'Eric Abraham'
-								},
-								{
-									model: 'company',
-									uuid: ROYAL_COURT_THEATRE_COMPANY_UUID,
-									name: 'Royal Court Theatre',
-									creditedMembers: [
-										{
-											model: 'person',
-											uuid: SAM_PRITCHARD_PERSON_UUID,
-											name: 'Sam Pritchard'
-										},
-										{
-											model: 'person',
-											uuid: VICKY_FEATHERSTONE_PERSON_UUID,
-											name: 'Vicky Featherstone'
-										},
-										{
-											model: 'person',
-											uuid: LUCY_DAVIES_PERSON_UUID,
-											name: 'Lucy Davies'
-										}
-									]
-								},
 								{
 									model: 'company',
 									uuid: OLD_VIC_PRODUCTIONS_COMPANY_UUID,
@@ -2323,6 +2220,33 @@ describe('Productions with producer', () => {
 									model: 'person',
 									uuid: PAUL_ELLIOTT_PERSON_UUID,
 									name: 'Paul Elliott'
+								},
+								{
+									model: 'company',
+									uuid: ROYAL_COURT_THEATRE_COMPANY_UUID,
+									name: 'Royal Court Theatre',
+									creditedMembers: [
+										{
+											model: 'person',
+											uuid: VICKY_FEATHERSTONE_PERSON_UUID,
+											name: 'Vicky Featherstone'
+										},
+										{
+											model: 'person',
+											uuid: HAMISH_PIRIE_PERSON_UUID,
+											name: 'Hamish Pirie'
+										},
+										{
+											model: 'person',
+											uuid: LUCY_DAVIES_PERSON_UUID,
+											name: 'Lucy Davies'
+										}
+									]
+								},
+								{
+									model: 'person',
+									uuid: ERIC_ABRAHAM_PERSON_UUID,
+									name: 'Eric Abraham'
 								}
 							]
 						}
@@ -2422,14 +2346,14 @@ describe('Productions with producer', () => {
 				},
 				{
 					model: 'production',
-					uuid: WHITE_PEARL_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
-					name: 'White Pearl',
-					startDate: '2019-05-10',
-					endDate: '2019-06-15',
+					uuid: LIGHTS_OUT_THE_SITE_PRODUCTION_UUID,
+					name: 'Lights Out',
+					startDate: '2017-05-17',
+					endDate: '2017-05-19',
 					theatre: {
 						model: 'theatre',
-						uuid: JERWOOD_THEATRE_DOWNSTAIRS_UUID,
-						name: 'Jerwood Theatre Downstairs',
+						uuid: THE_SITE_THEATRE_UUID,
+						name: 'The Site',
 						surTheatre: {
 							model: 'theatre',
 							uuid: ROYAL_COURT_THEATRE_UUID,
@@ -2439,17 +2363,17 @@ describe('Productions with producer', () => {
 					producerCredits: [
 						{
 							model: 'producerCredit',
-							name: 'Co-Producing',
+							name: 'Co-Producing by',
 							creditedMembers: [
+								{
+									model: 'person',
+									uuid: NICK_SALMON_PERSON_UUID,
+									name: 'Nick Salmon'
+								},
 								{
 									model: 'person',
 									uuid: MATTHEW_BYAM_SHAW_PERSON_UUID,
 									name: 'Matthew Byam Shaw'
-								},
-								{
-									model: 'person',
-									uuid: HARRIET_ASTBURY_PERSON_UUID,
-									name: 'Harriet Astbury'
 								},
 								{
 									model: 'person',
@@ -2458,6 +2382,33 @@ describe('Productions with producer', () => {
 								}
 							],
 							coCreditedEntities: [
+								{
+									model: 'person',
+									uuid: ERIC_ABRAHAM_PERSON_UUID,
+									name: 'Eric Abraham'
+								},
+								{
+									model: 'company',
+									uuid: ROYAL_COURT_THEATRE_COMPANY_UUID,
+									name: 'Royal Court Theatre',
+									creditedMembers: [
+										{
+											model: 'person',
+											uuid: SAM_PRITCHARD_PERSON_UUID,
+											name: 'Sam Pritchard'
+										},
+										{
+											model: 'person',
+											uuid: VICKY_FEATHERSTONE_PERSON_UUID,
+											name: 'Vicky Featherstone'
+										},
+										{
+											model: 'person',
+											uuid: LUCY_DAVIES_PERSON_UUID,
+											name: 'Lucy Davies'
+										}
+									]
+								},
 								{
 									model: 'company',
 									uuid: OLD_VIC_PRODUCTIONS_COMPANY_UUID,
@@ -2468,7 +2419,45 @@ describe('Productions with producer', () => {
 									model: 'person',
 									uuid: PAUL_ELLIOTT_PERSON_UUID,
 									name: 'Paul Elliott'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'production',
+					uuid: HANGMEN_WYNDHAMS_PRODUCTION_UUID,
+					name: 'Hangmen',
+					startDate: '2015-12-01',
+					endDate: '2016-03-05',
+					theatre: {
+						model: 'theatre',
+						uuid: WYNDHAMS_THEATRE_UUID,
+						name: 'Wyndham\'s Theatre',
+						surTheatre: null
+					},
+					producerCredits: [
+						{
+							model: 'producerCredit',
+							name: 'Co-Producers',
+							creditedMembers: [
+								{
+									model: 'person',
+									uuid: MATTHEW_BYAM_SHAW_PERSON_UUID,
+									name: 'Matthew Byam Shaw'
 								},
+								{
+									model: 'person',
+									uuid: NIA_JANIS_PERSON_UUID,
+									name: 'Nia Janis'
+								},
+								{
+									model: 'person',
+									uuid: NICK_SALMON_PERSON_UUID,
+									name: 'Nick Salmon'
+								}
+							],
+							coCreditedEntities: [
 								{
 									model: 'company',
 									uuid: ROYAL_COURT_THEATRE_COMPANY_UUID,
@@ -2481,15 +2470,26 @@ describe('Productions with producer', () => {
 										},
 										{
 											model: 'person',
-											uuid: HAMISH_PIRIE_PERSON_UUID,
-											name: 'Hamish Pirie'
+											uuid: LUCY_DAVIES_PERSON_UUID,
+											name: 'Lucy Davies'
 										},
 										{
 											model: 'person',
-											uuid: LUCY_DAVIES_PERSON_UUID,
-											name: 'Lucy Davies'
+											uuid: OLA_INCE_PERSON_UUID,
+											name: 'Ola Ince'
 										}
 									]
+								},
+								{
+									model: 'person',
+									uuid: PAUL_ELLIOTT_PERSON_UUID,
+									name: 'Paul Elliott'
+								},
+								{
+									model: 'company',
+									uuid: OLD_VIC_PRODUCTIONS_COMPANY_UUID,
+									name: 'Old Vic Productions',
+									creditedMembers: []
 								},
 								{
 									model: 'person',

--- a/test-e2e/model-interaction/roles-with-alternating-cast.test.js
+++ b/test-e2e/model-interaction/roles-with-alternating-cast.test.js
@@ -175,51 +175,6 @@ describe('Roles with alternating cast', () => {
 			const expectedProductions = [
 				{
 					model: 'production',
-					uuid: TRUE_WEST_CRUCIBLE_PRODUCTION_UUID,
-					name: 'True West',
-					startDate: '2010-05-13',
-					endDate: '2010-06-05',
-					theatre: {
-						model: 'theatre',
-						uuid: CRUCIBLE_THEATRE_UUID,
-						name: 'Crucible Theatre',
-						surTheatre: null
-					},
-					performers: [
-						{
-							model: 'person',
-							uuid: NIGEL_HARMAN_PERSON_UUID,
-							name: 'Nigel Harman',
-							roleName: 'Austin',
-							qualifier: null,
-							otherRoles: [
-								{
-									model: 'character',
-									uuid: LEE_CHARACTER_UUID,
-									name: 'Lee',
-									qualifier: null
-								}
-							]
-						},
-						{
-							model: 'person',
-							uuid: JOHN_LIGHT_PERSON_UUID,
-							name: 'John Light',
-							roleName: 'Austin',
-							qualifier: null,
-							otherRoles: [
-								{
-									model: 'character',
-									uuid: LEE_CHARACTER_UUID,
-									name: 'Lee',
-									qualifier: null
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'production',
 					uuid: TRUE_WEST_VAUDEVILLE_PRODUCTION_UUID,
 					name: 'True West',
 					startDate: '2018-11-23',
@@ -250,6 +205,51 @@ describe('Roles with alternating cast', () => {
 							model: 'person',
 							uuid: JOHNNY_FLYNN_PERSON_UUID,
 							name: 'Johnny Flynn',
+							roleName: 'Austin',
+							qualifier: null,
+							otherRoles: [
+								{
+									model: 'character',
+									uuid: LEE_CHARACTER_UUID,
+									name: 'Lee',
+									qualifier: null
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'production',
+					uuid: TRUE_WEST_CRUCIBLE_PRODUCTION_UUID,
+					name: 'True West',
+					startDate: '2010-05-13',
+					endDate: '2010-06-05',
+					theatre: {
+						model: 'theatre',
+						uuid: CRUCIBLE_THEATRE_UUID,
+						name: 'Crucible Theatre',
+						surTheatre: null
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: NIGEL_HARMAN_PERSON_UUID,
+							name: 'Nigel Harman',
+							roleName: 'Austin',
+							qualifier: null,
+							otherRoles: [
+								{
+									model: 'character',
+									uuid: LEE_CHARACTER_UUID,
+									name: 'Lee',
+									qualifier: null
+								}
+							]
+						},
+						{
+							model: 'person',
+							uuid: JOHN_LIGHT_PERSON_UUID,
+							name: 'John Light',
 							roleName: 'Austin',
 							qualifier: null,
 							otherRoles: [
@@ -280,51 +280,6 @@ describe('Roles with alternating cast', () => {
 			const expectedProductions = [
 				{
 					model: 'production',
-					uuid: TRUE_WEST_CRUCIBLE_PRODUCTION_UUID,
-					name: 'True West',
-					startDate: '2010-05-13',
-					endDate: '2010-06-05',
-					theatre: {
-						model: 'theatre',
-						uuid: CRUCIBLE_THEATRE_UUID,
-						name: 'Crucible Theatre',
-						surTheatre: null
-					},
-					performers: [
-						{
-							model: 'person',
-							uuid: NIGEL_HARMAN_PERSON_UUID,
-							name: 'Nigel Harman',
-							roleName: 'Lee',
-							qualifier: null,
-							otherRoles: [
-								{
-									model: 'character',
-									uuid: AUSTIN_CHARACTER_UUID,
-									name: 'Austin',
-									qualifier: null
-								}
-							]
-						},
-						{
-							model: 'person',
-							uuid: JOHN_LIGHT_PERSON_UUID,
-							name: 'John Light',
-							roleName: 'Lee',
-							qualifier: null,
-							otherRoles: [
-								{
-									model: 'character',
-									uuid: AUSTIN_CHARACTER_UUID,
-									name: 'Austin',
-									qualifier: null
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'production',
 					uuid: TRUE_WEST_VAUDEVILLE_PRODUCTION_UUID,
 					name: 'True West',
 					startDate: '2018-11-23',
@@ -355,6 +310,51 @@ describe('Roles with alternating cast', () => {
 							model: 'person',
 							uuid: JOHNNY_FLYNN_PERSON_UUID,
 							name: 'Johnny Flynn',
+							roleName: 'Lee',
+							qualifier: null,
+							otherRoles: [
+								{
+									model: 'character',
+									uuid: AUSTIN_CHARACTER_UUID,
+									name: 'Austin',
+									qualifier: null
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'production',
+					uuid: TRUE_WEST_CRUCIBLE_PRODUCTION_UUID,
+					name: 'True West',
+					startDate: '2010-05-13',
+					endDate: '2010-06-05',
+					theatre: {
+						model: 'theatre',
+						uuid: CRUCIBLE_THEATRE_UUID,
+						name: 'Crucible Theatre',
+						surTheatre: null
+					},
+					performers: [
+						{
+							model: 'person',
+							uuid: NIGEL_HARMAN_PERSON_UUID,
+							name: 'Nigel Harman',
+							roleName: 'Lee',
+							qualifier: null,
+							otherRoles: [
+								{
+									model: 'character',
+									uuid: AUSTIN_CHARACTER_UUID,
+									name: 'Austin',
+									qualifier: null
+								}
+							]
+						},
+						{
+							model: 'person',
+							uuid: JOHN_LIGHT_PERSON_UUID,
+							name: 'John Light',
 							roleName: 'Lee',
 							qualifier: null,
 							otherRoles: [

--- a/test-e2e/model-interaction/theatre-with-multi-prods.test.js
+++ b/test-e2e/model-interaction/theatre-with-multi-prods.test.js
@@ -93,10 +93,10 @@ describe('Theatre with multiple productions', () => {
 			const expectedProductions = [
 				{
 					model: 'production',
-					uuid: A_STREETCAR_NAMED_DESIRE_DONMAR_PRODUCTION_UUID,
-					name: 'A Streetcar Named Desire',
-					startDate: '2009-07-23',
-					endDate: '2009-10-03',
+					uuid: RED_DONMAR_PRODUCTION_UUID,
+					name: 'Red',
+					startDate: '2009-12-03',
+					endDate: '2010-02-06',
 					subTheatre: null
 				},
 				{
@@ -109,10 +109,10 @@ describe('Theatre with multiple productions', () => {
 				},
 				{
 					model: 'production',
-					uuid: RED_DONMAR_PRODUCTION_UUID,
-					name: 'Red',
-					startDate: '2009-12-03',
-					endDate: '2010-02-06',
+					uuid: A_STREETCAR_NAMED_DESIRE_DONMAR_PRODUCTION_UUID,
+					name: 'A Streetcar Named Desire',
+					startDate: '2009-07-23',
+					endDate: '2009-10-03',
 					subTheatre: null
 				}
 			];


### PR DESCRIPTION
This PR applies a primary ordering clause of `production.startDate DESC` (i.e. productions with the most recent start date come first) wherever productions are listed, e.g. a person credit page lists the productions in which they appeared in the cast.