### PR TITLE
Add classes with more granular responsibilities

### DIFF
--- a/src/models/CharacterDepiction.js
+++ b/src/models/CharacterDepiction.js
@@ -1,0 +1,32 @@
+import Character from './Character';
+
+export default class CharacterDepiction extends Character {
+
+	constructor (props = {}) {
+
+		super(props);
+
+		const { underlyingName, qualifier } = props;
+
+		this.underlyingName = underlyingName?.trim() || '';
+		this.qualifier = qualifier?.trim() || '';
+
+	}
+
+	validateUnderlyingName () {
+
+		this.validateStringForProperty('underlyingName', { isRequired: false });
+
+	}
+
+	validateCharacterNameUnderlyingNameDisparity () {
+
+		if (Boolean(this.underlyingName) && this.name === this.underlyingName) {
+
+			this.addPropertyError('underlyingName', 'Underlying name is only required if different from character name');
+
+		}
+
+	}
+
+}

--- a/src/models/CharacterGroup.js
+++ b/src/models/CharacterGroup.js
@@ -1,6 +1,6 @@
 import { getDuplicateCharacterIndices } from '../lib/get-duplicate-indices';
 import Base from './Base';
-import { Character } from '.';
+import { CharacterDepiction } from '.';
 
 export default class CharacterGroup extends Base {
 
@@ -11,7 +11,7 @@ export default class CharacterGroup extends Base {
 		const { characters } = props;
 
 		this.characters = characters
-			? characters.map(character => new Character({ ...character, isAssociation: true }))
+			? characters.map(character => new CharacterDepiction(character))
 			: [];
 
 	}

--- a/src/models/Company.js
+++ b/src/models/Company.js
@@ -1,5 +1,4 @@
 import Base from './Base';
-import { Person } from '.';
 
 export default class Company extends Base {
 
@@ -7,18 +6,10 @@ export default class Company extends Base {
 
 		super(props);
 
-		const { uuid, differentiator, creditedMembers, isProductionAssociation } = props;
+		const { uuid, differentiator } = props;
 
 		this.uuid = uuid;
 		this.differentiator = differentiator?.trim() || '';
-
-		if (isProductionAssociation) {
-
-			this.creditedMembers = creditedMembers
-				? creditedMembers.map(creditedMember => new Person(creditedMember))
-				: [];
-
-		}
 
 	}
 

--- a/src/models/CompanyWithCreditedMembers.js
+++ b/src/models/CompanyWithCreditedMembers.js
@@ -1,0 +1,37 @@
+import { isEntityInArray } from '../lib/get-duplicate-entity-info';
+import Company from './Company';
+import { Person } from '.';
+
+export default class CompanyWithCreditedMembers extends Company {
+
+	constructor (props = {}) {
+
+		super(props);
+
+		const { creditedMembers } = props;
+
+		this.creditedMembers = creditedMembers
+			? creditedMembers.map(creditedMember => new Person(creditedMember))
+			: [];
+
+	}
+
+	runInputValidations (opts) {
+
+		this.validateNamePresenceIfNamedChildren(this.creditedMembers);
+
+		this.creditedMembers.forEach(creditedMember => {
+
+			creditedMember.validateName({ isRequired: false });
+
+			creditedMember.validateDifferentiator();
+
+			creditedMember.validateUniquenessInGroup(
+				{ isDuplicate: isEntityInArray(creditedMember, opts.duplicateEntities) }
+			);
+
+		});
+
+	}
+
+}

--- a/src/models/Material.js
+++ b/src/models/Material.js
@@ -1,47 +1,31 @@
 import { getDuplicateNameIndices } from '../lib/get-duplicate-indices';
-import Base from './Base';
+import MaterialBase from './MaterialBase';
 import { CharacterGroup, WritingCredit } from '.';
 
-export default class Material extends Base {
+export default class Material extends MaterialBase {
 
 	constructor (props = {}) {
 
 		super(props);
 
 		const {
-			uuid,
-			differentiator,
 			format,
 			originalVersionMaterial,
 			writingCredits,
-			characterGroups,
-			isAssociation
+			characterGroups
 		} = props;
 
-		this.uuid = uuid;
-		this.differentiator = differentiator?.trim() || '';
+		this.format = format?.trim() || '';
 
-		if (!isAssociation) {
+		this.originalVersionMaterial = new MaterialBase(originalVersionMaterial);
 
-			this.format = format?.trim() || '';
+		this.writingCredits = writingCredits
+			? writingCredits.map(writingCredit => new WritingCredit(writingCredit))
+			: [];
 
-			this.originalVersionMaterial = new Material({ ...originalVersionMaterial, isAssociation: true });
-
-			this.writingCredits = writingCredits
-				? writingCredits.map(writingCredit => new WritingCredit(writingCredit))
-				: [];
-
-			this.characterGroups = characterGroups
-				? characterGroups.map(characterGroup => new CharacterGroup(characterGroup))
-				: [];
-
-		}
-
-	}
-
-	get model () {
-
-		return 'material';
+		this.characterGroups = characterGroups
+			? characterGroups.map(characterGroup => new CharacterGroup(characterGroup))
+			: [];
 
 	}
 

--- a/src/models/MaterialBase.js
+++ b/src/models/MaterialBase.js
@@ -1,6 +1,6 @@
 import Base from './Base';
 
-export default class Character extends Base {
+export default class MaterialBase extends Base {
 
 	constructor (props = {}) {
 
@@ -15,7 +15,7 @@ export default class Character extends Base {
 
 	get model () {
 
-		return 'character';
+		return 'material';
 
 	}
 

--- a/src/models/ProducerCredit.js
+++ b/src/models/ProducerCredit.js
@@ -1,6 +1,6 @@
 import { getDuplicateEntities, isEntityInArray } from '../lib/get-duplicate-entity-info';
 import Base from './Base';
-import { Company, Person } from '.';
+import { CompanyWithCreditedMembers, Person } from '.';
 
 export default class ProducerCredit extends Base {
 
@@ -14,7 +14,7 @@ export default class ProducerCredit extends Base {
 			? entities.map(entity => {
 				switch (entity.model) {
 					case 'company':
-						return new Company({ ...entity, isProductionAssociation: true });
+						return new CompanyWithCreditedMembers(entity);
 					default:
 						return new Person(entity);
 				}
@@ -45,23 +45,7 @@ export default class ProducerCredit extends Base {
 
 			entity.validateUniquenessInGroup({ isDuplicate: isEntityInArray(entity, duplicateEntities) });
 
-			if (entity.model === 'company') {
-
-				entity.validateNamePresenceIfNamedChildren(entity.creditedMembers);
-
-				entity.creditedMembers.forEach(creditedMember => {
-
-					creditedMember.validateName({ isRequired: false });
-
-					creditedMember.validateDifferentiator();
-
-					creditedMember.validateUniquenessInGroup(
-						{ isDuplicate: isEntityInArray(creditedMember, duplicateEntities) }
-					);
-
-				});
-
-			}
+			if (entity.model === 'company') entity.runInputValidations({ duplicateEntities });
 
 		});
 

--- a/src/models/Production.js
+++ b/src/models/Production.js
@@ -1,7 +1,7 @@
 import { getDuplicateBaseInstanceIndices, getDuplicateNameIndices } from '../lib/get-duplicate-indices';
 import { isValidDate } from '../lib/is-valid-date';
 import Base from './Base';
-import { CastMember, CreativeCredit, CrewCredit, Material, ProducerCredit, Venue } from '.';
+import { CastMember, CreativeCredit, CrewCredit, MaterialBase, ProducerCredit, VenueBase } from '.';
 
 export default class Production extends Base {
 
@@ -30,9 +30,9 @@ export default class Production extends Base {
 
 		this.endDate = endDate?.trim() || '';
 
-		this.material = new Material({ ...material, isAssociation: true });
+		this.material = new MaterialBase(material);
 
-		this.venue = new Venue({ ...venue, isAssociation: true });
+		this.venue = new VenueBase(venue);
 
 		this.producerCredits = producerCredits
 			? producerCredits.map(producerCredit => new ProducerCredit(producerCredit))

--- a/src/models/ProductionTeamCredit.js
+++ b/src/models/ProductionTeamCredit.js
@@ -1,6 +1,6 @@
 import { getDuplicateEntities, isEntityInArray } from '../lib/get-duplicate-entity-info';
 import Base from './Base';
-import { Company, Person } from '.';
+import { CompanyWithCreditedMembers, Person } from '.';
 
 export default class ProductionTeamCredit extends Base {
 
@@ -14,7 +14,7 @@ export default class ProductionTeamCredit extends Base {
 			? entities.map(entity => {
 				switch (entity.model) {
 					case 'company':
-						return new Company({ ...entity, isProductionAssociation: true });
+						return new CompanyWithCreditedMembers(entity);
 					default:
 						return new Person(entity);
 				}
@@ -41,23 +41,7 @@ export default class ProductionTeamCredit extends Base {
 
 			entity.validateUniquenessInGroup({ isDuplicate: isEntityInArray(entity, duplicateEntities) });
 
-			if (entity.model === 'company') {
-
-				entity.validateNamePresenceIfNamedChildren(entity.creditedMembers);
-
-				entity.creditedMembers.forEach(creditedMember => {
-
-					creditedMember.validateName({ isRequired: false });
-
-					creditedMember.validateDifferentiator();
-
-					creditedMember.validateUniquenessInGroup(
-						{ isDuplicate: isEntityInArray(creditedMember, duplicateEntities) }
-					);
-
-				});
-
-			}
+			if (entity.model === 'company') entity.runInputValidations({ duplicateEntities });
 
 		});
 

--- a/src/models/Venue.js
+++ b/src/models/Venue.js
@@ -1,30 +1,17 @@
 import { getDuplicateBaseInstanceIndices } from '../lib/get-duplicate-indices';
-import Base from './Base';
+import VenueBase from './VenueBase';
 
-export default class Venue extends Base {
+export default class Venue extends VenueBase {
 
 	constructor (props = {}) {
 
 		super(props);
 
-		const { uuid, differentiator, subVenues, isAssociation } = props;
+		const { subVenues } = props;
 
-		this.uuid = uuid;
-		this.differentiator = differentiator?.trim() || '';
-
-		if (!isAssociation) {
-
-			this.subVenues = subVenues
-				? subVenues.map(subVenue => new this.constructor({ ...subVenue, isAssociation: true }))
-				: [];
-
-		}
-
-	}
-
-	get model () {
-
-		return 'venue';
+		this.subVenues = subVenues
+			? subVenues.map(subVenue => new VenueBase(subVenue))
+			: [];
 
 	}
 

--- a/src/models/VenueBase.js
+++ b/src/models/VenueBase.js
@@ -1,6 +1,6 @@
 import Base from './Base';
 
-export default class Character extends Base {
+export default class Venue extends Base {
 
 	constructor (props = {}) {
 
@@ -15,7 +15,7 @@ export default class Character extends Base {
 
 	get model () {
 
-		return 'character';
+		return 'venue';
 
 	}
 

--- a/src/models/WritingCredit.js
+++ b/src/models/WritingCredit.js
@@ -1,6 +1,6 @@
 import { getDuplicateEntityIndices } from '../lib/get-duplicate-indices';
 import Base from './Base';
-import { Company, Person, Material } from '.';
+import { Company, Person, MaterialBase } from '.';
 import { CREDIT_TYPES } from '../utils/constants';
 
 export default class WritingCredit extends Base {
@@ -19,7 +19,7 @@ export default class WritingCredit extends Base {
 					case 'company':
 						return new Company(entity);
 					case 'material':
-						return new Material({ ...entity, isAssociation: true });
+						return new MaterialBase(entity);
 					default:
 						return new Person(entity);
 				}

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,29 +1,37 @@
 import CastMember from './CastMember';
 import Character from './Character';
+import CharacterDepiction from './CharacterDepiction';
 import CharacterGroup from './CharacterGroup';
 import Company from './Company';
+import CompanyWithCreditedMembers from './CompanyWithCreditedMembers';
 import CreativeCredit from './CreativeCredit';
 import CrewCredit from './CrewCredit';
 import Material from './Material';
+import MaterialBase from './MaterialBase';
 import Person from './Person';
 import ProducerCredit from './ProducerCredit';
 import Production from './Production';
 import Role from './Role';
 import Venue from './Venue';
+import VenueBase from './VenueBase';
 import WritingCredit from './WritingCredit';
 
 export {
 	CastMember,
 	Character,
+	CharacterDepiction,
 	CharacterGroup,
 	Company,
+	CompanyWithCreditedMembers,
 	CreativeCredit,
 	CrewCredit,
 	Material,
+	MaterialBase,
 	Person,
 	ProducerCredit,
 	Production,
 	Role,
 	Venue,
+	VenueBase,
 	WritingCredit
 };

--- a/test-unit/src/models/CharacterDepiction.test.js
+++ b/test-unit/src/models/CharacterDepiction.test.js
@@ -1,0 +1,131 @@
+import { expect } from 'chai';
+import { spy } from 'sinon';
+
+import CharacterDepiction from '../../../src/models/CharacterDepiction';
+
+describe('CharacterDepiction model', () => {
+
+	describe('constructor method', () => {
+
+		describe('underlyingName property', () => {
+
+			it('assigns empty string if absent from props', () => {
+
+				const instance = new CharacterDepiction({ name: 'Prince Hal' });
+				expect(instance.underlyingName).to.equal('');
+
+			});
+
+			it('assigns empty string if included in props but value is empty string', () => {
+
+				const instance = new CharacterDepiction({ name: 'Prince Hal', underlyingName: '' });
+				expect(instance.underlyingName).to.equal('');
+
+			});
+
+			it('assigns empty string if included in props but value is whitespace-only string', () => {
+
+				const instance = new CharacterDepiction({ name: 'Prince Hal', underlyingName: ' ' });
+				expect(instance.underlyingName).to.equal('');
+
+			});
+
+			it('assigns value if included in props and value is string with length', () => {
+
+				const instance = new CharacterDepiction({ name: 'Prince Hal', underlyingName: 'King Henry V' });
+				expect(instance.underlyingName).to.equal('King Henry V');
+
+			});
+
+			it('trims value before assigning', () => {
+
+				const instance = new CharacterDepiction({ name: 'Prince Hal', underlyingName: ' King Henry V ' });
+				expect(instance.underlyingName).to.equal('King Henry V');
+
+			});
+
+		});
+
+	});
+
+	describe('validateUnderlyingName method', () => {
+
+		it('will call validateStringForProperty method', () => {
+
+			const instance = new CharacterDepiction({ name: 'Prince Hal', underlyingName: 'King Henry V' });
+			spy(instance, 'validateStringForProperty');
+			instance.validateUnderlyingName();
+			expect(instance.validateStringForProperty.calledOnce).to.be.true;
+			expect(instance.validateStringForProperty.calledWithExactly(
+				'underlyingName', { isRequired: false }
+			)).to.be.true;
+
+		});
+
+	});
+
+	describe('validateCharacterNameUnderlyingNameDisparity method', () => {
+
+		context('valid data', () => {
+
+			context('role name without a character name', () => {
+
+				it('will not add properties to errors property', () => {
+
+					const instance = new CharacterDepiction({ name: 'Prince Hal', underlyingName: '' });
+					spy(instance, 'addPropertyError');
+					instance.validateCharacterNameUnderlyingNameDisparity();
+					expect(instance.addPropertyError.notCalled).to.be.true;
+
+				});
+
+			});
+
+			context('role name and different character name', () => {
+
+				it('will not add properties to errors property', () => {
+
+					const instance = new CharacterDepiction({ name: 'Prince Hal', underlyingName: 'King Henry V' });
+					spy(instance, 'addPropertyError');
+					instance.validateCharacterNameUnderlyingNameDisparity();
+					expect(instance.addPropertyError.notCalled).to.be.true;
+
+				});
+
+			});
+
+			context('no role name and no character name', () => {
+
+				it('will not add properties to errors property', () => {
+
+					const instance = new CharacterDepiction({ name: '', underlyingName: '' });
+					spy(instance, 'addPropertyError');
+					instance.validateCharacterNameUnderlyingNameDisparity();
+					expect(instance.addPropertyError.notCalled).to.be.true;
+
+				});
+
+			});
+
+		});
+
+		context('invalid data', () => {
+
+			it('adds properties whose values are arrays to errors property', () => {
+
+				const instance = new CharacterDepiction({ name: 'King Henry V', underlyingName: 'King Henry V' });
+				spy(instance, 'addPropertyError');
+				instance.validateCharacterNameUnderlyingNameDisparity();
+				expect(instance.addPropertyError.calledOnce).to.be.true;
+				expect(instance.addPropertyError.calledWithExactly(
+					'underlyingName',
+					'Underlying name is only required if different from character name'
+				)).to.be.true;
+
+			});
+
+		});
+
+	});
+
+});

--- a/test-unit/src/models/CharacterGroup.test.js
+++ b/test-unit/src/models/CharacterGroup.test.js
@@ -2,15 +2,15 @@ import { expect } from 'chai';
 import proxyquire from 'proxyquire';
 import { assert, createStubInstance, spy, stub } from 'sinon';
 
-import { Character } from '../../../src/models';
+import { CharacterDepiction } from '../../../src/models';
 
 describe('CharacterGroup model', () => {
 
 	let stubs;
 
-	const CharacterStub = function () {
+	const CharacterDepictionStub = function () {
 
-		return createStubInstance(Character);
+		return createStubInstance(CharacterDepiction);
 
 	};
 
@@ -21,7 +21,7 @@ describe('CharacterGroup model', () => {
 				getDuplicateCharacterIndices: stub().returns([])
 			},
 			models: {
-				Character: CharacterStub
+				CharacterDepiction: CharacterDepictionStub
 			}
 		};
 
@@ -70,9 +70,9 @@ describe('CharacterGroup model', () => {
 				};
 				const instance = createInstance(props);
 				expect(instance.characters.length).to.equal(3);
-				expect(instance.characters[0] instanceof Character).to.be.true;
-				expect(instance.characters[1] instanceof Character).to.be.true;
-				expect(instance.characters[2] instanceof Character).to.be.true;
+				expect(instance.characters[0] instanceof CharacterDepiction).to.be.true;
+				expect(instance.characters[1] instanceof CharacterDepiction).to.be.true;
+				expect(instance.characters[2] instanceof CharacterDepiction).to.be.true;
 
 			});
 

--- a/test-unit/src/models/Company.test.js
+++ b/test-unit/src/models/Company.test.js
@@ -1,41 +1,8 @@
 import { expect } from 'chai';
-import proxyquire from 'proxyquire';
-import { createStubInstance } from 'sinon';
 
-import { Person } from '../../../src/models';
+import Company from '../../../src/models/Company';
 
 describe('Company model', () => {
-
-	let stubs;
-
-	const PersonStub = function () {
-
-		return createStubInstance(Person);
-
-	};
-
-	beforeEach(() => {
-
-		stubs = {
-			models: {
-				Person: PersonStub
-			}
-		};
-
-	});
-
-	const createSubject = () =>
-		proxyquire('../../../src/models/Company', {
-			'.': stubs.models
-		}).default;
-
-	const createInstance = props => {
-
-		const Person = createSubject();
-
-		return new Person(props);
-
-	};
 
 	describe('constructor method', () => {
 
@@ -43,103 +10,36 @@ describe('Company model', () => {
 
 			it('assigns empty string if absent from props', () => {
 
-				const instance = createInstance({ name: 'London Theatre Company' });
+				const instance = new Company({ name: 'London Theatre Company' });
 				expect(instance.differentiator).to.equal('');
 
 			});
 
 			it('assigns empty string if included in props but value is empty string', () => {
 
-				const instance = createInstance({ name: 'London Theatre Company', differentiator: '' });
+				const instance = new Company({ name: 'London Theatre Company', differentiator: '' });
 				expect(instance.differentiator).to.equal('');
 
 			});
 
 			it('assigns empty string if included in props but value is whitespace-only string', () => {
 
-				const instance = createInstance({ name: 'London Theatre Company', differentiator: ' ' });
+				const instance = new Company({ name: 'London Theatre Company', differentiator: ' ' });
 				expect(instance.differentiator).to.equal('');
 
 			});
 
 			it('assigns value if included in props and value is string with length', () => {
 
-				const instance = createInstance({ name: 'London Theatre Company', differentiator: '1' });
+				const instance = new Company({ name: 'London Theatre Company', differentiator: '1' });
 				expect(instance.differentiator).to.equal('1');
 
 			});
 
 			it('trims value before assigning', () => {
 
-				const instance = createInstance({ name: 'London Theatre Company', differentiator: ' 1 ' });
+				const instance = new Company({ name: 'London Theatre Company', differentiator: ' 1 ' });
 				expect(instance.differentiator).to.equal('1');
-
-			});
-
-		});
-
-		describe('creditedMembers property', () => {
-
-			context('it is not an association of a production instance', () => {
-
-				it('will not assign any value if absent from props', () => {
-
-					const props = { name: 'Autograph' };
-					const instance = createInstance(props);
-					expect(instance).not.to.have.property('creditedMembers');
-
-				});
-
-				it('will not assign any value if included in props', () => {
-
-					const props = {
-						name: 'Autograph',
-						creditedMembers: [
-							{
-								name: 'Andrew Bruce'
-							}
-						]
-					};
-					const instance = createInstance(props);
-					expect(instance).not.to.have.property('creditedMembers');
-
-				});
-
-			});
-
-			context('instance is not subject, i.e. it is an association of a production instance', () => {
-
-				it('assigns empty array if absent from props', () => {
-
-					const instance = createInstance({ name: 'Autograph', isProductionAssociation: true });
-					expect(instance.creditedMembers).to.deep.equal([]);
-
-				});
-
-				it('assigns array of creditedMembers if included in props, retaining those with empty or whitespace-only string names', () => {
-
-					const props = {
-						name: 'Autograph',
-						creditedMembers: [
-							{
-								name: 'Andrew Bruce'
-							},
-							{
-								name: ''
-							},
-							{
-								name: ' '
-							}
-						],
-						isProductionAssociation: true
-					};
-					const instance = createInstance(props);
-					expect(instance.creditedMembers.length).to.equal(3);
-					expect(instance.creditedMembers[0] instanceof Person).to.be.true;
-					expect(instance.creditedMembers[1] instanceof Person).to.be.true;
-					expect(instance.creditedMembers[2] instanceof Person).to.be.true;
-
-				});
 
 			});
 

--- a/test-unit/src/models/CompanyWithCreditedMembers.test.js
+++ b/test-unit/src/models/CompanyWithCreditedMembers.test.js
@@ -1,0 +1,124 @@
+import { expect } from 'chai';
+import proxyquire from 'proxyquire';
+import { assert, createStubInstance, spy, stub } from 'sinon';
+
+import { Person } from '../../../src/models';
+
+describe('CompanyWithCreditedMembers model', () => {
+
+	let stubs;
+
+	const PersonStub = function () {
+
+		return createStubInstance(Person);
+
+	};
+
+	beforeEach(() => {
+
+		stubs = {
+			getDuplicatesInfoModule: {
+				isEntityInArray: stub().returns(false)
+			},
+			models: {
+				Person: PersonStub
+			}
+		};
+
+	});
+
+	const createSubject = () =>
+		proxyquire('../../../src/models/CompanyWithCreditedMembers', {
+			'../lib/get-duplicate-entity-info': stubs.getDuplicatesInfoModule,
+			'.': stubs.models
+		}).default;
+
+	const createInstance = props => {
+
+		const Person = createSubject();
+
+		return new Person(props);
+
+	};
+
+	describe('constructor method', () => {
+
+		describe('creditedMembers property', () => {
+
+			it('assigns empty array if absent from props', () => {
+
+				const instance = createInstance({ name: 'Autograph' });
+				expect(instance.creditedMembers).to.deep.equal([]);
+
+			});
+
+			it('assigns array of creditedMembers if included in props, retaining those with empty or whitespace-only string names', () => {
+
+				const props = {
+					name: 'Autograph',
+					creditedMembers: [
+						{
+							name: 'Andrew Bruce'
+						},
+						{
+							name: ''
+						},
+						{
+							name: ' '
+						}
+					]
+				};
+				const instance = createInstance(props);
+				expect(instance.creditedMembers.length).to.equal(3);
+				expect(instance.creditedMembers[0] instanceof Person).to.be.true;
+				expect(instance.creditedMembers[1] instanceof Person).to.be.true;
+				expect(instance.creditedMembers[2] instanceof Person).to.be.true;
+
+			});
+
+		});
+
+	});
+
+	describe('runInputValidations method', () => {
+
+		it('calls instance validate method and associated models\' validate methods', () => {
+
+			const props = {
+				name: 'Fiery Angel',
+				creditedMembers: [
+					{
+						name: 'Edward Snape'
+					}
+				]
+			};
+			const instance = createInstance(props);
+			instance.creditedMembers[0].name = 'Edward Snape';
+			spy(instance, 'validateNamePresenceIfNamedChildren');
+			instance.runInputValidations({ duplicateEntities: [] });
+			assert.callOrder(
+				instance.validateNamePresenceIfNamedChildren,
+				instance.creditedMembers[0].validateName,
+				instance.creditedMembers[0].validateDifferentiator,
+				stubs.getDuplicatesInfoModule.isEntityInArray,
+				instance.creditedMembers[0].validateUniquenessInGroup
+			);
+			expect(instance.validateNamePresenceIfNamedChildren.calledOnce).to.be.true;
+			expect(instance.creditedMembers[0].validateName.calledOnce).to.be.true;
+			expect(instance.creditedMembers[0].validateName.calledWithExactly({ isRequired: false })).to.be.true;
+			expect(instance.creditedMembers[0].validateDifferentiator.calledOnce).to.be.true;
+			expect(instance.creditedMembers[0].validateDifferentiator.calledWithExactly()).to.be.true;
+			expect(stubs.getDuplicatesInfoModule.isEntityInArray.calledOnce).to.be.true;
+			expect(stubs.getDuplicatesInfoModule.isEntityInArray.calledWithExactly(
+				instance.creditedMembers[0], []
+			)).to.be.true;
+			expect(instance.creditedMembers[0].validateUniquenessInGroup.calledOnce).to.be.true;
+			expect(instance.creditedMembers[0].validateUniquenessInGroup.calledWithExactly(
+				{ isDuplicate: false }
+			)).to.be.true;
+
+		});
+
+	});
+
+});

--- a/test-unit/src/models/Material.test.js
+++ b/test-unit/src/models/Material.test.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import proxyquire from 'proxyquire';
 import { assert, createStubInstance, spy, stub } from 'sinon';
 
-import { CharacterGroup, WritingCredit } from '../../../src/models';
+import { CharacterGroup, MaterialBase, WritingCredit } from '../../../src/models';
 
 describe('Material model', () => {
 
@@ -50,116 +50,46 @@ describe('Material model', () => {
 
 	describe('constructor method', () => {
 
-		describe('differentiator property', () => {
+		describe('format property', () => {
 
 			it('assigns empty string if absent from props', () => {
 
-				const instance = createInstance({ name: 'Home' });
-				expect(instance.differentiator).to.equal('');
+				const instance = createInstance({ name: 'The Tragedy of Hamlet, Prince of Denmark' });
+				expect(instance.format).to.equal('');
 
 			});
 
 			it('assigns empty string if included in props but value is empty string', () => {
 
-				const instance = createInstance({ name: 'Home', differentiator: '' });
-				expect(instance.differentiator).to.equal('');
+				const instance = createInstance({ name: 'The Tragedy of Hamlet, Prince of Denmark', format: '' });
+				expect(instance.format).to.equal('');
 
 			});
 
 			it('assigns empty string if included in props but value is whitespace-only string', () => {
 
-				const instance = createInstance({ name: 'Home', differentiator: ' ' });
-				expect(instance.differentiator).to.equal('');
+				const instance = createInstance({ name: 'The Tragedy of Hamlet, Prince of Denmark', format: ' ' });
+				expect(instance.format).to.equal('');
 
 			});
 
 			it('assigns value if included in props and value is string with length', () => {
 
-				const instance = createInstance({ name: 'Home', differentiator: '1' });
-				expect(instance.differentiator).to.equal('1');
+				const instance = createInstance({
+					name: 'The Tragedy of Hamlet, Prince of Denmark',
+					format: 'play'
+				});
+				expect(instance.format).to.equal('play');
 
 			});
 
 			it('trims value before assigning', () => {
 
-				const instance = createInstance({ name: 'Home', differentiator: ' 1 ' });
-				expect(instance.differentiator).to.equal('1');
-
-			});
-
-		});
-
-		describe('format property', () => {
-
-			context('instance is subject', () => {
-
-				it('assigns empty string if absent from props', () => {
-
-					const instance = createInstance({ name: 'The Tragedy of Hamlet, Prince of Denmark' });
-					expect(instance.format).to.equal('');
-
+				const instance = createInstance({
+					name: 'The Tragedy of Hamlet, Prince of Denmark',
+					format: ' play '
 				});
-
-				it('assigns empty string if included in props but value is empty string', () => {
-
-					const instance = createInstance({ name: 'The Tragedy of Hamlet, Prince of Denmark', format: '' });
-					expect(instance.format).to.equal('');
-
-				});
-
-				it('assigns empty string if included in props but value is whitespace-only string', () => {
-
-					const instance = createInstance({ name: 'The Tragedy of Hamlet, Prince of Denmark', format: ' ' });
-					expect(instance.format).to.equal('');
-
-				});
-
-				it('assigns value if included in props and value is string with length', () => {
-
-					const instance = createInstance({
-						name: 'The Tragedy of Hamlet, Prince of Denmark',
-						format: 'play'
-					});
-					expect(instance.format).to.equal('play');
-
-				});
-
-				it('trims value before assigning', () => {
-
-					const instance = createInstance({
-						name: 'The Tragedy of Hamlet, Prince of Denmark',
-						format: ' play '
-					});
-					expect(instance.format).to.equal('play');
-
-				});
-
-			});
-
-			context('instance is not subject, i.e. it is an association of another instance', () => {
-
-				it('will not assign any value if absent from props', () => {
-
-					const props = {
-						name: 'The Tragedy of Hamlet, Prince of Denmark',
-						isAssociation: true
-					};
-					const instance = createInstance(props);
-					expect(instance).not.to.have.property('format');
-
-				});
-
-				it('will not assign any value if included in props', () => {
-
-					const props = {
-						name: 'The Tragedy of Hamlet, Prince of Denmark',
-						format: 'play',
-						isAssociation: true
-					};
-					const instance = createInstance(props);
-					expect(instance).not.to.have.property('format');
-
-				});
+				expect(instance.format).to.equal('play');
 
 			});
 
@@ -167,63 +97,27 @@ describe('Material model', () => {
 
 		describe('originalVersionMaterial property', () => {
 
-			context('instance is subject', () => {
+			it('assigns instance if absent from props', () => {
 
-				it('assigns instance if absent from props', () => {
-
-					const instance = createInstance({
-						name: 'The Seagull',
-						differentiator: '2'
-					});
-					expect(instance.originalVersionMaterial.constructor.name).to.equal('Material');
-
+				const instance = createInstance({
+					name: 'The Seagull',
+					differentiator: '2'
 				});
-
-				it('assigns instance if included in props', () => {
-
-					const instance = createInstance({
-						name: 'The Seagull',
-						differentiator: '2',
-						originalVersionMaterial: {
-							name: 'The Seagull',
-							differentiator: '1'
-						}
-					});
-					expect(instance.originalVersionMaterial.constructor.name).to.equal('Material');
-
-				});
+				expect(instance.originalVersionMaterial instanceof MaterialBase).to.be.true;
 
 			});
 
-			context('instance is not subject, i.e. it is an association of another instance', () => {
+			it('assigns instance if included in props', () => {
 
-				it('will not assign any value if absent from props', () => {
-
-					const props = {
+				const instance = createInstance({
+					name: 'The Seagull',
+					differentiator: '2',
+					originalVersionMaterial: {
 						name: 'The Seagull',
-						differentiator: '2',
-						isAssociation: true
-					};
-					const instance = createInstance(props);
-					expect(instance).not.to.have.property('originalVersionMaterial');
-
+						differentiator: '1'
+					}
 				});
-
-				it('will not assign any value if included in props', () => {
-
-					const props = {
-						name: 'The Seagull',
-						differentiator: '2',
-						originalVersionMaterial: {
-							name: 'The Seagull',
-							differentiator: '1'
-						},
-						isAssociation: true
-					};
-					const instance = createInstance(props);
-					expect(instance).not.to.have.property('originalVersionMaterial');
-
-				});
+				expect(instance.originalVersionMaterial instanceof MaterialBase).to.be.true;
 
 			});
 
@@ -231,69 +125,34 @@ describe('Material model', () => {
 
 		describe('writingCredits property', () => {
 
-			context('instance is subject', () => {
+			it('assigns empty array if absent from props', () => {
 
-				it('assigns empty array if absent from props', () => {
-
-					const instance = createInstance({ name: 'The Tragedy of Hamlet, Prince of Denmark' });
-					expect(instance.writingCredits).to.deep.equal([]);
-
-				});
-
-				it('assigns array of writingCredits if included in props, retaining those with empty or whitespace-only string names', () => {
-
-					const props = {
-						name: 'The Tragedy of Hamlet, Prince of Denmark',
-						writingCredits: [
-							{
-								name: 'version by'
-							},
-							{
-								name: ''
-							},
-							{
-								name: ' '
-							}
-						]
-					};
-					const instance = createInstance(props);
-					expect(instance.writingCredits.length).to.equal(3);
-					expect(instance.writingCredits[0] instanceof WritingCredit).to.be.true;
-					expect(instance.writingCredits[1] instanceof WritingCredit).to.be.true;
-					expect(instance.writingCredits[2] instanceof WritingCredit).to.be.true;
-
-				});
+				const instance = createInstance({ name: 'The Tragedy of Hamlet, Prince of Denmark' });
+				expect(instance.writingCredits).to.deep.equal([]);
 
 			});
 
-			context('instance is not subject, i.e. it is an association of another instance', () => {
+			it('assigns array of writingCredits if included in props, retaining those with empty or whitespace-only string names', () => {
 
-				it('will not assign any value if absent from props', () => {
-
-					const props = {
-						name: 'The Tragedy of Hamlet, Prince of Denmark',
-						isAssociation: true
-					};
-					const instance = createInstance(props);
-					expect(instance).not.to.have.property('writingCredits');
-
-				});
-
-				it('will not assign any value if included in props', () => {
-
-					const props = {
-						name: 'The Tragedy of Hamlet, Prince of Denmark',
-						writingCredits: [
-							{
-								name: 'version by'
-							}
-						],
-						isAssociation: true
-					};
-					const instance = createInstance(props);
-					expect(instance).not.to.have.property('writingCredits');
-
-				});
+				const props = {
+					name: 'The Tragedy of Hamlet, Prince of Denmark',
+					writingCredits: [
+						{
+							name: 'version by'
+						},
+						{
+							name: ''
+						},
+						{
+							name: ' '
+						}
+					]
+				};
+				const instance = createInstance(props);
+				expect(instance.writingCredits.length).to.equal(3);
+				expect(instance.writingCredits[0] instanceof WritingCredit).to.be.true;
+				expect(instance.writingCredits[1] instanceof WritingCredit).to.be.true;
+				expect(instance.writingCredits[2] instanceof WritingCredit).to.be.true;
 
 			});
 
@@ -301,69 +160,34 @@ describe('Material model', () => {
 
 		describe('characterGroups property', () => {
 
-			context('instance is subject', () => {
+			it('assigns empty array if absent from props', () => {
 
-				it('assigns empty array if absent from props', () => {
-
-					const instance = createInstance({ name: 'The Tragedy of Hamlet, Prince of Denmark' });
-					expect(instance.characterGroups).to.deep.equal([]);
-
-				});
-
-				it('assigns array of characterGroups if included in props, retaining those with empty or whitespace-only string names', () => {
-
-					const props = {
-						name: 'The Tragedy of Hamlet, Prince of Denmark',
-						characterGroups: [
-							{
-								name: 'Court of Elsinore'
-							},
-							{
-								name: ''
-							},
-							{
-								name: ' '
-							}
-						]
-					};
-					const instance = createInstance(props);
-					expect(instance.characterGroups.length).to.equal(3);
-					expect(instance.characterGroups[0] instanceof CharacterGroup).to.be.true;
-					expect(instance.characterGroups[1] instanceof CharacterGroup).to.be.true;
-					expect(instance.characterGroups[2] instanceof CharacterGroup).to.be.true;
-
-				});
+				const instance = createInstance({ name: 'The Tragedy of Hamlet, Prince of Denmark' });
+				expect(instance.characterGroups).to.deep.equal([]);
 
 			});
 
-			context('instance is not subject, i.e. it is an association of another instance', () => {
+			it('assigns array of characterGroups if included in props, retaining those with empty or whitespace-only string names', () => {
 
-				it('will not assign any value if absent from props', () => {
-
-					const props = {
-						name: 'The Tragedy of Hamlet, Prince of Denmark',
-						isAssociation: true
-					};
-					const instance = createInstance(props);
-					expect(instance).not.to.have.property('characterGroups');
-
-				});
-
-				it('will not assign any value if included in props', () => {
-
-					const props = {
-						name: 'The Tragedy of Hamlet, Prince of Denmark',
-						characterGroups: [
-							{
-								name: 'Court of Elsinore'
-							}
-						],
-						isAssociation: true
-					};
-					const instance = createInstance(props);
-					expect(instance).not.to.have.property('characterGroups');
-
-				});
+				const props = {
+					name: 'The Tragedy of Hamlet, Prince of Denmark',
+					characterGroups: [
+						{
+							name: 'Court of Elsinore'
+						},
+						{
+							name: ''
+						},
+						{
+							name: ' '
+						}
+					]
+				};
+				const instance = createInstance(props);
+				expect(instance.characterGroups.length).to.equal(3);
+				expect(instance.characterGroups[0] instanceof CharacterGroup).to.be.true;
+				expect(instance.characterGroups[1] instanceof CharacterGroup).to.be.true;
+				expect(instance.characterGroups[2] instanceof CharacterGroup).to.be.true;
 
 			});
 

--- a/test-unit/src/models/MaterialBase.test.js
+++ b/test-unit/src/models/MaterialBase.test.js
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 
-import Character from '../../../src/models/Character';
+import MaterialBase from '../../../src/models/MaterialBase';
 
-describe('Character model', () => {
+describe('MaterialBase model', () => {
 
 	describe('constructor method', () => {
 
@@ -10,35 +10,35 @@ describe('Character model', () => {
 
 			it('assigns empty string if absent from props', () => {
 
-				const instance = new Character({ name: 'Demetrius' });
+				const instance = new MaterialBase({ name: 'The Seagull' });
 				expect(instance.differentiator).to.equal('');
 
 			});
 
 			it('assigns empty string if included in props but value is empty string', () => {
 
-				const instance = new Character({ name: 'Demetrius', differentiator: '' });
+				const instance = new MaterialBase({ name: 'The Seagull', differentiator: '' });
 				expect(instance.differentiator).to.equal('');
 
 			});
 
 			it('assigns empty string if included in props but value is whitespace-only string', () => {
 
-				const instance = new Character({ name: 'Demetrius', differentiator: ' ' });
+				const instance = new MaterialBase({ name: 'The Seagull', differentiator: ' ' });
 				expect(instance.differentiator).to.equal('');
 
 			});
 
 			it('assigns value if included in props and value is string with length', () => {
 
-				const instance = new Character({ name: 'Demetrius', differentiator: '1' });
+				const instance = new MaterialBase({ name: 'The Seagull', differentiator: '1' });
 				expect(instance.differentiator).to.equal('1');
 
 			});
 
 			it('trims value before assigning', () => {
 
-				const instance = new Character({ name: 'Demetrius', differentiator: ' 1 ' });
+				const instance = new MaterialBase({ name: 'The Seagull', differentiator: ' 1 ' });
 				expect(instance.differentiator).to.equal('1');
 
 			});

--- a/test-unit/src/models/ProducerCredit.test.js
+++ b/test-unit/src/models/ProducerCredit.test.js
@@ -2,15 +2,15 @@ import { expect } from 'chai';
 import proxyquire from 'proxyquire';
 import { assert, createStubInstance, spy, stub } from 'sinon';
 
-import { Company, Person } from '../../../src/models';
+import { CompanyWithCreditedMembers, Person } from '../../../src/models';
 
 describe('ProducerCredit model', () => {
 
 	let stubs;
 
-	const CompanyStub = function () {
+	const CompanyWithCreditedMembersStub = function () {
 
-		return createStubInstance(Company);
+		return createStubInstance(CompanyWithCreditedMembers);
 
 	};
 
@@ -28,7 +28,7 @@ describe('ProducerCredit model', () => {
 				isEntityInArray: stub().returns(false)
 			},
 			models: {
-				Company: CompanyStub,
+				CompanyWithCreditedMembers: CompanyWithCreditedMembersStub,
 				Person: PersonStub
 			}
 		};
@@ -91,11 +91,11 @@ describe('ProducerCredit model', () => {
 				const instance = createInstance(props);
 				expect(instance.entities.length).to.equal(6);
 				expect(instance.entities[0] instanceof Person).to.be.true;
-				expect(instance.entities[1] instanceof Company).to.be.true;
+				expect(instance.entities[1] instanceof CompanyWithCreditedMembers).to.be.true;
 				expect(instance.entities[2] instanceof Person).to.be.true;
-				expect(instance.entities[3] instanceof Company).to.be.true;
+				expect(instance.entities[3] instanceof CompanyWithCreditedMembers).to.be.true;
 				expect(instance.entities[4] instanceof Person).to.be.true;
-				expect(instance.entities[5] instanceof Company).to.be.true;
+				expect(instance.entities[5] instanceof CompanyWithCreditedMembers).to.be.true;
 
 			});
 
@@ -115,20 +115,13 @@ describe('ProducerCredit model', () => {
 					},
 					{
 						model: 'company',
-						name: 'Fiery Angel',
-						creditedMembers: [
-							{
-								name: 'Edward Snape'
-							}
-						]
+						name: 'Fiery Angel'
 					}
 				]
 			};
 			const instance = createInstance(props);
 			instance.entities[0].name = 'Jason Haigh-Ellery';
 			instance.entities[1].name = 'Fiery Angel';
-			instance.entities[1].creditedMembers = [createStubInstance(Person)];
-			instance.entities[1].creditedMembers[0].name = 'Edward Snape';
 			spy(instance, 'validateName');
 			spy(instance, 'validateUniquenessInGroup');
 			spy(instance, 'validateNamePresenceIfNamedChildren');
@@ -145,11 +138,7 @@ describe('ProducerCredit model', () => {
 				instance.entities[1].validateDifferentiator,
 				stubs.getDuplicatesInfoModule.isEntityInArray,
 				instance.entities[1].validateUniquenessInGroup,
-				instance.entities[1].validateNamePresenceIfNamedChildren,
-				instance.entities[1].creditedMembers[0].validateName,
-				instance.entities[1].creditedMembers[0].validateDifferentiator,
-				stubs.getDuplicatesInfoModule.isEntityInArray,
-				instance.entities[1].creditedMembers[0].validateUniquenessInGroup
+				instance.entities[1].runInputValidations
 			);
 			expect(instance.validateName.calledOnce).to.be.true;
 			expect(instance.validateName.calledWithExactly({ isRequired: false })).to.be.true;
@@ -163,7 +152,7 @@ describe('ProducerCredit model', () => {
 			expect(instance.entities[0].validateName.calledWithExactly({ isRequired: false })).to.be.true;
 			expect(instance.entities[0].validateDifferentiator.calledOnce).to.be.true;
 			expect(instance.entities[0].validateDifferentiator.calledWithExactly()).to.be.true;
-			expect(stubs.getDuplicatesInfoModule.isEntityInArray.calledThrice).to.be.true;
+			expect(stubs.getDuplicatesInfoModule.isEntityInArray.calledTwice).to.be.true;
 			expect(stubs.getDuplicatesInfoModule.isEntityInArray.getCall(0).calledWithExactly(
 				instance.entities[0], 'getDuplicateEntities response'
 			)).to.be.true;
@@ -182,23 +171,9 @@ describe('ProducerCredit model', () => {
 			expect(instance.entities[1].validateUniquenessInGroup.calledWithExactly(
 				{ isDuplicate: false }
 			)).to.be.true;
-			expect(instance.entities[1].validateNamePresenceIfNamedChildren.calledOnce).to.be.true;
-			expect(instance.entities[1].validateNamePresenceIfNamedChildren.calledWithExactly(
-				instance.entities[1].creditedMembers
-			)).to.be.true;
-			expect(instance.entities[1].creditedMembers[0].validateName.calledOnce).to.be.true;
-			expect(instance.entities[1].creditedMembers[0].validateName.calledWithExactly(
-				{ isRequired: false }
-			)).to.be.true;
-			expect(instance.entities[1].creditedMembers[0].validateDifferentiator.calledOnce).to.be.true;
-			expect(instance.entities[1].creditedMembers[0].validateDifferentiator.calledWithExactly())
-				.to.be.true;
-			expect(stubs.getDuplicatesInfoModule.isEntityInArray.getCall(2).calledWithExactly(
-				instance.entities[1].creditedMembers[0], 'getDuplicateEntities response'
-			)).to.be.true;
-			expect(instance.entities[1].creditedMembers[0].validateUniquenessInGroup.calledOnce).to.be.true;
-			expect(instance.entities[1].creditedMembers[0].validateUniquenessInGroup.calledWithExactly(
-				{ isDuplicate: false }
+			expect(instance.entities[1].runInputValidations.calledOnce).to.be.true;
+			expect(instance.entities[1].runInputValidations.calledWithExactly(
+				{ duplicateEntities: 'getDuplicateEntities response' }
 			)).to.be.true;
 
 		});

--- a/test-unit/src/models/Production.test.js
+++ b/test-unit/src/models/Production.test.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import proxyquire from 'proxyquire';
 import { assert, createStubInstance, spy, stub } from 'sinon';
 
-import { CastMember, CreativeCredit, CrewCredit, Material, ProducerCredit, Venue } from '../../../src/models';
+import { CastMember, CreativeCredit, CrewCredit, MaterialBase, ProducerCredit, VenueBase } from '../../../src/models';
 
 describe('Production model', () => {
 
@@ -26,9 +26,9 @@ describe('Production model', () => {
 
 	};
 
-	const MaterialStub = function () {
+	const MaterialBaseStub = function () {
 
-		return createStubInstance(Material);
+		return createStubInstance(MaterialBase);
 
 	};
 
@@ -38,9 +38,9 @@ describe('Production model', () => {
 
 	};
 
-	const VenueStub = function () {
+	const VenueBaseStub = function () {
 
-		return createStubInstance(Venue);
+		return createStubInstance(VenueBase);
 
 	};
 
@@ -60,9 +60,9 @@ describe('Production model', () => {
 				CastMember: CastMemberStub,
 				CreativeCredit: CreativeCreditStub,
 				CrewCredit: CrewCreditStub,
-				Material: MaterialStub,
+				MaterialBase: MaterialBaseStub,
 				ProducerCredit: ProducerCreditStub,
-				Venue: VenueStub
+				VenueBase: VenueBaseStub
 			}
 		};
 

--- a/test-unit/src/models/ProductionTeamCredit.test.js
+++ b/test-unit/src/models/ProductionTeamCredit.test.js
@@ -2,15 +2,15 @@ import { expect } from 'chai';
 import proxyquire from 'proxyquire';
 import { assert, createStubInstance, spy, stub } from 'sinon';
 
-import { Company, Person } from '../../../src/models';
+import { CompanyWithCreditedMembers, Person } from '../../../src/models';
 
 describe('ProductionTeamCredit model', () => {
 
 	let stubs;
 
-	const CompanyStub = function () {
+	const CompanyWithCreditedMembersStub = function () {
 
-		return createStubInstance(Company);
+		return createStubInstance(CompanyWithCreditedMembers);
 
 	};
 
@@ -28,7 +28,7 @@ describe('ProductionTeamCredit model', () => {
 				isEntityInArray: stub().returns(false)
 			},
 			models: {
-				Company: CompanyStub,
+				CompanyWithCreditedMembers: CompanyWithCreditedMembersStub,
 				Person: PersonStub
 			}
 		};
@@ -91,11 +91,11 @@ describe('ProductionTeamCredit model', () => {
 				const instance = createInstance(props);
 				expect(instance.entities.length).to.equal(6);
 				expect(instance.entities[0] instanceof Person).to.be.true;
-				expect(instance.entities[1] instanceof Company).to.be.true;
+				expect(instance.entities[1] instanceof CompanyWithCreditedMembers).to.be.true;
 				expect(instance.entities[2] instanceof Person).to.be.true;
-				expect(instance.entities[3] instanceof Company).to.be.true;
+				expect(instance.entities[3] instanceof CompanyWithCreditedMembers).to.be.true;
 				expect(instance.entities[4] instanceof Person).to.be.true;
-				expect(instance.entities[5] instanceof Company).to.be.true;
+				expect(instance.entities[5] instanceof CompanyWithCreditedMembers).to.be.true;
 
 			});
 
@@ -115,12 +115,7 @@ describe('ProductionTeamCredit model', () => {
 					},
 					{
 						model: 'company',
-						name: 'Assistant Stage Managers Ltd',
-						creditedMembers: [
-							{
-								name: 'Julia Wickham'
-							}
-						]
+						name: 'Assistant Stage Managers Ltd'
 					}
 				]
 			};
@@ -146,11 +141,7 @@ describe('ProductionTeamCredit model', () => {
 				instance.entities[1].validateDifferentiator,
 				stubs.getDuplicatesInfoModule.isEntityInArray,
 				instance.entities[1].validateUniquenessInGroup,
-				instance.entities[1].validateNamePresenceIfNamedChildren,
-				instance.entities[1].creditedMembers[0].validateName,
-				instance.entities[1].creditedMembers[0].validateDifferentiator,
-				stubs.getDuplicatesInfoModule.isEntityInArray,
-				instance.entities[1].creditedMembers[0].validateUniquenessInGroup
+				instance.entities[1].runInputValidations
 			);
 			expect(instance.validateName.calledOnce).to.be.true;
 			expect(instance.validateName.calledWithExactly({ isRequired: false })).to.be.true;
@@ -168,7 +159,7 @@ describe('ProductionTeamCredit model', () => {
 			expect(instance.entities[0].validateName.calledWithExactly({ isRequired: false })).to.be.true;
 			expect(instance.entities[0].validateDifferentiator.calledOnce).to.be.true;
 			expect(instance.entities[0].validateDifferentiator.calledWithExactly()).to.be.true;
-			expect(stubs.getDuplicatesInfoModule.isEntityInArray.calledThrice).to.be.true;
+			expect(stubs.getDuplicatesInfoModule.isEntityInArray.calledTwice).to.be.true;
 			expect(stubs.getDuplicatesInfoModule.isEntityInArray.getCall(0).calledWithExactly(
 				instance.entities[0], 'getDuplicateEntities response'
 			)).to.be.true;
@@ -187,23 +178,9 @@ describe('ProductionTeamCredit model', () => {
 			expect(instance.entities[1].validateUniquenessInGroup.calledWithExactly(
 				{ isDuplicate: false }
 			)).to.be.true;
-			expect(instance.entities[1].validateNamePresenceIfNamedChildren.calledOnce).to.be.true;
-			expect(instance.entities[1].validateNamePresenceIfNamedChildren.calledWithExactly(
-				instance.entities[1].creditedMembers
-			)).to.be.true;
-			expect(instance.entities[1].creditedMembers[0].validateName.calledOnce).to.be.true;
-			expect(instance.entities[1].creditedMembers[0].validateName.calledWithExactly(
-				{ isRequired: false }
-			)).to.be.true;
-			expect(instance.entities[1].creditedMembers[0].validateDifferentiator.calledOnce).to.be.true;
-			expect(instance.entities[1].creditedMembers[0].validateDifferentiator.calledWithExactly())
-				.to.be.true;
-			expect(stubs.getDuplicatesInfoModule.isEntityInArray.getCall(2).calledWithExactly(
-				instance.entities[1].creditedMembers[0], 'getDuplicateEntities response'
-			)).to.be.true;
-			expect(instance.entities[1].creditedMembers[0].validateUniquenessInGroup.calledOnce).to.be.true;
-			expect(instance.entities[1].creditedMembers[0].validateUniquenessInGroup.calledWithExactly(
-				{ isDuplicate: false }
+			expect(instance.entities[1].runInputValidations.calledOnce).to.be.true;
+			expect(instance.entities[1].runInputValidations.calledWithExactly(
+				{ duplicateEntities: 'getDuplicateEntities response' }
 			)).to.be.true;
 
 		});

--- a/test-unit/src/models/Venue.test.js
+++ b/test-unit/src/models/Venue.test.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { assert, createSandbox, spy } from 'sinon';
 
 import * as getDuplicateIndicesModule from '../../../src/lib/get-duplicate-indices';
-import Venue from '../../../src/models/Venue';
+import { Venue, VenueBase } from '../../../src/models';
 
 describe('Venue model', () => {
 
@@ -27,106 +27,36 @@ describe('Venue model', () => {
 
 	describe('constructor method', () => {
 
-		describe('differentiator property', () => {
-
-			it('assigns empty string if absent from props', () => {
-
-				const instance = new Venue({ name: 'New Theatre' });
-				expect(instance.differentiator).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is empty string', () => {
-
-				const instance = new Venue({ name: 'New Theatre', differentiator: '' });
-				expect(instance.differentiator).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is whitespace-only string', () => {
-
-				const instance = new Venue({ name: 'New Theatre', differentiator: ' ' });
-				expect(instance.differentiator).to.equal('');
-
-			});
-
-			it('assigns value if included in props and value is string with length', () => {
-
-				const instance = new Venue({ name: 'New Theatre', differentiator: '1' });
-				expect(instance.differentiator).to.equal('1');
-
-			});
-
-			it('trims value before assigning', () => {
-
-				const instance = new Venue({ name: 'New Theatre', differentiator: ' 1 ' });
-				expect(instance.differentiator).to.equal('1');
-
-			});
-
-		});
-
 		describe('sub-venues property', () => {
 
-			context('instance is subject', () => {
+			it('assigns empty array if absent from props', () => {
 
-				it('assigns empty array if absent from props', () => {
-
-					const instance = new Venue({ name: 'National Theatre' });
-					expect(instance.subVenues).to.deep.equal([]);
-
-				});
-
-				it('assigns array of sub-venues if included in props, retaining those with empty or whitespace-only string names', () => {
-
-					const props = {
-						name: 'National Theatre',
-						subVenues: [
-							{
-								name: 'Olivier Theatre'
-							},
-							{
-								name: ''
-							},
-							{
-								name: ' '
-							}
-						]
-					};
-					const instance = new Venue(props);
-					expect(instance.subVenues.length).to.equal(3);
-					expect(instance.subVenues[0].constructor.name).to.equal('Venue');
-					expect(instance.subVenues[1].constructor.name).to.equal('Venue');
-					expect(instance.subVenues[2].constructor.name).to.equal('Venue');
-
-				});
+				const instance = new Venue({ name: 'National Theatre' });
+				expect(instance.subVenues).to.deep.equal([]);
 
 			});
 
-			context('instance is not subject, i.e. it is an association of another instance', () => {
+			it('assigns array of sub-venues if included in props, retaining those with empty or whitespace-only string names', () => {
 
-				it('will not assign any value if absent from props', () => {
-
-					const instance = new Venue({ name: 'National Theatre', isAssociation: true });
-					expect(instance).not.to.have.property('subVenues');
-
-				});
-
-				it('will not assign any value if included in props', () => {
-
-					const props = {
-						name: 'National Theatre',
-						subVenues: [
-							{
-								name: 'Olivier Theatre'
-							}
-						],
-						isAssociation: true
-					};
-					const instance = new Venue(props);
-					expect(instance).not.to.have.property('subVenues');
-
-				});
+				const props = {
+					name: 'National Theatre',
+					subVenues: [
+						{
+							name: 'Olivier Theatre'
+						},
+						{
+							name: ''
+						},
+						{
+							name: ' '
+						}
+					]
+				};
+				const instance = new Venue(props);
+				expect(instance.subVenues.length).to.equal(3);
+				expect(instance.subVenues[0] instanceof VenueBase).to.be.true;
+				expect(instance.subVenues[1] instanceof VenueBase).to.be.true;
+				expect(instance.subVenues[2] instanceof VenueBase).to.be.true;
 
 			});
 

--- a/test-unit/src/models/VenueBase.test.js
+++ b/test-unit/src/models/VenueBase.test.js
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 
-import Character from '../../../src/models/Character';
+import VenueBase from '../../../src/models/VenueBase';
 
-describe('Character model', () => {
+describe('VenueBase model', () => {
 
 	describe('constructor method', () => {
 
@@ -10,35 +10,35 @@ describe('Character model', () => {
 
 			it('assigns empty string if absent from props', () => {
 
-				const instance = new Character({ name: 'Demetrius' });
+				const instance = new VenueBase({ name: 'New Theatre' });
 				expect(instance.differentiator).to.equal('');
 
 			});
 
 			it('assigns empty string if included in props but value is empty string', () => {
 
-				const instance = new Character({ name: 'Demetrius', differentiator: '' });
+				const instance = new VenueBase({ name: 'New Theatre', differentiator: '' });
 				expect(instance.differentiator).to.equal('');
 
 			});
 
 			it('assigns empty string if included in props but value is whitespace-only string', () => {
 
-				const instance = new Character({ name: 'Demetrius', differentiator: ' ' });
+				const instance = new VenueBase({ name: 'New Theatre', differentiator: ' ' });
 				expect(instance.differentiator).to.equal('');
 
 			});
 
 			it('assigns value if included in props and value is string with length', () => {
 
-				const instance = new Character({ name: 'Demetrius', differentiator: '1' });
+				const instance = new VenueBase({ name: 'New Theatre', differentiator: '1' });
 				expect(instance.differentiator).to.equal('1');
 
 			});
 
 			it('trims value before assigning', () => {
 
-				const instance = new Character({ name: 'Demetrius', differentiator: ' 1 ' });
+				const instance = new VenueBase({ name: 'New Theatre', differentiator: ' 1 ' });
 				expect(instance.differentiator).to.equal('1');
 
 			});

--- a/test-unit/src/models/WritingCredit.test.js
+++ b/test-unit/src/models/WritingCredit.test.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import proxyquire from 'proxyquire';
 import { assert, createStubInstance, spy, stub } from 'sinon';
 
-import { Company, Person, Material } from '../../../src/models';
+import { Company, Person, MaterialBase } from '../../../src/models';
 
 describe('WritingCredit model', () => {
 
@@ -14,9 +14,9 @@ describe('WritingCredit model', () => {
 
 	};
 
-	const MaterialStub = function () {
+	const MaterialBaseStub = function () {
 
-		return createStubInstance(Material);
+		return createStubInstance(MaterialBase);
 
 	};
 
@@ -34,7 +34,7 @@ describe('WritingCredit model', () => {
 			},
 			models: {
 				Company: CompanyStub,
-				Material: MaterialStub,
+				MaterialBase: MaterialBaseStub,
 				Person: PersonStub
 			}
 		};
@@ -144,13 +144,13 @@ describe('WritingCredit model', () => {
 				expect(instance.entities.length).to.equal(9);
 				expect(instance.entities[0] instanceof Person).to.be.true;
 				expect(instance.entities[1] instanceof Company).to.be.true;
-				expect(instance.entities[2] instanceof Material).to.be.true;
+				expect(instance.entities[2] instanceof MaterialBase).to.be.true;
 				expect(instance.entities[3] instanceof Person).to.be.true;
 				expect(instance.entities[4] instanceof Company).to.be.true;
-				expect(instance.entities[5] instanceof Material).to.be.true;
+				expect(instance.entities[5] instanceof MaterialBase).to.be.true;
 				expect(instance.entities[6] instanceof Person).to.be.true;
 				expect(instance.entities[7] instanceof Company).to.be.true;
-				expect(instance.entities[8] instanceof Material).to.be.true;
+				expect(instance.entities[8] instanceof MaterialBase).to.be.true;
 
 			});
 


### PR DESCRIPTION
To prevent classes needing to be provided specific configuration upon instantiation to decide the properties an instance should have, this PR uses inheritance to create subclasses with consistent properties and more granular responsibilities.

This pattern had already been used with `class CastMember extends Person`.

Sometimes the subclass requires properties in addition to the class when used as a subject, in which scenario the `class CastMember extends Person` pattern can be applied:
- `CompanyWithCreditedMembers extends Company`
  - `Company` has `uuid` and `differentiator` properties; `CompanyWithCreditedMembers` also has `creditedMembers`
- `CharacterDepiction extends Character`
  - `Character` has `uuid` and `differentiator` properties; `CharacterDepiction` also has `underlyingName` and `qualifier`

However, there are the inverse scenario when the class used as the subject requires more properties than when it is used as an association. In this case `{Model}Base` is used as the bare bones class that can be used for associations whilst `{Model}` is used when the class is the subject, so as to keep the consistency of the subject class name being the simplest and most obvious expression of the model name. E.g.
- `Material extends MaterialBase`
  - `MaterialBase` has `uuid` and `differentiator` properties; `Material` also has `format`, `originalVersionMaterial`, `writingCredits`, and `characterGroups`
- `Venue extends VenueBase`
  - `VenueBase` has `uuid` and `differentiator` properties; `Venue` also has `subVenues`