### PR TITLE
Remove unrequired model property from Cypher delete query return values

### DIFF
--- a/src/models/Entity.js
+++ b/src/models/Entity.js
@@ -164,7 +164,7 @@ export default class Entity extends Base {
 
 		const { getDeleteQuery } = sharedQueries;
 
-		const { model, name, differentiator, isDeleted, associatedModels } = await neo4jQuery({
+		const { name, differentiator, isDeleted, associatedModels } = await neo4jQuery({
 			query: getDeleteQuery(this.model),
 			params: { uuid: this.uuid }
 		});
@@ -172,7 +172,6 @@ export default class Entity extends Base {
 		if (isDeleted) {
 
 			return new this.constructor({
-				model,
 				name,
 				...(this.hasDifferentiatorProperty() && { differentiator })
 			});

--- a/src/neo4j/cypher-queries/shared.js
+++ b/src/neo4j/cypher-queries/shared.js
@@ -86,7 +86,6 @@ const getDeleteQuery = model => {
 			DETACH DELETE deletableInstance
 
 			RETURN
-				'${model}' AS model,
 				CASE WHEN isDeleted
 					THEN deletableInstanceName
 					ELSE undeletableInstance.name

--- a/test-unit/src/models/Entity.test.js
+++ b/test-unit/src/models/Entity.test.js
@@ -702,7 +702,7 @@ describe('Entity model', () => {
 					)).to.be.true;
 					expect(instance.constructor.calledOnce).to.be.true;
 					expect(instance.constructor.calledWithExactly(
-						{ model: 'venue', name: 'Almeida Theatre', differentiator: null }
+						{ name: 'Almeida Theatre', differentiator: null }
 					)).to.be.true;
 					expect(instance.addPropertyError.notCalled).to.be.true;
 					expect(instance.setErrorStatus.notCalled).to.be.true;
@@ -745,9 +745,7 @@ describe('Entity model', () => {
 						{ query: 'getDeleteQuery response', params: { uuid: instance.uuid } }
 					)).to.be.true;
 					expect(instance.constructor.calledOnce).to.be.true;
-					expect(instance.constructor.calledWithExactly(
-						{ model: 'production', name: 'Hamlet' }
-					)).to.be.true;
+					expect(instance.constructor.calledWithExactly({ name: 'Hamlet' })).to.be.true;
 					expect(instance.addPropertyError.notCalled).to.be.true;
 					expect(instance.setErrorStatus.notCalled).to.be.true;
 					expect(result instanceof Production).to.be.true;

--- a/test-unit/src/neo4j/cypher-queries/shared.test.js
+++ b/test-unit/src/neo4j/cypher-queries/shared.test.js
@@ -186,7 +186,6 @@ describe('Cypher Queries Shared module', () => {
 					DETACH DELETE deletableInstance
 
 					RETURN
-						'venue' AS model,
 						CASE WHEN isDeleted
 							THEN deletableInstanceName
 							ELSE undeletableInstance.name


### PR DESCRIPTION
This PR removes the `model` property from the Cypher delete query's return values.

Its only usage was to be passed as an argument to instantiate a new instance of the model in the scenario of the instance being deleted in the database.

However, class constructors do not use `model` as an argument; each class has a getter function and the model value is acquired from there, meaning this usage of the `model` value is unnecessary and can be removed (which in turn means that value does not need to be acquired and returned by the Cypher delete query).