### PR TITLE
Use const when creating test context-specific instance in model unit tests

### DIFF
--- a/test-unit/src/models/Base.test.js
+++ b/test-unit/src/models/Base.test.js
@@ -39,35 +39,35 @@ describe('Base model', () => {
 
 			it('assigns empty string if absent from props', () => {
 
-				instance = new Base({});
+				const instance = new Base({});
 				expect(instance.name).to.equal('');
 
 			});
 
 			it('assigns empty string if included in props but value is empty string', () => {
 
-				instance = new Base({ name: '' });
+				const instance = new Base({ name: '' });
 				expect(instance.name).to.equal('');
 
 			});
 
 			it('assigns empty string if included in props but value is whitespace-only string', () => {
 
-				instance = new Base({ name: ' ' });
+				const instance = new Base({ name: ' ' });
 				expect(instance.name).to.equal('');
 
 			});
 
 			it('assigns value if included in props and value is string with length', () => {
 
-				instance = new Base({ name: 'Barfoo' });
+				const instance = new Base({ name: 'Barfoo' });
 				expect(instance.name).to.equal('Barfoo');
 
 			});
 
 			it('trims value before assigning', () => {
 
-				instance = new Base({ name: ' Barfoo ' });
+				const instance = new Base({ name: ' Barfoo ' });
 				expect(instance.name).to.equal('Barfoo');
 
 			});
@@ -122,7 +122,7 @@ describe('Base model', () => {
 
 			it('will call addPropertyError method', () => {
 
-				instance = new Base({ name: '' });
+				const instance = new Base({ name: '' });
 				spy(instance, 'addPropertyError');
 				instance.validateStringForProperty('name', { isRequired: true });
 				assert.callOrder(


### PR DESCRIPTION
Instead of overwriting the `instance` globally available within the context of the test, this PR ensures consistency that when an `instance` is created within the specific context of a single test that `const` is used to instead create a new variable.