### PR TITLE
Add hasErrors stub test-specific response in Entity class unit tests

### DIFF
--- a/test-unit/src/models/Entity.test.js
+++ b/test-unit/src/models/Entity.test.js
@@ -786,6 +786,7 @@ describe('Entity model', () => {
 
 				it('returns instance without deleting', async () => {
 
+					stubs.hasErrors.returns(true);
 					stubs.neo4jQuery.resolves({
 						model: 'venue',
 						name: 'Almeida Theatre',
@@ -818,7 +819,7 @@ describe('Entity model', () => {
 						uuid: undefined,
 						name: 'Almeida Theatre',
 						differentiator: null,
-						hasErrors: false,
+						hasErrors: true,
 						errors: {
 							associations: [
 								'Production'
@@ -835,6 +836,7 @@ describe('Entity model', () => {
 				it('returns instance without deleting', async () => {
 
 					const instance = new Production({ name: 'Foobar' });
+					stubs.hasErrors.returns(true);
 					stubs.neo4jQuery.resolves({
 						model: 'production',
 						name: 'Hamlet',
@@ -868,7 +870,7 @@ describe('Entity model', () => {
 						startDate: '',
 						pressDate: '',
 						endDate: '',
-						hasErrors: false,
+						hasErrors: true,
 						errors: {
 							associations: [
 								'Venue'


### PR DESCRIPTION
The `Entity` class unit tests for the `delete` method include an expectation of what the return value should look like.

It currently includes a populated `errors` object but then contradictorily has `hasErrors: false` owing to `false` being returned by the `hasErrors` module stub.

To avoid confusion, this PR applies a change so that for these specific tests the `hasErrors` module stub returns `true` so that the return object is reflective of what it would actually look like outside of a test context.