### PR TITLE
Revise Entity class runDatabaseValidations method

### DIFF
--- a/src/models/Entity.js
+++ b/src/models/Entity.js
@@ -63,6 +63,8 @@ export default class Entity extends Base {
 
 	async runDatabaseValidations () {
 
+		if (this.model === 'production') return;
+
 		await this.validateUniquenessInDatabase();
 
 	}

--- a/src/models/Production.js
+++ b/src/models/Production.js
@@ -131,12 +131,4 @@ export default class Production extends Entity {
 
 	}
 
-	// Overrides Base model runDatabaseValidations() method because Production instances
-	// do not require database validation as they can have the same name as others.
-	runDatabaseValidations () {
-
-		return;
-
-	}
-
 }

--- a/test-unit/src/models/Entity.test.js
+++ b/test-unit/src/models/Entity.test.js
@@ -247,12 +247,29 @@ describe('Entity model', () => {
 
 	describe('runDatabaseValidations method', () => {
 
-		it('will call validateUniquenessInDatabase method', () => {
+		context('model is not production', () => {
 
-			spy(instance, 'validateUniquenessInDatabase');
-			instance.runDatabaseValidations();
-			expect(instance.validateUniquenessInDatabase.calledOnce).to.be.true;
-			expect(instance.validateUniquenessInDatabase.calledWithExactly()).to.be.true;
+			it('will call validateUniquenessInDatabase method', () => {
+
+				spy(instance, 'validateUniquenessInDatabase');
+				instance.runDatabaseValidations();
+				expect(instance.validateUniquenessInDatabase.calledOnce).to.be.true;
+				expect(instance.validateUniquenessInDatabase.calledWithExactly()).to.be.true;
+
+			});
+
+		});
+
+		context('model is production', () => {
+
+			it('will return without calling validateUniquenessInDatabase method (because when productions are created they are treated as unique)', () => {
+
+				const instance = new Production();
+				spy(instance, 'validateUniquenessInDatabase');
+				instance.runDatabaseValidations();
+				expect(instance.validateUniquenessInDatabase.notCalled).to.be.true;
+
+			});
 
 		});
 

--- a/test-unit/src/models/Production.test.js
+++ b/test-unit/src/models/Production.test.js
@@ -51,11 +51,6 @@ describe('Production model', () => {
 				getDuplicateBaseInstanceIndices: stub().returns([]),
 				getDuplicateNameIndices: stub().returns([])
 			},
-			Base: {
-				neo4jQueryModule: {
-					neo4jQuery: stub()
-				}
-			},
 			models: {
 				CastMember: CastMemberStub,
 				CreativeCredit: CreativeCreditStub,
@@ -71,9 +66,6 @@ describe('Production model', () => {
 	const createSubject = () =>
 		proxyquire('../../../src/models/Production', {
 			'../lib/get-duplicate-indices': stubs.getDuplicateIndicesModule,
-			'./Base': proxyquire('../../../src/models/Base', {
-				'../neo4j/query': stubs.Base.neo4jQueryModule
-			}),
 			'.': stubs.models
 		}).default;
 
@@ -810,18 +802,6 @@ describe('Production model', () => {
 				});
 
 			});
-
-		});
-
-	});
-
-	describe('runDatabaseValidations method', () => {
-
-		it('does nothing, i.e. it overrides the Base model runDatabaseValidations() method with an empty function', () => {
-
-			const instance = createInstance({ name: 'Hamlet' });
-			instance.runDatabaseValidations();
-			expect(stubs.Base.neo4jQueryModule.neo4jQuery.notCalled).to.be.true;
 
 		});
 


### PR DESCRIPTION
This PR revises the `Entity` class `runDatabaseValidations` method so that it handles instances of the `Production` class (an extension of the `Entity` class) by returning immediately as they do not have any database validations to run.

`Production` instance can be determined by using the model getter function and means that the `runDatabaseValidations` method in the `Production` class (that was used to override the one inherited from the `Entity` class by virtue of extension) can be removed.