### PR TITLE
Replace arrays with sets where appropriate

### DIFF
--- a/src/lib/prepare-as-params.js
+++ b/src/lib/prepare-as-params.js
@@ -9,19 +9,19 @@ const CREW_CREDITS = 'crewCredits';
 const PRODUCER_CREDITS = 'producerCredits';
 const WRITING_CREDITS = 'writingCredits';
 
-const EMPTY_NAME_EXCEPTION_KEYS = [
+const EMPTY_NAME_EXCEPTION_KEYS = new Set([
 	CHARACTER_GROUPS,
 	PRODUCER_CREDITS,
 	WRITING_CREDITS
-];
+]);
 
-const REQUIRES_NAMED_CHILDREN_KEYS = [
+const REQUIRES_NAMED_CHILDREN_KEYS = new Set([
 	CHARACTER_GROUPS,
 	CREATIVE_CREDITS,
 	CREW_CREDITS,
 	PRODUCER_CREDITS,
 	WRITING_CREDITS
-];
+]);
 
 export const prepareAsParams = instance => {
 
@@ -29,10 +29,10 @@ export const prepareAsParams = instance => {
 
 	const hasNameOrIsExempt = key => item =>
 		Boolean(item.name) ||
-		EMPTY_NAME_EXCEPTION_KEYS.includes(key);
+		EMPTY_NAME_EXCEPTION_KEYS.has(key);
 
 	const hasNamedChildrenIfRequired = key => item =>
-		!REQUIRES_NAMED_CHILDREN_KEYS.includes(key) ||
+		!REQUIRES_NAMED_CHILDREN_KEYS.has(key) ||
 		item[key === CHARACTER_GROUPS ? 'characters' : 'entities']?.some(child => Boolean(child.name));
 
 	const applyPositionPropertyAndRecurseObject = (item, index, array) => {

--- a/src/models/Base.js
+++ b/src/models/Base.js
@@ -41,7 +41,7 @@ export default class Base {
 
 			const uniquenessErrorMessage = 'This item has been duplicated within the group';
 
-			const properties = [
+			const properties = new Set([
 				'name',
 				'underlyingName',
 				'characterName',
@@ -49,7 +49,7 @@ export default class Base {
 				'characterDifferentiator',
 				'qualifier',
 				'group'
-			];
+			]);
 
 			properties.forEach(property => {
 

--- a/src/neo4j/create-constraints.js
+++ b/src/neo4j/create-constraints.js
@@ -2,14 +2,14 @@ import directly from 'directly';
 
 import { neo4jQuery } from './query';
 
-const MODELS = [
+const MODELS = new Set([
 	'Character',
 	'Company',
 	'Material',
 	'Person',
 	'Production',
 	'Venue'
-];
+]);
 
 const createConstraint = async model => {
 
@@ -45,7 +45,7 @@ export default async () => {
 
 		const modelsWithConstraint = constraints.map(constraint => constraint.labelsOrTypes[0]);
 
-		const modelsToConstrain = MODELS.filter(model => !modelsWithConstraint.includes(model));
+		const modelsToConstrain = [...MODELS].filter(model => !modelsWithConstraint.includes(model));
 
 		console.log('Neo4j database: Creating constraints…'); // eslint-disable-line no-console
 

--- a/src/neo4j/create-indexes.js
+++ b/src/neo4j/create-indexes.js
@@ -2,13 +2,13 @@ import directly from 'directly';
 
 import { neo4jQuery } from './query';
 
-const MODELS = [
+const MODELS = new Set([
 	'Character',
 	'Company',
 	'Material',
 	'Person',
 	'Venue'
-];
+]);
 
 const createIndex = async model => {
 
@@ -47,7 +47,7 @@ export default async () => {
 				.filter(index => index.properties.includes('name'))
 				.map(index => index.labelsOrTypes[0]);
 
-		const modelsToIndex = MODELS.filter(model => !modelsWithIndex.includes(model));
+		const modelsToIndex = [...MODELS].filter(model => !modelsWithIndex.includes(model));
 
 		console.log('Neo4j database: Creating indexes…'); // eslint-disable-line no-console
 


### PR DESCRIPTION
> The **`Set`** object lets you store unique values of any type, whether primitive values or object references.

> #### Description
> `Set` objects are collections of values. You can iterate through the elements of a set in insertion order. A value in the `Set` **may only occur once**; it is unique in the `Set`'s collection.

There are arrays in this repo whose values should always be unique, so this PR changes those to use sets instead.

### References:
- [MDN Web Docs: Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set)