### PR TITLE
Add database seeds for The Donkey Show

### DIFF
--- a/db-seeding/seeds/materials/the-donkey-show.json
+++ b/db-seeding/seeds/materials/the-donkey-show.json
@@ -1,0 +1,93 @@
+{
+	"name": "The Donkey Show",
+	"format": "musical",
+	"writingCredits": [
+		{
+			"name": "book by",
+			"entities": [
+				{
+					"name": "Diane Paulus"
+				},
+				{
+					"name": "Randy Weiner"
+				}
+			]
+		},
+		{
+			"name": "adapted from",
+			"entities": [
+				{
+					"model": "material",
+					"name": "A Midsummer Night's Dream"
+				}
+			]
+		}
+	],
+	"characterGroups": [
+		{
+			"characters": [
+				{
+					"name": "Oberon"
+				},
+				{
+					"name": "Tytania",
+					"underlyingName": "Titania"
+				},
+				{
+					"name": "Dr Wheelgood",
+					"underlyingName": "Puck"
+				},
+				{
+					"name": "Helen",
+					"underlyingName": "Helena"
+				},
+				{
+					"name": "Dimitri",
+					"underlyingName": "Demetrius",
+					"differentiator": "1"
+				},
+				{
+					"name": "Sander",
+					"underlyingName": "Lysander"
+				},
+				{
+					"name": "Mia",
+					"underlyingName": "Hermia"
+				},
+				{
+					"name": "Vinnie",
+					"qualifier": "#1",
+					"underlyingName": "Nick Bottom"
+				},
+				{
+					"name": "Vinnie",
+					"qualifier": "#2",
+					"underlyingName": "Nick Bottom"
+				},
+				{
+					"name": "Mustard Seed",
+					"underlyingName": "Mustardseed"
+				},
+				{
+					"name": "Cob Web",
+					"underlyingName": "Cobweb"
+				},
+				{
+					"name": "Moth"
+				},
+				{
+					"name": "Peaseblossom"
+				},
+				{
+					"name": "Fleetwood Coupe DeVille"
+				},
+				{
+					"name": "Disco Lady"
+				},
+				{
+					"name": "DJ Fernando Pacheski"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/productions/the-donkey-show.json
+++ b/db-seeding/seeds/productions/the-donkey-show.json
@@ -1,0 +1,200 @@
+{
+	"name": "The Donkey Show",
+	"startDate": "2000-09-12",
+	"pressDate": "2000-09-18",
+	"endDate": "2002-01-02",
+	"material": {
+		"name": "The Donkey Show"
+	},
+	"venue": {
+		"name": "Hanover Grand"
+	},
+	"producerCredits": [
+		{
+			"name": "presented by",
+			"entities": [
+				{
+					"model": "company",
+					"name": "Pleasance Theatre Festival"
+				},
+				{
+					"name": "David Babani"
+				}
+			]
+		},
+		{
+			"name": "with",
+			"entities": [
+				{
+					"model": "company",
+					"name": "Project 400"
+				}
+			]
+		},
+		{
+			"name": "in association with",
+			"entities": [
+				{
+					"name": "Jordan Roth"
+				}
+			]
+		}
+	],
+	"cast": [
+		{
+			"name": "Rachel Benboy Murdy",
+			"roles": [
+				{
+					"name": "Oberon"
+				},
+				{
+					"name": "Mia"
+				}
+			]
+		},
+		{
+			"name": "Anna Wilson",
+			"roles": [
+				{
+					"name": "Tytania"
+				},
+				{
+					"name": "Sander"
+				}
+			]
+		},
+		{
+			"name": "Roman Pietrs",
+			"roles": [
+				{
+					"name": "Dr Wheelgood"
+				}
+			]
+		},
+		{
+			"name": "Jordin Ruderman",
+			"roles": [
+				{
+					"name": "Helen"
+				},
+				{
+					"name": "Vinnie",
+					"qualifier": "#1"
+				}
+			]
+		},
+		{
+			"name": "Emily Hellstrom",
+			"roles": [
+				{
+					"name": "Dimitri"
+				},
+				{
+					"name": "Vinnie",
+					"qualifier": "#2"
+				}
+			]
+		},
+		{
+			"name": "Oscar Estevez",
+			"roles": [
+				{
+					"name": "Mustard Seed"
+				}
+			]
+		},
+		{
+			"name": "Luke Miller",
+			"roles": [
+				{
+					"name": "Cob Web"
+				}
+			]
+		},
+		{
+			"name": "Dan Cryer",
+			"roles": [
+				{
+					"name": "Moth"
+				}
+			]
+		},
+		{
+			"name": "Kesu James",
+			"roles": [
+				{
+					"name": "Peaseblossom"
+				}
+			]
+		},
+		{
+			"name": "Barry Brisco",
+			"roles": [
+				{
+					"name": "Fleetwood Coupe DeVille"
+				}
+			]
+		},
+		{
+			"name": "Danuta",
+			"roles": [
+				{
+					"name": "Disco Lady"
+				}
+			]
+		},
+		{
+			"name": "djRobG",
+			"roles": [
+				{
+					"name": "DJ Fernando Pacheski"
+				}
+			]
+		}
+	],
+	"creativeCredits": [
+		{
+			"name": "Directors",
+			"entities": [
+				{
+					"name": "Diane Paulus"
+				},
+				{
+					"name": "Randy Weiner"
+				}
+			]
+		},
+		{
+			"name": "Designer",
+			"entities": [
+				{
+					"name": "Scott Pask"
+				}
+			]
+		},
+		{
+			"name": "Costume Designer",
+			"entities": [
+				{
+					"name": "David C Woolard"
+				}
+			]
+		},
+		{
+			"name": "Lighting Designer",
+			"entities": [
+				{
+					"name": "Kevin Adams"
+				}
+			]
+		},
+		{
+			"name": "Sound Designer",
+			"entities": [
+				{
+					"name": "Brett Jarvis"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
This PR adds database seeds for the material and production of The Donkey Show (musical) as it is quite useful to have an example of a source material (A Midsummer Night's Dream) that has multiple subsequent materials based upon it (the other one is The Indian Boy).