### PR TITLE
Upgrade Docker Neo4j image version 4.2.1 -> 4.2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     docker:
       - image: circleci/node:14.13.0
-      - image: neo4j:4.2.1
+      - image: neo4j:4.2.7
         environment:
           NEO4J_AUTH: none
     steps:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     neo4j:
         container_name: neo4j-test
-        image: neo4j:4.2.1
+        image: neo4j:4.2.7
         environment:
             - NEO4J_AUTH=none
         ports:


### PR DESCRIPTION
I have upgraded my Neo4j Desktop to v4.2.7 so that I am using a version that has fixed [this issue](https://stackoverflow.com/questions/67912270/neo4j-applying-index-and-constraint-changes-query-results).

This PR makes the corresponding upgrades to the Docker Neo4j images used for the end-to-end tests to ensure consistency between the developer and test environments.

### References:
- [Stack Overflow: Neo4j: Applying index and constraint changes query results](https://stackoverflow.com/questions/67912270/neo4j-applying-index-and-constraint-changes-query-results)