### PR TITLE
Revise Cypher queries to specify sourceMaterialWriter node label via conditional statement

### DIFF
--- a/src/neo4j/cypher-queries/character.js
+++ b/src/neo4j/cypher-queries/character.js
@@ -7,6 +7,7 @@ const getShowQuery = () => `
 		WHERE entity:Person OR entity:Company OR entity:Material
 
 	OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->(sourceMaterialWriter)
+		WHERE sourceMaterialWriter:Person OR sourceMaterialWriter:Company
 
 	WITH
 		character,

--- a/src/neo4j/cypher-queries/company.js
+++ b/src/neo4j/cypher-queries/company.js
@@ -19,6 +19,7 @@ const getShowQuery = () => `
 			WHERE entity:Person OR entity:Company OR entity:Material
 
 		OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->(sourceMaterialWriter)
+			WHERE sourceMaterialWriter:Person OR sourceMaterialWriter:Company
 
 		WITH
 			company,

--- a/src/neo4j/cypher-queries/material.js
+++ b/src/neo4j/cypher-queries/material.js
@@ -302,6 +302,7 @@ const getShowQuery = () => `
 		OPTIONAL MATCH (entity)<-[originalVersionWritingEntityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]-(material)
 
 		OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->(sourceMaterialWriter)
+			WHERE sourceMaterialWriter:Person OR sourceMaterialWriter:Company
 
 		WITH
 			material,
@@ -571,6 +572,7 @@ const getListQuery = () => `
 		WHERE entity:Person OR entity:Company OR entity:Material
 
 	OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->(sourceMaterialWriter)
+		WHERE sourceMaterialWriter:Person OR sourceMaterialWriter:Company
 
 	WITH material, entityRel, entity, sourceMaterialWriterRel, sourceMaterialWriter
 		ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriterRel.entityPosition

--- a/src/neo4j/cypher-queries/person.js
+++ b/src/neo4j/cypher-queries/person.js
@@ -19,6 +19,7 @@ const getShowQuery = () => `
 			WHERE entity:Person OR entity:Company OR entity:Material
 
 		OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->(sourceMaterialWriter)
+			WHERE sourceMaterialWriter:Person OR sourceMaterialWriter:Company
 
 		WITH
 			person,

--- a/src/neo4j/cypher-queries/production.js
+++ b/src/neo4j/cypher-queries/production.js
@@ -688,6 +688,7 @@ const getShowQuery = () => `
 		WHERE entity:Person OR entity:Company OR entity:Material
 
 	OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->(sourceMaterialWriter)
+		WHERE sourceMaterialWriter:Person OR sourceMaterialWriter:Company
 
 	WITH production, venue, material, entityRel, entity, sourceMaterialWriterRel, sourceMaterialWriter
 		ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriterRel.entityPosition


### PR DESCRIPTION
The Cypher query lines being amended in this PR (at bottom of this paragraph) currently rely on the data adhering to the intended model, i.e. nodes with the `Material` label should only ever have a `:HAS_WRITING_ENTITY` relationship pointing towards nodes with a `Person` or `Company` label, meaning it is implicit that the `sourceMaterialWriter` variable will only ever be a node with one of those two labels.
```
OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->(sourceMaterialWriter)
```

However, it is often better to explicit, as is the case with the Cypher lines that precede those being amended in this PR:
```
OPTIONAL MATCH (material)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity)
	WHERE entity:Person OR entity:Company OR entity:Material
```
I.e. the conditional statement here could be removed as nodes with a `Material` label will only ever have `:HAS_WRITING_ENTITY` or `:USES_SOURCE_MATERIAL` relationships pointing towards nodes with a `Person`, `Company`, or `Material` label, but for explicitness a conditional statement makes clear that the `entity` variable will be a node with one of those labels.