### PR TITLE
Add material year property

### DIFF
--- a/db-seeding/seeds/materials/3-winters.json
+++ b/db-seeding/seeds/materials/3-winters.json
@@ -1,6 +1,7 @@
 {
 	"name": "3 Winters",
 	"format": "play",
+	"year": 2014,
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/a-midsummer-nights-dream.json
+++ b/db-seeding/seeds/materials/a-midsummer-nights-dream.json
@@ -1,6 +1,7 @@
 {
 	"name": "A Midsummer Night's Dream",
 	"format": "play",
+	"year": 1595,
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/coriolanus.json
+++ b/db-seeding/seeds/materials/coriolanus.json
@@ -1,6 +1,7 @@
 {
 	"name": "Coriolanus",
 	"format": "play",
+	"year": 1608,
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/death-on-the-nile-novel.json
+++ b/db-seeding/seeds/materials/death-on-the-nile-novel.json
@@ -1,6 +1,7 @@
 {
 	"name": "Death on the Nile",
 	"format": "novel",
+	"year": 1937,
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/hamlet.json
+++ b/db-seeding/seeds/materials/hamlet.json
@@ -1,6 +1,7 @@
 {
 	"name": "Hamlet",
 	"format": "play",
+	"year": 1601,
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/happy-days.json
+++ b/db-seeding/seeds/materials/happy-days.json
@@ -1,6 +1,7 @@
 {
 	"name": "Happy Days",
 	"format": "play",
+	"year": 1961,
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/henry-iv-part-1.json
+++ b/db-seeding/seeds/materials/henry-iv-part-1.json
@@ -1,6 +1,7 @@
 {
 	"name": "Henry IV, Part 1",
 	"format": "play",
+	"year": 1597,
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/henry-iv-part-2.json
+++ b/db-seeding/seeds/materials/henry-iv-part-2.json
@@ -1,6 +1,7 @@
 {
 	"name": "Henry IV, Part 2",
 	"format": "play",
+	"year": 1599,
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/henry-v.json
+++ b/db-seeding/seeds/materials/henry-v.json
@@ -1,6 +1,7 @@
 {
 	"name": "Henry V",
 	"format": "play",
+	"year": 1599,
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/julius-caesar.json
+++ b/db-seeding/seeds/materials/julius-caesar.json
@@ -1,6 +1,7 @@
 {
 	"name": "Julius Caesar",
 	"format": "play",
+	"year": 1599,
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/little-eyolf.json
+++ b/db-seeding/seeds/materials/little-eyolf.json
@@ -1,6 +1,7 @@
 {
 	"name": "Little Eyolf",
 	"format": "play",
+	"year": 1894,
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/miss-julie-original-version.json
+++ b/db-seeding/seeds/materials/miss-julie-original-version.json
@@ -1,6 +1,7 @@
 {
 	"name": "Miss Julie",
 	"format": "play",
+	"year": 1888,
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/miss-julie-subsequent-version-1.json
+++ b/db-seeding/seeds/materials/miss-julie-subsequent-version-1.json
@@ -1,6 +1,7 @@
 {
 	"name": "After Miss Julie",
 	"format": "play",
+	"year": 1996,
 	"originalVersionMaterial": {
 		"name": "Miss Julie"
 	},

--- a/db-seeding/seeds/materials/miss-julie-subsequent-version-2.json
+++ b/db-seeding/seeds/materials/miss-julie-subsequent-version-2.json
@@ -1,6 +1,7 @@
 {
 	"name": "Julie",
 	"format": "play",
+	"year": 2018,
 	"originalVersionMaterial": {
 		"name": "Miss Julie"
 	},

--- a/db-seeding/seeds/materials/mrs-affleck.json
+++ b/db-seeding/seeds/materials/mrs-affleck.json
@@ -1,6 +1,7 @@
 {
 	"name": "Mrs Affleck",
 	"format": "play",
+	"year": 2009,
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/murder-on-the-nile-play.json
+++ b/db-seeding/seeds/materials/murder-on-the-nile-play.json
@@ -1,6 +1,7 @@
 {
 	"name": "Murder on the Nile",
 	"format": "play",
+	"year": 1944,
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/peer-gynt-original-version.json
+++ b/db-seeding/seeds/materials/peer-gynt-original-version.json
@@ -2,6 +2,7 @@
 	"name": "Peer Gynt",
 	"differentiator": "1",
 	"format": "play",
+	"year": 1867,
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/peer-gynt-subsequent-version-1.json
+++ b/db-seeding/seeds/materials/peer-gynt-subsequent-version-1.json
@@ -2,6 +2,7 @@
 	"name": "Peer Gynt",
 	"differentiator": "2",
 	"format": "play",
+	"year": 2000,
 	"originalVersionMaterial": {
 		"name": "Peer Gynt",
 		"differentiator": "1"

--- a/db-seeding/seeds/materials/peer-gynt-subsequent-version-2.json
+++ b/db-seeding/seeds/materials/peer-gynt-subsequent-version-2.json
@@ -2,6 +2,7 @@
 	"name": "Peer Gynt",
 	"differentiator": "3",
 	"format": "play",
+	"year": 2007,
 	"originalVersionMaterial": {
 		"name": "Peer Gynt",
 		"differentiator": "1"

--- a/db-seeding/seeds/materials/rock-n-roll.json
+++ b/db-seeding/seeds/materials/rock-n-roll.json
@@ -1,6 +1,7 @@
 {
 	"name": "Rock 'n' Roll",
 	"format": "play",
+	"year": 2006,
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/rope.json
+++ b/db-seeding/seeds/materials/rope.json
@@ -1,6 +1,7 @@
 {
 	"name": "Rope",
 	"format": "play",
+	"year": 1929,
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/shakespeares-villains.json
+++ b/db-seeding/seeds/materials/shakespeares-villains.json
@@ -1,6 +1,7 @@
 {
 	"name": "Shakespeare's Villains",
 	"format": "play",
+	"year": 1998,
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-b-file.json
+++ b/db-seeding/seeds/materials/the-b-file.json
@@ -1,6 +1,7 @@
 {
 	"name": "The B File",
 	"format": "play",
+	"year": 1992,
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-dark-philosophers.json
+++ b/db-seeding/seeds/materials/the-dark-philosophers.json
@@ -1,6 +1,7 @@
 {
 	"name": "The Dark Philosophers",
 	"format": "play",
+	"year": 2011,
 	"writingCredits": [
 		{
 			"name": "adapted by",

--- a/db-seeding/seeds/materials/the-donkey-show.json
+++ b/db-seeding/seeds/materials/the-donkey-show.json
@@ -1,6 +1,7 @@
 {
 	"name": "The Donkey Show",
 	"format": "musical",
+	"year": 2000,
 	"writingCredits": [
 		{
 			"name": "book by",

--- a/db-seeding/seeds/materials/the-dumb-waiter.json
+++ b/db-seeding/seeds/materials/the-dumb-waiter.json
@@ -1,6 +1,7 @@
 {
 	"name": "The Dumb Waiter",
 	"format": "play",
+	"year": 1959,
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-girl-on-the-train-film.json
+++ b/db-seeding/seeds/materials/the-girl-on-the-train-film.json
@@ -2,6 +2,7 @@
 	"name": "The Girl on the Train",
 	"differentiator": "2",
 	"format": "film",
+	"year": 2016,
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-girl-on-the-train-novel.json
+++ b/db-seeding/seeds/materials/the-girl-on-the-train-novel.json
@@ -2,6 +2,7 @@
 	"name": "The Girl on the Train",
 	"differentiator": "1",
 	"format": "novel",
+	"year": 2015,
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-girl-on-the-train-play.json
+++ b/db-seeding/seeds/materials/the-girl-on-the-train-play.json
@@ -2,6 +2,7 @@
 	"name": "The Girl on the Train",
 	"differentiator": "3",
 	"format": "play",
+	"year": 2018,
 	"writingCredits": [
 		{
 			"name": "based on",

--- a/db-seeding/seeds/materials/the-indian-boy.json
+++ b/db-seeding/seeds/materials/the-indian-boy.json
@@ -1,6 +1,7 @@
 {
 	"name": "The Indian Boy",
 	"format": "play",
+	"year": 2006,
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-ladykillers-1-screenplay.json
+++ b/db-seeding/seeds/materials/the-ladykillers-1-screenplay.json
@@ -2,6 +2,7 @@
 	"name": "The Ladykillers",
 	"differentiator": "1",
 	"format": "motion picture screenplay",
+	"year": 1955,
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-ladykillers-2-play.json
+++ b/db-seeding/seeds/materials/the-ladykillers-2-play.json
@@ -2,6 +2,7 @@
 	"name": "The Ladykillers",
 	"differentiator": "2",
 	"format": "play",
+	"year": 2011,
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-seagull-original-version.json
+++ b/db-seeding/seeds/materials/the-seagull-original-version.json
@@ -2,6 +2,7 @@
 	"name": "The Seagull",
 	"differentiator": "1",
 	"format": "play",
+	"year": 1896,
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-seagull-subsequent-version.json
+++ b/db-seeding/seeds/materials/the-seagull-subsequent-version.json
@@ -2,6 +2,7 @@
 	"name": "The Seagull",
 	"differentiator": "2",
 	"format": "play",
+	"year": 2013,
 	"originalVersionMaterial": {
 		"name": "The Seagull",
 		"differentiator": "1"

--- a/db-seeding/seeds/materials/three-sisters-original-version.json
+++ b/db-seeding/seeds/materials/three-sisters-original-version.json
@@ -2,6 +2,7 @@
 	"name": "Three Sisters",
 	"differentiator": "1",
 	"format": "play",
+	"year": 1901,
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/three-sisters-subsequent-version-1.json
+++ b/db-seeding/seeds/materials/three-sisters-subsequent-version-1.json
@@ -2,6 +2,7 @@
 	"name": "Three Sisters",
 	"differentiator": "2",
 	"format": "play",
+	"year": 2012,
 	"originalVersionMaterial": {
 		"name": "Three Sisters",
 		"differentiator": "1"

--- a/db-seeding/seeds/materials/three-sisters-subsequent-version-2.json
+++ b/db-seeding/seeds/materials/three-sisters-subsequent-version-2.json
@@ -2,6 +2,7 @@
 	"name": "Three Sisters",
 	"differentiator": "3",
 	"format": "play",
+	"year": 2019,
 	"originalVersionMaterial": {
 		"name": "Three Sisters",
 		"differentiator": "1"

--- a/db-seeding/seeds/materials/titus-andronicus.json
+++ b/db-seeding/seeds/materials/titus-andronicus.json
@@ -1,6 +1,7 @@
 {
 	"name": "Titus Andronicus",
 	"format": "play",
+	"year": 1593,
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/true-west.json
+++ b/db-seeding/seeds/materials/true-west.json
@@ -1,6 +1,7 @@
 {
 	"name": "True West",
 	"format": "play",
+	"year": 1980,
 	"writingCredits": [
 		{
 			"entities": [

--- a/src/lib/is-valid-year.js
+++ b/src/lib/is-valid-year.js
@@ -1,0 +1,7 @@
+const YEAR_MIN_VALUE = 0;
+const YEAR_MAX_VALUE = 9999;
+
+export const isValidYear = year =>
+	(parseInt(year) || year === 0) &&
+	(year >= YEAR_MIN_VALUE) &&
+	(year <= YEAR_MAX_VALUE);

--- a/src/models/Material.js
+++ b/src/models/Material.js
@@ -1,4 +1,5 @@
 import { getDuplicateNameIndices } from '../lib/get-duplicate-indices';
+import { isValidYear } from '../lib/is-valid-year';
 import MaterialBase from './MaterialBase';
 import { CharacterGroup, WritingCredit } from '.';
 
@@ -10,12 +11,15 @@ export default class Material extends MaterialBase {
 
 		const {
 			format,
+			year,
 			originalVersionMaterial,
 			writingCredits,
 			characterGroups
 		} = props;
 
 		this.format = format?.trim() || '';
+
+		this.year = parseInt(year) || year?.trim() || '';
 
 		this.originalVersionMaterial = new MaterialBase(originalVersionMaterial);
 
@@ -36,6 +40,8 @@ export default class Material extends MaterialBase {
 		this.validateDifferentiator();
 
 		this.validateFormat({ isRequired: false });
+
+		this.validateYear({ isRequired: false });
 
 		this.originalVersionMaterial.validateName({ isRequired: false });
 
@@ -63,6 +69,13 @@ export default class Material extends MaterialBase {
 	validateFormat (opts) {
 
 		this.validateStringForProperty('format', { isRequired: opts.isRequired });
+
+	}
+
+	validateYear () {
+
+		if (Boolean(this.year) && !isValidYear(this.year))
+			this.addPropertyError('year', 'Value needs to be a valid year');
 
 	}
 

--- a/src/neo4j/cypher-queries/character.js
+++ b/src/neo4j/cypher-queries/character.js
@@ -55,6 +55,7 @@ const getShowQuery = () => `
 					.uuid,
 					.name,
 					.format,
+					.year,
 					writingCredits: sourceMaterialWritingCredits
 				}
 			END
@@ -83,7 +84,7 @@ const getShowQuery = () => `
 				ELSE materialRel { .displayName, .qualifier, .group }
 			END
 		) AS depictions
-		ORDER BY material.name
+		ORDER BY material.year DESC, material.name
 
 	WITH character,
 		COLLECT(
@@ -94,6 +95,7 @@ const getShowQuery = () => `
 					.uuid,
 					.name,
 					.format,
+					.year,
 					writingCredits: writingCredits,
 					depictions: depictions
 				}

--- a/src/neo4j/cypher-queries/company.js
+++ b/src/neo4j/cypher-queries/company.js
@@ -95,6 +95,7 @@ const getShowQuery = () => `
 						uuid: CASE entity.uuid WHEN company.uuid THEN null ELSE entity.uuid END,
 						.name,
 						.format,
+						.year,
 						writingCredits: sourceMaterialWritingCredits
 					}
 				END
@@ -114,7 +115,7 @@ const getShowQuery = () => `
 					}
 				END
 			) AS writingCredits
-			ORDER BY material.name
+			ORDER BY material.year DESC, material.name
 
 		WITH company,
 			COLLECT(
@@ -125,6 +126,7 @@ const getShowQuery = () => `
 						.uuid,
 						.name,
 						.format,
+						.year,
 						writingCredits: writingCredits,
 						creditType: creditType,
 						hasDirectCredit: hasDirectCredit,
@@ -450,21 +452,21 @@ const getShowQuery = () => `
 				material.hasDirectCredit AND
 				NOT material.isSubsequentVersion AND
 				material.creditType IS NULL |
-			material { .model, .uuid, .name, .format, .writingCredits }
+			material { .model, .uuid, .name, .format, .year, .writingCredits }
 		] AS materials,
 		[
 			material IN materials WHERE material.isSubsequentVersion |
-			material { .model, .uuid, .name, .format, .writingCredits }
+			material { .model, .uuid, .name, .format, .year, .writingCredits }
 		] AS subsequentVersionMaterials,
 		[
 			material IN materials WHERE
 				material.isSourcingMaterial OR
 				material.creditType = 'NON_SPECIFIC_SOURCE_MATERIAL' |
-			material { .model, .uuid, .name, .format, .writingCredits }
+			material { .model, .uuid, .name, .format, .year, .writingCredits }
 		] AS sourcingMaterials,
 		[
 			material IN materials WHERE material.creditType = 'RIGHTS_GRANTOR' |
-			material { .model, .uuid, .name, .format, .writingCredits }
+			material { .model, .uuid, .name, .format, .year, .writingCredits }
 		] AS rightsGrantorMaterials,
 		producerProductions,
 		creativeProductions,

--- a/src/neo4j/cypher-queries/person.js
+++ b/src/neo4j/cypher-queries/person.js
@@ -95,6 +95,7 @@ const getShowQuery = () => `
 						uuid: CASE entity.uuid WHEN person.uuid THEN null ELSE entity.uuid END,
 						.name,
 						.format,
+						.year,
 						writingCredits: sourceMaterialWritingCredits
 					}
 				END
@@ -114,7 +115,7 @@ const getShowQuery = () => `
 					}
 				END
 			) AS writingCredits
-			ORDER BY material.name
+			ORDER BY material.year DESC, material.name
 
 		WITH person,
 			COLLECT(
@@ -125,6 +126,7 @@ const getShowQuery = () => `
 						.uuid,
 						.name,
 						.format,
+						.year,
 						writingCredits: writingCredits,
 						creditType: creditType,
 						hasDirectCredit: hasDirectCredit,
@@ -623,21 +625,21 @@ const getShowQuery = () => `
 				material.hasDirectCredit AND
 				NOT material.isSubsequentVersion AND
 				material.creditType IS NULL |
-			material { .model, .uuid, .name, .format, .writingCredits }
+			material { .model, .uuid, .name, .format, .year, .writingCredits }
 		] AS materials,
 		[
 			material IN materials WHERE material.isSubsequentVersion |
-			material { .model, .uuid, .name, .format, .writingCredits }
+			material { .model, .uuid, .name, .format, .year, .writingCredits }
 		] AS subsequentVersionMaterials,
 		[
 			material IN materials WHERE
 				material.isSourcingMaterial OR
 				material.creditType = 'NON_SPECIFIC_SOURCE_MATERIAL' |
-			material { .model, .uuid, .name, .format, .writingCredits }
+			material { .model, .uuid, .name, .format, .year, .writingCredits }
 		] AS sourcingMaterials,
 		[
 			material IN materials WHERE material.creditType = 'RIGHTS_GRANTOR' |
-			material { .model, .uuid, .name, .format, .writingCredits }
+			material { .model, .uuid, .name, .format, .year, .writingCredits }
 		] AS rightsGrantorMaterials,
 		producerProductions,
 		castMemberProductions,

--- a/src/neo4j/cypher-queries/production.js
+++ b/src/neo4j/cypher-queries/production.js
@@ -729,6 +729,7 @@ const getShowQuery = () => `
 					.uuid,
 					.name,
 					.format,
+					.year,
 					writingCredits: sourceMaterialWritingCredits
 				}
 			END
@@ -766,7 +767,7 @@ const getShowQuery = () => `
 	WITH production, venue, castMember,
 		CASE material WHEN NULL
 			THEN null
-			ELSE material { model: 'material', .uuid, .name, .format, writingCredits: writingCredits }
+			ELSE material { model: 'material', .uuid, .name, .format, .year, writingCredits: writingCredits }
 		END AS material,
 		COLLECT(
 			CASE role.roleName WHEN NULL

--- a/test-e2e/crud/materials-api.test.js
+++ b/test-e2e/crud/materials-api.test.js
@@ -25,6 +25,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 				name: '',
 				differentiator: '',
 				format: '',
+				year: '',
 				errors: {},
 				originalVersionMaterial: {
 					model: 'material',
@@ -108,6 +109,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 				name: 'Uncle Vanya',
 				differentiator: '',
 				format: '',
+				year: '',
 				errors: {},
 				originalVersionMaterial: {
 					model: 'material',
@@ -167,6 +169,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 				name: 'Uncle Vanya',
 				differentiator: '',
 				format: '',
+				year: '',
 				errors: {},
 				originalVersionMaterial: {
 					model: 'material',
@@ -230,6 +233,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 				name: 'The Cherry Orchard',
 				differentiator: '',
 				format: '',
+				year: '',
 				errors: {},
 				originalVersionMaterial: {
 					model: 'material',
@@ -289,6 +293,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 				name: 'The Cherry Orchard',
 				differentiator: null,
 				format: null,
+				year: null,
 				originalVersionMaterial: null,
 				subsequentVersionMaterials: [],
 				sourcingMaterials: [],
@@ -315,6 +320,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 				name: 'The Cherry Orchard',
 				differentiator: '',
 				format: '',
+				year: '',
 				errors: {},
 				originalVersionMaterial: {
 					model: 'material',
@@ -380,6 +386,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 					name: 'John Gabriel Borkman',
 					differentiator: '2',
 					format: 'play',
+					year: 2007,
 					originalVersionMaterial: {
 						name: 'John Gabriel Borkman',
 						differentiator: '1'
@@ -454,6 +461,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 				name: 'John Gabriel Borkman',
 				differentiator: '2',
 				format: 'play',
+				year: 2007,
 				errors: {},
 				originalVersionMaterial: {
 					model: 'material',
@@ -618,11 +626,13 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 				name: 'John Gabriel Borkman',
 				differentiator: '2',
 				format: 'play',
+				year: 2007,
 				originalVersionMaterial: {
 					model: 'material',
 					uuid: JOHN_GABRIEL_BORKMAN_ORIGINAL_VERSION_MATERIAL_UUID,
 					name: 'John Gabriel Borkman',
 					format: null,
+					year: null,
 					writingCredits: []
 				},
 				subsequentVersionMaterials: [],
@@ -664,6 +674,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 								uuid: JOHN_GABRIEL_BORKMAN_SOURCE_MATERIAL_MATERIAL_UUID,
 								name: 'John Gabriel Borkman',
 								format: null,
+								year: null,
 								writingCredits: []
 							}
 						]
@@ -716,6 +727,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 				name: 'John Gabriel Borkman',
 				differentiator: '2',
 				format: 'play',
+				year: 2007,
 				errors: {},
 				originalVersionMaterial: {
 					model: 'material',
@@ -878,6 +890,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 					name: 'Three Sisters',
 					differentiator: '2',
 					format: 'play',
+					year: 2012,
 					originalVersionMaterial: {
 						name: 'Three Sisters',
 						differentiator: '1'
@@ -952,6 +965,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 				name: 'Three Sisters',
 				differentiator: '2',
 				format: 'play',
+				year: 2012,
 				errors: {},
 				originalVersionMaterial: {
 					model: 'material',
@@ -1116,11 +1130,13 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 				name: 'Three Sisters',
 				differentiator: '2',
 				format: 'play',
+				year: 2012,
 				originalVersionMaterial: {
 					model: 'material',
 					uuid: THREE_SISTERS_ORIGINAL_VERSION_MATERIAL_UUID,
 					name: 'Three Sisters',
 					format: null,
+					year: null,
 					writingCredits: []
 				},
 				subsequentVersionMaterials: [],
@@ -1162,6 +1178,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 								uuid: THREE_SISTERS_SOURCE_MATERIAL_MATERIAL_UUID,
 								name: 'Three Sisters',
 								format: null,
+								year: null,
 								writingCredits: []
 							}
 						]
@@ -1220,6 +1237,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 				name: 'Three Sisters',
 				differentiator: '2',
 				format: '',
+				year: '',
 				errors: {},
 				originalVersionMaterial: {
 					model: 'material',
@@ -1280,6 +1298,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 				name: 'Three Sisters',
 				differentiator: '2',
 				format: '',
+				year: '',
 				errors: {},
 				originalVersionMaterial: {
 					model: 'material',
@@ -1301,9 +1320,11 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 
 	describe('GET list endpoint', () => {
 
-		const UNCLE_VANYA_MATERIAL_UUID = '2';
-		const THE_CHERRY_ORCHARD_MATERIAL_UUID = '6';
-		const THREE_SISTERS_MATERIAL_UUID = '10';
+		const HAUNTING_JULIA_MATERIAL_UUID = '2';
+		const A_WORD_FROM_OUR_SPONSOR_MATERIAL_UUID = '6';
+		const THE_MUSICAL_JIGSAW_PLAY_MATERIAL_UUID = '10';
+		const DREAMS_FROM_A_SUMMER_HOUSE_MATERIAL_UUID = '14';
+		const COMMUNICATING_DOORS_MATERIAL_UUID = '18';
 
 		before(async () => {
 
@@ -1316,22 +1337,41 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 			await chai.request(app)
 				.post('/materials')
 				.send({
-					name: 'Uncle Vanya',
-					format: 'play'
+					name: 'Haunting Julia',
+					format: 'play',
+					year: 1994
 				});
 
 			await chai.request(app)
 				.post('/materials')
 				.send({
-					name: 'The Cherry Orchard',
-					format: 'play'
+					name: 'A Word from Our Sponsor',
+					format: 'play',
+					year: 1995
 				});
 
 			await chai.request(app)
 				.post('/materials')
 				.send({
-					name: 'Three Sisters',
-					format: 'play'
+					name: 'The Musical Jigsaw Play',
+					format: 'play',
+					year: 1994
+				});
+
+			await chai.request(app)
+				.post('/materials')
+				.send({
+					name: 'Dreams from a Summer House',
+					format: 'play',
+					year: 1992
+				});
+
+			await chai.request(app)
+				.post('/materials')
+				.send({
+					name: 'Communicating Doors',
+					format: 'play',
+					year: 1994
 				});
 
 		});
@@ -1342,7 +1382,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 
 		});
 
-		it('lists all materials ordered by name', async () => {
+		it('lists all materials ordered by year then name', async () => {
 
 			const response = await chai.request(app)
 				.get('/materials');
@@ -1350,23 +1390,42 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 			const expectedResponseBody = [
 				{
 					model: 'material',
-					uuid: THE_CHERRY_ORCHARD_MATERIAL_UUID,
-					name: 'The Cherry Orchard',
+					uuid: A_WORD_FROM_OUR_SPONSOR_MATERIAL_UUID,
+					name: 'A Word from Our Sponsor',
 					format: 'play',
+					year: 1995,
 					writingCredits: []
 				},
 				{
 					model: 'material',
-					uuid: THREE_SISTERS_MATERIAL_UUID,
-					name: 'Three Sisters',
+					uuid: COMMUNICATING_DOORS_MATERIAL_UUID,
+					name: 'Communicating Doors',
 					format: 'play',
+					year: 1994,
 					writingCredits: []
 				},
 				{
 					model: 'material',
-					uuid: UNCLE_VANYA_MATERIAL_UUID,
-					name: 'Uncle Vanya',
+					uuid: HAUNTING_JULIA_MATERIAL_UUID,
+					name: 'Haunting Julia',
 					format: 'play',
+					year: 1994,
+					writingCredits: []
+				},
+				{
+					model: 'material',
+					uuid: THE_MUSICAL_JIGSAW_PLAY_MATERIAL_UUID,
+					name: 'The Musical Jigsaw Play',
+					format: 'play',
+					year: 1994,
+					writingCredits: []
+				},
+				{
+					model: 'material',
+					uuid: DREAMS_FROM_A_SUMMER_HOUSE_MATERIAL_UUID,
+					name: 'Dreams from a Summer House',
+					format: 'play',
+					year: 1992,
 					writingCredits: []
 				}
 			];

--- a/test-e2e/crud/productions-api.test.js
+++ b/test-e2e/crud/productions-api.test.js
@@ -1504,6 +1504,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 					uuid: THE_TRAGEDY_OF_HAMLET_PRINCE_OF_DENMARK_MATERIAL_UUID,
 					name: 'The Tragedy of Hamlet, Prince of Denmark',
 					format: null,
+					year: null,
 					writingCredits: []
 				},
 				venue: {
@@ -3393,6 +3394,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 					uuid: THE_TRAGEDY_OF_KING_RICHARD_III_MATERIAL_UUID,
 					name: 'The Tragedy of King Richard III',
 					format: null,
+					year: null,
 					writingCredits: []
 				},
 				venue: {

--- a/test-e2e/instance-validation-failures/materials-api.test.js
+++ b/test-e2e/instance-validation-failures/materials-api.test.js
@@ -45,6 +45,7 @@ describe('Instance validation failures: Materials API', () => {
 					name: '',
 					differentiator: '',
 					format: '',
+					year: '',
 					hasErrors: true,
 					errors: {
 						name: [
@@ -86,6 +87,7 @@ describe('Instance validation failures: Materials API', () => {
 					name: 'The Wild Duck',
 					differentiator: '',
 					format: '',
+					year: '',
 					hasErrors: true,
 					errors: {
 						name: [
@@ -156,6 +158,7 @@ describe('Instance validation failures: Materials API', () => {
 					name: '',
 					differentiator: '',
 					format: '',
+					year: '',
 					hasErrors: true,
 					errors: {
 						name: [
@@ -203,6 +206,7 @@ describe('Instance validation failures: Materials API', () => {
 					name: 'The Wild Duck',
 					differentiator: '',
 					format: '',
+					year: '',
 					hasErrors: true,
 					errors: {
 						name: [
@@ -283,6 +287,7 @@ describe('Instance validation failures: Materials API', () => {
 					name: 'Ghosts',
 					differentiator: null,
 					format: '',
+					year: '',
 					hasErrors: true,
 					errors: {
 						associations: [

--- a/test-e2e/model-interaction/char-diff-groups-same-material.test.js
+++ b/test-e2e/model-interaction/char-diff-groups-same-material.test.js
@@ -52,6 +52,7 @@ describe('Character with multiple appearances in the same material in different 
 			.send({
 				name: '3 Winters',
 				format: 'play',
+				year: 2014,
 				characterGroups: [
 					{
 						name: '2011',
@@ -215,6 +216,7 @@ describe('Character with multiple appearances in the same material in different 
 					uuid: THREE_WINTERS_MATERIAL_UUID,
 					name: '3 Winters',
 					format: 'play',
+					year: 2014,
 					writingCredits: [],
 					depictions: [
 						{
@@ -291,6 +293,7 @@ describe('Character with multiple appearances in the same material in different 
 					uuid: THREE_WINTERS_MATERIAL_UUID,
 					name: '3 Winters',
 					format: 'play',
+					year: 2014,
 					writingCredits: [],
 					depictions: [
 						{
@@ -359,6 +362,7 @@ describe('Character with multiple appearances in the same material in different 
 					uuid: THREE_WINTERS_MATERIAL_UUID,
 					name: '3 Winters',
 					format: 'play',
+					year: 2014,
 					writingCredits: [],
 					depictions: [
 						{
@@ -435,6 +439,7 @@ describe('Character with multiple appearances in the same material in different 
 					uuid: THREE_WINTERS_MATERIAL_UUID,
 					name: '3 Winters',
 					format: 'play',
+					year: 2014,
 					writingCredits: [],
 					depictions: [
 						{

--- a/test-e2e/model-interaction/char-in-multi-prods-of-multi-materials.test.js
+++ b/test-e2e/model-interaction/char-in-multi-prods-of-multi-materials.test.js
@@ -50,6 +50,7 @@ describe('Character in multiple productions of multiple materials', () => {
 			.send({
 				name: 'Henry IV, Part 1',
 				format: 'play',
+				year: 1597,
 				characterGroups: [
 					{
 						characters: [
@@ -66,6 +67,7 @@ describe('Character in multiple productions of multiple materials', () => {
 			.send({
 				name: 'Henry IV, Part 2',
 				format: 'play',
+				year: 1599,
 				characterGroups: [
 					{
 						characters: [
@@ -82,6 +84,7 @@ describe('Character in multiple productions of multiple materials', () => {
 			.send({
 				name: 'The Merry Wives of Windsor',
 				format: 'play',
+				year: 1597,
 				characterGroups: [
 					{
 						characters: [
@@ -349,17 +352,19 @@ describe('Character in multiple productions of multiple materials', () => {
 			const expectedMaterials = [
 				{
 					model: 'material',
-					uuid: HENRY_IV_PART_1_MATERIAL_UUID,
-					name: 'Henry IV, Part 1',
+					uuid: HENRY_IV_PART_2_MATERIAL_UUID,
+					name: 'Henry IV, Part 2',
 					format: 'play',
+					year: 1599,
 					writingCredits: [],
 					depictions: []
 				},
 				{
 					model: 'material',
-					uuid: HENRY_IV_PART_2_MATERIAL_UUID,
-					name: 'Henry IV, Part 2',
+					uuid: HENRY_IV_PART_1_MATERIAL_UUID,
+					name: 'Henry IV, Part 1',
 					format: 'play',
+					year: 1597,
 					writingCredits: [],
 					depictions: []
 				},
@@ -368,6 +373,7 @@ describe('Character in multiple productions of multiple materials', () => {
 					uuid: THE_MERRY_WIVES_OF_WINDSOR_MATERIAL_UUID,
 					name: 'The Merry Wives of Windsor',
 					format: 'play',
+					year: 1597,
 					writingCredits: [],
 					depictions: []
 				}

--- a/test-e2e/model-interaction/char-multi-appearances-same-material.test.js
+++ b/test-e2e/model-interaction/char-multi-appearances-same-material.test.js
@@ -44,6 +44,7 @@ describe('Character with multiple appearances in the same material under differe
 			.send({
 				name: 'Rock \'n\' Roll',
 				format: 'play',
+				year: 2006,
 				characterGroups: [
 					{
 						characters: [
@@ -163,6 +164,7 @@ describe('Character with multiple appearances in the same material under differe
 					uuid: ROCK_N_ROLL_MATERIAL_UUID,
 					name: 'Rock \'n\' Roll',
 					format: 'play',
+					year: 2006,
 					writingCredits: [],
 					depictions: [
 						{

--- a/test-e2e/model-interaction/char-with-variant-depiction-portrayal-names.test.js
+++ b/test-e2e/model-interaction/char-with-variant-depiction-portrayal-names.test.js
@@ -68,6 +68,7 @@ describe('Character with variant depiction and portrayal names', () => {
 			.send({
 				name: 'Henry IV, Part 1',
 				format: 'play',
+				year: 1597,
 				characterGroups: [
 					{
 						characters: [
@@ -91,6 +92,7 @@ describe('Character with variant depiction and portrayal names', () => {
 			.send({
 				name: 'Henry IV, Part 2',
 				format: 'play',
+				year: 1599,
 				characterGroups: [
 					{
 						characters: [
@@ -114,6 +116,7 @@ describe('Character with variant depiction and portrayal names', () => {
 			.send({
 				name: 'Henry V',
 				format: 'play',
+				year: 1599,
 				characterGroups: [
 					{
 						characters: [
@@ -137,6 +140,7 @@ describe('Character with variant depiction and portrayal names', () => {
 			.send({
 				name: 'The Merry Wives of Windsor',
 				format: 'play',
+				year: 1597,
 				characterGroups: [
 					{
 						characters: [
@@ -433,23 +437,10 @@ describe('Character with variant depiction and portrayal names', () => {
 			const expectedMaterials = [
 				{
 					model: 'material',
-					uuid: HENRY_IV_PART_1_MATERIAL_UUID,
-					name: 'Henry IV, Part 1',
-					format: 'play',
-					writingCredits: [],
-					depictions: [
-						{
-							displayName: 'Henry, Prince of Wales',
-							qualifier: null,
-							group: null
-						}
-					]
-				},
-				{
-					model: 'material',
 					uuid: HENRY_IV_PART_2_MATERIAL_UUID,
 					name: 'Henry IV, Part 2',
 					format: 'play',
+					year: 1599,
 					writingCredits: [],
 					depictions: [
 						{
@@ -464,14 +455,31 @@ describe('Character with variant depiction and portrayal names', () => {
 					uuid: HENRY_V_MATERIAL_UUID,
 					name: 'Henry V',
 					format: 'play',
+					year: 1599,
 					writingCredits: [],
 					depictions: []
+				},
+				{
+					model: 'material',
+					uuid: HENRY_IV_PART_1_MATERIAL_UUID,
+					name: 'Henry IV, Part 1',
+					format: 'play',
+					year: 1597,
+					writingCredits: [],
+					depictions: [
+						{
+							displayName: 'Henry, Prince of Wales',
+							qualifier: null,
+							group: null
+						}
+					]
 				},
 				{
 					model: 'material',
 					uuid: THE_MERRY_WIVES_OF_WINDSOR_MATERIAL_UUID,
 					name: 'The Merry Wives of Windsor',
 					format: 'play',
+					year: 1597,
 					writingCredits: [],
 					depictions: [
 						{

--- a/test-e2e/model-interaction/char-with-variant-names-diff-materials.test.js
+++ b/test-e2e/model-interaction/char-with-variant-names-diff-materials.test.js
@@ -58,6 +58,7 @@ describe('Character with variant names from productions of different materials',
 			.send({
 				name: 'Hamlet',
 				format: 'play',
+				year: 1601,
 				characterGroups: [
 					{
 						characters: [
@@ -77,6 +78,7 @@ describe('Character with variant names from productions of different materials',
 			.send({
 				name: 'Rosencrantz and Guildenstern Are Dead',
 				format: 'play',
+				year: 1966,
 				characterGroups: [
 					{
 						characters: [
@@ -96,6 +98,7 @@ describe('Character with variant names from productions of different materials',
 			.send({
 				name: 'Fortinbras',
 				format: 'play',
+				year: 1991,
 				characterGroups: [
 					{
 						characters: [
@@ -115,6 +118,7 @@ describe('Character with variant names from productions of different materials',
 			.send({
 				name: 'Hamletmachine',
 				format: 'play',
+				year: 1977,
 				characterGroups: [
 					{
 						characters: [
@@ -313,14 +317,7 @@ describe('Character with variant names from productions of different materials',
 					uuid: FORTINBRAS_MATERIAL_UUID,
 					name: 'Fortinbras',
 					format: 'play',
-					writingCredits: [],
-					depictions: []
-				},
-				{
-					model: 'material',
-					uuid: HAMLET_MATERIAL_UUID,
-					name: 'Hamlet',
-					format: 'play',
+					year: 1991,
 					writingCredits: [],
 					depictions: []
 				},
@@ -329,6 +326,7 @@ describe('Character with variant names from productions of different materials',
 					uuid: HAMLETMACHINE_MATERIAL_UUID,
 					name: 'Hamletmachine',
 					format: 'play',
+					year: 1977,
 					writingCredits: [],
 					depictions: []
 				},
@@ -337,6 +335,16 @@ describe('Character with variant names from productions of different materials',
 					uuid: ROSENCRANTZ_AND_GUILDENSTERN_ARE_DEAD_MATERIAL_UUID,
 					name: 'Rosencrantz and Guildenstern Are Dead',
 					format: 'play',
+					year: 1966,
+					writingCredits: [],
+					depictions: []
+				},
+				{
+					model: 'material',
+					uuid: HAMLET_MATERIAL_UUID,
+					name: 'Hamlet',
+					format: 'play',
+					year: 1601,
 					writingCredits: [],
 					depictions: []
 				}

--- a/test-e2e/model-interaction/material-multi-versions-multi-wri-groups.test.js
+++ b/test-e2e/model-interaction/material-multi-versions-multi-wri-groups.test.js
@@ -50,6 +50,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 				name: 'Peer Gynt',
 				differentiator: '1',
 				format: 'play',
+				year: 1867,
 				writingCredits: [
 					{
 						entities: [
@@ -81,6 +82,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 				name: 'Peer Gynt',
 				differentiator: '2',
 				format: 'play',
+				year: 2000,
 				originalVersionMaterial: {
 					name: 'Peer Gynt',
 					differentiator: '1'
@@ -124,6 +126,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 				name: 'Peer Gynt',
 				differentiator: '3',
 				format: 'play',
+				year: 2007,
 				originalVersionMaterial: {
 					name: 'Peer Gynt',
 					differentiator: '1'
@@ -183,6 +186,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 				name: 'Ghosts',
 				differentiator: '1',
 				format: 'play',
+				year: 1881,
 				writingCredits: [
 					{
 						entities: [
@@ -206,6 +210,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 				name: 'Ghosts',
 				differentiator: '2',
 				format: 'play',
+				year: 2008,
 				originalVersionMaterial: {
 					name: 'Ghosts',
 					differentiator: '1'
@@ -305,6 +310,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 					uuid: PEER_GYNT_SUBSEQUENT_VERSION_2_MATERIAL_UUID,
 					name: 'Peer Gynt',
 					format: 'play',
+					year: 2007,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -345,6 +351,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 					uuid: PEER_GYNT_SUBSEQUENT_VERSION_1_MATERIAL_UUID,
 					name: 'Peer Gynt',
 					format: 'play',
+					year: 2000,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -405,6 +412,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 				uuid: PEER_GYNT_ORIGINAL_VERSION_MATERIAL_UUID,
 				name: 'Peer Gynt',
 				format: 'play',
+				year: 1867,
 				writingCredits: [
 					{
 						model: 'writingCredit',
@@ -502,6 +510,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 					uuid: GHOSTS_ORIGINAL_VERSION_MATERIAL_UUID,
 					name: 'Ghosts',
 					format: 'play',
+					year: 1881,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -526,6 +535,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 					uuid: PEER_GYNT_ORIGINAL_VERSION_MATERIAL_UUID,
 					name: 'Peer Gynt',
 					format: 'play',
+					year: 1867,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -561,6 +571,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 					uuid: GHOSTS_SUBSEQUENT_VERSION_MATERIAL_UUID,
 					name: 'Ghosts',
 					format: 'play',
+					year: 2008,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -617,6 +628,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 					uuid: PEER_GYNT_SUBSEQUENT_VERSION_2_MATERIAL_UUID,
 					name: 'Peer Gynt',
 					format: 'play',
+					year: 2007,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -673,6 +685,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 					uuid: PEER_GYNT_SUBSEQUENT_VERSION_1_MATERIAL_UUID,
 					name: 'Peer Gynt',
 					format: 'play',
+					year: 2000,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -723,6 +736,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 					uuid: GHOSTS_SUBSEQUENT_VERSION_MATERIAL_UUID,
 					name: 'Ghosts',
 					format: 'play',
+					year: 2008,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -779,6 +793,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 					uuid: PEER_GYNT_SUBSEQUENT_VERSION_2_MATERIAL_UUID,
 					name: 'Peer Gynt',
 					format: 'play',
+					year: 2007,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -850,6 +865,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 					uuid: GHOSTS_ORIGINAL_VERSION_MATERIAL_UUID,
 					name: 'Ghosts',
 					format: 'play',
+					year: 1881,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -874,6 +890,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 					uuid: PEER_GYNT_ORIGINAL_VERSION_MATERIAL_UUID,
 					name: 'Peer Gynt',
 					format: 'play',
+					year: 1867,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -909,6 +926,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 					uuid: GHOSTS_SUBSEQUENT_VERSION_MATERIAL_UUID,
 					name: 'Ghosts',
 					format: 'play',
+					year: 2008,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -965,6 +983,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 					uuid: PEER_GYNT_SUBSEQUENT_VERSION_2_MATERIAL_UUID,
 					name: 'Peer Gynt',
 					format: 'play',
+					year: 2007,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -1021,6 +1040,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 					uuid: PEER_GYNT_SUBSEQUENT_VERSION_1_MATERIAL_UUID,
 					name: 'Peer Gynt',
 					format: 'play',
+					year: 2000,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -1071,6 +1091,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 					uuid: GHOSTS_SUBSEQUENT_VERSION_MATERIAL_UUID,
 					name: 'Ghosts',
 					format: 'play',
+					year: 2008,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -1127,6 +1148,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 					uuid: PEER_GYNT_SUBSEQUENT_VERSION_2_MATERIAL_UUID,
 					name: 'Peer Gynt',
 					format: 'play',
+					year: 2007,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -1197,6 +1219,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 				uuid: PEER_GYNT_SUBSEQUENT_VERSION_2_MATERIAL_UUID,
 				name: 'Peer Gynt',
 				format: 'play',
+				year: 2007,
 				writingCredits: [
 					{
 						model: 'writingCredit',
@@ -1267,6 +1290,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 					uuid: PEER_GYNT_SUBSEQUENT_VERSION_2_MATERIAL_UUID,
 					name: 'Peer Gynt',
 					format: 'play',
+					year: 2007,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -1324,6 +1348,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 					uuid: PEER_GYNT_SUBSEQUENT_VERSION_1_MATERIAL_UUID,
 					name: 'Peer Gynt',
 					format: 'play',
+					year: 2000,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -1360,6 +1385,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 					uuid: PEER_GYNT_ORIGINAL_VERSION_MATERIAL_UUID,
 					name: 'Peer Gynt',
 					format: 'play',
+					year: 1867,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -1400,33 +1426,10 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 			const expectedResponseBody = [
 				{
 					model: 'material',
-					uuid: GHOSTS_ORIGINAL_VERSION_MATERIAL_UUID,
-					name: 'Ghosts',
-					format: 'play',
-					writingCredits: [
-						{
-							model: 'writingCredit',
-							name: 'by',
-							entities: [
-								{
-									model: 'person',
-									uuid: HENRIK_IBSEN_PERSON_UUID,
-									name: 'Henrik Ibsen'
-								},
-								{
-									model: 'company',
-									uuid: IBSEN_THEATRE_COMPANY_UUID,
-									name: 'Ibsen Theatre Company'
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'material',
 					uuid: GHOSTS_SUBSEQUENT_VERSION_MATERIAL_UUID,
 					name: 'Ghosts',
 					format: 'play',
+					year: 2008,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -1480,9 +1483,10 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 				},
 				{
 					model: 'material',
-					uuid: PEER_GYNT_ORIGINAL_VERSION_MATERIAL_UUID,
+					uuid: PEER_GYNT_SUBSEQUENT_VERSION_2_MATERIAL_UUID,
 					name: 'Peer Gynt',
 					format: 'play',
+					year: 2007,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -1499,6 +1503,38 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 									name: 'Ibsen Theatre Company'
 								}
 							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'translated by',
+							entities: [
+								{
+									model: 'person',
+									uuid: GERRY_BAMMAN_PERSON_UUID,
+									name: 'Gerry Bamman'
+								},
+								{
+									model: 'company',
+									uuid: BAMMAN_THEATRE_COMPANY_UUID,
+									name: 'Bamman Theatre Company'
+								},
+								{
+									model: 'person',
+									uuid: IRENE_B_BERMAN_PERSON_UUID,
+									name: 'Irene B Berman'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'adapted by',
+							entities: [
+								{
+									model: 'person',
+									uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
+									name: 'Baltasar Kormákur'
+								}
+							]
 						}
 					]
 				},
@@ -1507,6 +1543,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 					uuid: PEER_GYNT_SUBSEQUENT_VERSION_1_MATERIAL_UUID,
 					name: 'Peer Gynt',
 					format: 'play',
+					year: 2000,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -1539,9 +1576,10 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 				},
 				{
 					model: 'material',
-					uuid: PEER_GYNT_SUBSEQUENT_VERSION_2_MATERIAL_UUID,
-					name: 'Peer Gynt',
+					uuid: GHOSTS_ORIGINAL_VERSION_MATERIAL_UUID,
+					name: 'Ghosts',
 					format: 'play',
+					year: 1881,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -1558,36 +1596,29 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 									name: 'Ibsen Theatre Company'
 								}
 							]
-						},
+						}
+					]
+				},
+				{
+					model: 'material',
+					uuid: PEER_GYNT_ORIGINAL_VERSION_MATERIAL_UUID,
+					name: 'Peer Gynt',
+					format: 'play',
+					year: 1867,
+					writingCredits: [
 						{
 							model: 'writingCredit',
-							name: 'translated by',
+							name: 'by',
 							entities: [
 								{
 									model: 'person',
-									uuid: GERRY_BAMMAN_PERSON_UUID,
-									name: 'Gerry Bamman'
+									uuid: HENRIK_IBSEN_PERSON_UUID,
+									name: 'Henrik Ibsen'
 								},
 								{
 									model: 'company',
-									uuid: BAMMAN_THEATRE_COMPANY_UUID,
-									name: 'Bamman Theatre Company'
-								},
-								{
-									model: 'person',
-									uuid: IRENE_B_BERMAN_PERSON_UUID,
-									name: 'Irene B Berman'
-								}
-							]
-						},
-						{
-							model: 'writingCredit',
-							name: 'adapted by',
-							entities: [
-								{
-									model: 'person',
-									uuid: BALTASAR_KORMÁKUR_PERSON_UUID,
-									name: 'Baltasar Kormákur'
+									uuid: IBSEN_THEATRE_COMPANY_UUID,
+									name: 'Ibsen Theatre Company'
 								}
 							]
 						}

--- a/test-e2e/model-interaction/material-with-multi-prods.test.js
+++ b/test-e2e/model-interaction/material-with-multi-prods.test.js
@@ -37,7 +37,8 @@ describe('Material with multiple productions', () => {
 			.post('/materials')
 			.send({
 				name: 'Twelfth Night',
-				format: 'play'
+				format: 'play',
+				year: 1602
 			});
 
 		await chai.request(app)
@@ -167,6 +168,7 @@ describe('Material with multiple productions', () => {
 				uuid: TWELFTH_NIGHT_MATERIAL_UUID,
 				name: 'Twelfth Night',
 				format: 'play',
+				year: 1602,
 				writingCredits: []
 			};
 
@@ -187,6 +189,7 @@ describe('Material with multiple productions', () => {
 				uuid: TWELFTH_NIGHT_MATERIAL_UUID,
 				name: 'Twelfth Night',
 				format: 'play',
+				year: 1602,
 				writingCredits: []
 			};
 
@@ -207,6 +210,7 @@ describe('Material with multiple productions', () => {
 				uuid: TWELFTH_NIGHT_MATERIAL_UUID,
 				name: 'Twelfth Night',
 				format: 'play',
+				year: 1602,
 				writingCredits: []
 			};
 

--- a/test-e2e/model-interaction/material-with-multiple-credited-entities.test.js
+++ b/test-e2e/model-interaction/material-with-multiple-credited-entities.test.js
@@ -33,6 +33,7 @@ describe('Materials with entities credited multiple times', () => {
 			.send({
 				name: 'Material name',
 				format: 'play',
+				year: 2015,
 				writingCredits: [
 					{
 						entities: [
@@ -134,6 +135,7 @@ describe('Materials with entities credited multiple times', () => {
 					uuid: MATERIAL_UUID,
 					name: 'Material name',
 					format: 'play',
+					year: 2015,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -189,6 +191,7 @@ describe('Materials with entities credited multiple times', () => {
 					uuid: MATERIAL_UUID,
 					name: 'Material name',
 					format: 'play',
+					year: 2015,
 					writingCredits: [
 						{
 							model: 'writingCredit',

--- a/test-e2e/model-interaction/material-with-rights-grantor.test.js
+++ b/test-e2e/model-interaction/material-with-rights-grantor.test.js
@@ -36,6 +36,7 @@ describe('Materials with rights grantor credits', () => {
 				name: 'The Ladykillers',
 				differentiator: '1',
 				format: 'motion picture screenplay',
+				year: 1955,
 				writingCredits: [
 					{
 						entities: [
@@ -53,6 +54,7 @@ describe('Materials with rights grantor credits', () => {
 				name: 'The Ladykillers',
 				differentiator: '2',
 				format: 'play',
+				year: 2011,
 				writingCredits: [
 					{
 						entities: [
@@ -112,6 +114,7 @@ describe('Materials with rights grantor credits', () => {
 					uuid: THE_LADYKILLERS_PLAY_MATERIAL_UUID,
 					name: 'The Ladykillers',
 					format: 'play',
+					year: 2011,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -133,6 +136,7 @@ describe('Materials with rights grantor credits', () => {
 									uuid: THE_LADYKILLERS_SCREENPLAY_MATERIAL_UUID,
 									name: 'The Ladykillers',
 									format: 'motion picture screenplay',
+									year: 1955,
 									writingCredits: [
 										{
 											model: 'writingCredit',
@@ -187,6 +191,7 @@ describe('Materials with rights grantor credits', () => {
 					uuid: THE_LADYKILLERS_PLAY_MATERIAL_UUID,
 					name: 'The Ladykillers',
 					format: 'play',
+					year: 2011,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -208,6 +213,7 @@ describe('Materials with rights grantor credits', () => {
 									uuid: THE_LADYKILLERS_SCREENPLAY_MATERIAL_UUID,
 									name: 'The Ladykillers',
 									format: 'motion picture screenplay',
+									year: 1955,
 									writingCredits: [
 										{
 											model: 'writingCredit',

--- a/test-e2e/model-interaction/material-with-source-material.test.js
+++ b/test-e2e/model-interaction/material-with-source-material.test.js
@@ -67,6 +67,7 @@ describe('Materials with source material', () => {
 			.send({
 				name: 'A Midsummer Night\'s Dream',
 				format: 'play',
+				year: 1595,
 				writingCredits: [
 					{
 						entities: [
@@ -88,6 +89,7 @@ describe('Materials with source material', () => {
 			.send({
 				name: 'The Donkey Show',
 				format: 'musical',
+				year: 2000,
 				writingCredits: [
 					{
 						name: 'book by',
@@ -117,6 +119,7 @@ describe('Materials with source material', () => {
 			.send({
 				name: 'The Indian Boy',
 				format: 'play',
+				year: 2006,
 				writingCredits: [
 					{
 						entities: [
@@ -156,6 +159,7 @@ describe('Materials with source material', () => {
 			.send({
 				name: 'Shakespeare\'s Villains',
 				format: 'play',
+				year: 1998,
 				writingCredits: [
 					{
 						entities: [
@@ -200,6 +204,7 @@ describe('Materials with source material', () => {
 			.send({
 				name: 'A Moorish Captain',
 				format: 'tale',
+				year: 1565,
 				writingCredits: [
 					{
 						entities: [
@@ -222,6 +227,7 @@ describe('Materials with source material', () => {
 			.send({
 				name: 'Othello',
 				format: 'play',
+				year: 1603,
 				writingCredits: [
 					{
 						entities: [
@@ -394,63 +400,10 @@ describe('Materials with source material', () => {
 			const expectedSourcingMaterials = [
 				{
 					model: 'material',
-					uuid: THE_DONKEY_SHOW_MATERIAL_UUID,
-					name: 'The Donkey Show',
-					format: 'musical',
-					writingCredits: [
-						{
-							model: 'writingCredit',
-							name: 'book by',
-							entities: [
-								{
-									model: 'person',
-									uuid: DIANE_PAULUS_PERSON_UUID,
-									name: 'Diane Paulus'
-								},
-								{
-									model: 'person',
-									uuid: RANDY_WEINER_PERSON_UUID,
-									name: 'Randy Weiner'
-								}
-							]
-						},
-						{
-							model: 'writingCredit',
-							name: 'based on',
-							entities: [
-								{
-									model: 'material',
-									uuid: null,
-									name: 'A Midsummer Night\'s Dream',
-									format: 'play',
-									writingCredits: [
-										{
-											model: 'writingCredit',
-											name: 'by',
-											entities: [
-												{
-													model: 'person',
-													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
-													name: 'William Shakespeare'
-												},
-												{
-													model: 'company',
-													uuid: THE_KINGS_MEN_COMPANY_UUID,
-													name: 'The King\'s Men'
-												}
-											]
-										}
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'material',
 					uuid: THE_INDIAN_BOY_MATERIAL_UUID,
 					name: 'The Indian Boy',
 					format: 'play',
+					year: 2006,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -477,6 +430,63 @@ describe('Materials with source material', () => {
 									uuid: null,
 									name: 'A Midsummer Night\'s Dream',
 									format: 'play',
+									year: 1595,
+									writingCredits: [
+										{
+											model: 'writingCredit',
+											name: 'by',
+											entities: [
+												{
+													model: 'person',
+													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+													name: 'William Shakespeare'
+												},
+												{
+													model: 'company',
+													uuid: THE_KINGS_MEN_COMPANY_UUID,
+													name: 'The King\'s Men'
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'material',
+					uuid: THE_DONKEY_SHOW_MATERIAL_UUID,
+					name: 'The Donkey Show',
+					format: 'musical',
+					year: 2000,
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'book by',
+							entities: [
+								{
+									model: 'person',
+									uuid: DIANE_PAULUS_PERSON_UUID,
+									name: 'Diane Paulus'
+								},
+								{
+									model: 'person',
+									uuid: RANDY_WEINER_PERSON_UUID,
+									name: 'Randy Weiner'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'based on',
+							entities: [
+								{
+									model: 'material',
+									uuid: null,
+									name: 'A Midsummer Night\'s Dream',
+									format: 'play',
+									year: 1595,
 									writingCredits: [
 										{
 											model: 'writingCredit',
@@ -601,6 +611,7 @@ describe('Materials with source material', () => {
 							uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
 							name: 'A Midsummer Night\'s Dream',
 							format: 'play',
+							year: 1595,
 							writingCredits: [
 								{
 									model: 'writingCredit',
@@ -689,6 +700,7 @@ describe('Materials with source material', () => {
 					uuid: OTHELLO_MATERIAL_UUID,
 					name: 'Othello',
 					format: 'play',
+					year: 1603,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -715,6 +727,7 @@ describe('Materials with source material', () => {
 									uuid: null,
 									name: 'A Moorish Captain',
 									format: 'tale',
+									year: 1565,
 									writingCredits: [
 										{
 											model: 'writingCredit',
@@ -778,6 +791,7 @@ describe('Materials with source material', () => {
 							uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
 							name: 'A Moorish Captain',
 							format: 'tale',
+							year: 1565,
 							writingCredits: [
 								{
 									model: 'writingCredit',
@@ -816,9 +830,10 @@ describe('Materials with source material', () => {
 			const expectedSourcingMaterials = [
 				{
 					model: 'material',
-					uuid: OTHELLO_MATERIAL_UUID,
-					name: 'Othello',
+					uuid: THE_INDIAN_BOY_MATERIAL_UUID,
+					name: 'The Indian Boy',
 					format: 'play',
+					year: 2006,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -826,13 +841,69 @@ describe('Materials with source material', () => {
 							entities: [
 								{
 									model: 'person',
-									uuid: null,
-									name: 'William Shakespeare'
+									uuid: RONA_MUNRO_PERSON_UUID,
+									name: 'Rona Munro'
 								},
 								{
 									model: 'company',
-									uuid: THE_KINGS_MEN_COMPANY_UUID,
-									name: 'The King\'s Men'
+									uuid: ROYAL_SHAKESPEARE_COMPANY_UUID,
+									name: 'Royal Shakespeare Company'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'inspired by',
+							entities: [
+								{
+									model: 'material',
+									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
+									name: 'A Midsummer Night\'s Dream',
+									format: 'play',
+									year: 1595,
+									writingCredits: [
+										{
+											model: 'writingCredit',
+											name: 'by',
+											entities: [
+												{
+													model: 'person',
+													uuid: null,
+													name: 'William Shakespeare'
+												},
+												{
+													model: 'company',
+													uuid: THE_KINGS_MEN_COMPANY_UUID,
+													name: 'The King\'s Men'
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'material',
+					uuid: THE_DONKEY_SHOW_MATERIAL_UUID,
+					name: 'The Donkey Show',
+					format: 'musical',
+					year: 2000,
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'book by',
+							entities: [
+								{
+									model: 'person',
+									uuid: DIANE_PAULUS_PERSON_UUID,
+									name: 'Diane Paulus'
+								},
+								{
+									model: 'person',
+									uuid: RANDY_WEINER_PERSON_UUID,
+									name: 'Randy Weiner'
 								}
 							]
 						},
@@ -842,9 +913,10 @@ describe('Materials with source material', () => {
 							entities: [
 								{
 									model: 'material',
-									uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
-									name: 'A Moorish Captain',
-									format: 'tale',
+									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
+									name: 'A Midsummer Night\'s Dream',
+									format: 'play',
+									year: 1595,
 									writingCredits: [
 										{
 											model: 'writingCredit',
@@ -873,6 +945,7 @@ describe('Materials with source material', () => {
 					uuid: SHAKESPEARES_VILLAINS_MATERIAL_UUID,
 					name: 'Shakespeare\'s Villains',
 					format: 'play',
+					year: 1998,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -910,23 +983,24 @@ describe('Materials with source material', () => {
 				},
 				{
 					model: 'material',
-					uuid: THE_DONKEY_SHOW_MATERIAL_UUID,
-					name: 'The Donkey Show',
-					format: 'musical',
+					uuid: OTHELLO_MATERIAL_UUID,
+					name: 'Othello',
+					format: 'play',
+					year: 1603,
 					writingCredits: [
 						{
 							model: 'writingCredit',
-							name: 'book by',
+							name: 'by',
 							entities: [
 								{
 									model: 'person',
-									uuid: DIANE_PAULUS_PERSON_UUID,
-									name: 'Diane Paulus'
+									uuid: null,
+									name: 'William Shakespeare'
 								},
 								{
-									model: 'person',
-									uuid: RANDY_WEINER_PERSON_UUID,
-									name: 'Randy Weiner'
+									model: 'company',
+									uuid: THE_KINGS_MEN_COMPANY_UUID,
+									name: 'The King\'s Men'
 								}
 							]
 						},
@@ -936,63 +1010,10 @@ describe('Materials with source material', () => {
 							entities: [
 								{
 									model: 'material',
-									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
-									name: 'A Midsummer Night\'s Dream',
-									format: 'play',
-									writingCredits: [
-										{
-											model: 'writingCredit',
-											name: 'by',
-											entities: [
-												{
-													model: 'person',
-													uuid: null,
-													name: 'William Shakespeare'
-												},
-												{
-													model: 'company',
-													uuid: THE_KINGS_MEN_COMPANY_UUID,
-													name: 'The King\'s Men'
-												}
-											]
-										}
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'material',
-					uuid: THE_INDIAN_BOY_MATERIAL_UUID,
-					name: 'The Indian Boy',
-					format: 'play',
-					writingCredits: [
-						{
-							model: 'writingCredit',
-							name: 'by',
-							entities: [
-								{
-									model: 'person',
-									uuid: RONA_MUNRO_PERSON_UUID,
-									name: 'Rona Munro'
-								},
-								{
-									model: 'company',
-									uuid: ROYAL_SHAKESPEARE_COMPANY_UUID,
-									name: 'Royal Shakespeare Company'
-								}
-							]
-						},
-						{
-							model: 'writingCredit',
-							name: 'inspired by',
-							entities: [
-								{
-									model: 'material',
-									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
-									name: 'A Midsummer Night\'s Dream',
-									format: 'play',
+									uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
+									name: 'A Moorish Captain',
+									format: 'tale',
+									year: 1565,
 									writingCredits: [
 										{
 											model: 'writingCredit',
@@ -1036,6 +1057,7 @@ describe('Materials with source material', () => {
 					uuid: THE_INDIAN_BOY_MATERIAL_UUID,
 					name: 'The Indian Boy',
 					format: 'play',
+					year: 2006,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -1062,6 +1084,7 @@ describe('Materials with source material', () => {
 									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
 									name: 'A Midsummer Night\'s Dream',
 									format: 'play',
+									year: 1595,
 									writingCredits: [
 										{
 											model: 'writingCredit',
@@ -1105,6 +1128,7 @@ describe('Materials with source material', () => {
 					uuid: SHAKESPEARES_VILLAINS_MATERIAL_UUID,
 					name: 'Shakespeare\'s Villains',
 					format: 'play',
+					year: 1998,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -1157,9 +1181,10 @@ describe('Materials with source material', () => {
 			const expectedSourcingMaterials = [
 				{
 					model: 'material',
-					uuid: OTHELLO_MATERIAL_UUID,
-					name: 'Othello',
+					uuid: THE_INDIAN_BOY_MATERIAL_UUID,
+					name: 'The Indian Boy',
 					format: 'play',
+					year: 2006,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -1167,13 +1192,69 @@ describe('Materials with source material', () => {
 							entities: [
 								{
 									model: 'person',
-									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
-									name: 'William Shakespeare'
+									uuid: RONA_MUNRO_PERSON_UUID,
+									name: 'Rona Munro'
 								},
 								{
 									model: 'company',
-									uuid: null,
-									name: 'The King\'s Men'
+									uuid: ROYAL_SHAKESPEARE_COMPANY_UUID,
+									name: 'Royal Shakespeare Company'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'inspired by',
+							entities: [
+								{
+									model: 'material',
+									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
+									name: 'A Midsummer Night\'s Dream',
+									format: 'play',
+									year: 1595,
+									writingCredits: [
+										{
+											model: 'writingCredit',
+											name: 'by',
+											entities: [
+												{
+													model: 'person',
+													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+													name: 'William Shakespeare'
+												},
+												{
+													model: 'company',
+													uuid: null,
+													name: 'The King\'s Men'
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'material',
+					uuid: THE_DONKEY_SHOW_MATERIAL_UUID,
+					name: 'The Donkey Show',
+					format: 'musical',
+					year: 2000,
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'book by',
+							entities: [
+								{
+									model: 'person',
+									uuid: DIANE_PAULUS_PERSON_UUID,
+									name: 'Diane Paulus'
+								},
+								{
+									model: 'person',
+									uuid: RANDY_WEINER_PERSON_UUID,
+									name: 'Randy Weiner'
 								}
 							]
 						},
@@ -1183,9 +1264,10 @@ describe('Materials with source material', () => {
 							entities: [
 								{
 									model: 'material',
-									uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
-									name: 'A Moorish Captain',
-									format: 'tale',
+									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
+									name: 'A Midsummer Night\'s Dream',
+									format: 'play',
+									year: 1595,
 									writingCredits: [
 										{
 											model: 'writingCredit',
@@ -1214,6 +1296,7 @@ describe('Materials with source material', () => {
 					uuid: SHAKESPEARES_VILLAINS_MATERIAL_UUID,
 					name: 'Shakespeare\'s Villains',
 					format: 'play',
+					year: 1998,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -1251,23 +1334,24 @@ describe('Materials with source material', () => {
 				},
 				{
 					model: 'material',
-					uuid: THE_DONKEY_SHOW_MATERIAL_UUID,
-					name: 'The Donkey Show',
-					format: 'musical',
+					uuid: OTHELLO_MATERIAL_UUID,
+					name: 'Othello',
+					format: 'play',
+					year: 1603,
 					writingCredits: [
 						{
 							model: 'writingCredit',
-							name: 'book by',
+							name: 'by',
 							entities: [
 								{
 									model: 'person',
-									uuid: DIANE_PAULUS_PERSON_UUID,
-									name: 'Diane Paulus'
+									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+									name: 'William Shakespeare'
 								},
 								{
-									model: 'person',
-									uuid: RANDY_WEINER_PERSON_UUID,
-									name: 'Randy Weiner'
+									model: 'company',
+									uuid: null,
+									name: 'The King\'s Men'
 								}
 							]
 						},
@@ -1277,63 +1361,10 @@ describe('Materials with source material', () => {
 							entities: [
 								{
 									model: 'material',
-									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
-									name: 'A Midsummer Night\'s Dream',
-									format: 'play',
-									writingCredits: [
-										{
-											model: 'writingCredit',
-											name: 'by',
-											entities: [
-												{
-													model: 'person',
-													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
-													name: 'William Shakespeare'
-												},
-												{
-													model: 'company',
-													uuid: null,
-													name: 'The King\'s Men'
-												}
-											]
-										}
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'material',
-					uuid: THE_INDIAN_BOY_MATERIAL_UUID,
-					name: 'The Indian Boy',
-					format: 'play',
-					writingCredits: [
-						{
-							model: 'writingCredit',
-							name: 'by',
-							entities: [
-								{
-									model: 'person',
-									uuid: RONA_MUNRO_PERSON_UUID,
-									name: 'Rona Munro'
-								},
-								{
-									model: 'company',
-									uuid: ROYAL_SHAKESPEARE_COMPANY_UUID,
-									name: 'Royal Shakespeare Company'
-								}
-							]
-						},
-						{
-							model: 'writingCredit',
-							name: 'inspired by',
-							entities: [
-								{
-									model: 'material',
-									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
-									name: 'A Midsummer Night\'s Dream',
-									format: 'play',
+									uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
+									name: 'A Moorish Captain',
+									format: 'tale',
+									year: 1565,
 									writingCredits: [
 										{
 											model: 'writingCredit',
@@ -1377,6 +1408,7 @@ describe('Materials with source material', () => {
 					uuid: THE_INDIAN_BOY_MATERIAL_UUID,
 					name: 'The Indian Boy',
 					format: 'play',
+					year: 2006,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -1403,6 +1435,7 @@ describe('Materials with source material', () => {
 									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
 									name: 'A Midsummer Night\'s Dream',
 									format: 'play',
+									year: 1595,
 									writingCredits: [
 										{
 											model: 'writingCredit',
@@ -1446,6 +1479,7 @@ describe('Materials with source material', () => {
 					uuid: SHAKESPEARES_VILLAINS_MATERIAL_UUID,
 					name: 'Shakespeare\'s Villains',
 					format: 'play',
+					year: 1998,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -1500,6 +1534,7 @@ describe('Materials with source material', () => {
 				uuid: THE_INDIAN_BOY_MATERIAL_UUID,
 				name: 'The Indian Boy',
 				format: 'play',
+				year: 2006,
 				writingCredits: [
 					{
 						model: 'writingCredit',
@@ -1526,6 +1561,7 @@ describe('Materials with source material', () => {
 								uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
 								name: 'A Midsummer Night\'s Dream',
 								format: 'play',
+								year: 1595,
 								writingCredits: [
 									{
 										model: 'writingCredit',
@@ -1567,6 +1603,7 @@ describe('Materials with source material', () => {
 				uuid: SHAKESPEARES_VILLAINS_MATERIAL_UUID,
 				name: 'Shakespeare\'s Villains',
 				format: 'play',
+				year: 1998,
 				writingCredits: [
 					{
 						model: 'writingCredit',
@@ -1620,6 +1657,7 @@ describe('Materials with source material', () => {
 				uuid: OTHELLO_MATERIAL_UUID,
 				name: 'Othello',
 				format: 'play',
+				year: 1603,
 				writingCredits: [
 					{
 						model: 'writingCredit',
@@ -1646,6 +1684,7 @@ describe('Materials with source material', () => {
 								uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
 								name: 'A Moorish Captain',
 								format: 'tale',
+								year: 1565,
 								writingCredits: [
 									{
 										model: 'writingCredit',
@@ -1688,6 +1727,7 @@ describe('Materials with source material', () => {
 					uuid: THE_INDIAN_BOY_MATERIAL_UUID,
 					name: 'The Indian Boy',
 					format: 'play',
+					year: 2006,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -1714,6 +1754,7 @@ describe('Materials with source material', () => {
 									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
 									name: 'A Midsummer Night\'s Dream',
 									format: 'play',
+									year: 1595,
 									writingCredits: [
 										{
 											model: 'writingCredit',
@@ -1755,64 +1796,10 @@ describe('Materials with source material', () => {
 			const expectedMaterials = [
 				{
 					model: 'material',
-					uuid: OTHELLO_MATERIAL_UUID,
-					name: 'Othello',
-					format: 'play',
-					writingCredits: [
-						{
-							model: 'writingCredit',
-							name: 'by',
-							entities: [
-								{
-									model: 'person',
-									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
-									name: 'William Shakespeare'
-								},
-								{
-									model: 'company',
-									uuid: THE_KINGS_MEN_COMPANY_UUID,
-									name: 'The King\'s Men'
-								}
-							]
-						},
-						{
-							model: 'writingCredit',
-							name: 'based on',
-							entities: [
-								{
-									model: 'material',
-									uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
-									name: 'A Moorish Captain',
-									format: 'tale',
-									writingCredits: [
-										{
-											model: 'writingCredit',
-											name: 'by',
-											entities: [
-												{
-													model: 'person',
-													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
-													name: 'William Shakespeare'
-												},
-												{
-													model: 'company',
-													uuid: THE_KINGS_MEN_COMPANY_UUID,
-													name: 'The King\'s Men'
-												}
-											]
-										}
-									]
-								}
-							]
-						}
-					],
-					depictions: []
-				},
-				{
-					model: 'material',
 					uuid: SHAKESPEARES_VILLAINS_MATERIAL_UUID,
 					name: 'Shakespeare\'s Villains',
 					format: 'play',
+					year: 1998,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -1843,6 +1830,63 @@ describe('Materials with source material', () => {
 									model: 'company',
 									uuid: THE_KINGS_MEN_COMPANY_UUID,
 									name: 'The King\'s Men'
+								}
+							]
+						}
+					],
+					depictions: []
+				},
+				{
+					model: 'material',
+					uuid: OTHELLO_MATERIAL_UUID,
+					name: 'Othello',
+					format: 'play',
+					year: 1603,
+					writingCredits: [
+						{
+							model: 'writingCredit',
+							name: 'by',
+							entities: [
+								{
+									model: 'person',
+									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+									name: 'William Shakespeare'
+								},
+								{
+									model: 'company',
+									uuid: THE_KINGS_MEN_COMPANY_UUID,
+									name: 'The King\'s Men'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'based on',
+							entities: [
+								{
+									model: 'material',
+									uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
+									name: 'A Moorish Captain',
+									format: 'tale',
+									year: 1565,
+									writingCredits: [
+										{
+											model: 'writingCredit',
+											name: 'by',
+											entities: [
+												{
+													model: 'person',
+													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+													name: 'William Shakespeare'
+												},
+												{
+													model: 'company',
+													uuid: THE_KINGS_MEN_COMPANY_UUID,
+													name: 'The King\'s Men'
+												}
+											]
+										}
+									]
 								}
 							]
 						}
@@ -1869,9 +1913,10 @@ describe('Materials with source material', () => {
 			const expectedResponseBody = [
 				{
 					model: 'material',
-					uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
-					name: 'A Midsummer Night\'s Dream',
+					uuid: THE_INDIAN_BOY_MATERIAL_UUID,
+					name: 'The Indian Boy',
 					format: 'play',
+					year: 2006,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -1879,13 +1924,44 @@ describe('Materials with source material', () => {
 							entities: [
 								{
 									model: 'person',
-									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
-									name: 'William Shakespeare'
+									uuid: RONA_MUNRO_PERSON_UUID,
+									name: 'Rona Munro'
 								},
 								{
 									model: 'company',
-									uuid: THE_KINGS_MEN_COMPANY_UUID,
-									name: 'The King\'s Men'
+									uuid: ROYAL_SHAKESPEARE_COMPANY_UUID,
+									name: 'Royal Shakespeare Company'
+								}
+							]
+						},
+						{
+							model: 'writingCredit',
+							name: 'inspired by',
+							entities: [
+								{
+									model: 'material',
+									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
+									name: 'A Midsummer Night\'s Dream',
+									format: 'play',
+									year: 1595,
+									writingCredits: [
+										{
+											model: 'writingCredit',
+											name: 'by',
+											entities: [
+												{
+													model: 'person',
+													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+													name: 'William Shakespeare'
+												},
+												{
+													model: 'company',
+													uuid: THE_KINGS_MEN_COMPANY_UUID,
+													name: 'The King\'s Men'
+												}
+											]
+										}
+									]
 								}
 							]
 						}
@@ -1893,47 +1969,24 @@ describe('Materials with source material', () => {
 				},
 				{
 					model: 'material',
-					uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
-					name: 'A Moorish Captain',
-					format: 'tale',
+					uuid: THE_DONKEY_SHOW_MATERIAL_UUID,
+					name: 'The Donkey Show',
+					format: 'musical',
+					year: 2000,
 					writingCredits: [
 						{
 							model: 'writingCredit',
-							name: 'by',
+							name: 'book by',
 							entities: [
 								{
 									model: 'person',
-									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
-									name: 'William Shakespeare'
+									uuid: DIANE_PAULUS_PERSON_UUID,
+									name: 'Diane Paulus'
 								},
-								{
-									model: 'company',
-									uuid: THE_KINGS_MEN_COMPANY_UUID,
-									name: 'The King\'s Men'
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'material',
-					uuid: OTHELLO_MATERIAL_UUID,
-					name: 'Othello',
-					format: 'play',
-					writingCredits: [
-						{
-							model: 'writingCredit',
-							name: 'by',
-							entities: [
 								{
 									model: 'person',
-									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
-									name: 'William Shakespeare'
-								},
-								{
-									model: 'company',
-									uuid: THE_KINGS_MEN_COMPANY_UUID,
-									name: 'The King\'s Men'
+									uuid: RANDY_WEINER_PERSON_UUID,
+									name: 'Randy Weiner'
 								}
 							]
 						},
@@ -1943,9 +1996,10 @@ describe('Materials with source material', () => {
 							entities: [
 								{
 									model: 'material',
-									uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
-									name: 'A Moorish Captain',
-									format: 'tale',
+									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
+									name: 'A Midsummer Night\'s Dream',
+									format: 'play',
+									year: 1595,
 									writingCredits: [
 										{
 											model: 'writingCredit',
@@ -1974,6 +2028,7 @@ describe('Materials with source material', () => {
 					uuid: SHAKESPEARES_VILLAINS_MATERIAL_UUID,
 					name: 'Shakespeare\'s Villains',
 					format: 'play',
+					year: 1998,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -2011,23 +2066,24 @@ describe('Materials with source material', () => {
 				},
 				{
 					model: 'material',
-					uuid: THE_DONKEY_SHOW_MATERIAL_UUID,
-					name: 'The Donkey Show',
-					format: 'musical',
+					uuid: OTHELLO_MATERIAL_UUID,
+					name: 'Othello',
+					format: 'play',
+					year: 1603,
 					writingCredits: [
 						{
 							model: 'writingCredit',
-							name: 'book by',
+							name: 'by',
 							entities: [
 								{
 									model: 'person',
-									uuid: DIANE_PAULUS_PERSON_UUID,
-									name: 'Diane Paulus'
+									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+									name: 'William Shakespeare'
 								},
 								{
-									model: 'person',
-									uuid: RANDY_WEINER_PERSON_UUID,
-									name: 'Randy Weiner'
+									model: 'company',
+									uuid: THE_KINGS_MEN_COMPANY_UUID,
+									name: 'The King\'s Men'
 								}
 							]
 						},
@@ -2037,9 +2093,10 @@ describe('Materials with source material', () => {
 							entities: [
 								{
 									model: 'material',
-									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
-									name: 'A Midsummer Night\'s Dream',
-									format: 'play',
+									uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
+									name: 'A Moorish Captain',
+									format: 'tale',
+									year: 1565,
 									writingCredits: [
 										{
 											model: 'writingCredit',
@@ -2065,9 +2122,10 @@ describe('Materials with source material', () => {
 				},
 				{
 					model: 'material',
-					uuid: THE_INDIAN_BOY_MATERIAL_UUID,
-					name: 'The Indian Boy',
+					uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
+					name: 'A Midsummer Night\'s Dream',
 					format: 'play',
+					year: 1595,
 					writingCredits: [
 						{
 							model: 'writingCredit',
@@ -2075,43 +2133,38 @@ describe('Materials with source material', () => {
 							entities: [
 								{
 									model: 'person',
-									uuid: RONA_MUNRO_PERSON_UUID,
-									name: 'Rona Munro'
+									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+									name: 'William Shakespeare'
 								},
 								{
 									model: 'company',
-									uuid: ROYAL_SHAKESPEARE_COMPANY_UUID,
-									name: 'Royal Shakespeare Company'
+									uuid: THE_KINGS_MEN_COMPANY_UUID,
+									name: 'The King\'s Men'
 								}
 							]
-						},
+						}
+					]
+				},
+				{
+					model: 'material',
+					uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
+					name: 'A Moorish Captain',
+					format: 'tale',
+					year: 1565,
+					writingCredits: [
 						{
 							model: 'writingCredit',
-							name: 'inspired by',
+							name: 'by',
 							entities: [
 								{
-									model: 'material',
-									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
-									name: 'A Midsummer Night\'s Dream',
-									format: 'play',
-									writingCredits: [
-										{
-											model: 'writingCredit',
-											name: 'by',
-											entities: [
-												{
-													model: 'person',
-													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
-													name: 'William Shakespeare'
-												},
-												{
-													model: 'company',
-													uuid: THE_KINGS_MEN_COMPANY_UUID,
-													name: 'The King\'s Men'
-												}
-											]
-										}
-									]
+									model: 'person',
+									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+									name: 'William Shakespeare'
+								},
+								{
+									model: 'company',
+									uuid: THE_KINGS_MEN_COMPANY_UUID,
+									name: 'The King\'s Men'
 								}
 							]
 						}

--- a/test-e2e/uniqueness-in-db/materials-api.test.js
+++ b/test-e2e/uniqueness-in-db/materials-api.test.js
@@ -51,6 +51,7 @@ describe('Uniqueness in database: Materials API', () => {
 				name: 'Home',
 				differentiator: '',
 				format: '',
+				year: '',
 				errors: {},
 				originalVersionMaterial: {
 					model: 'material',
@@ -114,6 +115,7 @@ describe('Uniqueness in database: Materials API', () => {
 				name: 'Home',
 				differentiator: '',
 				format: '',
+				year: '',
 				hasErrors: true,
 				errors: {
 					name: [
@@ -156,6 +158,7 @@ describe('Uniqueness in database: Materials API', () => {
 				name: 'Home',
 				differentiator: '1',
 				format: '',
+				year: '',
 				errors: {},
 				originalVersionMaterial: {
 					model: 'material',
@@ -221,6 +224,7 @@ describe('Uniqueness in database: Materials API', () => {
 				name: 'Home',
 				differentiator: '1',
 				format: '',
+				year: '',
 				hasErrors: true,
 				errors: {
 					name: [
@@ -263,6 +267,7 @@ describe('Uniqueness in database: Materials API', () => {
 				name: 'Home',
 				differentiator: '2',
 				format: '',
+				year: '',
 				errors: {},
 				originalVersionMaterial: {
 					model: 'material',
@@ -327,6 +332,7 @@ describe('Uniqueness in database: Materials API', () => {
 				name: 'Home',
 				differentiator: '',
 				format: '',
+				year: '',
 				errors: {},
 				originalVersionMaterial: {
 					model: 'material',

--- a/test-int/instance-validation-failures/material.test.js
+++ b/test-int/instance-validation-failures/material.test.js
@@ -8,6 +8,7 @@ describe('Material instance', () => {
 
 	const STRING_MAX_LENGTH = 1000;
 	const ABOVE_MAX_LENGTH_STRING = 'a'.repeat(STRING_MAX_LENGTH + 1);
+	const INVALID_YEAR_STRING = 'Nineteen Fifty-Nine';
 
 	const sandbox = createSandbox();
 
@@ -38,6 +39,7 @@ describe('Material instance', () => {
 					name: '',
 					differentiator: '',
 					format: '',
+					year: '',
 					hasErrors: true,
 					errors: {
 						name: [
@@ -73,6 +75,7 @@ describe('Material instance', () => {
 					name: ABOVE_MAX_LENGTH_STRING,
 					differentiator: '',
 					format: '',
+					year: '',
 					hasErrors: true,
 					errors: {
 						name: [
@@ -108,6 +111,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					differentiator: ABOVE_MAX_LENGTH_STRING,
 					format: '',
+					year: '',
 					hasErrors: true,
 					errors: {
 						differentiator: [
@@ -143,10 +147,47 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					differentiator: '',
 					format: ABOVE_MAX_LENGTH_STRING,
+					year: '',
 					hasErrors: true,
 					errors: {
 						format: [
 							'Value is too long'
+						]
+					},
+					originalVersionMaterial: {
+						uuid: undefined,
+						name: '',
+						differentiator: '',
+						errors: {}
+					},
+					writingCredits: [],
+					characterGroups: []
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+		context('year value exceeds maximum limit', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instance = new Material({ name: 'Rosmersholm', year: INVALID_YEAR_STRING });
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					uuid: undefined,
+					name: 'Rosmersholm',
+					differentiator: '',
+					format: '',
+					year: INVALID_YEAR_STRING,
+					hasErrors: true,
+					errors: {
+						year: [
+							'Value needs to be a valid year'
 						]
 					},
 					originalVersionMaterial: {
@@ -185,6 +226,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					differentiator: '',
 					format: '',
+					year: '',
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
@@ -228,6 +270,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					differentiator: '',
 					format: '',
+					year: '',
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
@@ -270,6 +313,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					differentiator: '',
 					format: '',
+					year: '',
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
@@ -317,6 +361,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					differentiator: '',
 					format: '',
+					year: '',
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
@@ -371,6 +416,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					differentiator: '',
 					format: '',
+					year: '',
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
@@ -436,6 +482,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					differentiator: '',
 					format: '',
+					year: '',
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
@@ -499,6 +546,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					differentiator: '',
 					format: '',
+					year: '',
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
@@ -562,6 +610,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					differentiator: '',
 					format: '',
+					year: '',
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
@@ -626,6 +675,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					differentiator: '',
 					format: '',
+					year: '',
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
@@ -689,6 +739,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					differentiator: '',
 					format: '',
+					year: '',
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
@@ -753,6 +804,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					differentiator: '',
 					format: '',
+					year: '',
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
@@ -825,6 +877,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					differentiator: '',
 					format: '',
+					year: '',
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
@@ -918,6 +971,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					differentiator: '',
 					format: '',
+					year: '',
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
@@ -979,6 +1033,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					differentiator: '',
 					format: '',
+					year: '',
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
@@ -1032,6 +1087,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					differentiator: '',
 					format: '',
+					year: '',
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
@@ -1095,6 +1151,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					differentiator: '',
 					format: '',
+					year: '',
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
@@ -1159,6 +1216,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					differentiator: '',
 					format: '',
+					year: '',
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
@@ -1223,6 +1281,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					differentiator: '',
 					format: '',
+					year: '',
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
@@ -1287,6 +1346,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					differentiator: '',
 					format: '',
+					year: '',
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
@@ -1351,6 +1411,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					differentiator: '',
 					format: '',
+					year: '',
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
@@ -1425,6 +1486,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					differentiator: '',
 					format: '',
+					year: '',
 					hasErrors: true,
 					errors: {},
 					originalVersionMaterial: {
@@ -1531,6 +1593,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					differentiator: '',
 					format: '',
+					year: '',
 					hasErrors: true,
 					errors: {
 						name: [
@@ -1592,6 +1655,7 @@ describe('Material instance', () => {
 					name: 'Rosmersholm',
 					differentiator: '',
 					format: '',
+					year: '',
 					hasErrors: true,
 					errors: {
 						name: [

--- a/test-unit/src/lib/is-valid-year.test.js
+++ b/test-unit/src/lib/is-valid-year.test.js
@@ -1,0 +1,57 @@
+import { expect } from 'chai';
+
+import { isValidYear } from '../../../src/lib/is-valid-year';
+
+describe('Is Valid Year module', () => {
+
+	context('year cannot be parsed as integer', () => {
+
+		it('returns false', () => {
+
+			expect(isValidYear('Nineteen Fifty-Nine')).to.be.false;
+
+		});
+
+	});
+
+	context('year is less than 0', () => {
+
+		it('returns false', () => {
+
+			expect(isValidYear(-1)).to.be.false;
+
+		});
+
+	});
+
+	context('year is more than 9999', () => {
+
+		it('returns false', () => {
+
+			expect(isValidYear(10000)).to.be.false;
+
+		});
+
+	});
+
+	context('year is 0', () => {
+
+		it('returns true', () => {
+
+			expect(isValidYear(0)).to.be.true;
+
+		});
+
+	});
+
+	context('year is 9999', () => {
+
+		it('returns true', () => {
+
+			expect(isValidYear(9999)).to.be.true;
+
+		});
+
+	});
+
+});

--- a/test-unit/src/neo4j/cypher-queries/material.test.js
+++ b/test-unit/src/neo4j/cypher-queries/material.test.js
@@ -14,7 +14,13 @@ describe('Cypher Queries Material module', () => {
 			const compactedResult = removeExcessWhitespace(result);
 
 			const startSegment = removeExcessWhitespace(`
-				CREATE (material:Material { uuid: $uuid, name: $name, differentiator: $differentiator, format: $format })
+				CREATE (material:Material {
+					uuid: $uuid,
+					name: $name,
+					differentiator: $differentiator,
+					format: $format,
+					year: $year
+				})
 			`);
 
 			const middleSegment = removeExcessWhitespace(`
@@ -28,6 +34,7 @@ describe('Cypher Queries Material module', () => {
 					material.name AS name,
 					material.differentiator AS differentiator,
 					material.format AS format,
+					material.year AS year,
 					{
 						name: COALESCE(originalVersionMaterial.name, ''),
 						differentiator: COALESCE(originalVersionMaterial.differentiator, '')
@@ -88,7 +95,8 @@ describe('Cypher Queries Material module', () => {
 				SET
 					material.name = $name,
 					material.differentiator = $differentiator,
-					material.format = $format
+					material.format = $format,
+					material.year = $year
 			`);
 
 			const middleSegment = removeExcessWhitespace(`
@@ -102,6 +110,7 @@ describe('Cypher Queries Material module', () => {
 					material.name AS name,
 					material.differentiator AS differentiator,
 					material.format AS format,
+					material.year AS year,
 					{
 						name: COALESCE(originalVersionMaterial.name, ''),
 						differentiator: COALESCE(originalVersionMaterial.differentiator, '')


### PR DESCRIPTION
This PR adds the `year` property to materials.

The decision has been made to simply call the property `year` (i.e. as opposed to `yearWritten`), as the assigned year value will mean something different to different types of material:
- Plays and novels will be year written/published
- Films will be year released

Future work will address the complexities of years attributed to materials:
- Materials that require a range of years where an exact year is unknown, e.g. King John: 1595-1598 (ref. [Shakespeare bibliography Wikipedia page](https://en.wikipedia.org/wiki/Shakespeare_bibliography))
- Materials that require an indication that the year is approximate, e.g. Richard III: around 1593 (ref. [Shakespeare bibliography Wikipedia page](https://en.wikipedia.org/wiki/Shakespeare_bibliography))
- Materials that require a combination of a range of years and an approximate year, e.g. Antony and Cleopatra: _Many scholars believe it was written in 1606–07_ ([Antony and Cleopatra Wikipedia page](https://en.wikipedia.org/wiki/Antony_and_Cleopatra#Date_and_text))
- Materials where the year is uncertain, e.g. Henry IV, Part I: Likely early to mid 1590s (ref. [Shakespeare bibliography Wikipedia page](https://en.wikipedia.org/wiki/Shakespeare_bibliography))
- Materials that were written BCE (Before the Common Era), e.g. Antigone: 441 BC (ref. [Antigone Wikipedia page](https://en.wikipedia.org/wiki/Antigone_(Sophocles_play)))

---

#### A Midsummer Night's Dream (material, play)
<img width="882" alt="material-with-year" src="https://user-images.githubusercontent.com/10484515/122996832-3b1fc580-d3a3-11eb-8474-4af8bbbddeed.png">