### PR TITLE
Add role isAlternate property

### DIFF
--- a/db-seeding/seeds/productions/mrs-affleck.json
+++ b/db-seeding/seeds/productions/mrs-affleck.json
@@ -32,7 +32,8 @@
 			"name": "Omar Brown",
 			"roles": [
 				{
-					"name": "George Constantine"
+					"name": "George Constantine",
+					"isAlternate": true
 				}
 			]
 		},
@@ -40,7 +41,8 @@
 			"name": "René Gray",
 			"roles": [
 				{
-					"name": "George Constantine"
+					"name": "George Constantine",
+					"isAlternate": true
 				}
 			]
 		},

--- a/db-seeding/seeds/productions/titus-andronicus.json
+++ b/db-seeding/seeds/productions/titus-andronicus.json
@@ -108,7 +108,8 @@
 			"name": "Hugh Wyld",
 			"roles": [
 				{
-					"name": "Young Lucius"
+					"name": "Young Lucius",
+					"isAlternate": true
 				}
 			]
 		},
@@ -116,7 +117,8 @@
 			"name": "Steven Williams",
 			"roles": [
 				{
-					"name": "Young Lucius"
+					"name": "Young Lucius",
+					"isAlternate": true
 				}
 			]
 		},

--- a/db-seeding/seeds/productions/true-west-crucible.json
+++ b/db-seeding/seeds/productions/true-west-crucible.json
@@ -24,10 +24,12 @@
 			"name": "Nigel Harman",
 			"roles": [
 				{
-					"name": "Austin"
+					"name": "Austin",
+					"isAlternate": true
 				},
 				{
-					"name": "Lee"
+					"name": "Lee",
+					"isAlternate": true
 				}
 			]
 		},
@@ -35,10 +37,12 @@
 			"name": "John Light",
 			"roles": [
 				{
-					"name": "Lee"
+					"name": "Lee",
+					"isAlternate": true
 				},
 				{
-					"name": "Austin"
+					"name": "Austin",
+					"isAlternate": true
 				}
 			]
 		}

--- a/db-seeding/seeds/productions/true-west-vaudeville.json
+++ b/db-seeding/seeds/productions/true-west-vaudeville.json
@@ -24,10 +24,12 @@
 			"name": "Kit Harington",
 			"roles": [
 				{
-					"name": "Austin"
+					"name": "Austin",
+					"isAlternate": true
 				},
 				{
-					"name": "Lee"
+					"name": "Lee",
+					"isAlternate": true
 				}
 			]
 		},
@@ -35,10 +37,12 @@
 			"name": "Johnny Flynn",
 			"roles": [
 				{
-					"name": "Lee"
+					"name": "Lee",
+					"isAlternate": true
 				},
 				{
-					"name": "Austin"
+					"name": "Austin",
+					"isAlternate": true
 				}
 			]
 		}

--- a/src/models/Role.js
+++ b/src/models/Role.js
@@ -6,11 +6,12 @@ export default class Role extends Base {
 
 		super(props);
 
-		const { characterName, characterDifferentiator, qualifier } = props;
+		const { characterName, characterDifferentiator, qualifier, isAlternate } = props;
 
 		this.characterName = characterName?.trim() || '';
 		this.characterDifferentiator = characterDifferentiator?.trim() || '';
 		this.qualifier = qualifier?.trim() || '';
+		this.isAlternate = Boolean(isAlternate) || null;
 
 	}
 

--- a/src/neo4j/cypher-queries/character.js
+++ b/src/neo4j/cypher-queries/character.js
@@ -191,7 +191,8 @@ const getShowQuery = () => `
 					model: 'character',
 					uuid: otherCharacter.uuid,
 					name: otherRole.roleName,
-					qualifier: otherRole.qualifier
+					qualifier: otherRole.qualifier,
+					isAlternate: otherRole.isAlternate
 				}
 			END
 		)) AS otherRoles
@@ -204,6 +205,7 @@ const getShowQuery = () => `
 			.name,
 			roleName: role.roleName,
 			qualifier: role.qualifier,
+			isAlternate: role.isAlternate,
 			otherRoles: otherRoles
 		}) AS performers
 		ORDER BY production.startDate DESC, production.name, venue.name

--- a/src/neo4j/cypher-queries/person.js
+++ b/src/neo4j/cypher-queries/person.js
@@ -248,7 +248,7 @@ const getShowQuery = () => `
 		COLLECT(
 			CASE role.roleName WHEN NULL
 				THEN { name: 'Performer' }
-				ELSE role { model: 'character', uuid: character.uuid, name: role.roleName, .qualifier }
+				ELSE role { model: 'character', uuid: character.uuid, name: role.roleName, .qualifier, .isAlternate }
 			END
 		) AS roles
 		ORDER BY production.startDate DESC, production.name, venue.name

--- a/src/neo4j/cypher-queries/production.js
+++ b/src/neo4j/cypher-queries/production.js
@@ -199,7 +199,8 @@ const getCreateUpdateQuery = action => {
 							roleName: role.name,
 							characterName: role.characterName,
 							characterDifferentiator: role.characterDifferentiator,
-							qualifier: role.qualifier
+							qualifier: role.qualifier,
+							isAlternate: role.isAlternate
 						}]->(castMember)
 				)
 			)
@@ -506,7 +507,8 @@ const getEditQuery = () => `
 					name: role.roleName,
 					characterName: COALESCE(role.characterName, ''),
 					characterDifferentiator: COALESCE(role.characterDifferentiator, ''),
-					qualifier: COALESCE(role.qualifier, '')
+					qualifier: COALESCE(role.qualifier, ''),
+					isAlternate: role.isAlternate
 				}
 			END
 		) + [{}] AS roles
@@ -772,7 +774,7 @@ const getShowQuery = () => `
 		COLLECT(
 			CASE role.roleName WHEN NULL
 				THEN { name: 'Performer' }
-				ELSE role { model: 'character', uuid: character.uuid, name: role.roleName, .qualifier }
+				ELSE role { model: 'character', uuid: character.uuid, name: role.roleName, .qualifier, .isAlternate }
 			END
 		) AS roles
 

--- a/test-e2e/crud/productions-api.test.js
+++ b/test-e2e/crud/productions-api.test.js
@@ -67,6 +67,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
+								isAlternate: null,
 								errors: {}
 							}
 						]
@@ -189,6 +190,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
+								isAlternate: null,
 								errors: {}
 							}
 						]
@@ -285,6 +287,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
+								isAlternate: null,
 								errors: {}
 							}
 						]
@@ -385,6 +388,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
+								isAlternate: null,
 								errors: {}
 							}
 						]
@@ -631,7 +635,8 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 									name: 'Ambassador of the English',
 									characterName: 'English Ambassador',
 									characterDifferentiator: '1',
-									qualifier: 'quux'
+									qualifier: 'quux',
+									isAlternate: true
 								}
 							]
 						},
@@ -1054,6 +1059,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: 'Hamlet, Prince of Denmark',
 								characterDifferentiator: '1',
 								qualifier: 'foo',
+								isAlternate: null,
 								errors: {}
 							},
 							{
@@ -1062,6 +1068,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
+								isAlternate: null,
 								errors: {}
 							}
 						]
@@ -1078,6 +1085,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: 'Ghost of King Hamlet',
 								characterDifferentiator: '1',
 								qualifier: 'bar',
+								isAlternate: null,
 								errors: {}
 							},
 							{
@@ -1086,6 +1094,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: 'Player King',
 								characterDifferentiator: '1',
 								qualifier: 'baz',
+								isAlternate: null,
 								errors: {}
 							},
 							{
@@ -1094,6 +1103,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
+								isAlternate: null,
 								errors: {}
 							}
 						]
@@ -1110,6 +1120,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: 'Lucianus',
 								characterDifferentiator: '1',
 								qualifier: 'qux',
+								isAlternate: null,
 								errors: {}
 							},
 							{
@@ -1118,6 +1129,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: 'English Ambassador',
 								characterDifferentiator: '1',
 								qualifier: 'quux',
+								isAlternate: true,
 								errors: {}
 							},
 							{
@@ -1126,6 +1138,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
+								isAlternate: null,
 								errors: {}
 							}
 						]
@@ -1142,6 +1155,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
+								isAlternate: null,
 								errors: {}
 							}
 						]
@@ -1158,6 +1172,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
+								isAlternate: null,
 								errors: {}
 							}
 						]
@@ -1605,7 +1620,8 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'character',
 								uuid: null,
 								name: 'Hamlet',
-								qualifier: 'foo'
+								qualifier: 'foo',
+								isAlternate: null
 							}
 						]
 					},
@@ -1618,13 +1634,15 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'character',
 								uuid: null,
 								name: 'Ghost',
-								qualifier: 'bar'
+								qualifier: 'bar',
+								isAlternate: null
 							},
 							{
 								model: 'character',
 								uuid: null,
 								name: 'First Player',
-								qualifier: 'baz'
+								qualifier: 'baz',
+								isAlternate: null
 							}
 						]
 					},
@@ -1637,13 +1655,15 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'character',
 								uuid: null,
 								name: 'Third Player',
-								qualifier: 'qux'
+								qualifier: 'qux',
+								isAlternate: null
 							},
 							{
 								model: 'character',
 								uuid: null,
 								name: 'Ambassador of the English',
-								qualifier: 'quux'
+								qualifier: 'quux',
+								isAlternate: true
 							}
 						]
 					},
@@ -2025,6 +2045,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: 'Hamlet, Prince of Denmark',
 								characterDifferentiator: '1',
 								qualifier: 'foo',
+								isAlternate: null,
 								errors: {}
 							},
 							{
@@ -2033,6 +2054,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
+								isAlternate: null,
 								errors: {}
 							}
 						]
@@ -2049,6 +2071,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: 'Ghost of King Hamlet',
 								characterDifferentiator: '1',
 								qualifier: 'bar',
+								isAlternate: null,
 								errors: {}
 							},
 							{
@@ -2057,6 +2080,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: 'Player King',
 								characterDifferentiator: '1',
 								qualifier: 'baz',
+								isAlternate: null,
 								errors: {}
 							},
 							{
@@ -2065,6 +2089,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
+								isAlternate: null,
 								errors: {}
 							}
 						]
@@ -2081,6 +2106,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: 'Lucianus',
 								characterDifferentiator: '1',
 								qualifier: 'qux',
+								isAlternate: null,
 								errors: {}
 							},
 							{
@@ -2089,6 +2115,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: 'English Ambassador',
 								characterDifferentiator: '1',
 								qualifier: 'quux',
+								isAlternate: true,
 								errors: {}
 							},
 							{
@@ -2097,6 +2124,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
+								isAlternate: null,
 								errors: {}
 							}
 						]
@@ -2113,6 +2141,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
+								isAlternate: null,
 								errors: {}
 							}
 						]
@@ -2129,6 +2158,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
+								isAlternate: null,
 								errors: {}
 							}
 						]
@@ -2594,7 +2624,8 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 									name: 'Lord Mayor',
 									characterName: 'Lord Mayor of London',
 									characterDifferentiator: '1',
-									qualifier: 'quux'
+									qualifier: 'quux',
+									isAlternate: true
 								}
 							]
 						},
@@ -2944,6 +2975,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: 'King Richard III',
 								characterDifferentiator: '1',
 								qualifier: 'foo',
+								isAlternate: null,
 								errors: {}
 							},
 							{
@@ -2952,6 +2984,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
+								isAlternate: null,
 								errors: {}
 							}
 						]
@@ -2968,6 +3001,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: 'Sir Robert Brakenbury',
 								characterDifferentiator: '1',
 								qualifier: 'bar',
+								isAlternate: null,
 								errors: {}
 							},
 							{
@@ -2976,6 +3010,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: 'Henry, Earl of Richmond',
 								characterDifferentiator: '1',
 								qualifier: 'baz',
+								isAlternate: null,
 								errors: {}
 							},
 							{
@@ -2984,6 +3019,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
+								isAlternate: null,
 								errors: {}
 							}
 						]
@@ -3000,6 +3036,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: 'Sir Richard Ratcliffe',
 								characterDifferentiator: '1',
 								qualifier: 'qux',
+								isAlternate: null,
 								errors: {}
 							},
 							{
@@ -3008,6 +3045,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: 'Lord Mayor of London',
 								characterDifferentiator: '1',
 								qualifier: 'quux',
+								isAlternate: true,
 								errors: {}
 							},
 							{
@@ -3016,6 +3054,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
+								isAlternate: null,
 								errors: {}
 							}
 						]
@@ -3032,6 +3071,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
+								isAlternate: null,
 								errors: {}
 							}
 						]
@@ -3048,6 +3088,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
+								isAlternate: null,
 								errors: {}
 							}
 						]
@@ -3495,7 +3536,8 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'character',
 								uuid: null,
 								name: 'Richard, Duke of Gloucester',
-								qualifier: 'foo'
+								qualifier: 'foo',
+								isAlternate: null
 							}
 						]
 					},
@@ -3508,13 +3550,15 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'character',
 								uuid: null,
 								name: 'Brakenbury',
-								qualifier: 'bar'
+								qualifier: 'bar',
+								isAlternate: null
 							},
 							{
 								model: 'character',
 								uuid: null,
 								name: 'Richmond',
-								qualifier: 'baz'
+								qualifier: 'baz',
+								isAlternate: null
 							}
 						]
 					},
@@ -3527,13 +3571,15 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								model: 'character',
 								uuid: null,
 								name: 'Ratcliffe',
-								qualifier: 'qux'
+								qualifier: 'qux',
+								isAlternate: null
 							},
 							{
 								model: 'character',
 								uuid: null,
 								name: 'Lord Mayor',
-								qualifier: 'quux'
+								qualifier: 'quux',
+								isAlternate: true
 							}
 						]
 					},
@@ -3777,6 +3823,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
+								isAlternate: null,
 								errors: {}
 							}
 						]

--- a/test-e2e/model-interaction/cast-member-diff-roles-of-material.test.js
+++ b/test-e2e/model-interaction/cast-member-diff-roles-of-material.test.js
@@ -175,6 +175,7 @@ describe('Cast member performing different roles in different productions of sam
 							name: 'Antony Sher',
 							roleName: 'King Lear',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: []
 						}
 					]
@@ -198,6 +199,7 @@ describe('Cast member performing different roles in different productions of sam
 							name: 'Michael Gambon',
 							roleName: 'King Lear',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: []
 						}
 					]
@@ -236,6 +238,7 @@ describe('Cast member performing different roles in different productions of sam
 							name: 'Graham Turner',
 							roleName: 'Fool',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: []
 						}
 					]
@@ -259,6 +262,7 @@ describe('Cast member performing different roles in different productions of sam
 							name: 'Antony Sher',
 							roleName: 'Fool',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: []
 						}
 					]
@@ -287,7 +291,8 @@ describe('Cast member performing different roles in different productions of sam
 							model: 'character',
 							uuid: KING_LEAR_CHARACTER_UUID,
 							name: 'King Lear',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				},
@@ -300,7 +305,8 @@ describe('Cast member performing different roles in different productions of sam
 							model: 'character',
 							uuid: FOOL_CHARACTER_UUID,
 							name: 'Fool',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -328,7 +334,8 @@ describe('Cast member performing different roles in different productions of sam
 							model: 'character',
 							uuid: KING_LEAR_CHARACTER_UUID,
 							name: 'King Lear',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				},
@@ -341,7 +348,8 @@ describe('Cast member performing different roles in different productions of sam
 							model: 'character',
 							uuid: FOOL_CHARACTER_UUID,
 							name: 'Fool',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -377,7 +385,8 @@ describe('Cast member performing different roles in different productions of sam
 							model: 'character',
 							uuid: KING_LEAR_CHARACTER_UUID,
 							name: 'King Lear',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -413,7 +422,8 @@ describe('Cast member performing different roles in different productions of sam
 							model: 'character',
 							uuid: KING_LEAR_CHARACTER_UUID,
 							name: 'King Lear',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				},
@@ -434,7 +444,8 @@ describe('Cast member performing different roles in different productions of sam
 							model: 'character',
 							uuid: FOOL_CHARACTER_UUID,
 							name: 'Fool',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -470,7 +481,8 @@ describe('Cast member performing different roles in different productions of sam
 							model: 'character',
 							uuid: FOOL_CHARACTER_UUID,
 							name: 'Fool',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}

--- a/test-e2e/model-interaction/cast-member-same-role-of-material.test.js
+++ b/test-e2e/model-interaction/cast-member-same-role-of-material.test.js
@@ -143,6 +143,7 @@ describe('Cast member performing same role in different productions of same mate
 							name: 'Judi Dench',
 							roleName: 'Titania, Faerie Queene',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: []
 						}
 					]
@@ -166,6 +167,7 @@ describe('Cast member performing same role in different productions of same mate
 							name: 'Judi Dench',
 							roleName: 'Titania',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: []
 						}
 					]
@@ -194,7 +196,8 @@ describe('Cast member performing same role in different productions of same mate
 							model: 'character',
 							uuid: TITANIA_CHARACTER_UUID,
 							name: 'Titania',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -222,7 +225,8 @@ describe('Cast member performing same role in different productions of same mate
 							model: 'character',
 							uuid: TITANIA_CHARACTER_UUID,
 							name: 'Titania, Faerie Queene',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -258,7 +262,8 @@ describe('Cast member performing same role in different productions of same mate
 							model: 'character',
 							uuid: TITANIA_CHARACTER_UUID,
 							name: 'Titania, Faerie Queene',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				},
@@ -279,7 +284,8 @@ describe('Cast member performing same role in different productions of same mate
 							model: 'character',
 							uuid: TITANIA_CHARACTER_UUID,
 							name: 'Titania',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}

--- a/test-e2e/model-interaction/cast-member-with-multi-prods.test.js
+++ b/test-e2e/model-interaction/cast-member-with-multi-prods.test.js
@@ -153,19 +153,22 @@ describe('Cast member with multiple production credits', () => {
 							model: 'character',
 							uuid: null,
 							name: 'Congresswoman',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: null,
 							name: 'Sheryl Sloman',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: null,
 							name: 'Irene Gant',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				},
@@ -186,13 +189,15 @@ describe('Cast member with multiple production credits', () => {
 							model: 'character',
 							uuid: null,
 							name: 'Alaura Kingsley',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: null,
 							name: 'Carla Haywood',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				},
@@ -213,13 +218,15 @@ describe('Cast member with multiple production credits', () => {
 							model: 'character',
 							uuid: null,
 							name: 'Chorus',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: null,
 							name: 'Trojan slave',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -247,13 +254,15 @@ describe('Cast member with multiple production credits', () => {
 							model: 'character',
 							uuid: null,
 							name: 'Chorus',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: null,
 							name: 'Trojan slave',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -281,13 +290,15 @@ describe('Cast member with multiple production credits', () => {
 							model: 'character',
 							uuid: null,
 							name: 'Alaura Kingsley',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: null,
 							name: 'Carla Haywood',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -315,19 +326,22 @@ describe('Cast member with multiple production credits', () => {
 							model: 'character',
 							uuid: null,
 							name: 'Congresswoman',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: null,
 							name: 'Sheryl Sloman',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: null,
 							name: 'Irene Gant',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}

--- a/test-e2e/model-interaction/char-diff-groups-same-material.test.js
+++ b/test-e2e/model-interaction/char-diff-groups-same-material.test.js
@@ -261,6 +261,7 @@ describe('Character with multiple appearances in the same material in different 
 							name: 'Jodie McNee',
 							roleName: 'Alisa Kos',
 							qualifier: '2011',
+							isAlternate: null,
 							otherRoles: []
 						},
 						{
@@ -269,6 +270,7 @@ describe('Character with multiple appearances in the same material in different 
 							name: 'Bebe Sanders',
 							roleName: 'Alisa Kos',
 							qualifier: '1990',
+							isAlternate: null,
 							otherRoles: []
 						}
 					]
@@ -338,6 +340,7 @@ describe('Character with multiple appearances in the same material in different 
 							name: 'Siobhan Finneran',
 							roleName: 'Maša Kos',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: []
 						}
 					]
@@ -407,6 +410,7 @@ describe('Character with multiple appearances in the same material in different 
 							name: 'James Laurenson',
 							roleName: 'Aleksander King',
 							qualifier: '1990',
+							isAlternate: null,
 							otherRoles: []
 						},
 						{
@@ -415,6 +419,7 @@ describe('Character with multiple appearances in the same material in different 
 							name: 'Alex Price',
 							roleName: 'Aleksander King',
 							qualifier: '1945',
+							isAlternate: null,
 							otherRoles: []
 						}
 					]
@@ -479,6 +484,7 @@ describe('Character with multiple appearances in the same material in different 
 							name: 'Jo Herbert',
 							roleName: 'Rose King',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: []
 						}
 					]
@@ -585,7 +591,8 @@ describe('Character with multiple appearances in the same material in different 
 							model: 'character',
 							uuid: MAŠA_KOS_CHARACTER_UUID,
 							name: 'Maša Kos',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				},
@@ -598,7 +605,8 @@ describe('Character with multiple appearances in the same material in different 
 							model: 'character',
 							uuid: ROSE_KING_CHARACTER_UUID,
 							name: 'Rose King',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				},
@@ -611,7 +619,8 @@ describe('Character with multiple appearances in the same material in different 
 							model: 'character',
 							uuid: ALEKSANDER_KING_CHARACTER_UUID,
 							name: 'Aleksander King',
-							qualifier: '1990'
+							qualifier: '1990',
+							isAlternate: null
 						}
 					]
 				},
@@ -624,7 +633,8 @@ describe('Character with multiple appearances in the same material in different 
 							model: 'character',
 							uuid: ALISA_KOS_CHARACTER_UUID,
 							name: 'Alisa Kos',
-							qualifier: '2011'
+							qualifier: '2011',
+							isAlternate: null
 						}
 					]
 				},
@@ -637,7 +647,8 @@ describe('Character with multiple appearances in the same material in different 
 							model: 'character',
 							uuid: ALEKSANDER_KING_CHARACTER_UUID,
 							name: 'Aleksander King',
-							qualifier: '1945'
+							qualifier: '1945',
+							isAlternate: null
 						}
 					]
 				},
@@ -650,7 +661,8 @@ describe('Character with multiple appearances in the same material in different 
 							model: 'character',
 							uuid: ALISA_KOS_CHARACTER_UUID,
 							name: 'Alisa Kos',
-							qualifier: '1990'
+							qualifier: '1990',
+							isAlternate: null
 						}
 					]
 				}
@@ -686,7 +698,8 @@ describe('Character with multiple appearances in the same material in different 
 							model: 'character',
 							uuid: MAŠA_KOS_CHARACTER_UUID,
 							name: 'Maša Kos',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -722,7 +735,8 @@ describe('Character with multiple appearances in the same material in different 
 							model: 'character',
 							uuid: ROSE_KING_CHARACTER_UUID,
 							name: 'Rose King',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -758,7 +772,8 @@ describe('Character with multiple appearances in the same material in different 
 							model: 'character',
 							uuid: ALEKSANDER_KING_CHARACTER_UUID,
 							name: 'Aleksander King',
-							qualifier: '1990'
+							qualifier: '1990',
+							isAlternate: null
 						}
 					]
 				}
@@ -794,7 +809,8 @@ describe('Character with multiple appearances in the same material in different 
 							model: 'character',
 							uuid: ALISA_KOS_CHARACTER_UUID,
 							name: 'Alisa Kos',
-							qualifier: '2011'
+							qualifier: '2011',
+							isAlternate: null
 						}
 					]
 				}
@@ -830,7 +846,8 @@ describe('Character with multiple appearances in the same material in different 
 							model: 'character',
 							uuid: ALEKSANDER_KING_CHARACTER_UUID,
 							name: 'Aleksander King',
-							qualifier: '1945'
+							qualifier: '1945',
+							isAlternate: null
 						}
 					]
 				}
@@ -866,7 +883,8 @@ describe('Character with multiple appearances in the same material in different 
 							model: 'character',
 							uuid: ALISA_KOS_CHARACTER_UUID,
 							name: 'Alisa Kos',
-							qualifier: '1990'
+							qualifier: '1990',
+							isAlternate: null
 						}
 					]
 				}

--- a/test-e2e/model-interaction/char-in-multi-prods-of-multi-materials.test.js
+++ b/test-e2e/model-interaction/char-in-multi-prods-of-multi-materials.test.js
@@ -407,6 +407,7 @@ describe('Character in multiple productions of multiple materials', () => {
 							name: 'Roger Allam',
 							roleName: 'Sir John Falstaff',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: []
 						}
 					]
@@ -430,6 +431,7 @@ describe('Character in multiple productions of multiple materials', () => {
 							name: 'Roger Allam',
 							roleName: 'Sir John Falstaff',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: []
 						}
 					]
@@ -453,6 +455,7 @@ describe('Character in multiple productions of multiple materials', () => {
 							name: 'Roger Allam',
 							roleName: 'Sir John Falstaff',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: []
 						}
 					]
@@ -476,6 +479,7 @@ describe('Character in multiple productions of multiple materials', () => {
 							name: 'Michael Gambon',
 							roleName: 'Sir John Falstaff',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: []
 						}
 					]
@@ -499,6 +503,7 @@ describe('Character in multiple productions of multiple materials', () => {
 							name: 'Michael Gambon',
 							roleName: 'Sir John Falstaff',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: []
 						}
 					]
@@ -522,6 +527,7 @@ describe('Character in multiple productions of multiple materials', () => {
 							name: 'Michael Gambon',
 							roleName: 'Sir John Falstaff',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: []
 						}
 					]
@@ -545,6 +551,7 @@ describe('Character in multiple productions of multiple materials', () => {
 							name: 'Richard Cordery',
 							roleName: 'Sir John Falstaff',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: []
 						}
 					]
@@ -568,6 +575,7 @@ describe('Character in multiple productions of multiple materials', () => {
 							name: 'Richard Cordery',
 							roleName: 'Sir John Falstaff',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: []
 						}
 					]
@@ -591,6 +599,7 @@ describe('Character in multiple productions of multiple materials', () => {
 							name: 'Richard Cordery',
 							roleName: 'Sir John Falstaff',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: []
 						}
 					]

--- a/test-e2e/model-interaction/char-multi-appearances-same-material.test.js
+++ b/test-e2e/model-interaction/char-multi-appearances-same-material.test.js
@@ -209,12 +209,14 @@ describe('Character with multiple appearances in the same material under differe
 							name: 'Alice Eve',
 							roleName: 'Esme',
 							qualifier: 'younger',
+							isAlternate: null,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: ALICE_CHARACTER_UUID,
 									name: 'Alice',
-									qualifier: null
+									qualifier: null,
+									isAlternate: null
 								}
 							]
 						},
@@ -224,12 +226,14 @@ describe('Character with multiple appearances in the same material under differe
 							name: 'Sinead Cusack',
 							roleName: 'Esme',
 							qualifier: 'older',
+							isAlternate: null,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: ELEANOR_CHARACTER_UUID,
 									name: 'Eleanor',
-									qualifier: null
+									qualifier: null,
+									isAlternate: null
 								}
 							]
 						}
@@ -269,12 +273,14 @@ describe('Character with multiple appearances in the same material under differe
 							name: 'Alice Eve',
 							roleName: 'Alice',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: ESME_CHARACTER_UUID,
 									name: 'Esme',
-									qualifier: 'younger'
+									qualifier: 'younger',
+									isAlternate: null
 								}
 							]
 						}
@@ -314,12 +320,14 @@ describe('Character with multiple appearances in the same material under differe
 							name: 'Sinead Cusack',
 							roleName: 'Eleanor',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: ESME_CHARACTER_UUID,
 									name: 'Esme',
-									qualifier: 'older'
+									qualifier: 'older',
+									isAlternate: null
 								}
 							]
 						}
@@ -394,13 +402,15 @@ describe('Character with multiple appearances in the same material under differe
 							model: 'character',
 							uuid: ESME_CHARACTER_UUID,
 							name: 'Esme',
-							qualifier: 'younger'
+							qualifier: 'younger',
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: ALICE_CHARACTER_UUID,
 							name: 'Alice',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				},
@@ -413,7 +423,8 @@ describe('Character with multiple appearances in the same material under differe
 							model: 'character',
 							uuid: MAX_CHARACTER_UUID,
 							name: 'Max',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				},
@@ -426,13 +437,15 @@ describe('Character with multiple appearances in the same material under differe
 							model: 'character',
 							uuid: ELEANOR_CHARACTER_UUID,
 							name: 'Eleanor',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: ESME_CHARACTER_UUID,
 							name: 'Esme',
-							qualifier: 'older'
+							qualifier: 'older',
+							isAlternate: null
 						}
 					]
 				}
@@ -468,13 +481,15 @@ describe('Character with multiple appearances in the same material under differe
 							model: 'character',
 							uuid: ESME_CHARACTER_UUID,
 							name: 'Esme',
-							qualifier: 'younger'
+							qualifier: 'younger',
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: ALICE_CHARACTER_UUID,
 							name: 'Alice',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -510,13 +525,15 @@ describe('Character with multiple appearances in the same material under differe
 							model: 'character',
 							uuid: ELEANOR_CHARACTER_UUID,
 							name: 'Eleanor',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: ESME_CHARACTER_UUID,
 							name: 'Esme',
-							qualifier: 'older'
+							qualifier: 'older',
+							isAlternate: null
 						}
 					]
 				}

--- a/test-e2e/model-interaction/char-portrayed-with-other-roles.test.js
+++ b/test-e2e/model-interaction/char-portrayed-with-other-roles.test.js
@@ -146,24 +146,28 @@ describe('Character portrayed with other roles', () => {
 							name: 'Stephen Harper',
 							roleName: 'Joey\'s mother',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: DR_SCHWEYK_CHARACTER_UUID,
 									name: 'Dr Schweyk',
-									qualifier: null
+									qualifier: null,
+									isAlternate: null
 								},
 								{
 									model: 'character',
 									uuid: COCO_CHARACTER_UUID,
 									name: 'Coco',
-									qualifier: null
+									qualifier: null,
+									isAlternate: null
 								},
 								{
 									model: 'character',
 									uuid: GEORDIE_CHARACTER_UUID,
 									name: 'Geordie',
-									qualifier: null
+									qualifier: null,
+									isAlternate: null
 								}
 							]
 						}
@@ -203,24 +207,28 @@ describe('Character portrayed with other roles', () => {
 							name: 'Stephen Harper',
 							roleName: 'Dr Schweyk',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: JOEYS_MOTHER_CHARACTER_UUID,
 									name: 'Joey\'s mother',
-									qualifier: null
+									qualifier: null,
+									isAlternate: null
 								},
 								{
 									model: 'character',
 									uuid: COCO_CHARACTER_UUID,
 									name: 'Coco',
-									qualifier: null
+									qualifier: null,
+									isAlternate: null
 								},
 								{
 									model: 'character',
 									uuid: GEORDIE_CHARACTER_UUID,
 									name: 'Geordie',
-									qualifier: null
+									qualifier: null,
+									isAlternate: null
 								}
 							]
 						}
@@ -260,24 +268,28 @@ describe('Character portrayed with other roles', () => {
 							name: 'Stephen Harper',
 							roleName: 'Coco',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: JOEYS_MOTHER_CHARACTER_UUID,
 									name: 'Joey\'s mother',
-									qualifier: null
+									qualifier: null,
+									isAlternate: null
 								},
 								{
 									model: 'character',
 									uuid: DR_SCHWEYK_CHARACTER_UUID,
 									name: 'Dr Schweyk',
-									qualifier: null
+									qualifier: null,
+									isAlternate: null
 								},
 								{
 									model: 'character',
 									uuid: GEORDIE_CHARACTER_UUID,
 									name: 'Geordie',
-									qualifier: null
+									qualifier: null,
+									isAlternate: null
 								}
 							]
 						}
@@ -317,24 +329,28 @@ describe('Character portrayed with other roles', () => {
 							name: 'Stephen Harper',
 							roleName: 'Geordie',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: JOEYS_MOTHER_CHARACTER_UUID,
 									name: 'Joey\'s mother',
-									qualifier: null
+									qualifier: null,
+									isAlternate: null
 								},
 								{
 									model: 'character',
 									uuid: DR_SCHWEYK_CHARACTER_UUID,
 									name: 'Dr Schweyk',
-									qualifier: null
+									qualifier: null,
+									isAlternate: null
 								},
 								{
 									model: 'character',
 									uuid: COCO_CHARACTER_UUID,
 									name: 'Coco',
-									qualifier: null
+									qualifier: null,
+									isAlternate: null
 								}
 							]
 						}

--- a/test-e2e/model-interaction/char-with-variant-depiction-portrayal-names.test.js
+++ b/test-e2e/model-interaction/char-with-variant-depiction-portrayal-names.test.js
@@ -553,12 +553,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							name: 'Alex Hassell',
 							roleName: 'Henry V',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: SOLDIER_CHARACTER_UUID,
 									name: 'Soldier',
-									qualifier: null
+									qualifier: null,
+									isAlternate: null
 								}
 							]
 						}
@@ -583,12 +585,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							name: 'Alex Hassell',
 							roleName: 'Hal',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: ATTENDANT_CHARACTER_UUID,
 									name: 'Attendant',
-									qualifier: null
+									qualifier: null,
+									isAlternate: null
 								}
 							]
 						}
@@ -613,12 +617,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							name: 'Alex Hassell',
 							roleName: 'Henry, Prince of Wales',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: MESSENGER_CHARACTER_UUID,
 									name: 'Messenger',
-									qualifier: null
+									qualifier: null,
+									isAlternate: null
 								}
 							]
 						}
@@ -643,12 +649,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							name: 'Matthew Macfadyen',
 							roleName: 'Hal, Prince of England',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: ATTENDANT_CHARACTER_UUID,
 									name: 'Attendant',
-									qualifier: null
+									qualifier: null,
+									isAlternate: null
 								}
 							]
 						}
@@ -673,12 +681,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							name: 'Matthew Macfadyen',
 							roleName: 'Prince Hal',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: MESSENGER_CHARACTER_UUID,
 									name: 'Messenger',
-									qualifier: null
+									qualifier: null,
+									isAlternate: null
 								}
 							]
 						}
@@ -703,12 +713,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							name: 'Adrian Lester',
 							roleName: 'Henry V',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: SOLDIER_CHARACTER_UUID,
 									name: 'Soldier',
-									qualifier: null
+									qualifier: null,
+									isAlternate: null
 								}
 							]
 						}
@@ -748,12 +760,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							name: 'Alex Hassell',
 							roleName: 'Messenger',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: KING_HENRY_V_CHARACTER_UUID,
 									name: 'Henry, Prince of Wales',
-									qualifier: null
+									qualifier: null,
+									isAlternate: null
 								}
 							]
 						}
@@ -778,12 +792,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							name: 'Matthew Macfadyen',
 							roleName: 'Messenger',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: KING_HENRY_V_CHARACTER_UUID,
 									name: 'Prince Hal',
-									qualifier: null
+									qualifier: null,
+									isAlternate: null
 								}
 							]
 						}
@@ -823,12 +839,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							name: 'Alex Hassell',
 							roleName: 'Attendant',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: KING_HENRY_V_CHARACTER_UUID,
 									name: 'Hal',
-									qualifier: null
+									qualifier: null,
+									isAlternate: null
 								}
 							]
 						}
@@ -853,12 +871,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							name: 'Matthew Macfadyen',
 							roleName: 'Attendant',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: KING_HENRY_V_CHARACTER_UUID,
 									name: 'Hal, Prince of England',
-									qualifier: null
+									qualifier: null,
+									isAlternate: null
 								}
 							]
 						}
@@ -898,12 +918,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							name: 'Alex Hassell',
 							roleName: 'Soldier',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: KING_HENRY_V_CHARACTER_UUID,
 									name: 'Henry V',
-									qualifier: null
+									qualifier: null,
+									isAlternate: null
 								}
 							]
 						}
@@ -928,12 +950,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							name: 'Adrian Lester',
 							roleName: 'Soldier',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: KING_HENRY_V_CHARACTER_UUID,
 									name: 'Henry V',
-									qualifier: null
+									qualifier: null,
+									isAlternate: null
 								}
 							]
 						}
@@ -1062,13 +1086,15 @@ describe('Character with variant depiction and portrayal names', () => {
 							model: 'character',
 							uuid: KING_HENRY_V_CHARACTER_UUID,
 							name: 'Henry, Prince of Wales',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: MESSENGER_CHARACTER_UUID,
 							name: 'Messenger',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				},
@@ -1081,7 +1107,8 @@ describe('Character with variant depiction and portrayal names', () => {
 							model: 'character',
 							uuid: SIR_JOHN_FALSTAFF_CHARACTER_UUID,
 							name: 'Sir John Falstaff',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -1109,13 +1136,15 @@ describe('Character with variant depiction and portrayal names', () => {
 							model: 'character',
 							uuid: KING_HENRY_V_CHARACTER_UUID,
 							name: 'Hal',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: ATTENDANT_CHARACTER_UUID,
 							name: 'Attendant',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				},
@@ -1128,7 +1157,8 @@ describe('Character with variant depiction and portrayal names', () => {
 							model: 'character',
 							uuid: SIR_JOHN_FALSTAFF_CHARACTER_UUID,
 							name: 'Sir John Falstaff',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -1156,13 +1186,15 @@ describe('Character with variant depiction and portrayal names', () => {
 							model: 'character',
 							uuid: KING_HENRY_V_CHARACTER_UUID,
 							name: 'Henry V',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: SOLDIER_CHARACTER_UUID,
 							name: 'Soldier',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				},
@@ -1175,7 +1207,8 @@ describe('Character with variant depiction and portrayal names', () => {
 							model: 'character',
 							uuid: KING_OF_FRANCE_CHARACTER_UUID,
 							name: 'King of France',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -1203,13 +1236,15 @@ describe('Character with variant depiction and portrayal names', () => {
 							model: 'character',
 							uuid: KING_HENRY_V_CHARACTER_UUID,
 							name: 'Prince Hal',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: MESSENGER_CHARACTER_UUID,
 							name: 'Messenger',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				},
@@ -1222,7 +1257,8 @@ describe('Character with variant depiction and portrayal names', () => {
 							model: 'character',
 							uuid: SIR_JOHN_FALSTAFF_CHARACTER_UUID,
 							name: 'Sir John Falstaff',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -1250,13 +1286,15 @@ describe('Character with variant depiction and portrayal names', () => {
 							model: 'character',
 							uuid: KING_HENRY_V_CHARACTER_UUID,
 							name: 'Hal, Prince of England',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: ATTENDANT_CHARACTER_UUID,
 							name: 'Attendant',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				},
@@ -1269,7 +1307,8 @@ describe('Character with variant depiction and portrayal names', () => {
 							model: 'character',
 							uuid: SIR_JOHN_FALSTAFF_CHARACTER_UUID,
 							name: 'Sir John Falstaff',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -1297,13 +1336,15 @@ describe('Character with variant depiction and portrayal names', () => {
 							model: 'character',
 							uuid: KING_HENRY_V_CHARACTER_UUID,
 							name: 'Henry V',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: SOLDIER_CHARACTER_UUID,
 							name: 'Soldier',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				},
@@ -1316,7 +1357,8 @@ describe('Character with variant depiction and portrayal names', () => {
 							model: 'character',
 							uuid: KING_OF_FRANCE_CHARACTER_UUID,
 							name: 'King of France',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -1352,13 +1394,15 @@ describe('Character with variant depiction and portrayal names', () => {
 							model: 'character',
 							uuid: KING_HENRY_V_CHARACTER_UUID,
 							name: 'Henry V',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: SOLDIER_CHARACTER_UUID,
 							name: 'Soldier',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				},
@@ -1379,13 +1423,15 @@ describe('Character with variant depiction and portrayal names', () => {
 							model: 'character',
 							uuid: KING_HENRY_V_CHARACTER_UUID,
 							name: 'Hal',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: ATTENDANT_CHARACTER_UUID,
 							name: 'Attendant',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				},
@@ -1406,13 +1452,15 @@ describe('Character with variant depiction and portrayal names', () => {
 							model: 'character',
 							uuid: KING_HENRY_V_CHARACTER_UUID,
 							name: 'Henry, Prince of Wales',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: MESSENGER_CHARACTER_UUID,
 							name: 'Messenger',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -1448,13 +1496,15 @@ describe('Character with variant depiction and portrayal names', () => {
 							model: 'character',
 							uuid: KING_HENRY_V_CHARACTER_UUID,
 							name: 'Hal, Prince of England',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: ATTENDANT_CHARACTER_UUID,
 							name: 'Attendant',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				},
@@ -1475,13 +1525,15 @@ describe('Character with variant depiction and portrayal names', () => {
 							model: 'character',
 							uuid: KING_HENRY_V_CHARACTER_UUID,
 							name: 'Prince Hal',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: MESSENGER_CHARACTER_UUID,
 							name: 'Messenger',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -1517,13 +1569,15 @@ describe('Character with variant depiction and portrayal names', () => {
 							model: 'character',
 							uuid: KING_HENRY_V_CHARACTER_UUID,
 							name: 'Henry V',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: SOLDIER_CHARACTER_UUID,
 							name: 'Soldier',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}

--- a/test-e2e/model-interaction/char-with-variant-names-diff-materials.test.js
+++ b/test-e2e/model-interaction/char-with-variant-names-diff-materials.test.js
@@ -392,6 +392,7 @@ describe('Character with variant names from productions of different materials',
 							name: 'Gabriele Cicirello',
 							roleName: 'Hamlet, Prince of Denmark',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: []
 						}
 					]
@@ -415,6 +416,7 @@ describe('Character with variant names from productions of different materials',
 							name: 'Jack Hawkins',
 							roleName: 'Prince Hamlet',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: []
 						}
 					]
@@ -438,6 +440,7 @@ describe('Character with variant names from productions of different materials',
 							name: 'Rory Kinnear',
 							roleName: 'Hamlet, Prince of Denmark',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: []
 						}
 					]
@@ -461,6 +464,7 @@ describe('Character with variant names from productions of different materials',
 							name: 'Don Reilly',
 							roleName: 'Spirit of Hamlet',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: []
 						}
 					]
@@ -489,7 +493,8 @@ describe('Character with variant names from productions of different materials',
 							model: 'character',
 							uuid: HAMLET_CHARACTER_UUID,
 							name: 'Hamlet, Prince of Denmark',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				},
@@ -502,7 +507,8 @@ describe('Character with variant names from productions of different materials',
 							model: 'character',
 							uuid: CLAUDIUS_CHARACTER_UUID,
 							name: 'Claudius, King of Denmark',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -530,7 +536,8 @@ describe('Character with variant names from productions of different materials',
 							model: 'character',
 							uuid: HAMLET_CHARACTER_UUID,
 							name: 'Prince Hamlet',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				},
@@ -543,7 +550,8 @@ describe('Character with variant names from productions of different materials',
 							model: 'character',
 							uuid: CLAUDIUS_CHARACTER_UUID,
 							name: 'King Claudius',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -571,7 +579,8 @@ describe('Character with variant names from productions of different materials',
 							model: 'character',
 							uuid: HAMLET_CHARACTER_UUID,
 							name: 'Spirit of Hamlet',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				},
@@ -584,7 +593,8 @@ describe('Character with variant names from productions of different materials',
 							model: 'character',
 							uuid: CLAUDIUS_CHARACTER_UUID,
 							name: 'Spirit of Claudius',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -612,7 +622,8 @@ describe('Character with variant names from productions of different materials',
 							model: 'character',
 							uuid: HAMLET_CHARACTER_UUID,
 							name: 'Hamlet, Prince of Denmark',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				},
@@ -625,7 +636,8 @@ describe('Character with variant names from productions of different materials',
 							model: 'character',
 							uuid: CLAUDIUS_CHARACTER_UUID,
 							name: 'Claudius, King of Denmark',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -661,7 +673,8 @@ describe('Character with variant names from productions of different materials',
 							model: 'character',
 							uuid: HAMLET_CHARACTER_UUID,
 							name: 'Hamlet, Prince of Denmark',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -697,7 +710,8 @@ describe('Character with variant names from productions of different materials',
 							model: 'character',
 							uuid: HAMLET_CHARACTER_UUID,
 							name: 'Prince Hamlet',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -733,7 +747,8 @@ describe('Character with variant names from productions of different materials',
 							model: 'character',
 							uuid: HAMLET_CHARACTER_UUID,
 							name: 'Spirit of Hamlet',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -769,7 +784,8 @@ describe('Character with variant names from productions of different materials',
 							model: 'character',
 							uuid: HAMLET_CHARACTER_UUID,
 							name: 'Hamlet, Prince of Denmark',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}

--- a/test-e2e/model-interaction/char-with-variant-names-same-material.test.js
+++ b/test-e2e/model-interaction/char-with-variant-names-same-material.test.js
@@ -250,12 +250,14 @@ describe('Character with variant names from productions of the same material', (
 							name: 'David Rintoul',
 							roleName: 'Ghost of King Hamlet',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: FIRST_PLAYER_CHARACTER_UUID,
 									name: 'Player King',
-									qualifier: null
+									qualifier: null,
+									isAlternate: null
 								}
 							]
 						}
@@ -280,12 +282,14 @@ describe('Character with variant names from productions of the same material', (
 							name: 'Peter Eyre',
 							roleName: 'King Hamlet',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: FIRST_PLAYER_CHARACTER_UUID,
 									name: 'First Player',
-									qualifier: null
+									qualifier: null,
+									isAlternate: null
 								}
 							]
 						}
@@ -310,12 +314,14 @@ describe('Character with variant names from productions of the same material', (
 							name: 'Patrick Stewart',
 							roleName: 'Ghost',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: CLAUDIUS_CHARACTER_UUID,
 									name: 'Claudius, King of Denmark',
-									qualifier: null
+									qualifier: null,
+									isAlternate: null
 								}
 							]
 						}
@@ -345,7 +351,8 @@ describe('Character with variant names from productions of the same material', (
 							model: 'character',
 							uuid: HAMLET_CHARACTER_UUID,
 							name: 'Hamlet, Prince of Denmark',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				},
@@ -358,13 +365,15 @@ describe('Character with variant names from productions of the same material', (
 							model: 'character',
 							uuid: GHOST_CHARACTER_UUID,
 							name: 'Ghost of King Hamlet',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: FIRST_PLAYER_CHARACTER_UUID,
 							name: 'Player King',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -392,7 +401,8 @@ describe('Character with variant names from productions of the same material', (
 							model: 'character',
 							uuid: HAMLET_CHARACTER_UUID,
 							name: 'Hamlet, Prince of Denmark',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				},
@@ -405,13 +415,15 @@ describe('Character with variant names from productions of the same material', (
 							model: 'character',
 							uuid: CLAUDIUS_CHARACTER_UUID,
 							name: 'Claudius, King of Denmark',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: GHOST_CHARACTER_UUID,
 							name: 'Ghost',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -439,7 +451,8 @@ describe('Character with variant names from productions of the same material', (
 							model: 'character',
 							uuid: HAMLET_CHARACTER_UUID,
 							name: 'Hamlet, Prince of Denmark',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				},
@@ -452,13 +465,15 @@ describe('Character with variant names from productions of the same material', (
 							model: 'character',
 							uuid: GHOST_CHARACTER_UUID,
 							name: 'King Hamlet',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: FIRST_PLAYER_CHARACTER_UUID,
 							name: 'First Player',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -494,13 +509,15 @@ describe('Character with variant names from productions of the same material', (
 							model: 'character',
 							uuid: GHOST_CHARACTER_UUID,
 							name: 'Ghost of King Hamlet',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: FIRST_PLAYER_CHARACTER_UUID,
 							name: 'Player King',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -536,13 +553,15 @@ describe('Character with variant names from productions of the same material', (
 							model: 'character',
 							uuid: CLAUDIUS_CHARACTER_UUID,
 							name: 'Claudius, King of Denmark',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: GHOST_CHARACTER_UUID,
 							name: 'Ghost',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -578,13 +597,15 @@ describe('Character with variant names from productions of the same material', (
 							model: 'character',
 							uuid: GHOST_CHARACTER_UUID,
 							name: 'King Hamlet',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: FIRST_PLAYER_CHARACTER_UUID,
 							name: 'First Player',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}

--- a/test-e2e/model-interaction/diff-chars-same-name-diff-materials.test.js
+++ b/test-e2e/model-interaction/diff-chars-same-name-diff-materials.test.js
@@ -204,6 +204,7 @@ describe('Different characters with the same name from different materials', () 
 							name: 'Oscar Pearce',
 							roleName: 'Demetrius',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: []
 						}
 					]
@@ -242,6 +243,7 @@ describe('Different characters with the same name from different materials', () 
 							name: 'Sam Alexander',
 							roleName: 'Demetrius',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: []
 						}
 					]
@@ -325,7 +327,8 @@ describe('Different characters with the same name from different materials', () 
 							model: 'character',
 							uuid: DEMETRIUS_CHARACTER_1_UUID,
 							name: 'Demetrius',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				},
@@ -338,7 +341,8 @@ describe('Different characters with the same name from different materials', () 
 							model: 'character',
 							uuid: LYSANDER_CHARACTER_UUID,
 							name: 'Lysander',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -366,7 +370,8 @@ describe('Different characters with the same name from different materials', () 
 							model: 'character',
 							uuid: CHIRON_CHARACTER_UUID,
 							name: 'Chiron',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				},
@@ -379,7 +384,8 @@ describe('Different characters with the same name from different materials', () 
 							model: 'character',
 							uuid: DEMETRIUS_CHARACTER_2_UUID,
 							name: 'Demetrius',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -415,7 +421,8 @@ describe('Different characters with the same name from different materials', () 
 							model: 'character',
 							uuid: DEMETRIUS_CHARACTER_1_UUID,
 							name: 'Demetrius',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -451,7 +458,8 @@ describe('Different characters with the same name from different materials', () 
 							model: 'character',
 							uuid: DEMETRIUS_CHARACTER_2_UUID,
 							name: 'Demetrius',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}

--- a/test-e2e/model-interaction/diff-chars-same-name-same-material.test.js
+++ b/test-e2e/model-interaction/diff-chars-same-name-same-material.test.js
@@ -151,12 +151,14 @@ describe('Different characters with the same name from the same material', () =>
 							name: 'Paul Shearer',
 							roleName: 'Cinna',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: VOLUMNIUS_CHARACTER_UUID,
 									name: 'Volumnius',
-									qualifier: null
+									qualifier: null,
+									isAlternate: null
 								}
 							]
 						}
@@ -196,6 +198,7 @@ describe('Different characters with the same name from the same material', () =>
 							name: 'Leo Wringer',
 							roleName: 'Cinna',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: []
 						}
 					]
@@ -234,12 +237,14 @@ describe('Different characters with the same name from the same material', () =>
 							name: 'Paul Shearer',
 							roleName: 'Volumnius',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: CINNA_CHARACTER_1_UUID,
 									name: 'Cinna',
-									qualifier: null
+									qualifier: null,
+									isAlternate: null
 								}
 							]
 						}
@@ -302,13 +307,15 @@ describe('Different characters with the same name from the same material', () =>
 							model: 'character',
 							uuid: CINNA_CHARACTER_1_UUID,
 							name: 'Cinna',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: VOLUMNIUS_CHARACTER_UUID,
 							name: 'Volumnius',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				},
@@ -321,7 +328,8 @@ describe('Different characters with the same name from the same material', () =>
 							model: 'character',
 							uuid: CINNA_CHARACTER_2_UUID,
 							name: 'Cinna',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -357,13 +365,15 @@ describe('Different characters with the same name from the same material', () =>
 							model: 'character',
 							uuid: CINNA_CHARACTER_1_UUID,
 							name: 'Cinna',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						},
 						{
 							model: 'character',
 							uuid: VOLUMNIUS_CHARACTER_UUID,
 							name: 'Volumnius',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}
@@ -399,7 +409,8 @@ describe('Different characters with the same name from the same material', () =>
 							model: 'character',
 							uuid: CINNA_CHARACTER_2_UUID,
 							name: 'Cinna',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}

--- a/test-e2e/model-interaction/roles-with-alternating-cast.test.js
+++ b/test-e2e/model-interaction/roles-with-alternating-cast.test.js
@@ -76,10 +76,12 @@ describe('Roles with alternating cast', () => {
 						name: 'Nigel Harman',
 						roles: [
 							{
-								name: 'Austin'
+								name: 'Austin',
+								isAlternate: true
 							},
 							{
-								name: 'Lee'
+								name: 'Lee',
+								isAlternate: true
 							}
 						]
 					},
@@ -87,10 +89,12 @@ describe('Roles with alternating cast', () => {
 						name: 'John Light',
 						roles: [
 							{
-								name: 'Lee'
+								name: 'Lee',
+								isAlternate: true
 							},
 							{
-								name: 'Austin'
+								name: 'Austin',
+								isAlternate: true
 							}
 						]
 					}
@@ -115,10 +119,12 @@ describe('Roles with alternating cast', () => {
 						name: 'Kit Harington',
 						roles: [
 							{
-								name: 'Austin'
+								name: 'Austin',
+								isAlternate: true
 							},
 							{
-								name: 'Lee'
+								name: 'Lee',
+								isAlternate: true
 							}
 						]
 					},
@@ -126,10 +132,12 @@ describe('Roles with alternating cast', () => {
 						name: 'Johnny Flynn',
 						roles: [
 							{
-								name: 'Lee'
+								name: 'Lee',
+								isAlternate: true
 							},
 							{
-								name: 'Austin'
+								name: 'Austin',
+								isAlternate: true
 							}
 						]
 					}
@@ -192,12 +200,14 @@ describe('Roles with alternating cast', () => {
 							name: 'Kit Harington',
 							roleName: 'Austin',
 							qualifier: null,
+							isAlternate: true,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: LEE_CHARACTER_UUID,
 									name: 'Lee',
-									qualifier: null
+									qualifier: null,
+									isAlternate: true
 								}
 							]
 						},
@@ -207,12 +217,14 @@ describe('Roles with alternating cast', () => {
 							name: 'Johnny Flynn',
 							roleName: 'Austin',
 							qualifier: null,
+							isAlternate: true,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: LEE_CHARACTER_UUID,
 									name: 'Lee',
-									qualifier: null
+									qualifier: null,
+									isAlternate: true
 								}
 							]
 						}
@@ -237,12 +249,14 @@ describe('Roles with alternating cast', () => {
 							name: 'Nigel Harman',
 							roleName: 'Austin',
 							qualifier: null,
+							isAlternate: true,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: LEE_CHARACTER_UUID,
 									name: 'Lee',
-									qualifier: null
+									qualifier: null,
+									isAlternate: true
 								}
 							]
 						},
@@ -252,12 +266,14 @@ describe('Roles with alternating cast', () => {
 							name: 'John Light',
 							roleName: 'Austin',
 							qualifier: null,
+							isAlternate: true,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: LEE_CHARACTER_UUID,
 									name: 'Lee',
-									qualifier: null
+									qualifier: null,
+									isAlternate: true
 								}
 							]
 						}
@@ -297,12 +313,14 @@ describe('Roles with alternating cast', () => {
 							name: 'Kit Harington',
 							roleName: 'Lee',
 							qualifier: null,
+							isAlternate: true,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: AUSTIN_CHARACTER_UUID,
 									name: 'Austin',
-									qualifier: null
+									qualifier: null,
+									isAlternate: true
 								}
 							]
 						},
@@ -312,12 +330,14 @@ describe('Roles with alternating cast', () => {
 							name: 'Johnny Flynn',
 							roleName: 'Lee',
 							qualifier: null,
+							isAlternate: true,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: AUSTIN_CHARACTER_UUID,
 									name: 'Austin',
-									qualifier: null
+									qualifier: null,
+									isAlternate: true
 								}
 							]
 						}
@@ -342,12 +362,14 @@ describe('Roles with alternating cast', () => {
 							name: 'Nigel Harman',
 							roleName: 'Lee',
 							qualifier: null,
+							isAlternate: true,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: AUSTIN_CHARACTER_UUID,
 									name: 'Austin',
-									qualifier: null
+									qualifier: null,
+									isAlternate: true
 								}
 							]
 						},
@@ -357,12 +379,14 @@ describe('Roles with alternating cast', () => {
 							name: 'John Light',
 							roleName: 'Lee',
 							qualifier: null,
+							isAlternate: true,
 							otherRoles: [
 								{
 									model: 'character',
 									uuid: AUSTIN_CHARACTER_UUID,
 									name: 'Austin',
-									qualifier: null
+									qualifier: null,
+									isAlternate: true
 								}
 							]
 						}
@@ -392,13 +416,15 @@ describe('Roles with alternating cast', () => {
 							model: 'character',
 							uuid: AUSTIN_CHARACTER_UUID,
 							name: 'Austin',
-							qualifier: null
+							qualifier: null,
+							isAlternate: true
 						},
 						{
 							model: 'character',
 							uuid: LEE_CHARACTER_UUID,
 							name: 'Lee',
-							qualifier: null
+							qualifier: null,
+							isAlternate: true
 						}
 					]
 				},
@@ -411,13 +437,15 @@ describe('Roles with alternating cast', () => {
 							model: 'character',
 							uuid: LEE_CHARACTER_UUID,
 							name: 'Lee',
-							qualifier: null
+							qualifier: null,
+							isAlternate: true
 						},
 						{
 							model: 'character',
 							uuid: AUSTIN_CHARACTER_UUID,
 							name: 'Austin',
-							qualifier: null
+							qualifier: null,
+							isAlternate: true
 						}
 					]
 				}
@@ -445,13 +473,15 @@ describe('Roles with alternating cast', () => {
 							model: 'character',
 							uuid: AUSTIN_CHARACTER_UUID,
 							name: 'Austin',
-							qualifier: null
+							qualifier: null,
+							isAlternate: true
 						},
 						{
 							model: 'character',
 							uuid: LEE_CHARACTER_UUID,
 							name: 'Lee',
-							qualifier: null
+							qualifier: null,
+							isAlternate: true
 						}
 					]
 				},
@@ -464,13 +494,15 @@ describe('Roles with alternating cast', () => {
 							model: 'character',
 							uuid: LEE_CHARACTER_UUID,
 							name: 'Lee',
-							qualifier: null
+							qualifier: null,
+							isAlternate: true
 						},
 						{
 							model: 'character',
 							uuid: AUSTIN_CHARACTER_UUID,
 							name: 'Austin',
-							qualifier: null
+							qualifier: null,
+							isAlternate: true
 						}
 					]
 				}
@@ -506,13 +538,15 @@ describe('Roles with alternating cast', () => {
 							model: 'character',
 							uuid: AUSTIN_CHARACTER_UUID,
 							name: 'Austin',
-							qualifier: null
+							qualifier: null,
+							isAlternate: true
 						},
 						{
 							model: 'character',
 							uuid: LEE_CHARACTER_UUID,
 							name: 'Lee',
-							qualifier: null
+							qualifier: null,
+							isAlternate: true
 						}
 					]
 				}
@@ -548,13 +582,15 @@ describe('Roles with alternating cast', () => {
 							model: 'character',
 							uuid: LEE_CHARACTER_UUID,
 							name: 'Lee',
-							qualifier: null
+							qualifier: null,
+							isAlternate: true
 						},
 						{
 							model: 'character',
 							uuid: AUSTIN_CHARACTER_UUID,
 							name: 'Austin',
-							qualifier: null
+							qualifier: null,
+							isAlternate: true
 						}
 					]
 				}
@@ -590,13 +626,15 @@ describe('Roles with alternating cast', () => {
 							model: 'character',
 							uuid: AUSTIN_CHARACTER_UUID,
 							name: 'Austin',
-							qualifier: null
+							qualifier: null,
+							isAlternate: true
 						},
 						{
 							model: 'character',
 							uuid: LEE_CHARACTER_UUID,
 							name: 'Lee',
-							qualifier: null
+							qualifier: null,
+							isAlternate: true
 						}
 					]
 				}
@@ -632,13 +670,15 @@ describe('Roles with alternating cast', () => {
 							model: 'character',
 							uuid: LEE_CHARACTER_UUID,
 							name: 'Lee',
-							qualifier: null
+							qualifier: null,
+							isAlternate: true
 						},
 						{
 							model: 'character',
 							uuid: AUSTIN_CHARACTER_UUID,
 							name: 'Austin',
-							qualifier: null
+							qualifier: null,
+							isAlternate: true
 						}
 					]
 				}

--- a/test-e2e/model-interaction/venue-with-sub-venues.test.js
+++ b/test-e2e/model-interaction/venue-with-sub-venues.test.js
@@ -300,6 +300,7 @@ describe('Venue with sub-venues', () => {
 							name: 'Fiona Shaw',
 							roleName: 'Mother Courage',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: []
 						}
 					]
@@ -338,6 +339,7 @@ describe('Venue with sub-venues', () => {
 							name: 'Fiona Shaw',
 							roleName: 'King Richard II',
 							qualifier: null,
+							isAlternate: null,
 							otherRoles: []
 						}
 					]
@@ -480,7 +482,8 @@ describe('Venue with sub-venues', () => {
 							model: 'character',
 							uuid: MOTHER_COURAGE_CHARACTER_UUID,
 							name: 'Mother Courage',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				},
@@ -501,7 +504,8 @@ describe('Venue with sub-venues', () => {
 							model: 'character',
 							uuid: KING_RICHARD_II_CHARACTER_UUID,
 							name: 'King Richard II',
-							qualifier: null
+							qualifier: null,
+							isAlternate: null
 						}
 					]
 				}

--- a/test-e2e/uniqueness-in-db/productions-api.test.js
+++ b/test-e2e/uniqueness-in-db/productions-api.test.js
@@ -758,6 +758,7 @@ describe('Uniqueness in database: Productions API', () => {
 					characterName: '',
 					characterDifferentiator: '',
 					qualifier: '',
+					isAlternate: null,
 					errors: {}
 				}
 			]
@@ -775,6 +776,7 @@ describe('Uniqueness in database: Productions API', () => {
 					characterName: '',
 					characterDifferentiator: '',
 					qualifier: '',
+					isAlternate: null,
 					errors: {}
 				}
 			]

--- a/test-int/instance-validation-failures/production.test.js
+++ b/test-int/instance-validation-failures/production.test.js
@@ -1559,6 +1559,7 @@ describe('Production instance', () => {
 									characterName: '',
 									characterDifferentiator: '',
 									qualifier: '',
+									isAlternate: null,
 									errors: {}
 								}
 							]
@@ -1630,6 +1631,7 @@ describe('Production instance', () => {
 									characterName: '',
 									characterDifferentiator: '',
 									qualifier: '',
+									isAlternate: null,
 									errors: {
 										name: [
 											'Value is too long'
@@ -1705,6 +1707,7 @@ describe('Production instance', () => {
 									characterName: ABOVE_MAX_LENGTH_STRING,
 									characterDifferentiator: '',
 									qualifier: '',
+									isAlternate: null,
 									errors: {
 										characterName: [
 											'Value is too long'
@@ -1781,6 +1784,7 @@ describe('Production instance', () => {
 									characterName: '',
 									characterDifferentiator: ABOVE_MAX_LENGTH_STRING,
 									qualifier: '',
+									isAlternate: null,
 									errors: {
 										characterDifferentiator: [
 											'Value is too long'
@@ -1856,6 +1860,7 @@ describe('Production instance', () => {
 									characterName: '',
 									characterDifferentiator: '',
 									qualifier: ABOVE_MAX_LENGTH_STRING,
+									isAlternate: null,
 									errors: {
 										qualifier: [
 											'Value is too long'
@@ -1931,6 +1936,7 @@ describe('Production instance', () => {
 									characterName: 'Hamlet',
 									characterDifferentiator: '',
 									qualifier: '',
+									isAlternate: null,
 									errors: {
 										characterName: [
 											'Character name is only required if different from role name'
@@ -2016,6 +2022,7 @@ describe('Production instance', () => {
 									characterName: '',
 									characterDifferentiator: '',
 									qualifier: '',
+									isAlternate: null,
 									errors: {
 										name: [
 											'This item has been duplicated within the group'
@@ -2036,6 +2043,7 @@ describe('Production instance', () => {
 									characterName: '',
 									characterDifferentiator: '1',
 									qualifier: '',
+									isAlternate: null,
 									errors: {}
 								},
 								{
@@ -2043,6 +2051,7 @@ describe('Production instance', () => {
 									characterName: '',
 									characterDifferentiator: '',
 									qualifier: '',
+									isAlternate: null,
 									errors: {
 										name: [
 											'This item has been duplicated within the group'
@@ -2063,6 +2072,7 @@ describe('Production instance', () => {
 									characterName: '',
 									characterDifferentiator: '2',
 									qualifier: '',
+									isAlternate: null,
 									errors: {}
 								}
 							]

--- a/test-unit/src/models/Role.test.js
+++ b/test-unit/src/models/Role.test.js
@@ -124,6 +124,38 @@ describe('Role model', () => {
 
 		});
 
+		describe('isAlternate property', () => {
+
+			it('assigns null if absent from props', () => {
+
+				const instance = new Role({ name: 'Young Lucius' });
+				expect(instance.isAlternate).to.equal(null);
+
+			});
+
+			it('assigns null if included in props but value evaluates to false', () => {
+
+				const instance = new Role({ name: 'Young Lucius', isAlternate: false });
+				expect(instance.isAlternate).to.equal(null);
+
+			});
+
+			it('assigns true if included in props and value evaluates to true', () => {
+
+				const instance = new Role({ name: 'Young Lucius', isAlternate: 'foobar' });
+				expect(instance.isAlternate).to.equal(true);
+
+			});
+
+			it('assigns true if included in props and value is true', () => {
+
+				const instance = new Role({ name: 'Young Lucius', isAlternate: true });
+				expect(instance.isAlternate).to.equal(true);
+
+			});
+
+		});
+
 	});
 
 	describe('validateCharacterName method', () => {


### PR DESCRIPTION
This PR adds the `isAlternate` property to roles to denote when the performer is an alternate (i.e. is sharing the role with other performers).

---

#### Titus Andronicus at Globe Theatre (production)
<img width="325" alt="titus-andronicus-globe-production" src="https://user-images.githubusercontent.com/10484515/123840971-edf1a580-d906-11eb-8e0b-32be35de9fe7.png">

----

#### Hugh Wyld (person)
<img width="674" alt="hugh-wyld-person" src="https://user-images.githubusercontent.com/10484515/123841190-298c6f80-d907-11eb-8d83-34208b1ae285.png">

---

#### Young Lucius (character)
<img width="889" alt="young-lucius-character" src="https://user-images.githubusercontent.com/10484515/123841198-2c876000-d907-11eb-8b6f-1ae3646faa1e.png">

----

#### True West at Vaudeville Theatre (production)
<img width="292" alt="true-west-vaudeville-production" src="https://user-images.githubusercontent.com/10484515/123841210-2f825080-d907-11eb-9863-4b7922e325da.png">

---

#### Kit Harington (person)
<img width="552" alt="kit-harington-person" src="https://user-images.githubusercontent.com/10484515/123841216-314c1400-d907-11eb-924e-c4aa3e1fe788.png">

---

#### Austin (character)
<img width="932" alt="austin-character" src="https://user-images.githubusercontent.com/10484515/123841223-33ae6e00-d907-11eb-97f7-e81c9d17ffeb.png">