### PR TITLE
Revise capitalise function to convert to Pascal case

### DIFF
--- a/src/lib/strings.js
+++ b/src/lib/strings.js
@@ -1,10 +1,10 @@
 import { IRREGULAR_PLURAL_NOUNS_MAP } from '../utils/constants';
 
-const capitalise = string => string.charAt(0).toUpperCase() + string.substring(1).toLowerCase();
+const pascalCasify = string => string.charAt(0).toUpperCase() + string.substring(1);
 
 const pluralise = model => IRREGULAR_PLURAL_NOUNS_MAP[model] || `${model}s`;
 
 export {
-	capitalise,
+	pascalCasify,
 	pluralise
 };

--- a/src/neo4j/cypher-queries/shared.js
+++ b/src/neo4j/cypher-queries/shared.js
@@ -1,13 +1,13 @@
-import { capitalise } from '../../lib/strings';
+import { pascalCasify } from '../../lib/strings';
 
 const getExistenceQuery = model => `
-	MATCH (n:${capitalise(model)} { uuid: $uuid })
+	MATCH (n:${pascalCasify(model)} { uuid: $uuid })
 
 	RETURN n
 `;
 
 const getDuplicateRecordCountQuery = model => `
-	MATCH (n:${capitalise(model)} { name: $name })
+	MATCH (n:${pascalCasify(model)} { name: $name })
 		WHERE
 			(
 				($differentiator IS NULL AND n.differentiator IS NULL) OR
@@ -22,7 +22,7 @@ const getDuplicateRecordCountQuery = model => `
 `;
 
 const getCreateQuery = model => `
-	CREATE (n:${capitalise(model)} { uuid: $uuid, name: $name, differentiator: $differentiator })
+	CREATE (n:${pascalCasify(model)} { uuid: $uuid, name: $name, differentiator: $differentiator })
 
 	WITH n
 
@@ -30,7 +30,7 @@ const getCreateQuery = model => `
 `;
 
 const getEditQuery = model => `
-	MATCH (n:${capitalise(model)} { uuid: $uuid })
+	MATCH (n:${pascalCasify(model)} { uuid: $uuid })
 
 	RETURN
 		'${model}' AS model,
@@ -40,7 +40,7 @@ const getEditQuery = model => `
 `;
 
 const getUpdateQuery = model => `
-	MATCH (n:${capitalise(model)} { uuid: $uuid })
+	MATCH (n:${pascalCasify(model)} { uuid: $uuid })
 		SET
 			n.name = $name,
 			n.differentiator = $differentiator
@@ -52,7 +52,7 @@ const getUpdateQuery = model => `
 
 const getDeleteQuery = model => {
 
-	const label = capitalise(model);
+	const label = pascalCasify(model);
 
 	return `
 		MATCH (:${label} { uuid: $uuid })
@@ -101,7 +101,7 @@ const getDeleteQuery = model => {
 };
 
 const getListQuery = model => `
-	MATCH (n:${capitalise(model)})
+	MATCH (n:${pascalCasify(model)})
 
 	RETURN
 		'${model}' AS model,

--- a/test-unit/src/lib/strings.test.js
+++ b/test-unit/src/lib/strings.test.js
@@ -1,26 +1,26 @@
 import { expect } from 'chai';
 
-import { capitalise, pluralise } from '../../../src/lib/strings';
+import { pascalCasify, pluralise } from '../../../src/lib/strings';
 
 describe('Strings module', () => {
 
-	describe('capitalise function', () => {
+	describe('pascalCasify function', () => {
 
 		context('input string is lowercase', () => {
 
 			it('returns string with initial letter as capital', () => {
 
-				expect(capitalise('string')).to.equal('String');
+				expect(pascalCasify('foo')).to.equal('Foo');
 
 			});
 
 		});
 
-		context('input string is uppercase', () => {
+		context('input string is camel case', () => {
 
 			it('returns string with initial letter as capital', () => {
 
-				expect(capitalise('STRING')).to.equal('String');
+				expect(pascalCasify('fooBar')).to.equal('FooBar');
 
 			});
 

--- a/test-unit/src/neo4j/cypher-queries/shared.test.js
+++ b/test-unit/src/neo4j/cypher-queries/shared.test.js
@@ -14,11 +14,11 @@ describe('Cypher Queries Shared module', () => {
 	beforeEach(() => {
 
 		stubs = {
-			capitalise: sandbox.stub(strings, 'capitalise')
+			pascalCasify: sandbox.stub(strings, 'pascalCasify')
 		};
 
-		stubs.capitalise.withArgs('production').returns('Production');
-		stubs.capitalise.withArgs('venue').returns('Venue');
+		stubs.pascalCasify.withArgs('production').returns('Production');
+		stubs.pascalCasify.withArgs('venue').returns('Venue');
 
 	});
 
@@ -33,8 +33,8 @@ describe('Cypher Queries Shared module', () => {
 		it('returns requisite query', () => {
 
 			const result = cypherQueriesShared.getExistenceQuery('venue');
-			expect(stubs.capitalise.calledOnce).to.be.true;
-			expect(stubs.capitalise.calledWithExactly('venue')).to.be.true;
+			expect(stubs.pascalCasify.calledOnce).to.be.true;
+			expect(stubs.pascalCasify.calledWithExactly('venue')).to.be.true;
 			expect(removeExcessWhitespace(result)).to.equal(removeExcessWhitespace(`
 				MATCH (n:Venue { uuid: $uuid })
 
@@ -50,8 +50,8 @@ describe('Cypher Queries Shared module', () => {
 		it('returns requisite query', () => {
 
 			const result = cypherQueriesShared.getDuplicateRecordCountQuery('venue', undefined);
-			expect(stubs.capitalise.calledOnce).to.be.true;
-			expect(stubs.capitalise.calledWithExactly('venue')).to.be.true;
+			expect(stubs.pascalCasify.calledOnce).to.be.true;
+			expect(stubs.pascalCasify.calledWithExactly('venue')).to.be.true;
 			expect(removeExcessWhitespace(result)).to.equal(removeExcessWhitespace(`
 				MATCH (n:Venue { name: $name })
 					WHERE
@@ -76,9 +76,9 @@ describe('Cypher Queries Shared module', () => {
 		it('returns requisite query', () => {
 
 			const result = cypherQueriesShared.getCreateQuery('venue');
-			expect(stubs.capitalise.calledTwice).to.be.true;
-			expect(stubs.capitalise.firstCall.calledWithExactly('venue')).to.be.true;
-			expect(stubs.capitalise.secondCall.calledWithExactly('venue')).to.be.true;
+			expect(stubs.pascalCasify.calledTwice).to.be.true;
+			expect(stubs.pascalCasify.firstCall.calledWithExactly('venue')).to.be.true;
+			expect(stubs.pascalCasify.secondCall.calledWithExactly('venue')).to.be.true;
 			expect(removeExcessWhitespace(result)).to.equal(removeExcessWhitespace(`
 				CREATE (n:Venue { uuid: $uuid, name: $name, differentiator: $differentiator })
 
@@ -102,8 +102,8 @@ describe('Cypher Queries Shared module', () => {
 		it('returns requisite query', () => {
 
 			const result = cypherQueriesShared.getEditQuery('venue');
-			expect(stubs.capitalise.calledOnce).to.be.true;
-			expect(stubs.capitalise.calledWithExactly('venue')).to.be.true;
+			expect(stubs.pascalCasify.calledOnce).to.be.true;
+			expect(stubs.pascalCasify.calledWithExactly('venue')).to.be.true;
 			expect(removeExcessWhitespace(result)).to.equal(removeExcessWhitespace(`
 				MATCH (n:Venue { uuid: $uuid })
 
@@ -123,9 +123,9 @@ describe('Cypher Queries Shared module', () => {
 		it('returns requisite query', () => {
 
 			const result = cypherQueriesShared.getUpdateQuery('venue');
-			expect(stubs.capitalise.calledTwice).to.be.true;
-			expect(stubs.capitalise.firstCall.calledWithExactly('venue')).to.be.true;
-			expect(stubs.capitalise.secondCall.calledWithExactly('venue')).to.be.true;
+			expect(stubs.pascalCasify.calledTwice).to.be.true;
+			expect(stubs.pascalCasify.firstCall.calledWithExactly('venue')).to.be.true;
+			expect(stubs.pascalCasify.secondCall.calledWithExactly('venue')).to.be.true;
 			expect(removeExcessWhitespace(result)).to.equal(removeExcessWhitespace(`
 				MATCH (n:Venue { uuid: $uuid })
 					SET
@@ -152,8 +152,8 @@ describe('Cypher Queries Shared module', () => {
 		it('returns requisite query', () => {
 
 			const result = cypherQueriesShared.getDeleteQuery('venue');
-			expect(stubs.capitalise.calledOnce).to.be.true;
-			expect(stubs.capitalise.calledWithExactly('venue')).to.be.true;
+			expect(stubs.pascalCasify.calledOnce).to.be.true;
+			expect(stubs.pascalCasify.calledWithExactly('venue')).to.be.true;
 			expect(removeExcessWhitespace(result)).to.equal(removeExcessWhitespace(`
 				MATCH (:Venue { uuid: $uuid })
 
@@ -207,8 +207,8 @@ describe('Cypher Queries Shared module', () => {
 		it('returns requisite query', () => {
 
 			const result = cypherQueriesShared.getListQuery('venue');
-			expect(stubs.capitalise.calledOnce).to.be.true;
-			expect(stubs.capitalise.calledWithExactly('venue')).to.be.true;
+			expect(stubs.pascalCasify.calledOnce).to.be.true;
+			expect(stubs.pascalCasify.calledWithExactly('venue')).to.be.true;
 			expect(removeExcessWhitespace(result)).to.equal(removeExcessWhitespace(`
 				MATCH (n:Venue)
 


### PR DESCRIPTION
The app will shortly include model names of multiple words expressed in camel case, e.g. `awardCeremony`.

The current purpose of the `capitalise` function is to convert model names so they can be used as labels in Cypher queries, but the function in its current state would convert `awardCeremony` to `Awardceremony`, when it needs to be `AwardCeremony`.

This PR revises the `capitalise` function so that it instead converts camel case strings to Pascal case (the casing used for Neo4j labels), e.g.  `production` -> `Production` and `awardCeremony` -> `AwardCeremony`.

The case covered in the unit tests of the input string being uppercased (e.g. `FOO`) will not actually be encountered and so the test have also been revised so they only cover the two scenarios that would be encountered:
- all lowercase strings (e.g. `foo`)
- camel case strings (e.g. `fooBar`)