### PR TITLE
Add award ceremonies resource

### DIFF
--- a/src/controllers/award-ceremonies.js
+++ b/src/controllers/award-ceremonies.js
@@ -1,0 +1,36 @@
+/* eslint no-unused-vars: ["error", { "argsIgnorePattern": "next" }] */
+
+import { callInstanceMethod, callStaticListMethod } from '../lib/call-class-methods';
+import { sendJsonResponse } from '../lib/send-json-response';
+import { AwardCeremony } from '../models';
+
+const newRoute = (request, response, next) =>
+	sendJsonResponse(response, new AwardCeremony());
+
+const createRoute = (request, response, next) =>
+	callInstanceMethod(response, next, new AwardCeremony(request.body), 'create');
+
+const editRoute = (request, response, next) =>
+	callInstanceMethod(response, next, new AwardCeremony(request.params), 'edit');
+
+const updateRoute = (request, response, next) =>
+	callInstanceMethod(response, next, new AwardCeremony({ ...request.body, ...request.params }), 'update');
+
+const deleteRoute = (request, response, next) =>
+	callInstanceMethod(response, next, new AwardCeremony(request.params), 'delete');
+
+const showRoute = (request, response, next) =>
+	callInstanceMethod(response, next, new AwardCeremony(request.params), 'show');
+
+const listRoute = (request, response, next) =>
+	callStaticListMethod(response, next, AwardCeremony, 'awardCeremony');
+
+export {
+	newRoute,
+	createRoute,
+	editRoute,
+	updateRoute,
+	deleteRoute,
+	showRoute,
+	listRoute
+};

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -1,4 +1,5 @@
 import * as awards from './awards';
+import * as awardCeremonies from './award-ceremonies';
 import * as characters from './characters';
 import * as companies from './companies';
 import * as materials from './materials';
@@ -8,6 +9,7 @@ import * as venues from './venues';
 
 export {
 	awards,
+	awardCeremonies,
 	characters,
 	companies,
 	materials,

--- a/src/models/AwardCeremony.js
+++ b/src/models/AwardCeremony.js
@@ -1,0 +1,71 @@
+import { prepareAsParams } from '../lib/prepare-as-params';
+import Entity from './Entity';
+import { Award } from '.';
+import { getAwardContextualDuplicateRecordCountQuery } from '../neo4j/cypher-queries';
+import { neo4jQuery } from '../neo4j/query';
+
+export default class AwardCeremony extends Entity {
+
+	constructor (props = {}) {
+
+		super(props);
+
+		const { award } = props;
+
+		this.award = new Award(award);
+
+	}
+
+	get model () {
+
+		return 'awardCeremony';
+
+	}
+
+	runInputValidations () {
+
+		this.validateName({ isRequired: true });
+
+		this.award.validateName({ isRequired: false });
+
+		this.award.validateDifferentiator();
+
+	}
+
+	async runDatabaseValidations () {
+
+		await this.validateAwardContextualUniquenessInDatabase();
+
+	}
+
+	async validateAwardContextualUniquenessInDatabase () {
+
+		const preparedParams = prepareAsParams(this);
+
+		const { duplicateRecordCount } = await neo4jQuery({
+			query: getAwardContextualDuplicateRecordCountQuery(),
+			params: {
+				uuid: preparedParams.uuid,
+				name: preparedParams.name,
+				award: {
+					name: preparedParams.award.name,
+					differentiator: preparedParams.award.differentiator
+				}
+			}
+		});
+
+		if (duplicateRecordCount > 0) {
+
+			const uniquenessErrorMessage = 'Award ceremony already exists for given award';
+
+			this.addPropertyError('name', uniquenessErrorMessage);
+
+			this.award.addPropertyError('name', uniquenessErrorMessage);
+
+			this.award.addPropertyError('differentiator', uniquenessErrorMessage);
+
+		}
+
+	}
+
+}

--- a/src/models/Entity.js
+++ b/src/models/Entity.js
@@ -21,7 +21,7 @@ export default class Entity extends Base {
 
 		this.uuid = uuid;
 
-		if (this.model !== 'production') this.differentiator = differentiator?.trim() || '';
+		if (!['production', 'awardCeremony'].includes(this.model)) this.differentiator = differentiator?.trim() || '';
 
 	}
 

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,4 +1,5 @@
 import Award from './Award';
+import AwardCeremony from './AwardCeremony';
 import CastMember from './CastMember';
 import Character from './Character';
 import CharacterDepiction from './CharacterDepiction';
@@ -19,6 +20,7 @@ import WritingCredit from './WritingCredit';
 
 export {
 	Award,
+	AwardCeremony,
 	CastMember,
 	Character,
 	CharacterDepiction,

--- a/src/neo4j/create-constraints.js
+++ b/src/neo4j/create-constraints.js
@@ -4,6 +4,7 @@ import { neo4jQuery } from './query';
 
 const MODELS = new Set([
 	'Award',
+	'AwardCeremony',
 	'Character',
 	'Company',
 	'Material',

--- a/src/neo4j/create-indexes.js
+++ b/src/neo4j/create-indexes.js
@@ -4,6 +4,7 @@ import { neo4jQuery } from './query';
 
 const MODELS = new Set([
 	'Award',
+	'AwardCeremony',
 	'Character',
 	'Company',
 	'Material',

--- a/src/neo4j/cypher-queries/award-ceremony.js
+++ b/src/neo4j/cypher-queries/award-ceremony.js
@@ -1,0 +1,113 @@
+const getAwardContextualDuplicateRecordCountQuery = () => `
+	MATCH (awardCeremony:AwardCeremony { name: $name })<-[:PRESENTED_AT]-(award:Award { name: $award.name })
+		WHERE
+			(
+				$uuid IS NULL OR
+				$uuid <> awardCeremony.uuid
+			) AND
+			(
+				($award.differentiator IS NULL AND award.differentiator IS NULL) OR
+				$award.differentiator = award.differentiator
+			)
+
+	RETURN SIGN(COUNT(awardCeremony)) AS duplicateRecordCount
+`;
+
+const getCreateUpdateQuery = action => {
+
+	const createUpdateQueryOpeningMap = {
+		create: `
+			CREATE (awardCeremony:AwardCeremony { uuid: $uuid, name: $name })
+		`,
+		update: `
+			MATCH (awardCeremony:AwardCeremony { uuid: $uuid })
+
+			OPTIONAL MATCH (awardCeremony)-[relationship]-()
+
+			DELETE relationship
+
+			WITH DISTINCT awardCeremony
+
+			SET awardCeremony.name = $name
+		`
+	};
+
+	return `
+		${createUpdateQueryOpeningMap[action]}
+
+		WITH awardCeremony
+
+		OPTIONAL MATCH (existingAward:Award { name: $award.name })
+			WHERE
+				($award.differentiator IS NULL AND existingAward.differentiator IS NULL) OR
+				$award.differentiator = existingAward.differentiator
+
+		FOREACH (item IN CASE $award.name WHEN NULL THEN [] ELSE [1] END |
+			MERGE (award:Award {
+				uuid: COALESCE(existingAward.uuid, $award.uuid),
+				name: $award.name
+			})
+				ON CREATE SET award.differentiator = $award.differentiator
+
+			CREATE (awardCeremony)<-[:PRESENTED_AT]-(award)
+		)
+
+		WITH DISTINCT awardCeremony
+
+		${getEditQuery()}
+	`;
+
+};
+
+const getCreateQuery = () => getCreateUpdateQuery('create');
+
+const getEditQuery = () => `
+	MATCH (awardCeremony:AwardCeremony { uuid: $uuid })
+
+	OPTIONAL MATCH (awardCeremony)<-[:PRESENTED_AT]-(award:Award)
+
+	RETURN
+		'awardCeremony' AS model,
+		awardCeremony.uuid AS uuid,
+		awardCeremony.name AS name,
+		{ name: COALESCE(award.name, ''), differentiator: COALESCE(award.differentiator, '') } AS award
+`;
+
+const getUpdateQuery = () => getCreateUpdateQuery('update');
+
+const getShowQuery = () => `
+	MATCH (awardCeremony:AwardCeremony { uuid: $uuid })
+
+	OPTIONAL MATCH (awardCeremony)<-[:PRESENTED_AT]-(award:Award)
+
+	RETURN
+		'awardCeremony' AS model,
+		awardCeremony.uuid AS uuid,
+		awardCeremony.name AS name,
+		CASE award WHEN NULL THEN null ELSE award { model: 'award', .uuid, .name } END AS award
+`;
+
+const getListQuery = () => `
+	MATCH (awardCeremony:AwardCeremony)
+
+	OPTIONAL MATCH (awardCeremony)<-[:PRESENTED_AT]-(award:Award)
+
+	RETURN
+		'awardCeremony' AS model,
+		awardCeremony.uuid AS uuid,
+		awardCeremony.name AS name,
+		CASE award WHEN NULL THEN null ELSE award { model: 'award', .uuid, .name } END AS award
+
+	ORDER BY awardCeremony.name DESC, award.name
+
+	LIMIT 100
+`;
+
+export {
+	getAwardContextualDuplicateRecordCountQuery,
+	getCreateQuery,
+	getEditQuery,
+	getUpdateQuery,
+	getShowQuery,
+	getListQuery
+};

--- a/src/neo4j/cypher-queries/award.js
+++ b/src/neo4j/cypher-queries/award.js
@@ -1,10 +1,22 @@
 const getShowQuery = () => `
 	MATCH (award:Award { uuid: $uuid })
+
+	OPTIONAL MATCH (award)-[:PRESENTED_AT]->(awardCeremony:AwardCeremony)
+
+	WITH award, awardCeremony
+		ORDER BY awardCeremony.name DESC
+
 	RETURN
 		'award' AS model,
 		award.uuid AS uuid,
 		award.name AS name,
-		award.differentiator AS differentiator
+		award.differentiator AS differentiator,
+		COLLECT(
+			CASE awardCeremony WHEN NULL
+				THEN null
+				ELSE awardCeremony { model: 'awardCeremony', .uuid, .name }
+			END
+		) AS awardCeremonies
 `;
 
 export {

--- a/src/neo4j/cypher-queries/index.js
+++ b/src/neo4j/cypher-queries/index.js
@@ -1,4 +1,12 @@
 import { getShowQuery as getAwardShowQuery } from './award';
+import {
+	getAwardContextualDuplicateRecordCountQuery,
+	getCreateQuery as getAwardCeremonyCreateQuery,
+	getEditQuery as getAwardCeremonyEditQuery,
+	getUpdateQuery as getAwardCeremonyUpdateQuery,
+	getShowQuery as getAwardCeremonyShowQuery,
+	getListQuery as getAwardCeremonyListQuery
+} from './award-ceremony';
 import { getShowQuery as getCharacterShowQuery } from './character';
 import { getShowQuery as getCompanyShowQuery } from './company';
 import {
@@ -26,18 +34,21 @@ import {
 } from './venue';
 
 const getCreateQueries = {
+	awardCeremony: getAwardCeremonyCreateQuery,
 	material: getMaterialCreateQuery,
 	production: getProductionCreateQuery,
 	venue: getVenueCreateQuery
 };
 
 const getEditQueries = {
+	awardCeremony: getAwardCeremonyEditQuery,
 	material: getMaterialEditQuery,
 	production: getProductionEditQuery,
 	venue: getVenueEditQuery
 };
 
 const getUpdateQueries = {
+	awardCeremony: getAwardCeremonyUpdateQuery,
 	material: getMaterialUpdateQuery,
 	production: getProductionUpdateQuery,
 	venue: getVenueUpdateQuery
@@ -45,6 +56,7 @@ const getUpdateQueries = {
 
 const getShowQueries = {
 	award: getAwardShowQuery,
+	awardCeremony: getAwardCeremonyShowQuery,
 	character: getCharacterShowQuery,
 	company: getCompanyShowQuery,
 	person: getPersonShowQuery,
@@ -54,12 +66,14 @@ const getShowQueries = {
 };
 
 const getListQueries = {
+	awardCeremony: getAwardCeremonyListQuery,
 	material: getMaterialListQuery,
 	production: getProductionListQuery,
 	venue: getVenueListQuery
 };
 
 export {
+	getAwardContextualDuplicateRecordCountQuery,
 	getCreateQueries,
 	getEditQueries,
 	getUpdateQueries,

--- a/src/router.js
+++ b/src/router.js
@@ -4,6 +4,7 @@ import { Router } from 'express';
 
 import {
 	awards as awardsController,
+	awardCeremonies as awardCeremoniesController,
 	characters as charactersController,
 	companies as companiesController,
 	materials as materialsController,
@@ -13,6 +14,14 @@ import {
 } from './controllers';
 
 const router = new Router();
+
+router.get('/awards/ceremonies/new', awardCeremoniesController.newRoute);
+router.post('/awards/ceremonies', awardCeremoniesController.createRoute);
+router.get('/awards/ceremonies/:uuid/edit', awardCeremoniesController.editRoute);
+router.put('/awards/ceremonies/:uuid', awardCeremoniesController.updateRoute);
+router.delete('/awards/ceremonies/:uuid', awardCeremoniesController.deleteRoute);
+router.get('/awards/ceremonies/:uuid', awardCeremoniesController.showRoute);
+router.get('/awards/ceremonies', awardCeremoniesController.listRoute);
 
 router.get('/awards/new', awardsController.newRoute);
 router.post('/awards', awardsController.createRoute);

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -4,6 +4,7 @@ const CREDIT_TYPES = {
 };
 
 const IRREGULAR_PLURAL_NOUNS_MAP = {
+	awardCeremony: 'awardCeremonies',
 	company: 'companies',
 	person: 'people'
 };

--- a/test-e2e/crud/award-ceremonies-api.test.js
+++ b/test-e2e/crud/award-ceremonies-api.test.js
@@ -1,0 +1,549 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import { createSandbox } from 'sinon';
+import { v4 as uuid } from 'uuid';
+
+import app from '../../src/app';
+import countNodesWithLabel from '../test-helpers/neo4j/count-nodes-with-label';
+import purgeDatabase from '../test-helpers/neo4j/purge-database';
+
+describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
+
+	chai.use(chaiHttp);
+
+	const sandbox = createSandbox();
+
+	describe('GET new endpoint', () => {
+
+		it('responds with data required to prepare new award ceremony', async () => {
+
+			const response = await chai.request(app)
+				.get('/awards/ceremonies/new');
+
+			const expectedResponseBody = {
+				model: 'awardCeremony',
+				name: '',
+				errors: {},
+				award: {
+					model: 'award',
+					name: '',
+					differentiator: '',
+					errors: {}
+				}
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+
+		});
+
+	});
+
+	describe('CRUD with minimum range of attributes assigned values', () => {
+
+		const AWARD_CEREMONY_UUID = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+
+		before(async () => {
+
+			sandbox.stub(uuid, 'v4').returns(AWARD_CEREMONY_UUID);
+
+			await purgeDatabase();
+
+		});
+
+		after(() => {
+
+			sandbox.restore();
+
+		});
+
+		it('creates award ceremony', async () => {
+
+			expect(await countNodesWithLabel('AwardCeremony')).to.equal(0);
+
+			const response = await chai.request(app)
+				.post('/awards/ceremonies')
+				.send({
+					name: '2020'
+				});
+
+			const expectedResponseBody = {
+				model: 'awardCeremony',
+				uuid: AWARD_CEREMONY_UUID,
+				name: '2020',
+				errors: {},
+				award: {
+					model: 'award',
+					name: '',
+					differentiator: '',
+					errors: {}
+				}
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
+
+		});
+
+		it('gets data required to edit specific award ceremony', async () => {
+
+			const response = await chai.request(app)
+				.get(`/awards/ceremonies/${AWARD_CEREMONY_UUID}/edit`);
+
+			const expectedResponseBody = {
+				model: 'awardCeremony',
+				uuid: AWARD_CEREMONY_UUID,
+				name: '2020',
+				errors: {},
+				award: {
+					model: 'award',
+					name: '',
+					differentiator: '',
+					errors: {}
+				}
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+
+		});
+
+		it('updates award ceremony', async () => {
+
+			expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
+
+			const response = await chai.request(app)
+				.put(`/awards/ceremonies/${AWARD_CEREMONY_UUID}`)
+				.send({
+					name: '2019'
+				});
+
+			const expectedResponseBody = {
+				model: 'awardCeremony',
+				uuid: AWARD_CEREMONY_UUID,
+				name: '2019',
+				errors: {},
+				award: {
+					model: 'award',
+					name: '',
+					differentiator: '',
+					errors: {}
+				}
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
+
+		});
+
+		it('shows award ceremony', async () => {
+
+			const response = await chai.request(app)
+				.get(`/awards/ceremonies/${AWARD_CEREMONY_UUID}`);
+
+			const expectedResponseBody = {
+				model: 'awardCeremony',
+				uuid: AWARD_CEREMONY_UUID,
+				name: '2019',
+				award: null
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+
+		});
+
+		it('deletes award ceremony', async () => {
+
+			expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
+
+			const response = await chai.request(app)
+				.delete(`/awards/ceremonies/${AWARD_CEREMONY_UUID}`);
+
+			const expectedResponseBody = {
+				model: 'awardCeremony',
+				name: '2019',
+				errors: {},
+				award: {
+					model: 'award',
+					name: '',
+					differentiator: '',
+					errors: {}
+				}
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('AwardCeremony')).to.equal(0);
+
+		});
+
+	});
+
+	describe('CRUD with full range of attributes assigned values', () => {
+
+		const AWARD_CEREMONY_UUID = '2';
+		const LAURENCE_OLIVIER_AWARDS_AWARD_UUID = '3';
+		const EVENING_STANDARD_THEATRE_AWARDS_AWARD_UUID = '5';
+
+		before(async () => {
+
+			let uuidCallCount = 0;
+
+			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+
+			await purgeDatabase();
+
+		});
+
+		after(() => {
+
+			sandbox.restore();
+
+		});
+
+		it('creates award ceremony', async () => {
+
+			expect(await countNodesWithLabel('AwardCeremony')).to.equal(0);
+
+			const response = await chai.request(app)
+				.post('/awards/ceremonies')
+				.send({
+					name: '2019',
+					award: {
+						name: 'Laurence Olivier Awards',
+						differentiator: '1'					}
+				});
+
+			const expectedResponseBody = {
+				model: 'awardCeremony',
+				uuid: AWARD_CEREMONY_UUID,
+				name: '2019',
+				errors: {},
+				award: {
+					model: 'award',
+					name: 'Laurence Olivier Awards',
+					differentiator: '1',
+					errors: {}
+				}
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
+
+		});
+
+		it('shows award ceremony (post-creation)', async () => {
+
+			const response = await chai.request(app)
+				.get(`/awards/ceremonies/${AWARD_CEREMONY_UUID}`);
+
+			const expectedResponseBody = {
+				model: 'awardCeremony',
+				uuid: AWARD_CEREMONY_UUID,
+				name: '2019',
+				award: {
+					model: 'award',
+					uuid: LAURENCE_OLIVIER_AWARDS_AWARD_UUID,
+					name: 'Laurence Olivier Awards'
+				}
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+
+		});
+
+		it('gets data required to edit specific award ceremony', async () => {
+
+			const response = await chai.request(app)
+				.get(`/awards/ceremonies/${AWARD_CEREMONY_UUID}/edit`);
+
+			const expectedResponseBody = {
+				model: 'awardCeremony',
+				uuid: AWARD_CEREMONY_UUID,
+				name: '2019',
+				errors: {},
+				award: {
+					model: 'award',
+					name: 'Laurence Olivier Awards',
+					differentiator: '1',
+					errors: {}
+				}
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+
+		});
+
+		it('updates award ceremony', async () => {
+
+			expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
+
+			const response = await chai.request(app)
+				.put(`/awards/ceremonies/${AWARD_CEREMONY_UUID}`)
+				.send({
+					name: '2020',
+					award: {
+						name: 'Evening Standard Theatre Awards',
+						differentiator: '2'
+					}
+				});
+
+			const expectedResponseBody = {
+				model: 'awardCeremony',
+				uuid: AWARD_CEREMONY_UUID,
+				name: '2020',
+				errors: {},
+				award: {
+					model: 'award',
+					name: 'Evening Standard Theatre Awards',
+					differentiator: '2',
+					errors: {}
+				}
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
+
+		});
+
+		it('shows award ceremony (post-update)', async () => {
+
+			const response = await chai.request(app)
+				.get(`/awards/ceremonies/${AWARD_CEREMONY_UUID}`);
+
+			const expectedResponseBody = {
+				model: 'awardCeremony',
+				uuid: AWARD_CEREMONY_UUID,
+				name: '2020',
+				award: {
+					model: 'award',
+					uuid: EVENING_STANDARD_THEATRE_AWARDS_AWARD_UUID,
+					name: 'Evening Standard Theatre Awards'
+				}
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+
+		});
+
+		it('updates award ceremony to remove all associations prior to deletion', async () => {
+
+			expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
+
+			const response = await chai.request(app)
+				.put(`/awards/ceremonies/${AWARD_CEREMONY_UUID}`)
+				.send({
+					name: '2020'
+				});
+
+			const expectedResponseBody = {
+				model: 'awardCeremony',
+				uuid: AWARD_CEREMONY_UUID,
+				name: '2020',
+				errors: {},
+				award: {
+					model: 'award',
+					name: '',
+					differentiator: '',
+					errors: {}
+				}
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
+
+		});
+
+		it('deletes awards ceremony', async () => {
+
+			expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
+
+			const response = await chai.request(app)
+				.delete(`/awards/ceremonies/${AWARD_CEREMONY_UUID}`);
+
+			const expectedResponseBody = {
+				model: 'awardCeremony',
+				name: '2020',
+				errors: {},
+				award: {
+					model: 'award',
+					name: '',
+					differentiator: '',
+					errors: {}
+				}
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('AwardCeremony')).to.equal(0);
+
+		});
+
+	});
+
+	describe('GET list endpoint', () => {
+
+		const LAURENCE_OLIVIER_AWARDS_TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID = '2';
+		const LAURENCE_OLIVIER_AWARDS_AWARD_UUID = '3';
+		const LAURENCE_OLIVIER_AWARDS_TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID = '6';
+		const LAURENCE_OLIVIER_AWARDS_TWO_THOUSAND_AND_EIGHTEEN_AWARD_CEREMONY_UUID = '10';
+		const EVENING_STANDARD_THEATRE_AWARDS_TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID = '14';
+		const EVENING_STANDARD_THEATRE_AWARDS_AWARD_UUID = '15';
+		const EVENING_STANDARD_THEATRE_AWARDS_TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID = '18';
+		const EVENING_STANDARD_THEATRE_AWARDS_TWO_THOUSAND_AND_EIGHTEEN_AWARD_CEREMONY_UUID = '22';
+
+		before(async () => {
+
+			let uuidCallCount = 0;
+
+			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+
+			await purgeDatabase();
+
+			await chai.request(app)
+				.post('/awards/ceremonies')
+				.send({
+					name: '2019',
+					award: {
+						name: 'Laurence Olivier Awards'
+					}
+				});
+
+			await chai.request(app)
+				.post('/awards/ceremonies')
+				.send({
+					name: '2020',
+					award: {
+						name: 'Laurence Olivier Awards'
+					}
+				});
+
+			await chai.request(app)
+				.post('/awards/ceremonies')
+				.send({
+					name: '2018',
+					award: {
+						name: 'Laurence Olivier Awards'
+					}
+				});
+
+			await chai.request(app)
+				.post('/awards/ceremonies')
+				.send({
+					name: '2019',
+					award: {
+						name: 'Evening Standard Theatre Awards'
+					}
+				});
+
+			await chai.request(app)
+				.post('/awards/ceremonies')
+				.send({
+					name: '2020',
+					award: {
+						name: 'Evening Standard Theatre Awards'
+					}
+				});
+
+			await chai.request(app)
+				.post('/awards/ceremonies')
+				.send({
+					name: '2018',
+					award: {
+						name: 'Evening Standard Theatre Awards'
+					}
+				});
+
+		});
+
+		after(() => {
+
+			sandbox.restore();
+
+		});
+
+		it('lists all award ceremonies ordered by name then award name', async () => {
+
+			const response = await chai.request(app)
+				.get('/awards/ceremonies');
+
+			const expectedResponseBody = [
+				{
+					model: 'awardCeremony',
+					uuid: EVENING_STANDARD_THEATRE_AWARDS_TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID,
+					name: '2020',
+					award: {
+						model: 'award',
+						uuid: EVENING_STANDARD_THEATRE_AWARDS_AWARD_UUID,
+						name: 'Evening Standard Theatre Awards'
+					}
+				},
+				{
+					model: 'awardCeremony',
+					uuid: LAURENCE_OLIVIER_AWARDS_TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID,
+					name: '2020',
+					award: {
+						model: 'award',
+						uuid: LAURENCE_OLIVIER_AWARDS_AWARD_UUID,
+						name: 'Laurence Olivier Awards'
+					}
+				},
+				{
+					model: 'awardCeremony',
+					uuid: EVENING_STANDARD_THEATRE_AWARDS_TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID,
+					name: '2019',
+					award: {
+						model: 'award',
+						uuid: EVENING_STANDARD_THEATRE_AWARDS_AWARD_UUID,
+						name: 'Evening Standard Theatre Awards'
+					}
+				},
+				{
+					model: 'awardCeremony',
+					uuid: LAURENCE_OLIVIER_AWARDS_TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID,
+					name: '2019',
+					award: {
+						model: 'award',
+						uuid: LAURENCE_OLIVIER_AWARDS_AWARD_UUID,
+						name: 'Laurence Olivier Awards'
+					}
+				},
+				{
+					model: 'awardCeremony',
+					uuid: EVENING_STANDARD_THEATRE_AWARDS_TWO_THOUSAND_AND_EIGHTEEN_AWARD_CEREMONY_UUID,
+					name: '2018',
+					award: {
+						model: 'award',
+						uuid: EVENING_STANDARD_THEATRE_AWARDS_AWARD_UUID,
+						name: 'Evening Standard Theatre Awards'
+					}
+				},
+				{
+					model: 'awardCeremony',
+					uuid: LAURENCE_OLIVIER_AWARDS_TWO_THOUSAND_AND_EIGHTEEN_AWARD_CEREMONY_UUID,
+					name: '2018',
+					award: {
+						model: 'award',
+						uuid: LAURENCE_OLIVIER_AWARDS_AWARD_UUID,
+						name: 'Laurence Olivier Awards'
+					}
+				}
+			];
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+
+		});
+
+	});
+
+});

--- a/test-e2e/crud/awards-api.test.js
+++ b/test-e2e/crud/awards-api.test.js
@@ -127,7 +127,8 @@ describe('CRUD (Create, Read, Update, Delete): Awards API', () => {
 				model: 'award',
 				uuid: AWARD_UUID,
 				name: 'Evening Standard Theatre Awards',
-				differentiator: null
+				differentiator: null,
+				awardCeremonies: []
 			};
 
 			expect(response).to.have.status(200);

--- a/test-e2e/instance-validation-failures/award-ceremonies-api.test.js
+++ b/test-e2e/instance-validation-failures/award-ceremonies-api.test.js
@@ -1,0 +1,336 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+
+import app from '../../src/app';
+import countNodesWithLabel from '../test-helpers/neo4j/count-nodes-with-label';
+import createNode from '../test-helpers/neo4j/create-node';
+import createRelationship from '../test-helpers/neo4j/create-relationship';
+import isNodeExistent from '../test-helpers/neo4j/is-node-existent';
+import purgeDatabase from '../test-helpers/neo4j/purge-database';
+
+describe('Instance validation failures: Award ceremonies API', () => {
+
+	chai.use(chaiHttp);
+
+	describe('attempt to create instance', () => {
+
+		const TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+		const LAURENCE_OLIVIER_AWARDS_AWARD_UUID = 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy';
+
+		before(async () => {
+
+			await purgeDatabase();
+
+			await createNode({
+				label: 'AwardCeremony',
+				uuid: TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID,
+				name: '2020'
+			});
+
+			await createNode({
+				label: 'Award',
+				uuid: LAURENCE_OLIVIER_AWARDS_AWARD_UUID,
+				name: 'Laurence Olivier Awards'
+			});
+
+			await createRelationship({
+				sourceLabel: 'Award',
+				sourceUuid: LAURENCE_OLIVIER_AWARDS_AWARD_UUID,
+				destinationLabel: 'AwardCeremony',
+				destinationUuid: TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID,
+				relationshipName: 'PRESENTED_AT'
+			});
+
+		});
+
+		context('instance has input validation errors', () => {
+
+			it('returns instance with appropriate errors attached', async () => {
+
+				expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
+
+				const response = await chai.request(app)
+					.post('/awards/ceremonies')
+					.send({
+						name: ''
+					});
+
+				const expectedResponseBody = {
+					model: 'awardCeremony',
+					name: '',
+					hasErrors: true,
+					errors: {
+						name: [
+							'Value is too short'
+						]
+					},
+					award: {
+						model: 'award',
+						name: '',
+						differentiator: '',
+						errors: {}
+					}
+				};
+
+				expect(response).to.have.status(200);
+				expect(response.body).to.deep.equal(expectedResponseBody);
+				expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
+
+			});
+
+		});
+
+		context('instance has database validation errors', () => {
+
+			it('returns instance with appropriate errors attached', async () => {
+
+				expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
+
+				const response = await chai.request(app)
+					.post('/awards/ceremonies')
+					.send({
+						name: '2020',
+						award: {
+							name: 'Laurence Olivier Awards'
+						}
+					});
+
+				const expectedResponseBody = {
+					model: 'awardCeremony',
+					name: '2020',
+					hasErrors: true,
+					errors: {
+						name: [
+							'Award ceremony already exists for given award'
+						]
+					},
+					award: {
+						model: 'award',
+						name: 'Laurence Olivier Awards',
+						differentiator: '',
+						errors: {
+							name: [
+								'Award ceremony already exists for given award'
+							],
+							differentiator: [
+								'Award ceremony already exists for given award'
+							]
+						}
+					}
+				};
+
+				expect(response).to.have.status(200);
+				expect(response.body).to.deep.equal(expectedResponseBody);
+				expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
+
+			});
+
+		});
+
+	});
+
+	describe('attempt to update instance', () => {
+
+		const TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+		const TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID = 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy';
+		const LAURENCE_OLIVIER_AWARDS_AWARD_UUID = 'zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz';
+
+		before(async () => {
+
+			await purgeDatabase();
+
+			await createNode({
+				label: 'AwardCeremony',
+				uuid: TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID,
+				name: '2019'
+			});
+
+			await createNode({
+				label: 'AwardCeremony',
+				uuid: TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID,
+				name: '2020'
+			});
+
+			await createNode({
+				label: 'Award',
+				uuid: LAURENCE_OLIVIER_AWARDS_AWARD_UUID,
+				name: 'Laurence Olivier Awards'
+			});
+
+			await createRelationship({
+				sourceLabel: 'Award',
+				sourceUuid: LAURENCE_OLIVIER_AWARDS_AWARD_UUID,
+				destinationLabel: 'AwardCeremony',
+				destinationUuid: TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID,
+				relationshipName: 'PRESENTED_AT'
+			});
+
+		});
+
+		context('instance has input validation errors', () => {
+
+			it('returns instance with appropriate errors attached', async () => {
+
+				expect(await countNodesWithLabel('AwardCeremony')).to.equal(2);
+
+				const response = await chai.request(app)
+					.put(`/awards/ceremonies/${TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID}`)
+					.send({
+						name: ''
+					});
+
+				const expectedResponseBody = {
+					model: 'awardCeremony',
+					uuid: TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID,
+					name: '',
+					hasErrors: true,
+					errors: {
+						name: [
+							'Value is too short'
+						]
+					},
+					award: {
+						model: 'award',
+						name: '',
+						differentiator: '',
+						errors: {}
+					}
+				};
+
+				expect(response).to.have.status(200);
+				expect(response.body).to.deep.equal(expectedResponseBody);
+				expect(await countNodesWithLabel('AwardCeremony')).to.equal(2);
+				expect(await isNodeExistent({
+					label: 'AwardCeremony',
+					name: '2019',
+					uuid: TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID
+				})).to.be.true;
+
+			});
+
+		});
+
+		context('instance has database validation errors', () => {
+
+			it('returns instance with appropriate errors attached', async () => {
+
+				expect(await countNodesWithLabel('AwardCeremony')).to.equal(2);
+
+				const response = await chai.request(app)
+					.put(`/awards/ceremonies/${TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID}`)
+					.send({
+						name: '2020',
+						award: {
+							name: 'Laurence Olivier Awards'
+						}
+					});
+
+				const expectedResponseBody = {
+					model: 'awardCeremony',
+					uuid: TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID,
+					name: '2020',
+					hasErrors: true,
+					errors: {
+						name: [
+							'Award ceremony already exists for given award'
+						]
+					},
+					award: {
+						model: 'award',
+						name: 'Laurence Olivier Awards',
+						differentiator: '',
+						errors: {
+							name: [
+								'Award ceremony already exists for given award'
+							],
+							differentiator: [
+								'Award ceremony already exists for given award'
+							]
+						}
+					}
+				};
+
+				expect(response).to.have.status(200);
+				expect(response.body).to.deep.equal(expectedResponseBody);
+				expect(await countNodesWithLabel('AwardCeremony')).to.equal(2);
+				expect(await isNodeExistent({
+					label: 'AwardCeremony',
+					name: '2019',
+					uuid: TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID
+				})).to.be.true;
+
+			});
+
+		});
+
+	});
+
+	describe('attempt to delete instance', () => {
+
+		const TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+		const EVENING_STANDARD_THEATRE_AWARDS_AWARD_UUID = 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy';
+
+		before(async () => {
+
+			await purgeDatabase();
+
+			await createNode({
+				label: 'AwardCeremony',
+				uuid: TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID,
+				name: '2019'
+			});
+
+			await createNode({
+				label: 'Award',
+				uuid: EVENING_STANDARD_THEATRE_AWARDS_AWARD_UUID,
+				name: 'Evening Standard Theatre Awards'
+			});
+
+			await createRelationship({
+				sourceLabel: 'Award',
+				sourceUuid: EVENING_STANDARD_THEATRE_AWARDS_AWARD_UUID,
+				destinationLabel: 'AwardCeremony',
+				destinationUuid: TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID,
+				relationshipName: 'PRESENTED_AT'
+			});
+
+		});
+
+		context('instance has associations', () => {
+
+			it('returns instance with appropriate errors attached', async () => {
+
+				expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
+
+				const response = await chai.request(app)
+					.delete(`/awards/ceremonies/${TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID}`);
+
+				const expectedResponseBody = {
+					model: 'awardCeremony',
+					uuid: TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID,
+					name: '2019',
+					hasErrors: true,
+					errors: {
+						associations: [
+							'Award'
+						]
+					},
+					award: {
+						model: 'award',
+						name: '',
+						differentiator: '',
+						errors: {}
+					}
+				};
+
+				expect(response).to.have.status(200);
+				expect(response.body).to.deep.equal(expectedResponseBody);
+				expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
+
+			});
+
+		});
+
+	});
+
+});

--- a/test-e2e/instance-validation-failures/awards-api.test.js
+++ b/test-e2e/instance-validation-failures/awards-api.test.js
@@ -204,7 +204,7 @@ describe('Instance validation failures: Awards API', () => {
 	describe('attempt to delete instance', () => {
 
 		const EVENING_STANDARD_THEATRE_AWARDS_AWARD_UUID = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
-		const EVENING_STANDARD_AWARDS_2019_CEREMONY_UUID = 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy';
+		const TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID = 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy';
 
 		before(async () => {
 
@@ -217,14 +217,14 @@ describe('Instance validation failures: Awards API', () => {
 			});
 
 			await createNode({
-				label: 'Ceremony',
-				uuid: EVENING_STANDARD_AWARDS_2019_CEREMONY_UUID,
+				label: 'AwardCeremony',
+				uuid: TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID,
 				name: '2019'
 			});
 
 			await createRelationship({
-				sourceLabel: 'Ceremony',
-				sourceUuid: EVENING_STANDARD_AWARDS_2019_CEREMONY_UUID,
+				sourceLabel: 'AwardCeremony',
+				sourceUuid: TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID,
 				destinationLabel: 'Award',
 				destinationUuid: EVENING_STANDARD_THEATRE_AWARDS_AWARD_UUID,
 				relationshipName: 'PRESENTED_AT'
@@ -249,7 +249,7 @@ describe('Instance validation failures: Awards API', () => {
 					hasErrors: true,
 					errors: {
 						associations: [
-							'Ceremony'
+							'AwardCeremony'
 						]
 					}
 				};

--- a/test-e2e/model-interaction/awards-with-ceremonies.test.js
+++ b/test-e2e/model-interaction/awards-with-ceremonies.test.js
@@ -1,0 +1,163 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import { createSandbox } from 'sinon';
+import { v4 as uuid } from 'uuid';
+
+import app from '../../src/app';
+import purgeDatabase from '../test-helpers/neo4j/purge-database';
+
+describe('Awards with award ceremonies', () => {
+
+	chai.use(chaiHttp);
+
+	const LAURENCE_OLIVIER_AWARDS_TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID = '2';
+	const LAURENCE_OLIVIER_AWARDS_AWARD_UUID = '3';
+	const LAURENCE_OLIVIER_AWARDS_TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID = '6';
+	const LAURENCE_OLIVIER_AWARDS_TWO_THOUSAND_AND_EIGHTEEN_AWARD_CEREMONY_UUID = '10';
+	const EVENING_STANDARD_THEATRE_AWARDS_TWO_THOUSAND_AND_EIGHTEEN_AWARD_CEREMONY_UUID = '14';
+	const EVENING_STANDARD_THEATRE_AWARDS_AWARD_UUID = '15';
+	const EVENING_STANDARD_THEATRE_AWARDS_TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID = '18';
+	const EVENING_STANDARD_THEATRE_AWARDS_TWO_THOUSAND_AND_SEVENTEEN_AWARD_CEREMONY_UUID = '22';
+
+	let laurenceOlivierAwardsAward;
+	let eveningStandardTheatreAwardsAward;
+
+	const sandbox = createSandbox();
+
+	before(async () => {
+
+		let uuidCallCount = 0;
+
+		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+
+		await purgeDatabase();
+
+		await chai.request(app)
+			.post('/awards/ceremonies')
+			.send({
+				name: '2019',
+				award: {
+					name: 'Laurence Olivier Awards'
+				}
+			});
+
+		await chai.request(app)
+			.post('/awards/ceremonies')
+			.send({
+				name: '2020',
+				award: {
+					name: 'Laurence Olivier Awards'
+				}
+			});
+
+		await chai.request(app)
+			.post('/awards/ceremonies')
+			.send({
+				name: '2018',
+				award: {
+					name: 'Laurence Olivier Awards'
+				}
+			});
+
+		await chai.request(app)
+			.post('/awards/ceremonies')
+			.send({
+				name: '2018',
+				award: {
+					name: 'Evening Standard Theatre Awards'
+				}
+			});
+
+		await chai.request(app)
+			.post('/awards/ceremonies')
+			.send({
+				name: '2019',
+				award: {
+					name: 'Evening Standard Theatre Awards'
+				}
+			});
+
+		await chai.request(app)
+			.post('/awards/ceremonies')
+			.send({
+				name: '2017',
+				award: {
+					name: 'Evening Standard Theatre Awards'
+				}
+			});
+
+		laurenceOlivierAwardsAward = await chai.request(app)
+			.get(`/awards/${LAURENCE_OLIVIER_AWARDS_AWARD_UUID}`);
+
+		eveningStandardTheatreAwardsAward = await chai.request(app)
+			.get(`/awards/${EVENING_STANDARD_THEATRE_AWARDS_AWARD_UUID}`);
+
+	});
+
+	after(() => {
+
+		sandbox.restore();
+
+	});
+
+	describe('Laurence Olivier Awards (award)', () => {
+
+		it('includes its ceremonies', () => {
+
+			const expectedAwardCeremonies = [
+				{
+					model: 'awardCeremony',
+					uuid: LAURENCE_OLIVIER_AWARDS_TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID,
+					name: '2020'
+				},
+				{
+					model: 'awardCeremony',
+					uuid: LAURENCE_OLIVIER_AWARDS_TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID,
+					name: '2019'
+				},
+				{
+					model: 'awardCeremony',
+					uuid: LAURENCE_OLIVIER_AWARDS_TWO_THOUSAND_AND_EIGHTEEN_AWARD_CEREMONY_UUID,
+					name: '2018'
+				}
+			];
+
+			const { awardCeremonies } = laurenceOlivierAwardsAward.body;
+
+			expect(awardCeremonies).to.deep.equal(expectedAwardCeremonies);
+
+		});
+
+	});
+
+	describe('Evening Standard Theatre Awards (award)', () => {
+
+		it('includes its ceremonies', () => {
+
+			const expectedAwardCeremonies = [
+				{
+					model: 'awardCeremony',
+					uuid: EVENING_STANDARD_THEATRE_AWARDS_TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID,
+					name: '2019'
+				},
+				{
+					model: 'awardCeremony',
+					uuid: EVENING_STANDARD_THEATRE_AWARDS_TWO_THOUSAND_AND_EIGHTEEN_AWARD_CEREMONY_UUID,
+					name: '2018'
+				},
+				{
+					model: 'awardCeremony',
+					uuid: EVENING_STANDARD_THEATRE_AWARDS_TWO_THOUSAND_AND_SEVENTEEN_AWARD_CEREMONY_UUID,
+					name: '2017'
+				}
+			];
+
+			const { awardCeremonies } = eveningStandardTheatreAwardsAward.body;
+
+			expect(awardCeremonies).to.deep.equal(expectedAwardCeremonies);
+
+		});
+
+	});
+
+});

--- a/test-e2e/non-existent-instances/award-ceremonies-api.test.js
+++ b/test-e2e/non-existent-instances/award-ceremonies-api.test.js
@@ -1,0 +1,80 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+
+import app from '../../src/app';
+import purgeDatabase from '../test-helpers/neo4j/purge-database';
+
+describe('Non-existent instances: Award ceremonies API', () => {
+
+	chai.use(chaiHttp);
+
+	before(async () => {
+
+		await purgeDatabase();
+
+	});
+
+	describe('requests for instances that do not exist in database', () => {
+
+		const NON_EXISTENT_AWARD_CEREMONY_UUID = 'foobar';
+
+		describe('GET edit endpoint', () => {
+
+			it('responds with 404 Not Found error', async () => {
+
+				const response = await chai.request(app)
+					.get(`/awards/ceremonies/${NON_EXISTENT_AWARD_CEREMONY_UUID}/edit`);
+
+				expect(response).to.have.status(404);
+				expect(response.text).to.equal('Not Found');
+
+			});
+
+		});
+
+		describe('PUT update endpoint', () => {
+
+			it('responds with 404 Not Found error', async () => {
+
+				const response = await chai.request(app)
+					.put(`/awards/ceremonies/${NON_EXISTENT_AWARD_CEREMONY_UUID}`)
+					.send({ name: '2020' });
+
+				expect(response).to.have.status(404);
+				expect(response.text).to.equal('Not Found');
+
+			});
+
+		});
+
+		describe('GET show endpoint', () => {
+
+			it('responds with 404 Not Found error', async () => {
+
+				const response = await chai.request(app)
+					.get(`/awards/ceremonies/${NON_EXISTENT_AWARD_CEREMONY_UUID}`);
+
+				expect(response).to.have.status(404);
+				expect(response.text).to.equal('Not Found');
+
+			});
+
+		});
+
+		describe('DELETE delete endpoint', () => {
+
+			it('responds with 404 Not Found error', async () => {
+
+				const response = await chai.request(app)
+					.delete(`/awards/ceremonies/${NON_EXISTENT_AWARD_CEREMONY_UUID}`);
+
+				expect(response).to.have.status(404);
+				expect(response.text).to.equal('Not Found');
+
+			});
+
+		});
+
+	});
+
+});

--- a/test-e2e/uniqueness-in-db/award-ceremonies-api.test.js
+++ b/test-e2e/uniqueness-in-db/award-ceremonies-api.test.js
@@ -1,0 +1,137 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import { createSandbox } from 'sinon';
+import { v4 as uuid } from 'uuid';
+
+import app from '../../src/app';
+import countNodesWithLabel from '../test-helpers/neo4j/count-nodes-with-label';
+import createNode from '../test-helpers/neo4j/create-node';
+import purgeDatabase from '../test-helpers/neo4j/purge-database';
+
+describe('Uniqueness in database: Award ceremonies API', () => {
+
+	chai.use(chaiHttp);
+
+	const sandbox = createSandbox();
+
+	describe('Award ceremony award uniqueness in database', () => {
+
+		const TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+
+		const expectedAwardCriticsCircleTheatreAwards1 = {
+			model: 'award',
+			name: 'Critics\' Circle Theatre Awards',
+			differentiator: '',
+			errors: {}
+		};
+
+		const expectedAwardCriticsCircleTheatreAwards2 = {
+			model: 'award',
+			name: 'Critics\' Circle Theatre Awards',
+			differentiator: '1',
+			errors: {}
+		};
+
+		before(async () => {
+
+			let uuidCallCount = 0;
+
+			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+
+			await purgeDatabase();
+
+			await createNode({
+				label: 'AwardCeremony',
+				uuid: TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID,
+				name: '2020'
+			});
+
+		});
+
+		after(() => {
+
+			sandbox.restore();
+
+		});
+
+		it('updates award ceremony and creates award that does not have a differentiator', async () => {
+
+			expect(await countNodesWithLabel('Award')).to.equal(0);
+
+			const response = await chai.request(app)
+				.put(`/awards/ceremonies/${TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID}`)
+				.send({
+					name: '2020',
+					award: {
+						name: 'Critics\' Circle Theatre Awards'
+					}
+				});
+
+			expect(response).to.have.status(200);
+			expect(response.body.award).to.deep.equal(expectedAwardCriticsCircleTheatreAwards1);
+			expect(await countNodesWithLabel('Award')).to.equal(1);
+
+		});
+
+		it('updates award ceremony and creates award that has same name as existing award but uses a differentiator', async () => {
+
+			expect(await countNodesWithLabel('Award')).to.equal(1);
+
+			const response = await chai.request(app)
+				.put(`/awards/ceremonies/${TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID}`)
+				.send({
+					name: '2020',
+					award: {
+						name: 'Critics\' Circle Theatre Awards',
+						differentiator: '1'
+					}
+				});
+
+			expect(response).to.have.status(200);
+			expect(response.body.award).to.deep.equal(expectedAwardCriticsCircleTheatreAwards2);
+			expect(await countNodesWithLabel('Award')).to.equal(2);
+
+		});
+
+		it('updates award ceremony and uses existing award that does not have a differentiator', async () => {
+
+			expect(await countNodesWithLabel('Award')).to.equal(2);
+
+			const response = await chai.request(app)
+				.put(`/awards/ceremonies/${TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID}`)
+				.send({
+					name: '2020',
+					award: {
+						name: 'Critics\' Circle Theatre Awards'
+					}
+				});
+
+			expect(response).to.have.status(200);
+			expect(response.body.award).to.deep.equal(expectedAwardCriticsCircleTheatreAwards1);
+			expect(await countNodesWithLabel('Award')).to.equal(2);
+
+		});
+
+		it('updates award ceremony and uses existing award that has a differentiator', async () => {
+
+			expect(await countNodesWithLabel('Award')).to.equal(2);
+
+			const response = await chai.request(app)
+				.put(`/awards/ceremonies/${TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID}`)
+				.send({
+					name: '2020',
+					award: {
+						name: 'Critics\' Circle Theatre Awards',
+						differentiator: '1'
+					}
+				});
+
+			expect(response).to.have.status(200);
+			expect(response.body.award).to.deep.equal(expectedAwardCriticsCircleTheatreAwards2);
+			expect(await countNodesWithLabel('Award')).to.equal(2);
+
+		});
+
+	});
+
+});

--- a/test-int/instance-validation-failures/award-ceremony.test.js
+++ b/test-int/instance-validation-failures/award-ceremony.test.js
@@ -1,0 +1,224 @@
+import { expect } from 'chai';
+import { createSandbox } from 'sinon';
+
+import AwardCeremony from '../../src/models/AwardCeremony';
+import * as neo4jQueryModule from '../../src/neo4j/query';
+
+describe('AwardCeremony instance', () => {
+
+	const STRING_MAX_LENGTH = 1000;
+	const ABOVE_MAX_LENGTH_STRING = 'a'.repeat(STRING_MAX_LENGTH + 1);
+
+	const sandbox = createSandbox();
+
+	afterEach(() => {
+
+		sandbox.restore();
+
+	});
+
+	describe('input validation failure', () => {
+
+		beforeEach(() => {
+
+			sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ instanceCount: 0 });
+
+		});
+
+		context('name value is empty string', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instance = new AwardCeremony({ name: '' });
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					uuid: undefined,
+					name: '',
+					hasErrors: true,
+					errors: {
+						name: [
+							'Value is too short'
+						]
+					},
+					award: {
+						uuid: undefined,
+						name: '',
+						differentiator: '',
+						errors: {}
+					}
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+		context('name value exceeds maximum limit', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instance = new AwardCeremony({ name: ABOVE_MAX_LENGTH_STRING });
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					uuid: undefined,
+					name: ABOVE_MAX_LENGTH_STRING,
+					hasErrors: true,
+					errors: {
+						name: [
+							'Value is too long'
+						]
+					},
+					award: {
+						uuid: undefined,
+						name: '',
+						differentiator: '',
+						errors: {}
+					}
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+		context('award name value exceeds maximum limit', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instanceProps = {
+					name: '2020',
+					award: {
+						name: ABOVE_MAX_LENGTH_STRING
+					}
+				};
+
+				const instance = new AwardCeremony(instanceProps);
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					uuid: undefined,
+					name: '2020',
+					hasErrors: true,
+					errors: {},
+					award: {
+						uuid: undefined,
+						name: ABOVE_MAX_LENGTH_STRING,
+						differentiator: '',
+						errors: {
+							name: [
+								'Value is too long'
+							]
+						}
+					}
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+		context('award differentiator value exceeds maximum limit', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instanceProps = {
+					name: '2020',
+					award: {
+						name: 'Laurence Olivier Awards',
+						differentiator: ABOVE_MAX_LENGTH_STRING
+					}
+				};
+
+				const instance = new AwardCeremony(instanceProps);
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					uuid: undefined,
+					name: '2020',
+					hasErrors: true,
+					errors: {},
+					award: {
+						uuid: undefined,
+						name: 'Laurence Olivier Awards',
+						differentiator: ABOVE_MAX_LENGTH_STRING,
+						errors: {
+							differentiator: [
+								'Value is too long'
+							]
+						}
+					}
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+	});
+
+	describe('database validation failure', () => {
+
+		beforeEach(() => {
+
+			sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ duplicateRecordCount: 1 });
+
+		});
+
+		context('name value with relationship to award already exists in database', () => {
+
+			it('assigns appropriate error', async () => {
+
+				const instanceProps = {
+					name: '2020',
+					award: {
+						name: 'Laurence Olivier Awards'
+					}
+				};
+
+				const instance = new AwardCeremony(instanceProps);
+
+				const result = await instance.create();
+
+				const expectedResponseBody = {
+					uuid: undefined,
+					name: '2020',
+					hasErrors: true,
+					errors: {
+						name: [
+							'Award ceremony already exists for given award'
+						]
+					},
+					award: {
+						uuid: undefined,
+						name: 'Laurence Olivier Awards',
+						differentiator: '',
+						errors: {
+							name: [
+								'Award ceremony already exists for given award'
+							],
+							differentiator: [
+								'Award ceremony already exists for given award'
+							]
+						}
+					}
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		});
+
+	});
+
+});

--- a/test-unit/src/controllers/award-ceremonies.test.js
+++ b/test-unit/src/controllers/award-ceremonies.test.js
@@ -1,0 +1,156 @@
+import { expect } from 'chai';
+import proxyquire from 'proxyquire';
+import { createStubInstance, stub } from 'sinon';
+
+import { AwardCeremony } from '../../../src/models';
+
+describe('Award ceremonies controller', () => {
+
+	let stubs;
+
+	const AwardCeremonyStub = function () {
+
+		return createStubInstance(AwardCeremony);
+
+	};
+
+	beforeEach(() => {
+
+		stubs = {
+			callClassMethodsModule: {
+				callInstanceMethod: stub().resolves('callInstanceMethod response'),
+				callStaticListMethod: stub().resolves('callStaticListMethod response')
+			},
+			sendJsonResponseModule: {
+				sendJsonResponse: stub().returns('sendJsonResponse response')
+			},
+			models: {
+				AwardCeremony: AwardCeremonyStub
+			},
+			request: stub(),
+			response: stub(),
+			next: stub()
+		};
+
+	});
+
+	const createSubject = () =>
+		proxyquire('../../../src/controllers/award-ceremonies', {
+			'../lib/call-class-methods': stubs.callClassMethodsModule,
+			'../lib/send-json-response': stubs.sendJsonResponseModule,
+			'../models': stubs.models
+		});
+
+	const callFunction = functionName => {
+
+		const awardCeremoniesController = createSubject();
+
+		return awardCeremoniesController[functionName](stubs.request, stubs.response, stubs.next);
+
+	};
+
+	describe('newRoute function', () => {
+
+		it('calls sendJsonResponse module', () => {
+
+			expect(callFunction('newRoute')).to.equal('sendJsonResponse response');
+			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledOnce).to.be.true;
+			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledWithExactly(
+				stubs.response, stubs.models.AwardCeremony() // eslint-disable-line new-cap
+			)).to.be.true;
+
+		});
+
+	});
+
+	describe('createRoute function', () => {
+
+		it('calls callInstanceMethod module', async () => {
+
+			const result = await callFunction('createRoute');
+			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+				stubs.response, stubs.next, stubs.models.AwardCeremony(), 'create' // eslint-disable-line new-cap
+			)).to.be.true;
+			expect(result).to.equal('callInstanceMethod response');
+
+		});
+
+	});
+
+	describe('editRoute function', () => {
+
+		it('calls callInstanceMethod module', async () => {
+
+			const result = await callFunction('editRoute');
+			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+				stubs.response, stubs.next, stubs.models.AwardCeremony(), 'edit' // eslint-disable-line new-cap
+			)).to.be.true;
+			expect(result).to.equal('callInstanceMethod response');
+
+		});
+
+	});
+
+	describe('updateRoute function', () => {
+
+		it('calls callInstanceMethod module', async () => {
+
+			const result = await callFunction('updateRoute');
+			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+				stubs.response, stubs.next, stubs.models.AwardCeremony(), 'update' // eslint-disable-line new-cap
+			)).to.be.true;
+			expect(result).to.equal('callInstanceMethod response');
+
+		});
+
+	});
+
+	describe('deleteRoute function', () => {
+
+		it('calls callInstanceMethod module', async () => {
+
+			const result = await callFunction('deleteRoute');
+			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+				stubs.response, stubs.next, stubs.models.AwardCeremony(), 'delete' // eslint-disable-line new-cap
+			)).to.be.true;
+			expect(result).to.equal('callInstanceMethod response');
+
+		});
+
+	});
+
+	describe('showRoute function', () => {
+
+		it('calls callInstanceMethod module', async () => {
+
+			const result = await callFunction('showRoute');
+			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+				stubs.response, stubs.next, stubs.models.AwardCeremony(), 'show' // eslint-disable-line new-cap
+			)).to.be.true;
+			expect(result).to.equal('callInstanceMethod response');
+
+		});
+
+	});
+
+	describe('listRoute function', () => {
+
+		it('calls callStaticListMethod module', async () => {
+
+			const result = await callFunction('listRoute');
+			expect(stubs.callClassMethodsModule.callStaticListMethod.calledOnce).to.be.true;
+			expect(stubs.callClassMethodsModule.callStaticListMethod.calledWithExactly(
+				stubs.response, stubs.next, stubs.models.AwardCeremony, 'awardCeremony'
+			)).to.be.true;
+			expect(result).to.equal('callStaticListMethod response');
+
+		});
+
+	});
+
+});

--- a/test-unit/src/lib/strings.test.js
+++ b/test-unit/src/lib/strings.test.js
@@ -45,8 +45,9 @@ describe('Strings module', () => {
 			it('returns specific plural noun', () => {
 
 				const nouns = [
-					{ singular: 'person', plural: 'people' },
-					{ singular: 'company', plural: 'companies' }
+					{ singular: 'awardCeremony', plural: 'awardCeremonies' },
+					{ singular: 'company', plural: 'companies' },
+					{ singular: 'person', plural: 'people' }
 				];
 
 				nouns.forEach(noun => {

--- a/test-unit/src/models/AwardCeremony.test.js
+++ b/test-unit/src/models/AwardCeremony.test.js
@@ -1,0 +1,189 @@
+import { expect } from 'chai';
+import proxyquire from 'proxyquire';
+import { assert, createStubInstance, spy, stub } from 'sinon';
+
+import { Award } from '../../../src/models';
+
+describe('AwardCeremony model', () => {
+
+	let stubs;
+
+	const AwardStub = function () {
+
+		return createStubInstance(Award);
+
+	};
+
+	beforeEach(() => {
+
+		stubs = {
+			prepareAsParamsModule: {
+				prepareAsParams: stub().returns({
+					uuid: 'UUID_VALUE',
+					name: 'NAME_VALUE',
+					award: {
+						name: 'AWARD_UUID_VALUE',
+						differentiator: 'AWARD_DIFFERENTIATOR_VALUE'
+					}
+				})
+			},
+			models: {
+				Award: AwardStub
+			},
+			cypherQueriesModule: {
+				getAwardContextualDuplicateRecordCountQuery: stub()
+					.returns('getAwardContextualDuplicateRecordCountQuery response')
+			},
+			neo4jQueryModule: {
+				neo4jQuery: stub().resolves({ neo4jQueryMockResponseProperty: 'neo4jQueryMockResponseValue' })
+			}
+		};
+
+	});
+
+	const createSubject = () =>
+		proxyquire('../../../src/models/AwardCeremony', {
+			'../lib/prepare-as-params': stubs.prepareAsParamsModule,
+			'.': stubs.models,
+			'../neo4j/cypher-queries': stubs.cypherQueriesModule,
+			'../neo4j/query': stubs.neo4jQueryModule
+		}).default;
+
+	const createInstance = props => {
+
+		const AwardCeremony = createSubject();
+
+		return new AwardCeremony(props);
+
+	};
+
+	describe('runInputValidations method', () => {
+
+		it('calls instance validate method and associated models\' validate methods', () => {
+
+			const instance = createInstance();
+			spy(instance, 'validateName');
+			instance.runInputValidations();
+			assert.callOrder(
+				instance.validateName,
+				instance.award.validateName,
+				instance.award.validateDifferentiator
+			);
+			expect(instance.validateName.calledOnce).to.be.true;
+			expect(instance.validateName.calledWithExactly({ isRequired: true })).to.be.true;
+			expect(instance.award.validateName.calledOnce).to.be.true;
+			expect(instance.award.validateName.calledWithExactly({ isRequired: false })).to.be.true;
+			expect(instance.award.validateDifferentiator.calledOnce).to.be.true;
+			expect(instance.award.validateDifferentiator.calledWithExactly()).to.be.true;
+
+		});
+
+	});
+
+	describe('runDatabaseValidations method', () => {
+
+		it('calls instance validate method and associated models\' validate methods', async () => {
+
+			const instance = createInstance();
+			spy(instance, 'validateAwardContextualUniquenessInDatabase');
+			await instance.runDatabaseValidations();
+			expect(instance.validateAwardContextualUniquenessInDatabase.calledOnce).to.be.true;
+			expect(instance.validateAwardContextualUniquenessInDatabase.calledWithExactly()).to.be.true;
+
+		});
+
+	});
+
+	describe('validateAwardContextualUniquenessInDatabase method', () => {
+
+		context('valid data (results returned that indicate name does not already exist for given award)', () => {
+
+			it('will not call addPropertyError method', async () => {
+
+				const instance = createInstance();
+				stubs.neo4jQueryModule.neo4jQuery.resolves({ duplicateRecordCount: 0 });
+				spy(instance, 'addPropertyError');
+				await instance.validateAwardContextualUniquenessInDatabase();
+				assert.callOrder(
+					stubs.prepareAsParamsModule.prepareAsParams,
+					stubs.cypherQueriesModule.getAwardContextualDuplicateRecordCountQuery,
+					stubs.neo4jQueryModule.neo4jQuery
+				);
+				expect(stubs.prepareAsParamsModule.prepareAsParams.calledOnce).to.be.true;
+				expect(stubs.prepareAsParamsModule.prepareAsParams.calledWithExactly(instance)).to.be.true;
+				expect(stubs.cypherQueriesModule.getAwardContextualDuplicateRecordCountQuery.calledOnce).to.be.true;
+				expect(stubs.cypherQueriesModule.getAwardContextualDuplicateRecordCountQuery.calledWithExactly())
+					.to.be.true;
+				expect(stubs.neo4jQueryModule.neo4jQuery.calledOnce).to.be.true;
+				expect(stubs.neo4jQueryModule.neo4jQuery.calledWithExactly(
+					{
+						query: 'getAwardContextualDuplicateRecordCountQuery response',
+						params: {
+							uuid: 'UUID_VALUE',
+							name: 'NAME_VALUE',
+							award: {
+								name: 'AWARD_UUID_VALUE',
+								differentiator: 'AWARD_DIFFERENTIATOR_VALUE'
+							}
+						}
+					}
+				)).to.be.true;
+				expect(instance.addPropertyError.notCalled).to.be.true;
+				expect(instance.award.addPropertyError.notCalled).to.be.true;
+
+			});
+
+		});
+
+		context('invalid data (results returned that indicate name already exists  for given award)', () => {
+
+			it('will call addPropertyError method', async () => {
+
+				const instance = createInstance();
+				stubs.neo4jQueryModule.neo4jQuery.resolves({ duplicateRecordCount: 1 });
+				spy(instance, 'addPropertyError');
+				await instance.validateAwardContextualUniquenessInDatabase();
+				assert.callOrder(
+					stubs.prepareAsParamsModule.prepareAsParams,
+					stubs.cypherQueriesModule.getAwardContextualDuplicateRecordCountQuery,
+					stubs.neo4jQueryModule.neo4jQuery,
+					instance.addPropertyError
+				);
+				expect(stubs.prepareAsParamsModule.prepareAsParams.calledOnce).to.be.true;
+				expect(stubs.prepareAsParamsModule.prepareAsParams.calledWithExactly(instance)).to.be.true;
+				expect(stubs.cypherQueriesModule.getAwardContextualDuplicateRecordCountQuery.calledOnce).to.be.true;
+				expect(stubs.cypherQueriesModule.getAwardContextualDuplicateRecordCountQuery.calledWithExactly())
+					.to.be.true;
+				expect(stubs.neo4jQueryModule.neo4jQuery.calledOnce).to.be.true;
+				expect(stubs.neo4jQueryModule.neo4jQuery.calledWithExactly(
+					{
+						query: 'getAwardContextualDuplicateRecordCountQuery response',
+						params: {
+							uuid: 'UUID_VALUE',
+							name: 'NAME_VALUE',
+							award: {
+								name: 'AWARD_UUID_VALUE',
+								differentiator: 'AWARD_DIFFERENTIATOR_VALUE'
+							}
+						}
+					}
+				)).to.be.true;
+				expect(instance.addPropertyError.calledOnce).to.be.true;
+				expect(instance.addPropertyError.calledWithExactly(
+					'name', 'Award ceremony already exists for given award'
+				)).to.be.true;
+				expect(instance.award.addPropertyError.calledTwice).to.be.true;
+				expect(instance.award.addPropertyError.firstCall.calledWithExactly(
+					'name', 'Award ceremony already exists for given award'
+				)).to.be.true;
+				expect(instance.award.addPropertyError.secondCall.calledWithExactly(
+					'differentiator', 'Award ceremony already exists for given award'
+				)).to.be.true;
+
+			});
+
+		});
+
+	});
+
+});

--- a/test-unit/src/neo4j/cypher-queries/award-ceremony.test.js
+++ b/test-unit/src/neo4j/cypher-queries/award-ceremony.test.js
@@ -1,0 +1,80 @@
+import { expect } from 'chai';
+
+import * as cypherQueriesAwardCeremonies from '../../../../src/neo4j/cypher-queries/award-ceremony';
+import removeExcessWhitespace from '../../../test-helpers/remove-excess-whitespace';
+
+describe('Cypher Queries Award Ceremony module', () => {
+
+	describe('getCreateQuery function', () => {
+
+		it('returns requisite query', () => {
+
+			const result = cypherQueriesAwardCeremonies.getCreateQuery();
+
+			const compactedResult = removeExcessWhitespace(result);
+
+			const startSegment = removeExcessWhitespace(`
+				CREATE (awardCeremony:AwardCeremony { uuid: $uuid, name: $name })
+			`);
+
+			const middleSegment = removeExcessWhitespace(`
+				WITH awardCeremony
+			`);
+
+			const endSegment = removeExcessWhitespace(`
+				RETURN
+					'awardCeremony' AS model,
+					awardCeremony.uuid AS uuid,
+					awardCeremony.name AS name,
+					{ name: COALESCE(award.name, ''), differentiator: COALESCE(award.differentiator, '') } AS award
+			`);
+
+			expect(compactedResult.startsWith(startSegment)).to.be.true;
+			expect(compactedResult.includes(middleSegment)).to.be.true;
+			expect(compactedResult.endsWith(endSegment)).to.be.true;
+
+		});
+
+	});
+
+	describe('getUpdateQuery function', () => {
+
+		it('returns requisite query', () => {
+
+			const result = cypherQueriesAwardCeremonies.getUpdateQuery();
+
+			const compactedResult = removeExcessWhitespace(result);
+
+			const startSegment = removeExcessWhitespace(`
+				MATCH (awardCeremony:AwardCeremony { uuid: $uuid })
+
+				OPTIONAL MATCH (awardCeremony)-[relationship]-()
+
+				DELETE relationship
+
+				WITH DISTINCT awardCeremony
+
+				SET awardCeremony.name = $name
+			`);
+
+			const middleSegment = removeExcessWhitespace(`
+				WITH awardCeremony
+			`);
+
+			const endSegment = removeExcessWhitespace(`
+				RETURN
+					'awardCeremony' AS model,
+					awardCeremony.uuid AS uuid,
+					awardCeremony.name AS name,
+					{ name: COALESCE(award.name, ''), differentiator: COALESCE(award.differentiator, '') } AS award
+			`);
+
+			expect(compactedResult.startsWith(startSegment)).to.be.true;
+			expect(compactedResult.includes(middleSegment)).to.be.true;
+			expect(compactedResult.endsWith(endSegment)).to.be.true;
+
+		});
+
+	});
+
+});


### PR DESCRIPTION
This PR adds endpoints required to perform CRUD actions for award ceremonies, e.g. Laurence Olivier Awards 2020, Evening Standard Theatre Awards 2019, etc.

---

#### Award ceremonies list
<img width="327" alt="award-ceremonies-list" src="https://user-images.githubusercontent.com/10484515/131254826-5eaaa24b-f15e-4780-9b84-d601721544d3.png">

---

#### Laurence Olivier Awards 2020 (award ceremony)
<img width="191" alt="laurence-olivier-awards-2020-award-ceremony" src="https://user-images.githubusercontent.com/10484515/131254822-c0a8cc2d-55e7-4ec0-bb16-da2abe25ced6.png">