### PR TITLE
Remove Venue class runInputValidations method subVenues property check

### DIFF
--- a/src/models/Venue.js
+++ b/src/models/Venue.js
@@ -21,23 +21,19 @@ export default class Venue extends VenueBase {
 
 		this.validateDifferentiator();
 
-		if (Object.prototype.hasOwnProperty.call(this, 'subVenues')) {
+		const duplicateSubVenueIndices = getDuplicateBaseInstanceIndices(this.subVenues);
 
-			const duplicateSubVenueIndices = getDuplicateBaseInstanceIndices(this.subVenues);
+		this.subVenues.forEach((subVenue, index) => {
 
-			this.subVenues.forEach((subVenue, index) => {
+			subVenue.validateName({ isRequired: false });
 
-				subVenue.validateName({ isRequired: false });
+			subVenue.validateDifferentiator();
 
-				subVenue.validateDifferentiator();
+			subVenue.validateNoAssociationWithSelf(this.name, this.differentiator);
 
-				subVenue.validateNoAssociationWithSelf(this.name, this.differentiator);
+			subVenue.validateUniquenessInGroup({ isDuplicate: duplicateSubVenueIndices.includes(index) });
 
-				subVenue.validateUniquenessInGroup({ isDuplicate: duplicateSubVenueIndices.includes(index) });
-
-			});
-
-		}
+		});
 
 	}
 


### PR DESCRIPTION
Since more granular classes were introduced (e.g. the `VenueBase` class is used for venues associated to productions and to other venues as sub-venues, while the `Venue` class is used when the venue is the subject and needs to include its subvenues as a property), there is no longer any need to check for the presence of a `subVenues` property in the `Venue` class as it is now guaranteed.

(Previously the `runInputValidations` method was shared by the `VenueBase` and `Venue` classes because they co-existed in the consolidated `Venue` class, and so previously this check was to accommodate both scenarios.)