### PR TITLE
Use Node-native crypto module to generate UUIDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "express": "^4.17.1",
     "morgan": "^1.5.1",
     "neo4j-driver": "^4.0.2",
-    "source-map-support": "^0.5.19",
-    "uuid": "^3.0.1"
+    "source-map-support": "^0.5.19"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",

--- a/src/lib/prepare-as-params.js
+++ b/src/lib/prepare-as-params.js
@@ -1,5 +1,6 @@
+import { randomUUID } from 'crypto';
+
 import neo4j from 'neo4j-driver';
-import { v4 as uuid } from 'uuid';
 
 import { isObjectWithKeys } from './is-object-with-keys';
 
@@ -82,7 +83,7 @@ export const prepareAsParams = instance => {
 						instance.differentiator === recordedInstance.differentiator
 					);
 
-					accumulator[key] = instanceWithShareableUuid?.uuid || uuid();
+					accumulator[key] = instanceWithShareableUuid?.uuid || randomUUID({ disableEntropyCache: true });
 
 					if (!instanceWithShareableUuid) {
 

--- a/test-e2e/crud/award-ceremonies-api.test.js
+++ b/test-e2e/crud/award-ceremonies-api.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import countNodesWithLabel from '../test-helpers/neo4j/count-nodes-with-label';
@@ -45,7 +46,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 
 		before(async () => {
 
-			sandbox.stub(uuid, 'v4').returns(AWARD_CEREMONY_UUID);
+			sandbox.stub(crypto, 'randomUUID').returns(AWARD_CEREMONY_UUID);
 
 			await purgeDatabase();
 
@@ -192,7 +193,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -405,7 +406,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 

--- a/test-e2e/crud/awards-api.test.js
+++ b/test-e2e/crud/awards-api.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import countNodesWithLabel from '../test-helpers/neo4j/count-nodes-with-label';
@@ -40,7 +41,7 @@ describe('CRUD (Create, Read, Update, Delete): Awards API', () => {
 
 		before(async () => {
 
-			sandbox.stub(uuid, 'v4').returns(AWARD_UUID);
+			sandbox.stub(crypto, 'randomUUID').returns(AWARD_UUID);
 
 			await purgeDatabase();
 
@@ -168,7 +169,7 @@ describe('CRUD (Create, Read, Update, Delete): Awards API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 

--- a/test-e2e/crud/characters-api.test.js
+++ b/test-e2e/crud/characters-api.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import countNodesWithLabel from '../test-helpers/neo4j/count-nodes-with-label';
@@ -40,7 +41,7 @@ describe('CRUD (Create, Read, Update, Delete): Characters API', () => {
 
 		before(async () => {
 
-			sandbox.stub(uuid, 'v4').returns(CHARACTER_UUID);
+			sandbox.stub(crypto, 'randomUUID').returns(CHARACTER_UUID);
 
 			await purgeDatabase();
 
@@ -171,7 +172,7 @@ describe('CRUD (Create, Read, Update, Delete): Characters API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 

--- a/test-e2e/crud/companies-api.test.js
+++ b/test-e2e/crud/companies-api.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import countNodesWithLabel from '../test-helpers/neo4j/count-nodes-with-label';
@@ -40,7 +41,7 @@ describe('CRUD (Create, Read, Update, Delete): Companies API', () => {
 
 		before(async () => {
 
-			sandbox.stub(uuid, 'v4').returns(COMPANY_UUID);
+			sandbox.stub(crypto, 'randomUUID').returns(COMPANY_UUID);
 
 			await purgeDatabase();
 
@@ -174,7 +175,7 @@ describe('CRUD (Create, Read, Update, Delete): Companies API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 

--- a/test-e2e/crud/materials-api.test.js
+++ b/test-e2e/crud/materials-api.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import countNodesWithLabel from '../test-helpers/neo4j/count-nodes-with-label';
@@ -81,7 +82,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 
 		before(async () => {
 
-			sandbox.stub(uuid, 'v4').returns(MATERIAL_UUID);
+			sandbox.stub(crypto, 'randomUUID').returns(MATERIAL_UUID);
 
 			await purgeDatabase();
 
@@ -364,7 +365,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -1330,7 +1331,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 

--- a/test-e2e/crud/people-api.test.js
+++ b/test-e2e/crud/people-api.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import countNodesWithLabel from '../test-helpers/neo4j/count-nodes-with-label';
@@ -40,7 +41,7 @@ describe('CRUD (Create, Read, Update, Delete): People API', () => {
 
 		before(async () => {
 
-			sandbox.stub(uuid, 'v4').returns(PERSON_UUID);
+			sandbox.stub(crypto, 'randomUUID').returns(PERSON_UUID);
 
 			await purgeDatabase();
 
@@ -175,7 +176,7 @@ describe('CRUD (Create, Read, Update, Delete): People API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 

--- a/test-e2e/crud/productions-api.test.js
+++ b/test-e2e/crud/productions-api.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import countNodesWithLabel from '../test-helpers/neo4j/count-nodes-with-label';
@@ -120,7 +121,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -559,7 +560,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -3923,7 +3924,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 

--- a/test-e2e/crud/venues-api.test.js
+++ b/test-e2e/crud/venues-api.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import countNodesWithLabel from '../test-helpers/neo4j/count-nodes-with-label';
@@ -48,7 +49,7 @@ describe('CRUD (Create, Read, Update, Delete): Venues API', () => {
 
 		before(async () => {
 
-			sandbox.stub(uuid, 'v4').returns(VENUE_UUID);
+			sandbox.stub(crypto, 'randomUUID').returns(VENUE_UUID);
 
 			await purgeDatabase();
 
@@ -206,7 +207,7 @@ describe('CRUD (Create, Read, Update, Delete): Venues API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -515,7 +516,7 @@ describe('CRUD (Create, Read, Update, Delete): Venues API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 

--- a/test-e2e/model-interaction/awards-with-ceremonies.test.js
+++ b/test-e2e/model-interaction/awards-with-ceremonies.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
@@ -28,7 +29,7 @@ describe('Awards with award ceremonies', () => {
 
 		let uuidCallCount = 0;
 
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 		await purgeDatabase();
 

--- a/test-e2e/model-interaction/cast-member-diff-roles-of-material.test.js
+++ b/test-e2e/model-interaction/cast-member-diff-roles-of-material.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
@@ -34,7 +35,7 @@ describe('Cast member performing different roles in different productions of sam
 
 		let uuidCallCount = 0;
 
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 		await purgeDatabase();
 

--- a/test-e2e/model-interaction/cast-member-same-role-of-material.test.js
+++ b/test-e2e/model-interaction/cast-member-same-role-of-material.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
@@ -28,7 +29,7 @@ describe('Cast member performing same role in different productions of same mate
 
 		let uuidCallCount = 0;
 
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 		await purgeDatabase();
 

--- a/test-e2e/model-interaction/cast-member-with-multi-prods.test.js
+++ b/test-e2e/model-interaction/cast-member-with-multi-prods.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
@@ -29,7 +30,7 @@ describe('Cast member with multiple production credits', () => {
 
 		let uuidCallCount = 0;
 
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 		await purgeDatabase();
 

--- a/test-e2e/model-interaction/char-diff-groups-same-material.test.js
+++ b/test-e2e/model-interaction/char-diff-groups-same-material.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
@@ -43,7 +44,7 @@ describe('Character with multiple appearances in the same material in different 
 
 		let uuidCallCount = 0;
 
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 		await purgeDatabase();
 

--- a/test-e2e/model-interaction/char-groups-grouping.test.js
+++ b/test-e2e/model-interaction/char-groups-grouping.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
@@ -23,7 +24,7 @@ describe('Nameless character groups grouping', () => {
 
 		let uuidCallCount = 0;
 
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 		await purgeDatabase();
 

--- a/test-e2e/model-interaction/char-in-multi-prods-of-multi-materials.test.js
+++ b/test-e2e/model-interaction/char-in-multi-prods-of-multi-materials.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
@@ -41,7 +42,7 @@ describe('Character in multiple productions of multiple materials', () => {
 
 		let uuidCallCount = 0;
 
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 		await purgeDatabase();
 

--- a/test-e2e/model-interaction/char-multi-appearances-same-material.test.js
+++ b/test-e2e/model-interaction/char-multi-appearances-same-material.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
@@ -35,7 +36,7 @@ describe('Character with multiple appearances in the same material under differe
 
 		let uuidCallCount = 0;
 
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 		await purgeDatabase();
 

--- a/test-e2e/model-interaction/char-portrayed-with-other-roles.test.js
+++ b/test-e2e/model-interaction/char-portrayed-with-other-roles.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
@@ -29,7 +30,7 @@ describe('Character portrayed with other roles', () => {
 
 		let uuidCallCount = 0;
 
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 		await purgeDatabase();
 

--- a/test-e2e/model-interaction/char-with-variant-depiction-portrayal-names.test.js
+++ b/test-e2e/model-interaction/char-with-variant-depiction-portrayal-names.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
@@ -59,7 +60,7 @@ describe('Character with variant depiction and portrayal names', () => {
 
 		let uuidCallCount = 0;
 
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 		await purgeDatabase();
 

--- a/test-e2e/model-interaction/char-with-variant-names-diff-materials.test.js
+++ b/test-e2e/model-interaction/char-with-variant-names-diff-materials.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
@@ -49,7 +50,7 @@ describe('Character with variant names from productions of different materials',
 
 		let uuidCallCount = 0;
 
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 		await purgeDatabase();
 

--- a/test-e2e/model-interaction/char-with-variant-names-same-material.test.js
+++ b/test-e2e/model-interaction/char-with-variant-names-same-material.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
@@ -41,7 +42,7 @@ describe('Character with variant names from productions of the same material', (
 
 		let uuidCallCount = 0;
 
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 		await purgeDatabase();
 

--- a/test-e2e/model-interaction/diff-chars-same-name-diff-materials.test.js
+++ b/test-e2e/model-interaction/diff-chars-same-name-diff-materials.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
@@ -40,7 +41,7 @@ describe('Different characters with the same name from different materials', () 
 
 		let uuidCallCount = 0;
 
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 		await purgeDatabase();
 

--- a/test-e2e/model-interaction/diff-chars-same-name-same-material.test.js
+++ b/test-e2e/model-interaction/diff-chars-same-name-same-material.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
@@ -33,7 +34,7 @@ describe('Different characters with the same name from the same material', () =>
 
 		let uuidCallCount = 0;
 
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 		await purgeDatabase();
 

--- a/test-e2e/model-interaction/material-multi-versions-multi-wri-credits.test.js
+++ b/test-e2e/model-interaction/material-multi-versions-multi-wri-credits.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
@@ -40,7 +41,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 
 		let uuidCallCount = 0;
 
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 		await purgeDatabase();
 

--- a/test-e2e/model-interaction/material-with-multi-prods.test.js
+++ b/test-e2e/model-interaction/material-with-multi-prods.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
@@ -29,7 +30,7 @@ describe('Material with multiple productions', () => {
 
 		let uuidCallCount = 0;
 
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 		await purgeDatabase();
 

--- a/test-e2e/model-interaction/material-with-multiple-credited-entities.test.js
+++ b/test-e2e/model-interaction/material-with-multiple-credited-entities.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
@@ -24,7 +25,7 @@ describe('Materials with entities credited multiple times', () => {
 
 		let uuidCallCount = 0;
 
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 		await purgeDatabase();
 

--- a/test-e2e/model-interaction/material-with-rights-grantor.test.js
+++ b/test-e2e/model-interaction/material-with-rights-grantor.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
@@ -26,7 +27,7 @@ describe('Materials with rights grantor credits', () => {
 
 		let uuidCallCount = 0;
 
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 		await purgeDatabase();
 

--- a/test-e2e/model-interaction/material-with-source-material.test.js
+++ b/test-e2e/model-interaction/material-with-source-material.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
@@ -58,7 +59,7 @@ describe('Materials with source material', () => {
 
 		let uuidCallCount = 0;
 
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 		await purgeDatabase();
 

--- a/test-e2e/model-interaction/prods-with-creative-team.test.js
+++ b/test-e2e/model-interaction/prods-with-creative-team.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
@@ -55,7 +56,7 @@ describe('Productions with creative team', () => {
 
 		let uuidCallCount = 0;
 
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 		await purgeDatabase();
 

--- a/test-e2e/model-interaction/prods-with-crew.test.js
+++ b/test-e2e/model-interaction/prods-with-crew.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
@@ -55,7 +56,7 @@ describe('Productions with crew', () => {
 
 		let uuidCallCount = 0;
 
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 		await purgeDatabase();
 

--- a/test-e2e/model-interaction/prods-with-producers.test.js
+++ b/test-e2e/model-interaction/prods-with-producers.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
@@ -55,7 +56,7 @@ describe('Productions with producer', () => {
 
 		let uuidCallCount = 0;
 
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 		await purgeDatabase();
 

--- a/test-e2e/model-interaction/roles-with-alternating-cast.test.js
+++ b/test-e2e/model-interaction/roles-with-alternating-cast.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
@@ -36,7 +37,7 @@ describe('Roles with alternating cast', () => {
 
 		let uuidCallCount = 0;
 
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 		await purgeDatabase();
 

--- a/test-e2e/model-interaction/venue-with-multi-prods.test.js
+++ b/test-e2e/model-interaction/venue-with-multi-prods.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
@@ -26,7 +27,7 @@ describe('Venue with multiple productions', () => {
 
 		let uuidCallCount = 0;
 
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 		await purgeDatabase();
 

--- a/test-e2e/model-interaction/venue-with-sub-venues.test.js
+++ b/test-e2e/model-interaction/venue-with-sub-venues.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
@@ -38,7 +39,7 @@ describe('Venue with sub-venues', () => {
 
 		let uuidCallCount = 0;
 
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 		await purgeDatabase();
 

--- a/test-e2e/model-interaction/wri-groups-grouping.test.js
+++ b/test-e2e/model-interaction/wri-groups-grouping.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import purgeDatabase from '../test-helpers/neo4j/purge-database';
@@ -23,7 +24,7 @@ describe('Nameless writer groups grouping', () => {
 
 		let uuidCallCount = 0;
 
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 		await purgeDatabase();
 

--- a/test-e2e/uniqueness-in-db/award-ceremonies-api.test.js
+++ b/test-e2e/uniqueness-in-db/award-ceremonies-api.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import countNodesWithLabel from '../test-helpers/neo4j/count-nodes-with-label';
@@ -36,7 +37,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 

--- a/test-e2e/uniqueness-in-db/awards-api.test.js
+++ b/test-e2e/uniqueness-in-db/awards-api.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import countNodesWithLabel from '../test-helpers/neo4j/count-nodes-with-label';
@@ -20,7 +21,7 @@ describe('Uniqueness in database: Awards API', () => {
 
 		let uuidCallCount = 0;
 
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 		await purgeDatabase();
 

--- a/test-e2e/uniqueness-in-db/characters-api.test.js
+++ b/test-e2e/uniqueness-in-db/characters-api.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import countNodesWithLabel from '../test-helpers/neo4j/count-nodes-with-label';
@@ -20,7 +21,7 @@ describe('Uniqueness in database: Characters API', () => {
 
 		let uuidCallCount = 0;
 
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 		await purgeDatabase();
 

--- a/test-e2e/uniqueness-in-db/companies-api.test.js
+++ b/test-e2e/uniqueness-in-db/companies-api.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import countNodesWithLabel from '../test-helpers/neo4j/count-nodes-with-label';
@@ -20,7 +21,7 @@ describe('Uniqueness in database: Companies API', () => {
 
 		let uuidCallCount = 0;
 
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 		await purgeDatabase();
 

--- a/test-e2e/uniqueness-in-db/materials-api.test.js
+++ b/test-e2e/uniqueness-in-db/materials-api.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import countNodesWithLabel from '../test-helpers/neo4j/count-nodes-with-label';
@@ -23,7 +24,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 		let uuidCallCount = 0;
 
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -405,7 +406,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -529,7 +530,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -673,7 +674,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -821,7 +822,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -977,7 +978,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 

--- a/test-e2e/uniqueness-in-db/people-api.test.js
+++ b/test-e2e/uniqueness-in-db/people-api.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import countNodesWithLabel from '../test-helpers/neo4j/count-nodes-with-label';
@@ -20,7 +21,7 @@ describe('Uniqueness in database: People API', () => {
 
 		let uuidCallCount = 0;
 
-		sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 		await purgeDatabase();
 

--- a/test-e2e/uniqueness-in-db/productions-api.test.js
+++ b/test-e2e/uniqueness-in-db/productions-api.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import countNodesWithLabel from '../test-helpers/neo4j/count-nodes-with-label';
@@ -36,7 +37,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -156,7 +157,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -276,7 +277,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -440,7 +441,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -592,7 +593,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -786,7 +787,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -914,7 +915,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -1078,7 +1079,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -1230,7 +1231,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -1402,7 +1403,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -1566,7 +1567,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -1718,7 +1719,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 

--- a/test-e2e/uniqueness-in-db/venue-api.test.js
+++ b/test-e2e/uniqueness-in-db/venue-api.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
-import { v4 as uuid } from 'uuid';
 
 import app from '../../src/app';
 import countNodesWithLabel from '../test-helpers/neo4j/count-nodes-with-label';
@@ -23,7 +24,7 @@ describe('Uniqueness in database: Venues API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -255,7 +256,7 @@ describe('Uniqueness in database: Venues API', () => {
 
 			let uuidCallCount = 0;
 
-			sandbox.stub(uuid, 'v4').callsFake(() => (uuidCallCount++).toString());
+			sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 

--- a/test-unit/src/lib/prepare-as-params.test.js
+++ b/test-unit/src/lib/prepare-as-params.test.js
@@ -1,7 +1,8 @@
+import crypto from 'crypto';
+
 import { expect } from 'chai';
 import { createSandbox } from 'sinon';
 import neo4j from 'neo4j-driver';
-import { v4 as uuid } from 'uuid';
 
 import { prepareAsParams } from '../../../src/lib/prepare-as-params';
 import applyModelGetter from '../../test-helpers/apply-model-getter';
@@ -16,7 +17,7 @@ describe('Prepare As Params module', () => {
 
 		stubs = {
 			neo4jInt: sandbox.stub(neo4j, 'int').returnsArg(0),
-			uuid: sandbox.stub(uuid, 'v4').returns('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx')
+			cryptoRandomUUID: sandbox.stub(crypto, 'randomUUID').returns('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx')
 		};
 
 	});
@@ -80,7 +81,7 @@ describe('Prepare As Params module', () => {
 
 			const instance = { uuid: '' };
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.calledOnce).to.be.true;
+			expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
 			expect(stubs.neo4jInt.notCalled).to.be.true;
 			expect(result.uuid).to.equal('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
 
@@ -90,7 +91,7 @@ describe('Prepare As Params module', () => {
 
 			const instance = { uuid: undefined };
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.calledOnce).to.be.true;
+			expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
 			expect(stubs.neo4jInt.notCalled).to.be.true;
 			expect(result.uuid).to.equal('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
 
@@ -100,7 +101,7 @@ describe('Prepare As Params module', () => {
 
 			const instance = { uuid: 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy' };
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.notCalled).to.be.true;
+			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
 			expect(stubs.neo4jInt.notCalled).to.be.true;
 			expect(result.uuid).to.equal('yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy');
 
@@ -110,7 +111,7 @@ describe('Prepare As Params module', () => {
 
 			const instance = { foo: 'bar' };
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.notCalled).to.be.true;
+			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
 			expect(stubs.neo4jInt.notCalled).to.be.true;
 			expect(result.foo).to.equal('bar');
 
@@ -120,7 +121,7 @@ describe('Prepare As Params module', () => {
 
 			const instance = { foo: '' };
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.notCalled).to.be.true;
+			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
 			expect(stubs.neo4jInt.notCalled).to.be.true;
 			expect(result.foo).to.equal(null);
 
@@ -130,7 +131,7 @@ describe('Prepare As Params module', () => {
 
 			const instance = { foo: '' };
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.notCalled).to.be.true;
+			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
 			expect(stubs.neo4jInt.notCalled).to.be.true;
 			expect(result).not.to.have.property('position');
 
@@ -152,7 +153,7 @@ describe('Prepare As Params module', () => {
 
 			const instance = { venue: { uuid: '' } };
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.calledOnce).to.be.true;
+			expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
 			expect(stubs.neo4jInt.notCalled).to.be.true;
 			expect(result.venue.uuid).to.equal('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
 
@@ -162,7 +163,7 @@ describe('Prepare As Params module', () => {
 
 			const instance = { venue: { uuid: undefined } };
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.calledOnce).to.be.true;
+			expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
 			expect(stubs.neo4jInt.notCalled).to.be.true;
 			expect(result.venue.uuid).to.equal('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
 
@@ -172,7 +173,7 @@ describe('Prepare As Params module', () => {
 
 			const instance = { venue: { uuid: 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy' } };
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.notCalled).to.be.true;
+			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
 			expect(stubs.neo4jInt.notCalled).to.be.true;
 			expect(result.venue.uuid).to.equal('yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy');
 
@@ -182,7 +183,7 @@ describe('Prepare As Params module', () => {
 
 			const instance = { venue: { foo: 'bar' } };
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.notCalled).to.be.true;
+			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
 			expect(stubs.neo4jInt.notCalled).to.be.true;
 			expect(result.venue.foo).to.equal('bar');
 
@@ -192,7 +193,7 @@ describe('Prepare As Params module', () => {
 
 			const instance = { venue: { foo: '' } };
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.notCalled).to.be.true;
+			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
 			expect(stubs.neo4jInt.notCalled).to.be.true;
 			expect(result.venue.foo).to.equal(null);
 
@@ -202,7 +203,7 @@ describe('Prepare As Params module', () => {
 
 			const instance = { venue: { uuid: '' } };
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.calledOnce).to.be.true;
+			expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
 			expect(stubs.neo4jInt.notCalled).to.be.true;
 			expect(result.venue).not.to.have.property('position');
 
@@ -224,7 +225,7 @@ describe('Prepare As Params module', () => {
 
 			const instance = { cast: [{ uuid: '', name: 'David Calder' }] };
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.calledOnce).to.be.true;
+			expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
 			expect(stubs.neo4jInt.notCalled).to.be.true;
 			expect(result.cast[0].uuid).to.equal('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
 
@@ -234,7 +235,7 @@ describe('Prepare As Params module', () => {
 
 			const instance = { cast: [{ uuid: undefined, name: 'David Calder' }] };
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.calledOnce).to.be.true;
+			expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
 			expect(stubs.neo4jInt.notCalled).to.be.true;
 			expect(result.cast[0].uuid).to.equal('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
 
@@ -244,7 +245,7 @@ describe('Prepare As Params module', () => {
 
 			const instance = { cast: [{ uuid: 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy', name: 'David Calder' }] };
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.notCalled).to.be.true;
+			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
 			expect(stubs.neo4jInt.notCalled).to.be.true;
 			expect(result.cast[0].uuid).to.equal('yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy');
 
@@ -254,7 +255,7 @@ describe('Prepare As Params module', () => {
 
 			const instance = { cast: [{ foo: 'bar', name: 'David Calder' }] };
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.notCalled).to.be.true;
+			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
 			expect(stubs.neo4jInt.notCalled).to.be.true;
 			expect(result.cast[0].foo).to.equal('bar');
 
@@ -264,7 +265,7 @@ describe('Prepare As Params module', () => {
 
 			const instance = { cast: [{ foo: '', name: 'David Calder' }] };
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.notCalled).to.be.true;
+			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
 			expect(stubs.neo4jInt.notCalled).to.be.true;
 			expect(result.cast[0].foo).to.equal(null);
 
@@ -276,7 +277,7 @@ describe('Prepare As Params module', () => {
 
 				const instance = { cast: [{ uuid: '', name: 'David Calder' }] };
 				const result = prepareAsParams(instance);
-				expect(stubs.uuid.calledOnce).to.be.true;
+				expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
 				expect(stubs.neo4jInt.notCalled).to.be.true;
 				expect(result.cast[0]).to.not.have.property('position');
 
@@ -298,7 +299,7 @@ describe('Prepare As Params module', () => {
 
 				const instance = { cast: [{ uuid: '', name: 'David Calder' }, { uuid: '', name: 'Ruth Negga' }] };
 				const result = prepareAsParams(instance);
-				expect(stubs.uuid.calledTwice).to.be.true;
+				expect(stubs.cryptoRandomUUID.calledTwice).to.be.true;
 				expect(stubs.neo4jInt.calledTwice).to.be.true;
 				expect(stubs.neo4jInt.getCall(0).calledWithExactly(0)).to.be.true;
 				expect(stubs.neo4jInt.getCall(1).calledWithExactly(1)).to.be.true;
@@ -330,7 +331,7 @@ describe('Prepare As Params module', () => {
 
 				const instance = { cast: [{ uuid: '', name: '' }, { uuid: '', name: 'David Calder' }] };
 				const result = prepareAsParams(instance);
-				expect(stubs.uuid.calledOnce).to.be.true;
+				expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
 				expect(stubs.neo4jInt.notCalled).to.be.true;
 				expect(result.cast.length).to.equal(1);
 				expect(result.cast[0].name).to.equal('David Calder');
@@ -356,7 +357,7 @@ describe('Prepare As Params module', () => {
 					]
 				};
 				const result = prepareAsParams(instance);
-				expect(stubs.uuid.notCalled).to.be.true;
+				expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
 				expect(stubs.neo4jInt.notCalled).to.be.true;
 				expect(result.writingCredits.length).to.equal(1);
 				expect(result.writingCredits[0].name).to.be.null;
@@ -404,7 +405,7 @@ describe('Prepare As Params module', () => {
 					]
 				};
 				const result = prepareAsParams(instance);
-				expect(stubs.uuid.notCalled).to.be.true;
+				expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
 				expect(stubs.neo4jInt.notCalled).to.be.true;
 				expect(result.writingCredits.length).to.equal(1);
 				expect(result.writingCredits[0].name).to.equal('version by');
@@ -438,7 +439,7 @@ describe('Prepare As Params module', () => {
 					]
 				};
 				const result = prepareAsParams(instance);
-				expect(stubs.uuid.notCalled).to.be.true;
+				expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
 				expect(stubs.neo4jInt.calledThrice).to.be.true;
 				expect(result.cast.length).to.equal(3);
 
@@ -448,7 +449,7 @@ describe('Prepare As Params module', () => {
 
 		it('applies the same uuid value to items that will need to share the same database entry', () => {
 
-			stubs.uuid
+			stubs.cryptoRandomUUID
 				.onFirstCall().returns('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
 				.onSecondCall().returns('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb')
 				.onThirdCall().returns('cccccccc-cccc-cccc-cccc-cccccccccccc')
@@ -464,7 +465,7 @@ describe('Prepare As Params module', () => {
 				]
 			};
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.callCount).to.equal(4);
+			expect(stubs.cryptoRandomUUID.callCount).to.equal(4);
 			expect(stubs.neo4jInt.callCount).to.equal(6);
 			expect(result.characters[0].uuid).to.equal(result.characters[3].uuid);
 			expect(result.characters[1].uuid).to.equal(result.characters[4].uuid);
@@ -480,7 +481,7 @@ describe('Prepare As Params module', () => {
 
 			const instance = { production: { cast: [{ uuid: '', name: 'David Calder' }] } };
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.calledOnce).to.be.true;
+			expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
 			expect(stubs.neo4jInt.notCalled).to.be.true;
 			expect(result.production.cast[0].uuid).to.equal('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
 
@@ -490,7 +491,7 @@ describe('Prepare As Params module', () => {
 
 			const instance = { production: { cast: [{ uuid: undefined, name: 'David Calder' }] } };
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.calledOnce).to.be.true;
+			expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
 			expect(stubs.neo4jInt.notCalled).to.be.true;
 			expect(result.production.cast[0].uuid).to.equal('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
 
@@ -509,7 +510,7 @@ describe('Prepare As Params module', () => {
 				}
 			};
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.notCalled).to.be.true;
+			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
 			expect(stubs.neo4jInt.notCalled).to.be.true;
 			expect(result.production.cast[0].uuid).to.equal('yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy');
 
@@ -519,7 +520,7 @@ describe('Prepare As Params module', () => {
 
 			const instance = { production: { cast: [{ foo: 'bar', name: 'David Calder' }] } };
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.notCalled).to.be.true;
+			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
 			expect(stubs.neo4jInt.notCalled).to.be.true;
 			expect(result.production.cast[0].foo).to.equal('bar');
 
@@ -529,7 +530,7 @@ describe('Prepare As Params module', () => {
 
 			const instance = { production: { cast: [{ foo: '', name: 'David Calder' }] } };
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.notCalled).to.be.true;
+			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
 			expect(stubs.neo4jInt.notCalled).to.be.true;
 			expect(result.production.cast[0].foo).to.equal(null);
 
@@ -541,7 +542,7 @@ describe('Prepare As Params module', () => {
 
 				const instance = { production: { cast: [{ uuid: '', name: 'David Calder' }] } };
 				const result = prepareAsParams(instance);
-				expect(stubs.uuid.calledOnce).to.be.true;
+				expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
 				expect(stubs.neo4jInt.notCalled).to.be.true;
 				expect(result.production.cast[0]).to.not.have.property('position');
 
@@ -570,7 +571,7 @@ describe('Prepare As Params module', () => {
 					}
 				};
 				const result = prepareAsParams(instance);
-				expect(stubs.uuid.calledTwice).to.be.true;
+				expect(stubs.cryptoRandomUUID.calledTwice).to.be.true;
 				expect(stubs.neo4jInt.calledTwice).to.be.true;
 				expect(stubs.neo4jInt.getCall(0).calledWithExactly(0)).to.be.true;
 				expect(stubs.neo4jInt.getCall(1).calledWithExactly(1)).to.be.true;
@@ -604,7 +605,7 @@ describe('Prepare As Params module', () => {
 
 				const instance = { production: { cast: [{ uuid: '', name: '' }, { uuid: '', name: 'David Calder' }] } };
 				const result = prepareAsParams(instance);
-				expect(stubs.uuid.calledOnce).to.be.true;
+				expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
 				expect(stubs.neo4jInt.notCalled).to.be.true;
 				expect(result.production.cast.length).to.equal(1);
 				expect(result.production.cast[0].name).to.equal('David Calder');
@@ -632,7 +633,7 @@ describe('Prepare As Params module', () => {
 					}
 				};
 				const result = prepareAsParams(instance);
-				expect(stubs.uuid.notCalled).to.be.true;
+				expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
 				expect(stubs.neo4jInt.notCalled).to.be.true;
 				expect(result.material.writingCredits.length).to.equal(1);
 				expect(result.material.writingCredits[0].name).to.be.null;
@@ -682,7 +683,7 @@ describe('Prepare As Params module', () => {
 					}
 				};
 				const result = prepareAsParams(instance);
-				expect(stubs.uuid.notCalled).to.be.true;
+				expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
 				expect(stubs.neo4jInt.notCalled).to.be.true;
 				expect(result.material.writingCredits.length).to.equal(1);
 				expect(result.material.writingCredits[0].name).to.equal('version by');
@@ -718,7 +719,7 @@ describe('Prepare As Params module', () => {
 					}
 				};
 				const result = prepareAsParams(instance);
-				expect(stubs.uuid.notCalled).to.be.true;
+				expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
 				expect(stubs.neo4jInt.calledThrice).to.be.true;
 				expect(result.production.cast.length).to.equal(3);
 
@@ -728,7 +729,7 @@ describe('Prepare As Params module', () => {
 
 		it('applies the same uuid value to items that will need to share the same database entry', () => {
 
-			stubs.uuid
+			stubs.cryptoRandomUUID
 				.onFirstCall().returns('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
 				.onSecondCall().returns('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb')
 				.onThirdCall().returns('cccccccc-cccc-cccc-cccc-cccccccccccc')
@@ -746,7 +747,7 @@ describe('Prepare As Params module', () => {
 				}
 			};
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.callCount).to.equal(4);
+			expect(stubs.cryptoRandomUUID.callCount).to.equal(4);
 			expect(stubs.neo4jInt.callCount).to.equal(6);
 			expect(result.production.cast[0].uuid).to.equal(result.production.cast[3].uuid);
 			expect(result.production.cast[1].uuid).to.equal(result.production.cast[4].uuid);
@@ -762,7 +763,7 @@ describe('Prepare As Params module', () => {
 
 			const instance = { cast: [{ name: 'David Calder', roles: [{ uuid: '', name: 'Polonius' }] }] };
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.calledOnce).to.be.true;
+			expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
 			expect(stubs.neo4jInt.notCalled).to.be.true;
 			expect(result.cast[0].roles[0].uuid).to.equal('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
 
@@ -772,7 +773,7 @@ describe('Prepare As Params module', () => {
 
 			const instance = { cast: [{ name: 'David Calder', roles: [{ uuid: undefined, name: 'Polonius' }] }] };
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.calledOnce).to.be.true;
+			expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
 			expect(stubs.neo4jInt.notCalled).to.be.true;
 			expect(result.cast[0].roles[0].uuid).to.equal('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
 
@@ -794,7 +795,7 @@ describe('Prepare As Params module', () => {
 				]
 			};
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.notCalled).to.be.true;
+			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
 			expect(stubs.neo4jInt.notCalled).to.be.true;
 			expect(result.cast[0].roles[0].uuid).to.equal('yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy');
 
@@ -804,7 +805,7 @@ describe('Prepare As Params module', () => {
 
 			const instance = { cast: [{ name: 'David Calder', roles: [{ foo: 'bar', name: 'Polonius' }] }] };
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.notCalled).to.be.true;
+			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
 			expect(stubs.neo4jInt.notCalled).to.be.true;
 			expect(result.cast[0].roles[0].foo).to.equal('bar');
 
@@ -814,7 +815,7 @@ describe('Prepare As Params module', () => {
 
 			const instance = { cast: [{ name: 'David Calder', roles: [{ foo: '', name: 'Polonius' }] }] };
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.notCalled).to.be.true;
+			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
 			expect(stubs.neo4jInt.notCalled).to.be.true;
 			expect(result.cast[0].roles[0].foo).to.equal(null);
 
@@ -826,7 +827,7 @@ describe('Prepare As Params module', () => {
 
 				const instance = { cast: [{ name: 'David Calder', roles: [{ uuid: '', name: 'Polonius' }] }] };
 				const result = prepareAsParams(instance);
-				expect(stubs.uuid.calledOnce).to.be.true;
+				expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
 				expect(stubs.neo4jInt.notCalled).to.be.true;
 				expect(result.cast[0]).to.not.have.property('position');
 				expect(result.cast[0].roles[0]).to.not.have.property('position');
@@ -868,7 +869,7 @@ describe('Prepare As Params module', () => {
 					]
 				};
 				const result = prepareAsParams(instance);
-				expect(stubs.uuid.calledTwice).to.be.true;
+				expect(stubs.cryptoRandomUUID.calledTwice).to.be.true;
 				expect(stubs.neo4jInt.calledTwice).to.be.true;
 				expect(stubs.neo4jInt.getCall(0).calledWithExactly(0)).to.be.true;
 				expect(stubs.neo4jInt.getCall(1).calledWithExactly(1)).to.be.true;
@@ -916,7 +917,7 @@ describe('Prepare As Params module', () => {
 					]
 				};
 				const result = prepareAsParams(instance);
-				expect(stubs.uuid.calledOnce).to.be.true;
+				expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
 				expect(stubs.neo4jInt.notCalled).to.be.true;
 				expect(result.cast[0].roles.length).to.equal(1);
 				expect(result.cast[0].roles[0].name).to.equal('Polonius');
@@ -947,7 +948,7 @@ describe('Prepare As Params module', () => {
 					]
 				};
 				const result = prepareAsParams(instance);
-				expect(stubs.uuid.notCalled).to.be.true;
+				expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
 				expect(stubs.neo4jInt.notCalled).to.be.true;
 				expect(result.materials[0].writingCredits.length).to.equal(1);
 				expect(result.materials[0].writingCredits[0].name).to.be.null;
@@ -1000,7 +1001,7 @@ describe('Prepare As Params module', () => {
 					]
 				};
 				const result = prepareAsParams(instance);
-				expect(stubs.uuid.notCalled).to.be.true;
+				expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
 				expect(stubs.neo4jInt.notCalled).to.be.true;
 				expect(result.materials[0].writingCredits.length).to.equal(1);
 				expect(result.materials[0].writingCredits[0].name).to.equal('version by');
@@ -1039,7 +1040,7 @@ describe('Prepare As Params module', () => {
 					]
 				};
 				const result = prepareAsParams(instance);
-				expect(stubs.uuid.notCalled).to.be.true;
+				expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
 				expect(stubs.neo4jInt.calledThrice).to.be.true;
 				expect(result.productions[0].cast.length).to.equal(3);
 
@@ -1049,7 +1050,7 @@ describe('Prepare As Params module', () => {
 
 		it('applies the same uuid value to items in the same array that will need to share the same database entry', () => {
 
-			stubs.uuid
+			stubs.cryptoRandomUUID
 				.onFirstCall().returns('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
 				.onSecondCall().returns('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb')
 				.onThirdCall().returns('cccccccc-cccc-cccc-cccc-cccccccccccc')
@@ -1069,7 +1070,7 @@ describe('Prepare As Params module', () => {
 				]
 			};
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.callCount).to.equal(4);
+			expect(stubs.cryptoRandomUUID.callCount).to.equal(4);
 			expect(stubs.neo4jInt.callCount).to.equal(6);
 			expect(result.characterGroups[0].characters[0].uuid).to.equal(result.characterGroups[0].characters[3].uuid);
 			expect(result.characterGroups[0].characters[1].uuid).to.equal(result.characterGroups[0].characters[4].uuid);
@@ -1081,7 +1082,7 @@ describe('Prepare As Params module', () => {
 
 		it('applies the same uuid value to items in different arrays that will need to share the same database entry', () => {
 
-			stubs.uuid
+			stubs.cryptoRandomUUID
 				.onFirstCall().returns('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
 				.onSecondCall().returns('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb')
 				.onThirdCall().returns('cccccccc-cccc-cccc-cccc-cccccccccccc')
@@ -1107,7 +1108,7 @@ describe('Prepare As Params module', () => {
 				]
 			};
 			const result = prepareAsParams(instance);
-			expect(stubs.uuid.callCount).to.equal(4);
+			expect(stubs.cryptoRandomUUID.callCount).to.equal(4);
 			expect(stubs.neo4jInt.callCount).to.equal(8);
 			expect(result.characterGroups[0].characters[0].uuid).to.equal(result.characterGroups[1].characters[0].uuid);
 			expect(result.characterGroups[0].characters[1].uuid).to.equal(result.characterGroups[1].characters[1].uuid);


### PR DESCRIPTION
Replaces the `uuid` module for the new and more performant Node-native `crypto.randomUUID()` method.

> Running on my benchmark server locally, the uuid module has a mean execution time of about 1030 nanoseconds per UUID, with a minimum of 640 and a maximum of 870399. In contrast, crypto.randomUUID() has a mean execution time of only 350 nanoseconds per UUID, with a minimum of 220 and a maximum of 663551. Caching random data is not always desirable, so as an additional option, the Node.js implementation of crypto.randomUUID() allows the cache to be disabled:

> ```
> crypto.randomUUID({ disableEntropyCache: true })
> ```

> The output generated is identical, but the performance will be reduced because the random data has to be generated on every call.

Ref. [NearForm: Introducing new crypto capabilities in Node.js](https://www.nearform.com/blog/new-crypto-capabilities-in-node-js)

### References:
- [Node.js: Node v14.17.0 (LTS) - UUID support in the crypto module](https://nodejs.org/en/blog/release/v14.17.0/#uuid-support-in-the-crypto-module)
- [Node.js: Node.js v16.9.0 documentation - crypto.randomUUID([options])](https://nodejs.org/api/crypto.html#crypto_crypto_randomuuid_options)
- [NearForm: Introducing new crypto capabilities in Node.js](https://www.nearform.com/blog/new-crypto-capabilities-in-node-js)