### PR TITLE
Add award ceremony category nomination isWinner property

### DIFF
--- a/src/lib/prepare-as-params.js
+++ b/src/lib/prepare-as-params.js
@@ -101,7 +101,7 @@ export const prepareAsParams = instance => {
 
 				}
 				else if (typeof value === 'number') accumulator[key] = neo4j.int(value);
-				else if (value === '') accumulator[key] = null;
+				else if (value === '' || (typeof value === 'boolean' && !value)) accumulator[key] = null;
 				else accumulator[key] = value;
 
 			}

--- a/src/models/Nomination.js
+++ b/src/models/Nomination.js
@@ -9,7 +9,9 @@ export default class Nomination extends Base {
 
 		super(props);
 
-		const { entities } = props;
+		const { isWinner, entities } = props;
+
+		this.isWinner = Boolean(isWinner);
 
 		this.entities = entities
 			? entities.map(entity => {

--- a/src/neo4j/cypher-queries/award-ceremony.js
+++ b/src/neo4j/cypher-queries/award-ceremony.js
@@ -107,6 +107,7 @@ const getCreateUpdateQuery = action => {
 
 						CREATE (category)-
 							[:HAS_NOMINEE {
+								isWinner: nomination.isWinner,
 								nominationPosition: nomination.position,
 								entityPosition: nomineePersonParam.position
 							}]->(nomineePerson)
@@ -137,6 +138,7 @@ const getCreateUpdateQuery = action => {
 
 						CREATE (category)-
 							[:HAS_NOMINEE {
+								isWinner: nomination.isWinner,
 								nominationPosition: nomination.position,
 								entityPosition: nomineeCompanyParam.position
 							}]->(nomineeCompany)
@@ -249,6 +251,7 @@ const getEditQuery = () => `
 		categoryRel,
 		category,
 		nomineeEntityRel.nominationPosition AS nominationPosition,
+		nomineeEntityRel.isWinner AS isWinner,
 		[nomineeEntity IN COLLECT(
 			CASE nomineeEntity WHEN NULL
 				THEN null
@@ -263,7 +266,7 @@ const getEditQuery = () => `
 		COLLECT(
 			CASE SIZE(nomineeEntities) WHEN 1
 				THEN null
-				ELSE { entities: nomineeEntities }
+				ELSE { isWinner: COALESCE(isWinner, false), entities: nomineeEntities }
 			END
 		) + [{ entities: [{}] }] AS nominations
 		ORDER BY categoryRel.position
@@ -328,6 +331,7 @@ const getShowQuery = () => `
 		categoryRel,
 		category,
 		nomineeEntityRel.nominationPosition AS nominationPosition,
+		nomineeEntityRel.isWinner AS isWinner,
 		[nomineeEntity IN COLLECT(
 			CASE nomineeEntity WHEN NULL
 				THEN null
@@ -342,10 +346,7 @@ const getShowQuery = () => `
 		COLLECT(
 			CASE SIZE(nomineeEntities) WHEN 0
 				THEN null
-				ELSE {
-					model: 'NOMINATION',
-					entities: nomineeEntities
-				}
+				ELSE { model: 'NOMINATION', isWinner: COALESCE(isWinner, false), entities: nomineeEntities }
 			END
 		) AS nominations
 		ORDER BY categoryRel.position

--- a/src/neo4j/cypher-queries/company.js
+++ b/src/neo4j/cypher-queries/company.js
@@ -609,6 +609,7 @@ const getShowQuery = () => `
 		award,
 		COLLECT({
 			model: 'NOMINATION',
+			isWinner: COALESCE(nomineeRel.isWinner, false),
 			members: nominatedMembers,
 			coEntities: coNominatedEntities
 		}) AS nominations

--- a/src/neo4j/cypher-queries/person.js
+++ b/src/neo4j/cypher-queries/person.js
@@ -822,6 +822,7 @@ const getShowQuery = () => `
 		award,
 		COLLECT({
 			model: 'NOMINATION',
+			isWinner: COALESCE(entityRel.isWinner, false),
 			employerCompany: nominatedEmployerCompany,
 			coEntities: coNominatedEntities
 		}) AS nominations

--- a/test-e2e/crud/award-ceremonies-api.test.js
+++ b/test-e2e/crud/award-ceremonies-api.test.js
@@ -39,6 +39,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 						nominations: [
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -108,6 +109,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 						nominations: [
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -153,6 +155,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 						nominations: [
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -202,6 +205,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 						nominations: [
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -350,6 +354,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 									]
 								},
 								{
+									isWinner: true,
 									entities: [
 										{
 											name: 'Paul Arditti',
@@ -422,6 +427,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 									]
 								},
 								{
+									isWinner: true,
 									entities: [
 										{
 											name: 'Rupert Goold',
@@ -456,6 +462,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 						nominations: [
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -474,6 +481,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -500,6 +508,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: true,
 								errors: {},
 								entities: [
 									{
@@ -524,6 +533,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -562,6 +572,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -594,6 +605,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -613,6 +625,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 						nominations: [
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -631,6 +644,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -655,6 +669,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: true,
 								errors: {},
 								entities: [
 									{
@@ -673,6 +688,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -692,6 +708,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 						nominations: [
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -711,6 +728,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 						nominations: [
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -753,6 +771,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 						nominations: [
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								entities: [
 									{
 										model: 'PERSON',
@@ -763,6 +782,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								entities: [
 									{
 										model: 'COMPANY',
@@ -774,6 +794,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: true,
 								entities: [
 									{
 										model: 'PERSON',
@@ -789,6 +810,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								entities: [
 									{
 										model: 'COMPANY',
@@ -811,6 +833,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								entities: [
 									{
 										model: 'COMPANY',
@@ -834,6 +857,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 						nominations: [
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								entities: [
 									{
 										model: 'PERSON',
@@ -844,6 +868,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								entities: [
 									{
 										model: 'PERSON',
@@ -859,6 +884,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: true,
 								entities: [
 									{
 										model: 'PERSON',
@@ -906,6 +932,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 						nominations: [
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -924,6 +951,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -950,6 +978,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: true,
 								errors: {},
 								entities: [
 									{
@@ -974,6 +1003,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -1012,6 +1042,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -1044,6 +1075,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -1063,6 +1095,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 						nominations: [
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -1081,6 +1114,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -1105,6 +1139,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: true,
 								errors: {},
 								entities: [
 									{
@@ -1123,6 +1158,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -1142,6 +1178,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 						nominations: [
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -1161,6 +1198,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 						nominations: [
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -1198,6 +1236,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							name: 'Best Lighting Design',
 							nominations: [
 								{
+									isWinner: true,
 									entities: [
 										{
 											name: 'Paule Constable',
@@ -1277,19 +1316,20 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 								},
 								// Contrivance for purposes of test.
 								{
+									isWinner: true,
 									entities: [
 										{
 											name: 'Steven Hoggett',
-											differentiator: '1'
-										},
-										{
-											name: 'Lynne Page',
 											differentiator: '1'
 										}
 									]
 								},
 								{
 									entities: [
+										{
+											name: 'Lynne Page',
+											differentiator: '1'
+										},
 										{
 											name: 'Kate Prince',
 											differentiator: '1'
@@ -1323,6 +1363,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 						nominations: [
 							{
 								model: 'NOMINATION',
+								isWinner: true,
 								errors: {},
 								entities: [
 									{
@@ -1341,6 +1382,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -1367,6 +1409,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -1391,6 +1434,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -1429,6 +1473,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -1461,6 +1506,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -1480,6 +1526,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 						nominations: [
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -1498,17 +1545,12 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: true,
 								errors: {},
 								entities: [
 									{
 										model: 'PERSON',
 										name: 'Steven Hoggett',
-										differentiator: '1',
-										errors: {}
-									},
-									{
-										model: 'PERSON',
-										name: 'Lynne Page',
 										differentiator: '1',
 										errors: {}
 									},
@@ -1522,8 +1564,15 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
+									{
+										model: 'PERSON',
+										name: 'Lynne Page',
+										differentiator: '1',
+										errors: {}
+									},
 									{
 										model: 'PERSON',
 										name: 'Kate Prince',
@@ -1540,6 +1589,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -1559,6 +1609,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 						nominations: [
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -1578,6 +1629,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 						nominations: [
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{
@@ -1620,6 +1672,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 						nominations: [
 							{
 								model: 'NOMINATION',
+								isWinner: true,
 								entities: [
 									{
 										model: 'PERSON',
@@ -1630,6 +1683,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								entities: [
 									{
 										model: 'COMPANY',
@@ -1641,6 +1695,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								entities: [
 									{
 										model: 'PERSON',
@@ -1656,6 +1711,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								entities: [
 									{
 										model: 'COMPANY',
@@ -1678,6 +1734,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								entities: [
 									{
 										model: 'COMPANY',
@@ -1701,6 +1758,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 						nominations: [
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								entities: [
 									{
 										model: 'PERSON',
@@ -1711,22 +1769,24 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: true,
 								entities: [
 									{
 										model: 'PERSON',
 										uuid: STEVEN_HOGGETT_PERSON_UUID,
 										name: 'Steven Hoggett'
-									},
-									{
-										model: 'PERSON',
-										uuid: LYNNE_PAGE_PERSON_UUID,
-										name: 'Lynne Page'
 									}
 								]
 							},
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								entities: [
+									{
+										model: 'PERSON',
+										uuid: LYNNE_PAGE_PERSON_UUID,
+										name: 'Lynne Page'
+									},
 									{
 										model: 'PERSON',
 										uuid: KATE_PRINCE_PERSON_UUID,
@@ -1778,6 +1838,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 						nominations: [
 							{
 								model: 'NOMINATION',
+								isWinner: false,
 								errors: {},
 								entities: [
 									{

--- a/test-e2e/model-interaction/awards-ceremonies.test.js
+++ b/test-e2e/model-interaction/awards-ceremonies.test.js
@@ -85,9 +85,10 @@ describe('Award ceremonies', () => {
 								]
 							},
 							{
+								isWinner: true,
 								entities: [
 									{
-										name: 'David Suchet'
+										name: 'Kyle Soller'
 									}
 								]
 							}
@@ -108,6 +109,7 @@ describe('Award ceremonies', () => {
 						name: 'Best Actor',
 						nominations: [
 							{
+								isWinner: true,
 								entities: [
 									{
 										name: 'Andrew Scott'
@@ -135,6 +137,7 @@ describe('Award ceremonies', () => {
 						name: 'Best Miscellaneous Role',
 						nominations: [
 							{
+								isWinner: true,
 								entities: [
 									{
 										name: 'John Doe'
@@ -214,6 +217,7 @@ describe('Award ceremonies', () => {
 								]
 							},
 							{
+								isWinner: true,
 								entities: [
 									{
 										name: 'John Doe'
@@ -289,6 +293,7 @@ describe('Award ceremonies', () => {
 						name: 'Best Actor',
 						nominations: [
 							{
+								isWinner: true,
 								entities: [
 									{
 										name: 'Bryan Cranston'
@@ -338,6 +343,7 @@ describe('Award ceremonies', () => {
 								]
 							},
 							{
+								isWinner: true,
 								entities: [
 									{
 										name: 'Conor Corge'
@@ -406,6 +412,7 @@ describe('Award ceremonies', () => {
 								]
 							},
 							{
+								isWinner: true,
 								entities: [
 									{
 										name: 'Ralph Fiennes'
@@ -440,6 +447,7 @@ describe('Award ceremonies', () => {
 								]
 							},
 							{
+								isWinner: true,
 								entities: [
 									{
 										model: 'COMPANY',
@@ -500,6 +508,7 @@ describe('Award ceremonies', () => {
 								]
 							},
 							{
+								isWinner: true,
 								entities: [
 									{
 										name: 'Andrew Scott'
@@ -513,6 +522,7 @@ describe('Award ceremonies', () => {
 						name: 'Best Miscellaneous Role',
 						nominations: [
 							{
+								isWinner: true,
 								entities: [
 									{
 										name: 'John Doe'
@@ -565,6 +575,7 @@ describe('Award ceremonies', () => {
 								]
 							},
 							{
+								isWinner: true,
 								entities: [
 									{
 										name: 'Andrew Garfield'
@@ -592,6 +603,7 @@ describe('Award ceremonies', () => {
 								]
 							},
 							{
+								isWinner: true,
 								entities: [
 									{
 										name: 'John Doe'
@@ -679,6 +691,7 @@ describe('Award ceremonies', () => {
 								]
 							},
 							{
+								isWinner: true,
 								entities: [
 									{
 										name: 'Conor Corge'
@@ -740,6 +753,7 @@ describe('Award ceremonies', () => {
 						name: 'Best Actor',
 						nominations: [
 							{
+								isWinner: true,
 								entities: [
 									{
 										name: 'Andrew Scott'
@@ -811,6 +825,7 @@ describe('Award ceremonies', () => {
 								]
 							},
 							{
+								isWinner: true,
 								entities: [
 									{
 										model: 'COMPANY',
@@ -933,11 +948,13 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: false,
 											employerCompany: null,
 											coEntities: []
 										},
 										{
 											model: 'NOMINATION',
+											isWinner: false,
 											employerCompany: null,
 											coEntities: [
 												{
@@ -975,6 +992,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: true,
 											employerCompany: null,
 											coEntities: []
 										}
@@ -993,6 +1011,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: false,
 											employerCompany: null,
 											coEntities: [
 												{
@@ -1023,6 +1042,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: true,
 											employerCompany: null,
 											coEntities: [
 												{
@@ -1046,6 +1066,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: false,
 											employerCompany: null,
 											coEntities: [
 												{
@@ -1083,11 +1104,13 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: true,
 											employerCompany: null,
 											coEntities: []
 										},
 										{
 											model: 'NOMINATION',
+											isWinner: false,
 											employerCompany: null,
 											coEntities: [
 												{
@@ -1111,6 +1134,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: true,
 											employerCompany: null,
 											coEntities: [
 												{
@@ -1141,6 +1165,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: false,
 											employerCompany: null,
 											coEntities: [
 												{
@@ -1193,6 +1218,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: false,
 											members: [],
 											coEntities: [
 												{
@@ -1229,6 +1255,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: true,
 											members: [],
 											coEntities: []
 										}
@@ -1247,6 +1274,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: true,
 											members: [],
 											coEntities: [
 												{
@@ -1269,6 +1297,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: false,
 											members: [],
 											coEntities: []
 										}
@@ -1294,6 +1323,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: false,
 											members: [],
 											coEntities: [
 												{
@@ -1316,6 +1346,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: false,
 											members: [],
 											coEntities: []
 										}
@@ -1334,11 +1365,13 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: false,
 											members: [],
 											coEntities: []
 										},
 										{
 											model: 'NOMINATION',
+											isWinner: false,
 											members: [],
 											coEntities: [
 												{
@@ -1390,6 +1423,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: false,
 											employerCompany: null,
 											coEntities: [
 												{
@@ -1460,6 +1494,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: false,
 											employerCompany: null,
 											coEntities: [
 												{
@@ -1501,6 +1536,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: false,
 											employerCompany: null,
 											coEntities: [
 												{
@@ -1542,6 +1578,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: false,
 											employerCompany: null,
 											coEntities: [
 												{
@@ -1598,6 +1635,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: true,
 											employerCompany: null,
 											coEntities: [
 												{
@@ -1668,6 +1706,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: false,
 											employerCompany: null,
 											coEntities: [
 												{
@@ -1724,6 +1763,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: false,
 											employerCompany: null,
 											coEntities: [
 												{
@@ -1787,6 +1827,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: true,
 											employerCompany: null,
 											coEntities: [
 												{
@@ -1872,6 +1913,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: false,
 											members: [
 												{
 													model: 'PERSON',
@@ -1941,6 +1983,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: false,
 											members: [
 												{
 													model: 'PERSON',
@@ -1981,6 +2024,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: false,
 											members: [
 												{
 													model: 'PERSON',
@@ -2036,6 +2080,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: true,
 											members: [
 												{
 													model: 'PERSON',
@@ -2105,6 +2150,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: false,
 											members: [
 												{
 													model: 'PERSON',
@@ -2160,6 +2206,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: false,
 											members: [
 												{
 													model: 'PERSON',
@@ -2222,6 +2269,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: true,
 											members: [
 												{
 													model: 'PERSON',
@@ -2306,6 +2354,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: false,
 											employerCompany: {
 												model: 'COMPANY',
 												uuid: THEATRICALS_LTD_COMPANY_UUID,
@@ -2375,6 +2424,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: false,
 											employerCompany: {
 												model: 'COMPANY',
 												uuid: THEATRICALS_LTD_COMPANY_UUID,
@@ -2415,6 +2465,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: false,
 											employerCompany: {
 												model: 'COMPANY',
 												uuid: THEATRICALS_LTD_COMPANY_UUID,
@@ -2470,6 +2521,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: true,
 											employerCompany: {
 												model: 'COMPANY',
 												uuid: THEATRICALS_LTD_COMPANY_UUID,
@@ -2539,6 +2591,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: false,
 											employerCompany: {
 												model: 'COMPANY',
 												uuid: THEATRICALS_LTD_COMPANY_UUID,
@@ -2594,6 +2647,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: false,
 											employerCompany: {
 												model: 'COMPANY',
 												uuid: THEATRICALS_LTD_COMPANY_UUID,
@@ -2656,6 +2710,7 @@ describe('Award ceremonies', () => {
 									nominations: [
 										{
 											model: 'NOMINATION',
+											isWinner: true,
 											employerCompany: {
 												model: 'COMPANY',
 												uuid: THEATRICALS_LTD_COMPANY_UUID,

--- a/test-int/instance-validation-failures/award-ceremony.test.js
+++ b/test-int/instance-validation-failures/award-ceremony.test.js
@@ -337,6 +337,7 @@ describe('AwardCeremony instance', () => {
 							},
 							nominations: [
 								{
+									isWinner: false,
 									entities: [
 										{
 											uuid: undefined,
@@ -401,6 +402,7 @@ describe('AwardCeremony instance', () => {
 							errors: {},
 							nominations: [
 								{
+									isWinner: false,
 									entities: [
 										{
 											uuid: undefined,
@@ -470,6 +472,7 @@ describe('AwardCeremony instance', () => {
 							errors: {},
 							nominations: [
 								{
+									isWinner: false,
 									entities: [
 										{
 											uuid: undefined,
@@ -539,6 +542,7 @@ describe('AwardCeremony instance', () => {
 							errors: {},
 							nominations: [
 								{
+									isWinner: false,
 									entities: [
 										{
 											uuid: undefined,
@@ -610,6 +614,7 @@ describe('AwardCeremony instance', () => {
 							errors: {},
 							nominations: [
 								{
+									isWinner: false,
 									entities: [
 										{
 											uuid: undefined,
@@ -699,6 +704,7 @@ describe('AwardCeremony instance', () => {
 							errors: {},
 							nominations: [
 								{
+									isWinner: false,
 									entities: [
 										{
 											uuid: undefined,
@@ -831,6 +837,7 @@ describe('AwardCeremony instance', () => {
 							errors: {},
 							nominations: [
 								{
+									isWinner: false,
 									entities: [
 										{
 											uuid: undefined,
@@ -913,6 +920,7 @@ describe('AwardCeremony instance', () => {
 							errors: {},
 							nominations: [
 								{
+									isWinner: false,
 									entities: [
 										{
 											uuid: undefined,
@@ -996,6 +1004,7 @@ describe('AwardCeremony instance', () => {
 							errors: {},
 							nominations: [
 								{
+									isWinner: false,
 									entities: [
 										{
 											uuid: undefined,

--- a/test-unit/src/lib/prepare-as-params.test.js
+++ b/test-unit/src/lib/prepare-as-params.test.js
@@ -127,6 +127,16 @@ describe('Prepare As Params module', () => {
 
 		});
 
+		it('will assign null value to non-uuid properties with false values', () => {
+
+			const instance = { foo: false };
+			const result = prepareAsParams(instance);
+			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
+			expect(stubs.neo4jInt.notCalled).to.be.true;
+			expect(result.foo).to.equal(null);
+
+		});
+
 		it('will not add position property', () => {
 
 			const instance = { foo: '' };
@@ -199,6 +209,16 @@ describe('Prepare As Params module', () => {
 
 		});
 
+		it('will assign null value to non-uuid properties with false values', () => {
+
+			const instance = { venue: { foo: false } };
+			const result = prepareAsParams(instance);
+			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
+			expect(stubs.neo4jInt.notCalled).to.be.true;
+			expect(result.venue.foo).to.equal(null);
+
+		});
+
 		it('will not add position property', () => {
 
 			const instance = { venue: { uuid: '' } };
@@ -264,6 +284,16 @@ describe('Prepare As Params module', () => {
 		it('will assign null value to non-uuid properties with empty string values', () => {
 
 			const instance = { cast: [{ foo: '', name: 'David Calder' }] };
+			const result = prepareAsParams(instance);
+			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
+			expect(stubs.neo4jInt.notCalled).to.be.true;
+			expect(result.cast[0].foo).to.equal(null);
+
+		});
+
+		it('will assign null value to non-uuid properties with false values', () => {
+
+			const instance = { cast: [{ foo: false, name: 'David Calder' }] };
 			const result = prepareAsParams(instance);
 			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
 			expect(stubs.neo4jInt.notCalled).to.be.true;
@@ -543,6 +573,16 @@ describe('Prepare As Params module', () => {
 		it('will assign null value to non-uuid properties with empty string values', () => {
 
 			const instance = { production: { cast: [{ foo: '', name: 'David Calder' }] } };
+			const result = prepareAsParams(instance);
+			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
+			expect(stubs.neo4jInt.notCalled).to.be.true;
+			expect(result.production.cast[0].foo).to.equal(null);
+
+		});
+
+		it('will assign null value to non-uuid properties with false values', () => {
+
+			const instance = { production: { cast: [{ foo: false, name: 'David Calder' }] } };
 			const result = prepareAsParams(instance);
 			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
 			expect(stubs.neo4jInt.notCalled).to.be.true;
@@ -842,6 +882,16 @@ describe('Prepare As Params module', () => {
 		it('will assign null value to non-uuid properties with empty string values', () => {
 
 			const instance = { cast: [{ name: 'David Calder', roles: [{ foo: '', name: 'Polonius' }] }] };
+			const result = prepareAsParams(instance);
+			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
+			expect(stubs.neo4jInt.notCalled).to.be.true;
+			expect(result.cast[0].roles[0].foo).to.equal(null);
+
+		});
+
+		it('will assign null value to non-uuid properties with false values', () => {
+
+			const instance = { cast: [{ name: 'David Calder', roles: [{ foo: false, name: 'Polonius' }] }] };
 			const result = prepareAsParams(instance);
 			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
 			expect(stubs.neo4jInt.notCalled).to.be.true;

--- a/test-unit/src/models/Nomination.test.js
+++ b/test-unit/src/models/Nomination.test.js
@@ -51,6 +51,45 @@ describe('Nomination model', () => {
 
 	describe('constructor method', () => {
 
+		describe('isWinner property', () => {
+
+			it('assigns false if absent from props', () => {
+
+				const instance = createInstance({});
+				expect(instance.isWinner).to.equal(false);
+
+			});
+
+			it('assigns false if included in props but value is empty string', () => {
+
+				const instance = createInstance({ isWinner: '' });
+				expect(instance.isWinner).to.equal(false);
+
+			});
+
+			it('assigns true if included in props but value is whitespace-only string', () => {
+
+				const instance = createInstance({ isWinner: ' ' });
+				expect(instance.isWinner).to.equal(true);
+
+			});
+
+			it('assigns true if included in props and is string with length', () => {
+
+				const instance = createInstance({ isWinner: 'foo' });
+				expect(instance.isWinner).to.equal(true);
+
+			});
+
+			it('assigns true if included in props and is true', () => {
+
+				const instance = createInstance({ isWinner: true });
+				expect(instance.isWinner).to.equal(true);
+
+			});
+
+		});
+
 		describe('entities property', () => {
 
 			it('assigns empty array if absent from props', () => {


### PR DESCRIPTION
This PR adds the `isWinner` property to award ceremony category nominations to denote when the nomination resulted in a win.

---

#### Laurence Olivier Awards 2020 (award ceremony)
<img width="905" alt="laurence-olivier-awards-2020" src="https://user-images.githubusercontent.com/10484515/141829550-e8d53b3c-eb65-4e52-9ce5-b645291d905b.png">

----

#### John Doe (person)
<img width="890" alt="john-doe-person" src="https://user-images.githubusercontent.com/10484515/141829579-cd465a15-440f-4fac-a816-5f41e2b25114.png">

---

#### Backstage Ltd (company)
<img width="634" alt="backstage-ltd-company" src="https://user-images.githubusercontent.com/10484515/141829628-360c85d7-d4b3-483b-8fa8-c56e8a2bfa28.png">