### PR TITLE
Revise role isAlternate property

### DIFF
--- a/src/models/Role.js
+++ b/src/models/Role.js
@@ -12,7 +12,7 @@ export default class Role extends Base {
 		this.characterName = characterName?.trim() || '';
 		this.characterDifferentiator = characterDifferentiator?.trim() || '';
 		this.qualifier = qualifier?.trim() || '';
-		this.isAlternate = Boolean(isAlternate) || null;
+		this.isAlternate = Boolean(isAlternate);
 
 	}
 

--- a/src/neo4j/cypher-queries/character.js
+++ b/src/neo4j/cypher-queries/character.js
@@ -192,7 +192,7 @@ const getShowQuery = () => `
 					uuid: otherCharacter.uuid,
 					name: otherRole.roleName,
 					qualifier: otherRole.qualifier,
-					isAlternate: otherRole.isAlternate
+					isAlternate: COALESCE(otherRole.isAlternate, false)
 				}
 			END
 		)) AS otherRoles
@@ -205,7 +205,7 @@ const getShowQuery = () => `
 			.name,
 			roleName: role.roleName,
 			qualifier: role.qualifier,
-			isAlternate: role.isAlternate,
+			isAlternate: COALESCE(role.isAlternate, false),
 			otherRoles
 		}) AS performers
 		ORDER BY production.startDate DESC, production.name, venue.name

--- a/src/neo4j/cypher-queries/person.js
+++ b/src/neo4j/cypher-queries/person.js
@@ -248,7 +248,13 @@ const getShowQuery = () => `
 		COLLECT(
 			CASE role.roleName WHEN NULL
 				THEN { name: 'Performer' }
-				ELSE role { model: 'CHARACTER', uuid: character.uuid, name: role.roleName, .qualifier, .isAlternate }
+				ELSE role {
+					model: 'CHARACTER',
+					uuid: character.uuid,
+					name: role.roleName,
+					.qualifier,
+					isAlternate: COALESCE(role.isAlternate, false)
+				}
 			END
 		) AS roles
 		ORDER BY production.startDate DESC, production.name, venue.name

--- a/src/neo4j/cypher-queries/production.js
+++ b/src/neo4j/cypher-queries/production.js
@@ -504,7 +504,7 @@ const getEditQuery = () => `
 					characterName: COALESCE(role.characterName, ''),
 					characterDifferentiator: COALESCE(role.characterDifferentiator, ''),
 					qualifier: COALESCE(role.qualifier, ''),
-					isAlternate: role.isAlternate
+					isAlternate: COALESCE(role.isAlternate, false)
 				}
 			END
 		) + [{}] AS roles
@@ -761,7 +761,13 @@ const getShowQuery = () => `
 		COLLECT(
 			CASE role.roleName WHEN NULL
 				THEN { name: 'Performer' }
-				ELSE role { model: 'CHARACTER', uuid: character.uuid, name: role.roleName, .qualifier, .isAlternate }
+				ELSE role {
+					model: 'CHARACTER',
+					uuid: character.uuid,
+					name: role.roleName,
+					.qualifier,
+					isAlternate: COALESCE(role.isAlternate, false)
+				}
 			END
 		) AS roles
 

--- a/test-e2e/crud/productions-api.test.js
+++ b/test-e2e/crud/productions-api.test.js
@@ -68,7 +68,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							}
 						]
@@ -191,7 +191,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							}
 						]
@@ -288,7 +288,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							}
 						]
@@ -389,7 +389,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							}
 						]
@@ -1060,7 +1060,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: 'Hamlet, Prince of Denmark',
 								characterDifferentiator: '1',
 								qualifier: 'foo',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							},
 							{
@@ -1069,7 +1069,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							}
 						]
@@ -1086,7 +1086,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: 'Ghost of King Hamlet',
 								characterDifferentiator: '1',
 								qualifier: 'bar',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							},
 							{
@@ -1095,7 +1095,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: 'Player King',
 								characterDifferentiator: '1',
 								qualifier: 'baz',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							},
 							{
@@ -1104,7 +1104,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							}
 						]
@@ -1121,7 +1121,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: 'Lucianus',
 								characterDifferentiator: '1',
 								qualifier: 'qux',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							},
 							{
@@ -1139,7 +1139,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							}
 						]
@@ -1156,7 +1156,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							}
 						]
@@ -1173,7 +1173,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							}
 						]
@@ -1622,7 +1622,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								uuid: null,
 								name: 'Hamlet',
 								qualifier: 'foo',
-								isAlternate: null
+								isAlternate: false
 							}
 						]
 					},
@@ -1636,14 +1636,14 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								uuid: null,
 								name: 'Ghost',
 								qualifier: 'bar',
-								isAlternate: null
+								isAlternate: false
 							},
 							{
 								model: 'CHARACTER',
 								uuid: null,
 								name: 'First Player',
 								qualifier: 'baz',
-								isAlternate: null
+								isAlternate: false
 							}
 						]
 					},
@@ -1657,7 +1657,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								uuid: null,
 								name: 'Third Player',
 								qualifier: 'qux',
-								isAlternate: null
+								isAlternate: false
 							},
 							{
 								model: 'CHARACTER',
@@ -2046,7 +2046,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: 'Hamlet, Prince of Denmark',
 								characterDifferentiator: '1',
 								qualifier: 'foo',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							},
 							{
@@ -2055,7 +2055,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							}
 						]
@@ -2072,7 +2072,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: 'Ghost of King Hamlet',
 								characterDifferentiator: '1',
 								qualifier: 'bar',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							},
 							{
@@ -2081,7 +2081,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: 'Player King',
 								characterDifferentiator: '1',
 								qualifier: 'baz',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							},
 							{
@@ -2090,7 +2090,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							}
 						]
@@ -2107,7 +2107,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: 'Lucianus',
 								characterDifferentiator: '1',
 								qualifier: 'qux',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							},
 							{
@@ -2125,7 +2125,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							}
 						]
@@ -2142,7 +2142,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							}
 						]
@@ -2159,7 +2159,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							}
 						]
@@ -2976,7 +2976,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: 'King Richard III',
 								characterDifferentiator: '1',
 								qualifier: 'foo',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							},
 							{
@@ -2985,7 +2985,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							}
 						]
@@ -3002,7 +3002,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: 'Sir Robert Brakenbury',
 								characterDifferentiator: '1',
 								qualifier: 'bar',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							},
 							{
@@ -3011,7 +3011,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: 'Henry, Earl of Richmond',
 								characterDifferentiator: '1',
 								qualifier: 'baz',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							},
 							{
@@ -3020,7 +3020,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							}
 						]
@@ -3037,7 +3037,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: 'Sir Richard Ratcliffe',
 								characterDifferentiator: '1',
 								qualifier: 'qux',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							},
 							{
@@ -3055,7 +3055,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							}
 						]
@@ -3072,7 +3072,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							}
 						]
@@ -3089,7 +3089,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							}
 						]
@@ -3538,7 +3538,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								uuid: null,
 								name: 'Richard, Duke of Gloucester',
 								qualifier: 'foo',
-								isAlternate: null
+								isAlternate: false
 							}
 						]
 					},
@@ -3552,14 +3552,14 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								uuid: null,
 								name: 'Brakenbury',
 								qualifier: 'bar',
-								isAlternate: null
+								isAlternate: false
 							},
 							{
 								model: 'CHARACTER',
 								uuid: null,
 								name: 'Richmond',
 								qualifier: 'baz',
-								isAlternate: null
+								isAlternate: false
 							}
 						]
 					},
@@ -3573,7 +3573,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								uuid: null,
 								name: 'Ratcliffe',
 								qualifier: 'qux',
-								isAlternate: null
+								isAlternate: false
 							},
 							{
 								model: 'CHARACTER',
@@ -3824,7 +3824,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 								characterName: '',
 								characterDifferentiator: '',
 								qualifier: '',
-								isAlternate: null,
+								isAlternate: false,
 								errors: {}
 							}
 						]

--- a/test-e2e/model-interaction/cast-member-diff-roles-of-material.test.js
+++ b/test-e2e/model-interaction/cast-member-diff-roles-of-material.test.js
@@ -176,7 +176,7 @@ describe('Cast member performing different roles in different productions of sam
 							name: 'Antony Sher',
 							roleName: 'King Lear',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: []
 						}
 					]
@@ -200,7 +200,7 @@ describe('Cast member performing different roles in different productions of sam
 							name: 'Michael Gambon',
 							roleName: 'King Lear',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: []
 						}
 					]
@@ -239,7 +239,7 @@ describe('Cast member performing different roles in different productions of sam
 							name: 'Graham Turner',
 							roleName: 'Fool',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: []
 						}
 					]
@@ -263,7 +263,7 @@ describe('Cast member performing different roles in different productions of sam
 							name: 'Antony Sher',
 							roleName: 'Fool',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: []
 						}
 					]
@@ -293,7 +293,7 @@ describe('Cast member performing different roles in different productions of sam
 							uuid: KING_LEAR_CHARACTER_UUID,
 							name: 'King Lear',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -307,7 +307,7 @@ describe('Cast member performing different roles in different productions of sam
 							uuid: FOOL_CHARACTER_UUID,
 							name: 'Fool',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -336,7 +336,7 @@ describe('Cast member performing different roles in different productions of sam
 							uuid: KING_LEAR_CHARACTER_UUID,
 							name: 'King Lear',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -350,7 +350,7 @@ describe('Cast member performing different roles in different productions of sam
 							uuid: FOOL_CHARACTER_UUID,
 							name: 'Fool',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -387,7 +387,7 @@ describe('Cast member performing different roles in different productions of sam
 							uuid: KING_LEAR_CHARACTER_UUID,
 							name: 'King Lear',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -424,7 +424,7 @@ describe('Cast member performing different roles in different productions of sam
 							uuid: KING_LEAR_CHARACTER_UUID,
 							name: 'King Lear',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -446,7 +446,7 @@ describe('Cast member performing different roles in different productions of sam
 							uuid: FOOL_CHARACTER_UUID,
 							name: 'Fool',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -483,7 +483,7 @@ describe('Cast member performing different roles in different productions of sam
 							uuid: FOOL_CHARACTER_UUID,
 							name: 'Fool',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}

--- a/test-e2e/model-interaction/cast-member-same-role-of-material.test.js
+++ b/test-e2e/model-interaction/cast-member-same-role-of-material.test.js
@@ -144,7 +144,7 @@ describe('Cast member performing same role in different productions of same mate
 							name: 'Judi Dench',
 							roleName: 'Titania, Faerie Queene',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: []
 						}
 					]
@@ -168,7 +168,7 @@ describe('Cast member performing same role in different productions of same mate
 							name: 'Judi Dench',
 							roleName: 'Titania',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: []
 						}
 					]
@@ -198,7 +198,7 @@ describe('Cast member performing same role in different productions of same mate
 							uuid: TITANIA_CHARACTER_UUID,
 							name: 'Titania',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -227,7 +227,7 @@ describe('Cast member performing same role in different productions of same mate
 							uuid: TITANIA_CHARACTER_UUID,
 							name: 'Titania, Faerie Queene',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -264,7 +264,7 @@ describe('Cast member performing same role in different productions of same mate
 							uuid: TITANIA_CHARACTER_UUID,
 							name: 'Titania, Faerie Queene',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -286,7 +286,7 @@ describe('Cast member performing same role in different productions of same mate
 							uuid: TITANIA_CHARACTER_UUID,
 							name: 'Titania',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}

--- a/test-e2e/model-interaction/cast-member-with-multi-prods.test.js
+++ b/test-e2e/model-interaction/cast-member-with-multi-prods.test.js
@@ -155,21 +155,21 @@ describe('Cast member with multiple production credits', () => {
 							uuid: null,
 							name: 'Congresswoman',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: null,
 							name: 'Sheryl Sloman',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: null,
 							name: 'Irene Gant',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -191,14 +191,14 @@ describe('Cast member with multiple production credits', () => {
 							uuid: null,
 							name: 'Alaura Kingsley',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: null,
 							name: 'Carla Haywood',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -220,14 +220,14 @@ describe('Cast member with multiple production credits', () => {
 							uuid: null,
 							name: 'Chorus',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: null,
 							name: 'Trojan slave',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -256,14 +256,14 @@ describe('Cast member with multiple production credits', () => {
 							uuid: null,
 							name: 'Chorus',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: null,
 							name: 'Trojan slave',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -292,14 +292,14 @@ describe('Cast member with multiple production credits', () => {
 							uuid: null,
 							name: 'Alaura Kingsley',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: null,
 							name: 'Carla Haywood',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -328,21 +328,21 @@ describe('Cast member with multiple production credits', () => {
 							uuid: null,
 							name: 'Congresswoman',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: null,
 							name: 'Sheryl Sloman',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: null,
 							name: 'Irene Gant',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}

--- a/test-e2e/model-interaction/char-diff-groups-same-material.test.js
+++ b/test-e2e/model-interaction/char-diff-groups-same-material.test.js
@@ -262,7 +262,7 @@ describe('Character with multiple appearances in the same material in different 
 							name: 'Jodie McNee',
 							roleName: 'Alisa Kos',
 							qualifier: '2011',
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: []
 						},
 						{
@@ -271,7 +271,7 @@ describe('Character with multiple appearances in the same material in different 
 							name: 'Bebe Sanders',
 							roleName: 'Alisa Kos',
 							qualifier: '1990',
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: []
 						}
 					]
@@ -341,7 +341,7 @@ describe('Character with multiple appearances in the same material in different 
 							name: 'Siobhan Finneran',
 							roleName: 'Maša Kos',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: []
 						}
 					]
@@ -411,7 +411,7 @@ describe('Character with multiple appearances in the same material in different 
 							name: 'James Laurenson',
 							roleName: 'Aleksander King',
 							qualifier: '1990',
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: []
 						},
 						{
@@ -420,7 +420,7 @@ describe('Character with multiple appearances in the same material in different 
 							name: 'Alex Price',
 							roleName: 'Aleksander King',
 							qualifier: '1945',
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: []
 						}
 					]
@@ -485,7 +485,7 @@ describe('Character with multiple appearances in the same material in different 
 							name: 'Jo Herbert',
 							roleName: 'Rose King',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: []
 						}
 					]
@@ -593,7 +593,7 @@ describe('Character with multiple appearances in the same material in different 
 							uuid: MAŠA_KOS_CHARACTER_UUID,
 							name: 'Maša Kos',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -607,7 +607,7 @@ describe('Character with multiple appearances in the same material in different 
 							uuid: ROSE_KING_CHARACTER_UUID,
 							name: 'Rose King',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -621,7 +621,7 @@ describe('Character with multiple appearances in the same material in different 
 							uuid: ALEKSANDER_KING_CHARACTER_UUID,
 							name: 'Aleksander King',
 							qualifier: '1990',
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -635,7 +635,7 @@ describe('Character with multiple appearances in the same material in different 
 							uuid: ALISA_KOS_CHARACTER_UUID,
 							name: 'Alisa Kos',
 							qualifier: '2011',
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -649,7 +649,7 @@ describe('Character with multiple appearances in the same material in different 
 							uuid: ALEKSANDER_KING_CHARACTER_UUID,
 							name: 'Aleksander King',
 							qualifier: '1945',
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -663,7 +663,7 @@ describe('Character with multiple appearances in the same material in different 
 							uuid: ALISA_KOS_CHARACTER_UUID,
 							name: 'Alisa Kos',
 							qualifier: '1990',
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -700,7 +700,7 @@ describe('Character with multiple appearances in the same material in different 
 							uuid: MAŠA_KOS_CHARACTER_UUID,
 							name: 'Maša Kos',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -737,7 +737,7 @@ describe('Character with multiple appearances in the same material in different 
 							uuid: ROSE_KING_CHARACTER_UUID,
 							name: 'Rose King',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -774,7 +774,7 @@ describe('Character with multiple appearances in the same material in different 
 							uuid: ALEKSANDER_KING_CHARACTER_UUID,
 							name: 'Aleksander King',
 							qualifier: '1990',
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -811,7 +811,7 @@ describe('Character with multiple appearances in the same material in different 
 							uuid: ALISA_KOS_CHARACTER_UUID,
 							name: 'Alisa Kos',
 							qualifier: '2011',
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -848,7 +848,7 @@ describe('Character with multiple appearances in the same material in different 
 							uuid: ALEKSANDER_KING_CHARACTER_UUID,
 							name: 'Aleksander King',
 							qualifier: '1945',
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -885,7 +885,7 @@ describe('Character with multiple appearances in the same material in different 
 							uuid: ALISA_KOS_CHARACTER_UUID,
 							name: 'Alisa Kos',
 							qualifier: '1990',
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}

--- a/test-e2e/model-interaction/char-in-multi-prods-of-multi-materials.test.js
+++ b/test-e2e/model-interaction/char-in-multi-prods-of-multi-materials.test.js
@@ -408,7 +408,7 @@ describe('Character in multiple productions of multiple materials', () => {
 							name: 'Roger Allam',
 							roleName: 'Sir John Falstaff',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: []
 						}
 					]
@@ -432,7 +432,7 @@ describe('Character in multiple productions of multiple materials', () => {
 							name: 'Roger Allam',
 							roleName: 'Sir John Falstaff',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: []
 						}
 					]
@@ -456,7 +456,7 @@ describe('Character in multiple productions of multiple materials', () => {
 							name: 'Roger Allam',
 							roleName: 'Sir John Falstaff',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: []
 						}
 					]
@@ -480,7 +480,7 @@ describe('Character in multiple productions of multiple materials', () => {
 							name: 'Michael Gambon',
 							roleName: 'Sir John Falstaff',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: []
 						}
 					]
@@ -504,7 +504,7 @@ describe('Character in multiple productions of multiple materials', () => {
 							name: 'Michael Gambon',
 							roleName: 'Sir John Falstaff',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: []
 						}
 					]
@@ -528,7 +528,7 @@ describe('Character in multiple productions of multiple materials', () => {
 							name: 'Michael Gambon',
 							roleName: 'Sir John Falstaff',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: []
 						}
 					]
@@ -552,7 +552,7 @@ describe('Character in multiple productions of multiple materials', () => {
 							name: 'Richard Cordery',
 							roleName: 'Sir John Falstaff',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: []
 						}
 					]
@@ -576,7 +576,7 @@ describe('Character in multiple productions of multiple materials', () => {
 							name: 'Richard Cordery',
 							roleName: 'Sir John Falstaff',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: []
 						}
 					]
@@ -600,7 +600,7 @@ describe('Character in multiple productions of multiple materials', () => {
 							name: 'Richard Cordery',
 							roleName: 'Sir John Falstaff',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: []
 						}
 					]

--- a/test-e2e/model-interaction/char-multi-appearances-same-material.test.js
+++ b/test-e2e/model-interaction/char-multi-appearances-same-material.test.js
@@ -210,14 +210,14 @@ describe('Character with multiple appearances in the same material under differe
 							name: 'Alice Eve',
 							roleName: 'Esme',
 							qualifier: 'younger',
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: [
 								{
 									model: 'CHARACTER',
 									uuid: ALICE_CHARACTER_UUID,
 									name: 'Alice',
 									qualifier: null,
-									isAlternate: null
+									isAlternate: false
 								}
 							]
 						},
@@ -227,14 +227,14 @@ describe('Character with multiple appearances in the same material under differe
 							name: 'Sinead Cusack',
 							roleName: 'Esme',
 							qualifier: 'older',
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: [
 								{
 									model: 'CHARACTER',
 									uuid: ELEANOR_CHARACTER_UUID,
 									name: 'Eleanor',
 									qualifier: null,
-									isAlternate: null
+									isAlternate: false
 								}
 							]
 						}
@@ -274,14 +274,14 @@ describe('Character with multiple appearances in the same material under differe
 							name: 'Alice Eve',
 							roleName: 'Alice',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: [
 								{
 									model: 'CHARACTER',
 									uuid: ESME_CHARACTER_UUID,
 									name: 'Esme',
 									qualifier: 'younger',
-									isAlternate: null
+									isAlternate: false
 								}
 							]
 						}
@@ -321,14 +321,14 @@ describe('Character with multiple appearances in the same material under differe
 							name: 'Sinead Cusack',
 							roleName: 'Eleanor',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: [
 								{
 									model: 'CHARACTER',
 									uuid: ESME_CHARACTER_UUID,
 									name: 'Esme',
 									qualifier: 'older',
-									isAlternate: null
+									isAlternate: false
 								}
 							]
 						}
@@ -404,14 +404,14 @@ describe('Character with multiple appearances in the same material under differe
 							uuid: ESME_CHARACTER_UUID,
 							name: 'Esme',
 							qualifier: 'younger',
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: ALICE_CHARACTER_UUID,
 							name: 'Alice',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -425,7 +425,7 @@ describe('Character with multiple appearances in the same material under differe
 							uuid: MAX_CHARACTER_UUID,
 							name: 'Max',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -439,14 +439,14 @@ describe('Character with multiple appearances in the same material under differe
 							uuid: ELEANOR_CHARACTER_UUID,
 							name: 'Eleanor',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: ESME_CHARACTER_UUID,
 							name: 'Esme',
 							qualifier: 'older',
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -483,14 +483,14 @@ describe('Character with multiple appearances in the same material under differe
 							uuid: ESME_CHARACTER_UUID,
 							name: 'Esme',
 							qualifier: 'younger',
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: ALICE_CHARACTER_UUID,
 							name: 'Alice',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -527,14 +527,14 @@ describe('Character with multiple appearances in the same material under differe
 							uuid: ELEANOR_CHARACTER_UUID,
 							name: 'Eleanor',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: ESME_CHARACTER_UUID,
 							name: 'Esme',
 							qualifier: 'older',
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}

--- a/test-e2e/model-interaction/char-portrayed-with-other-roles.test.js
+++ b/test-e2e/model-interaction/char-portrayed-with-other-roles.test.js
@@ -147,28 +147,28 @@ describe('Character portrayed with other roles', () => {
 							name: 'Stephen Harper',
 							roleName: 'Joey\'s mother',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: [
 								{
 									model: 'CHARACTER',
 									uuid: DR_SCHWEYK_CHARACTER_UUID,
 									name: 'Dr Schweyk',
 									qualifier: null,
-									isAlternate: null
+									isAlternate: false
 								},
 								{
 									model: 'CHARACTER',
 									uuid: COCO_CHARACTER_UUID,
 									name: 'Coco',
 									qualifier: null,
-									isAlternate: null
+									isAlternate: false
 								},
 								{
 									model: 'CHARACTER',
 									uuid: GEORDIE_CHARACTER_UUID,
 									name: 'Geordie',
 									qualifier: null,
-									isAlternate: null
+									isAlternate: false
 								}
 							]
 						}
@@ -208,28 +208,28 @@ describe('Character portrayed with other roles', () => {
 							name: 'Stephen Harper',
 							roleName: 'Dr Schweyk',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: [
 								{
 									model: 'CHARACTER',
 									uuid: JOEYS_MOTHER_CHARACTER_UUID,
 									name: 'Joey\'s mother',
 									qualifier: null,
-									isAlternate: null
+									isAlternate: false
 								},
 								{
 									model: 'CHARACTER',
 									uuid: COCO_CHARACTER_UUID,
 									name: 'Coco',
 									qualifier: null,
-									isAlternate: null
+									isAlternate: false
 								},
 								{
 									model: 'CHARACTER',
 									uuid: GEORDIE_CHARACTER_UUID,
 									name: 'Geordie',
 									qualifier: null,
-									isAlternate: null
+									isAlternate: false
 								}
 							]
 						}
@@ -269,28 +269,28 @@ describe('Character portrayed with other roles', () => {
 							name: 'Stephen Harper',
 							roleName: 'Coco',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: [
 								{
 									model: 'CHARACTER',
 									uuid: JOEYS_MOTHER_CHARACTER_UUID,
 									name: 'Joey\'s mother',
 									qualifier: null,
-									isAlternate: null
+									isAlternate: false
 								},
 								{
 									model: 'CHARACTER',
 									uuid: DR_SCHWEYK_CHARACTER_UUID,
 									name: 'Dr Schweyk',
 									qualifier: null,
-									isAlternate: null
+									isAlternate: false
 								},
 								{
 									model: 'CHARACTER',
 									uuid: GEORDIE_CHARACTER_UUID,
 									name: 'Geordie',
 									qualifier: null,
-									isAlternate: null
+									isAlternate: false
 								}
 							]
 						}
@@ -330,28 +330,28 @@ describe('Character portrayed with other roles', () => {
 							name: 'Stephen Harper',
 							roleName: 'Geordie',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: [
 								{
 									model: 'CHARACTER',
 									uuid: JOEYS_MOTHER_CHARACTER_UUID,
 									name: 'Joey\'s mother',
 									qualifier: null,
-									isAlternate: null
+									isAlternate: false
 								},
 								{
 									model: 'CHARACTER',
 									uuid: DR_SCHWEYK_CHARACTER_UUID,
 									name: 'Dr Schweyk',
 									qualifier: null,
-									isAlternate: null
+									isAlternate: false
 								},
 								{
 									model: 'CHARACTER',
 									uuid: COCO_CHARACTER_UUID,
 									name: 'Coco',
 									qualifier: null,
-									isAlternate: null
+									isAlternate: false
 								}
 							]
 						}

--- a/test-e2e/model-interaction/char-with-variant-depiction-portrayal-names.test.js
+++ b/test-e2e/model-interaction/char-with-variant-depiction-portrayal-names.test.js
@@ -554,14 +554,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							name: 'Alex Hassell',
 							roleName: 'Henry V',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: [
 								{
 									model: 'CHARACTER',
 									uuid: SOLDIER_CHARACTER_UUID,
 									name: 'Soldier',
 									qualifier: null,
-									isAlternate: null
+									isAlternate: false
 								}
 							]
 						}
@@ -586,14 +586,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							name: 'Alex Hassell',
 							roleName: 'Hal',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: [
 								{
 									model: 'CHARACTER',
 									uuid: ATTENDANT_CHARACTER_UUID,
 									name: 'Attendant',
 									qualifier: null,
-									isAlternate: null
+									isAlternate: false
 								}
 							]
 						}
@@ -618,14 +618,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							name: 'Alex Hassell',
 							roleName: 'Henry, Prince of Wales',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: [
 								{
 									model: 'CHARACTER',
 									uuid: MESSENGER_CHARACTER_UUID,
 									name: 'Messenger',
 									qualifier: null,
-									isAlternate: null
+									isAlternate: false
 								}
 							]
 						}
@@ -650,14 +650,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							name: 'Matthew Macfadyen',
 							roleName: 'Hal, Prince of England',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: [
 								{
 									model: 'CHARACTER',
 									uuid: ATTENDANT_CHARACTER_UUID,
 									name: 'Attendant',
 									qualifier: null,
-									isAlternate: null
+									isAlternate: false
 								}
 							]
 						}
@@ -682,14 +682,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							name: 'Matthew Macfadyen',
 							roleName: 'Prince Hal',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: [
 								{
 									model: 'CHARACTER',
 									uuid: MESSENGER_CHARACTER_UUID,
 									name: 'Messenger',
 									qualifier: null,
-									isAlternate: null
+									isAlternate: false
 								}
 							]
 						}
@@ -714,14 +714,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							name: 'Adrian Lester',
 							roleName: 'Henry V',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: [
 								{
 									model: 'CHARACTER',
 									uuid: SOLDIER_CHARACTER_UUID,
 									name: 'Soldier',
 									qualifier: null,
-									isAlternate: null
+									isAlternate: false
 								}
 							]
 						}
@@ -761,14 +761,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							name: 'Alex Hassell',
 							roleName: 'Messenger',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: [
 								{
 									model: 'CHARACTER',
 									uuid: KING_HENRY_V_CHARACTER_UUID,
 									name: 'Henry, Prince of Wales',
 									qualifier: null,
-									isAlternate: null
+									isAlternate: false
 								}
 							]
 						}
@@ -793,14 +793,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							name: 'Matthew Macfadyen',
 							roleName: 'Messenger',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: [
 								{
 									model: 'CHARACTER',
 									uuid: KING_HENRY_V_CHARACTER_UUID,
 									name: 'Prince Hal',
 									qualifier: null,
-									isAlternate: null
+									isAlternate: false
 								}
 							]
 						}
@@ -840,14 +840,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							name: 'Alex Hassell',
 							roleName: 'Attendant',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: [
 								{
 									model: 'CHARACTER',
 									uuid: KING_HENRY_V_CHARACTER_UUID,
 									name: 'Hal',
 									qualifier: null,
-									isAlternate: null
+									isAlternate: false
 								}
 							]
 						}
@@ -872,14 +872,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							name: 'Matthew Macfadyen',
 							roleName: 'Attendant',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: [
 								{
 									model: 'CHARACTER',
 									uuid: KING_HENRY_V_CHARACTER_UUID,
 									name: 'Hal, Prince of England',
 									qualifier: null,
-									isAlternate: null
+									isAlternate: false
 								}
 							]
 						}
@@ -919,14 +919,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							name: 'Alex Hassell',
 							roleName: 'Soldier',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: [
 								{
 									model: 'CHARACTER',
 									uuid: KING_HENRY_V_CHARACTER_UUID,
 									name: 'Henry V',
 									qualifier: null,
-									isAlternate: null
+									isAlternate: false
 								}
 							]
 						}
@@ -951,14 +951,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							name: 'Adrian Lester',
 							roleName: 'Soldier',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: [
 								{
 									model: 'CHARACTER',
 									uuid: KING_HENRY_V_CHARACTER_UUID,
 									name: 'Henry V',
 									qualifier: null,
-									isAlternate: null
+									isAlternate: false
 								}
 							]
 						}
@@ -1088,14 +1088,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							uuid: KING_HENRY_V_CHARACTER_UUID,
 							name: 'Henry, Prince of Wales',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: MESSENGER_CHARACTER_UUID,
 							name: 'Messenger',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -1109,7 +1109,7 @@ describe('Character with variant depiction and portrayal names', () => {
 							uuid: SIR_JOHN_FALSTAFF_CHARACTER_UUID,
 							name: 'Sir John Falstaff',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -1138,14 +1138,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							uuid: KING_HENRY_V_CHARACTER_UUID,
 							name: 'Hal',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: ATTENDANT_CHARACTER_UUID,
 							name: 'Attendant',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -1159,7 +1159,7 @@ describe('Character with variant depiction and portrayal names', () => {
 							uuid: SIR_JOHN_FALSTAFF_CHARACTER_UUID,
 							name: 'Sir John Falstaff',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -1188,14 +1188,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							uuid: KING_HENRY_V_CHARACTER_UUID,
 							name: 'Henry V',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: SOLDIER_CHARACTER_UUID,
 							name: 'Soldier',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -1209,7 +1209,7 @@ describe('Character with variant depiction and portrayal names', () => {
 							uuid: KING_OF_FRANCE_CHARACTER_UUID,
 							name: 'King of France',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -1238,14 +1238,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							uuid: KING_HENRY_V_CHARACTER_UUID,
 							name: 'Prince Hal',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: MESSENGER_CHARACTER_UUID,
 							name: 'Messenger',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -1259,7 +1259,7 @@ describe('Character with variant depiction and portrayal names', () => {
 							uuid: SIR_JOHN_FALSTAFF_CHARACTER_UUID,
 							name: 'Sir John Falstaff',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -1288,14 +1288,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							uuid: KING_HENRY_V_CHARACTER_UUID,
 							name: 'Hal, Prince of England',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: ATTENDANT_CHARACTER_UUID,
 							name: 'Attendant',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -1309,7 +1309,7 @@ describe('Character with variant depiction and portrayal names', () => {
 							uuid: SIR_JOHN_FALSTAFF_CHARACTER_UUID,
 							name: 'Sir John Falstaff',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -1338,14 +1338,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							uuid: KING_HENRY_V_CHARACTER_UUID,
 							name: 'Henry V',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: SOLDIER_CHARACTER_UUID,
 							name: 'Soldier',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -1359,7 +1359,7 @@ describe('Character with variant depiction and portrayal names', () => {
 							uuid: KING_OF_FRANCE_CHARACTER_UUID,
 							name: 'King of France',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -1396,14 +1396,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							uuid: KING_HENRY_V_CHARACTER_UUID,
 							name: 'Henry V',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: SOLDIER_CHARACTER_UUID,
 							name: 'Soldier',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -1425,14 +1425,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							uuid: KING_HENRY_V_CHARACTER_UUID,
 							name: 'Hal',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: ATTENDANT_CHARACTER_UUID,
 							name: 'Attendant',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -1454,14 +1454,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							uuid: KING_HENRY_V_CHARACTER_UUID,
 							name: 'Henry, Prince of Wales',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: MESSENGER_CHARACTER_UUID,
 							name: 'Messenger',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -1498,14 +1498,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							uuid: KING_HENRY_V_CHARACTER_UUID,
 							name: 'Hal, Prince of England',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: ATTENDANT_CHARACTER_UUID,
 							name: 'Attendant',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -1527,14 +1527,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							uuid: KING_HENRY_V_CHARACTER_UUID,
 							name: 'Prince Hal',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: MESSENGER_CHARACTER_UUID,
 							name: 'Messenger',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -1571,14 +1571,14 @@ describe('Character with variant depiction and portrayal names', () => {
 							uuid: KING_HENRY_V_CHARACTER_UUID,
 							name: 'Henry V',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: SOLDIER_CHARACTER_UUID,
 							name: 'Soldier',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}

--- a/test-e2e/model-interaction/char-with-variant-names-diff-materials.test.js
+++ b/test-e2e/model-interaction/char-with-variant-names-diff-materials.test.js
@@ -393,7 +393,7 @@ describe('Character with variant names from productions of different materials',
 							name: 'Gabriele Cicirello',
 							roleName: 'Hamlet, Prince of Denmark',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: []
 						}
 					]
@@ -417,7 +417,7 @@ describe('Character with variant names from productions of different materials',
 							name: 'Jack Hawkins',
 							roleName: 'Prince Hamlet',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: []
 						}
 					]
@@ -441,7 +441,7 @@ describe('Character with variant names from productions of different materials',
 							name: 'Rory Kinnear',
 							roleName: 'Hamlet, Prince of Denmark',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: []
 						}
 					]
@@ -465,7 +465,7 @@ describe('Character with variant names from productions of different materials',
 							name: 'Don Reilly',
 							roleName: 'Spirit of Hamlet',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: []
 						}
 					]
@@ -495,7 +495,7 @@ describe('Character with variant names from productions of different materials',
 							uuid: HAMLET_CHARACTER_UUID,
 							name: 'Hamlet, Prince of Denmark',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -509,7 +509,7 @@ describe('Character with variant names from productions of different materials',
 							uuid: CLAUDIUS_CHARACTER_UUID,
 							name: 'Claudius, King of Denmark',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -538,7 +538,7 @@ describe('Character with variant names from productions of different materials',
 							uuid: HAMLET_CHARACTER_UUID,
 							name: 'Prince Hamlet',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -552,7 +552,7 @@ describe('Character with variant names from productions of different materials',
 							uuid: CLAUDIUS_CHARACTER_UUID,
 							name: 'King Claudius',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -581,7 +581,7 @@ describe('Character with variant names from productions of different materials',
 							uuid: HAMLET_CHARACTER_UUID,
 							name: 'Spirit of Hamlet',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -595,7 +595,7 @@ describe('Character with variant names from productions of different materials',
 							uuid: CLAUDIUS_CHARACTER_UUID,
 							name: 'Spirit of Claudius',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -624,7 +624,7 @@ describe('Character with variant names from productions of different materials',
 							uuid: HAMLET_CHARACTER_UUID,
 							name: 'Hamlet, Prince of Denmark',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -638,7 +638,7 @@ describe('Character with variant names from productions of different materials',
 							uuid: CLAUDIUS_CHARACTER_UUID,
 							name: 'Claudius, King of Denmark',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -675,7 +675,7 @@ describe('Character with variant names from productions of different materials',
 							uuid: HAMLET_CHARACTER_UUID,
 							name: 'Hamlet, Prince of Denmark',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -712,7 +712,7 @@ describe('Character with variant names from productions of different materials',
 							uuid: HAMLET_CHARACTER_UUID,
 							name: 'Prince Hamlet',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -749,7 +749,7 @@ describe('Character with variant names from productions of different materials',
 							uuid: HAMLET_CHARACTER_UUID,
 							name: 'Spirit of Hamlet',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -786,7 +786,7 @@ describe('Character with variant names from productions of different materials',
 							uuid: HAMLET_CHARACTER_UUID,
 							name: 'Hamlet, Prince of Denmark',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}

--- a/test-e2e/model-interaction/char-with-variant-names-same-material.test.js
+++ b/test-e2e/model-interaction/char-with-variant-names-same-material.test.js
@@ -251,14 +251,14 @@ describe('Character with variant names from productions of the same material', (
 							name: 'David Rintoul',
 							roleName: 'Ghost of King Hamlet',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: [
 								{
 									model: 'CHARACTER',
 									uuid: FIRST_PLAYER_CHARACTER_UUID,
 									name: 'Player King',
 									qualifier: null,
-									isAlternate: null
+									isAlternate: false
 								}
 							]
 						}
@@ -283,14 +283,14 @@ describe('Character with variant names from productions of the same material', (
 							name: 'Peter Eyre',
 							roleName: 'King Hamlet',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: [
 								{
 									model: 'CHARACTER',
 									uuid: FIRST_PLAYER_CHARACTER_UUID,
 									name: 'First Player',
 									qualifier: null,
-									isAlternate: null
+									isAlternate: false
 								}
 							]
 						}
@@ -315,14 +315,14 @@ describe('Character with variant names from productions of the same material', (
 							name: 'Patrick Stewart',
 							roleName: 'Ghost',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: [
 								{
 									model: 'CHARACTER',
 									uuid: CLAUDIUS_CHARACTER_UUID,
 									name: 'Claudius, King of Denmark',
 									qualifier: null,
-									isAlternate: null
+									isAlternate: false
 								}
 							]
 						}
@@ -353,7 +353,7 @@ describe('Character with variant names from productions of the same material', (
 							uuid: HAMLET_CHARACTER_UUID,
 							name: 'Hamlet, Prince of Denmark',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -367,14 +367,14 @@ describe('Character with variant names from productions of the same material', (
 							uuid: GHOST_CHARACTER_UUID,
 							name: 'Ghost of King Hamlet',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: FIRST_PLAYER_CHARACTER_UUID,
 							name: 'Player King',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -403,7 +403,7 @@ describe('Character with variant names from productions of the same material', (
 							uuid: HAMLET_CHARACTER_UUID,
 							name: 'Hamlet, Prince of Denmark',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -417,14 +417,14 @@ describe('Character with variant names from productions of the same material', (
 							uuid: CLAUDIUS_CHARACTER_UUID,
 							name: 'Claudius, King of Denmark',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: GHOST_CHARACTER_UUID,
 							name: 'Ghost',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -453,7 +453,7 @@ describe('Character with variant names from productions of the same material', (
 							uuid: HAMLET_CHARACTER_UUID,
 							name: 'Hamlet, Prince of Denmark',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -467,14 +467,14 @@ describe('Character with variant names from productions of the same material', (
 							uuid: GHOST_CHARACTER_UUID,
 							name: 'King Hamlet',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: FIRST_PLAYER_CHARACTER_UUID,
 							name: 'First Player',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -511,14 +511,14 @@ describe('Character with variant names from productions of the same material', (
 							uuid: GHOST_CHARACTER_UUID,
 							name: 'Ghost of King Hamlet',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: FIRST_PLAYER_CHARACTER_UUID,
 							name: 'Player King',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -555,14 +555,14 @@ describe('Character with variant names from productions of the same material', (
 							uuid: CLAUDIUS_CHARACTER_UUID,
 							name: 'Claudius, King of Denmark',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: GHOST_CHARACTER_UUID,
 							name: 'Ghost',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -599,14 +599,14 @@ describe('Character with variant names from productions of the same material', (
 							uuid: GHOST_CHARACTER_UUID,
 							name: 'King Hamlet',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: FIRST_PLAYER_CHARACTER_UUID,
 							name: 'First Player',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}

--- a/test-e2e/model-interaction/diff-chars-same-name-diff-materials.test.js
+++ b/test-e2e/model-interaction/diff-chars-same-name-diff-materials.test.js
@@ -205,7 +205,7 @@ describe('Different characters with the same name from different materials', () 
 							name: 'Oscar Pearce',
 							roleName: 'Demetrius',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: []
 						}
 					]
@@ -244,7 +244,7 @@ describe('Different characters with the same name from different materials', () 
 							name: 'Sam Alexander',
 							roleName: 'Demetrius',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: []
 						}
 					]
@@ -329,7 +329,7 @@ describe('Different characters with the same name from different materials', () 
 							uuid: DEMETRIUS_CHARACTER_1_UUID,
 							name: 'Demetrius',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -343,7 +343,7 @@ describe('Different characters with the same name from different materials', () 
 							uuid: LYSANDER_CHARACTER_UUID,
 							name: 'Lysander',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -372,7 +372,7 @@ describe('Different characters with the same name from different materials', () 
 							uuid: CHIRON_CHARACTER_UUID,
 							name: 'Chiron',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -386,7 +386,7 @@ describe('Different characters with the same name from different materials', () 
 							uuid: DEMETRIUS_CHARACTER_2_UUID,
 							name: 'Demetrius',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -423,7 +423,7 @@ describe('Different characters with the same name from different materials', () 
 							uuid: DEMETRIUS_CHARACTER_1_UUID,
 							name: 'Demetrius',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -460,7 +460,7 @@ describe('Different characters with the same name from different materials', () 
 							uuid: DEMETRIUS_CHARACTER_2_UUID,
 							name: 'Demetrius',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}

--- a/test-e2e/model-interaction/diff-chars-same-name-same-material.test.js
+++ b/test-e2e/model-interaction/diff-chars-same-name-same-material.test.js
@@ -152,14 +152,14 @@ describe('Different characters with the same name from the same material', () =>
 							name: 'Paul Shearer',
 							roleName: 'Cinna',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: [
 								{
 									model: 'CHARACTER',
 									uuid: VOLUMNIUS_CHARACTER_UUID,
 									name: 'Volumnius',
 									qualifier: null,
-									isAlternate: null
+									isAlternate: false
 								}
 							]
 						}
@@ -199,7 +199,7 @@ describe('Different characters with the same name from the same material', () =>
 							name: 'Leo Wringer',
 							roleName: 'Cinna',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: []
 						}
 					]
@@ -238,14 +238,14 @@ describe('Different characters with the same name from the same material', () =>
 							name: 'Paul Shearer',
 							roleName: 'Volumnius',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: [
 								{
 									model: 'CHARACTER',
 									uuid: CINNA_CHARACTER_1_UUID,
 									name: 'Cinna',
 									qualifier: null,
-									isAlternate: null
+									isAlternate: false
 								}
 							]
 						}
@@ -309,14 +309,14 @@ describe('Different characters with the same name from the same material', () =>
 							uuid: CINNA_CHARACTER_1_UUID,
 							name: 'Cinna',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: VOLUMNIUS_CHARACTER_UUID,
 							name: 'Volumnius',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -330,7 +330,7 @@ describe('Different characters with the same name from the same material', () =>
 							uuid: CINNA_CHARACTER_2_UUID,
 							name: 'Cinna',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -367,14 +367,14 @@ describe('Different characters with the same name from the same material', () =>
 							uuid: CINNA_CHARACTER_1_UUID,
 							name: 'Cinna',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						},
 						{
 							model: 'CHARACTER',
 							uuid: VOLUMNIUS_CHARACTER_UUID,
 							name: 'Volumnius',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}
@@ -411,7 +411,7 @@ describe('Different characters with the same name from the same material', () =>
 							uuid: CINNA_CHARACTER_2_UUID,
 							name: 'Cinna',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}

--- a/test-e2e/model-interaction/venue-with-sub-venues.test.js
+++ b/test-e2e/model-interaction/venue-with-sub-venues.test.js
@@ -301,7 +301,7 @@ describe('Venue with sub-venues', () => {
 							name: 'Fiona Shaw',
 							roleName: 'Mother Courage',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: []
 						}
 					]
@@ -340,7 +340,7 @@ describe('Venue with sub-venues', () => {
 							name: 'Fiona Shaw',
 							roleName: 'King Richard II',
 							qualifier: null,
-							isAlternate: null,
+							isAlternate: false,
 							otherRoles: []
 						}
 					]
@@ -484,7 +484,7 @@ describe('Venue with sub-venues', () => {
 							uuid: MOTHER_COURAGE_CHARACTER_UUID,
 							name: 'Mother Courage',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				},
@@ -506,7 +506,7 @@ describe('Venue with sub-venues', () => {
 							uuid: KING_RICHARD_II_CHARACTER_UUID,
 							name: 'King Richard II',
 							qualifier: null,
-							isAlternate: null
+							isAlternate: false
 						}
 					]
 				}

--- a/test-e2e/uniqueness-in-db/productions-api.test.js
+++ b/test-e2e/uniqueness-in-db/productions-api.test.js
@@ -759,7 +759,7 @@ describe('Uniqueness in database: Productions API', () => {
 					characterName: '',
 					characterDifferentiator: '',
 					qualifier: '',
-					isAlternate: null,
+					isAlternate: false,
 					errors: {}
 				}
 			]
@@ -777,7 +777,7 @@ describe('Uniqueness in database: Productions API', () => {
 					characterName: '',
 					characterDifferentiator: '',
 					qualifier: '',
-					isAlternate: null,
+					isAlternate: false,
 					errors: {}
 				}
 			]

--- a/test-int/instance-validation-failures/production.test.js
+++ b/test-int/instance-validation-failures/production.test.js
@@ -1558,7 +1558,7 @@ describe('Production instance', () => {
 									characterName: '',
 									characterDifferentiator: '',
 									qualifier: '',
-									isAlternate: null,
+									isAlternate: false,
 									errors: {}
 								}
 							]
@@ -1630,7 +1630,7 @@ describe('Production instance', () => {
 									characterName: '',
 									characterDifferentiator: '',
 									qualifier: '',
-									isAlternate: null,
+									isAlternate: false,
 									errors: {
 										name: [
 											'Value is too long'
@@ -1706,7 +1706,7 @@ describe('Production instance', () => {
 									characterName: ABOVE_MAX_LENGTH_STRING,
 									characterDifferentiator: '',
 									qualifier: '',
-									isAlternate: null,
+									isAlternate: false,
 									errors: {
 										characterName: [
 											'Value is too long'
@@ -1783,7 +1783,7 @@ describe('Production instance', () => {
 									characterName: '',
 									characterDifferentiator: ABOVE_MAX_LENGTH_STRING,
 									qualifier: '',
-									isAlternate: null,
+									isAlternate: false,
 									errors: {
 										characterDifferentiator: [
 											'Value is too long'
@@ -1859,7 +1859,7 @@ describe('Production instance', () => {
 									characterName: '',
 									characterDifferentiator: '',
 									qualifier: ABOVE_MAX_LENGTH_STRING,
-									isAlternate: null,
+									isAlternate: false,
 									errors: {
 										qualifier: [
 											'Value is too long'
@@ -1935,7 +1935,7 @@ describe('Production instance', () => {
 									characterName: 'Hamlet',
 									characterDifferentiator: '',
 									qualifier: '',
-									isAlternate: null,
+									isAlternate: false,
 									errors: {
 										characterName: [
 											'Character name is only required if different from role name'
@@ -2021,7 +2021,7 @@ describe('Production instance', () => {
 									characterName: '',
 									characterDifferentiator: '',
 									qualifier: '',
-									isAlternate: null,
+									isAlternate: false,
 									errors: {
 										name: [
 											'This item has been duplicated within the group'
@@ -2042,7 +2042,7 @@ describe('Production instance', () => {
 									characterName: '',
 									characterDifferentiator: '1',
 									qualifier: '',
-									isAlternate: null,
+									isAlternate: false,
 									errors: {}
 								},
 								{
@@ -2050,7 +2050,7 @@ describe('Production instance', () => {
 									characterName: '',
 									characterDifferentiator: '',
 									qualifier: '',
-									isAlternate: null,
+									isAlternate: false,
 									errors: {
 										name: [
 											'This item has been duplicated within the group'
@@ -2071,7 +2071,7 @@ describe('Production instance', () => {
 									characterName: '',
 									characterDifferentiator: '2',
 									qualifier: '',
-									isAlternate: null,
+									isAlternate: false,
 									errors: {}
 								}
 							]

--- a/test-unit/src/models/Role.test.js
+++ b/test-unit/src/models/Role.test.js
@@ -126,17 +126,24 @@ describe('Role model', () => {
 
 		describe('isAlternate property', () => {
 
-			it('assigns null if absent from props', () => {
+			it('assigns false if absent from props', () => {
 
 				const instance = new Role({ name: 'Young Lucius' });
-				expect(instance.isAlternate).to.equal(null);
+				expect(instance.isAlternate).to.equal(false);
 
 			});
 
-			it('assigns null if included in props but value evaluates to false', () => {
+			it('assigns false if included in props but value evaluates to false', () => {
+
+				const instance = new Role({ name: 'Young Lucius', isAlternate: null });
+				expect(instance.isAlternate).to.equal(false);
+
+			});
+
+			it('assigns false if included in props but value is false', () => {
 
 				const instance = new Role({ name: 'Young Lucius', isAlternate: false });
-				expect(instance.isAlternate).to.equal(null);
+				expect(instance.isAlternate).to.equal(false);
 
 			});
 


### PR DESCRIPTION
Follows the logic applied by award ceremony category nomination `isWinner` property in https://github.com/andygout/theatrebase-api/pull/452 so that the non-true value for `isAlternate` is `false` rather than `null`.