### PR TITLE
Revise Nomination model constructor isWinner property unit tests

### DIFF
--- a/test-unit/src/models/Nomination.test.js
+++ b/test-unit/src/models/Nomination.test.js
@@ -60,23 +60,23 @@ describe('Nomination model', () => {
 
 			});
 
-			it('assigns false if included in props but value is empty string', () => {
+			it('assigns false if included in props but value evaluates to false', () => {
 
-				const instance = createInstance({ isWinner: '' });
+				const instance = createInstance({ isWinner: null });
 				expect(instance.isWinner).to.equal(false);
 
 			});
 
-			it('assigns true if included in props but value is whitespace-only string', () => {
+			it('assigns false if included in props but value is false', () => {
 
-				const instance = createInstance({ isWinner: ' ' });
-				expect(instance.isWinner).to.equal(true);
+				const instance = createInstance({ isWinner: false });
+				expect(instance.isWinner).to.equal(false);
 
 			});
 
-			it('assigns true if included in props and is string with length', () => {
+			it('assigns true if included in props and value evaluates to true', () => {
 
-				const instance = createInstance({ isWinner: 'foo' });
+				const instance = createInstance({ isWinner: 'foobar' });
 				expect(instance.isWinner).to.equal(true);
 
 			});


### PR DESCRIPTION
The equivalent tests for the Role model `isAlternate` property are more succinct in covering the requisite test cases and so this PR adopts the same for the Nomination `isWinner` property.