### PR TITLE
Re-order :HAS_NOMINEE relationship properties

### DIFF
--- a/src/neo4j/cypher-queries/award-ceremony.js
+++ b/src/neo4j/cypher-queries/award-ceremony.js
@@ -107,9 +107,9 @@ const getCreateUpdateQuery = action => {
 
 						CREATE (category)-
 							[:HAS_NOMINEE {
-								isWinner: nomination.isWinner,
 								nominationPosition: nomination.position,
-								entityPosition: nomineePersonParam.position
+								entityPosition: nomineePersonParam.position,
+								isWinner: nomination.isWinner
 							}]->(nomineePerson)
 					)
 
@@ -138,9 +138,9 @@ const getCreateUpdateQuery = action => {
 
 						CREATE (category)-
 							[:HAS_NOMINEE {
-								isWinner: nomination.isWinner,
 								nominationPosition: nomination.position,
-								entityPosition: nomineeCompanyParam.position
+								entityPosition: nomineeCompanyParam.position,
+								isWinner: nomination.isWinner
 							}]->(nomineeCompany)
 					)
 


### PR DESCRIPTION
When properties are assigned to equivalent relationships, the position values are always assigned first.

This PR ensures that ordering remains consistent in the award ceremony Cypher query and so makes the queries easier to read.