### PR TITLE
Remove unrequired model association prop assignment in unit tests

### DIFF
--- a/test-unit/src/models/CompanyWithMembers.test.js
+++ b/test-unit/src/models/CompanyWithMembers.test.js
@@ -93,7 +93,6 @@ describe('CompanyWithMembers model', () => {
 				]
 			};
 			const instance = createInstance(props);
-			instance.members[0].name = 'Edward Snape';
 			spy(instance, 'validateNamePresenceIfNamedChildren');
 			instance.runInputValidations({ duplicateEntities: [] });
 			assert.callOrder(

--- a/test-unit/src/models/Nomination.test.js
+++ b/test-unit/src/models/Nomination.test.js
@@ -254,8 +254,6 @@ describe('Nomination model', () => {
 				]
 			};
 			const instance = createInstance(props);
-			instance.entities[0].name = 'Simon Baker';
-			instance.entities[1].name = 'Autograph';
 			instance.runInputValidations();
 			assert.callOrder(
 				stubs.getDuplicateEntityInfoModule.getDuplicateEntities,

--- a/test-unit/src/models/ProducerCredit.test.js
+++ b/test-unit/src/models/ProducerCredit.test.js
@@ -120,8 +120,6 @@ describe('ProducerCredit model', () => {
 				]
 			};
 			const instance = createInstance(props);
-			instance.entities[0].name = 'Jason Haigh-Ellery';
-			instance.entities[1].name = 'Fiery Angel';
 			spy(instance, 'validateName');
 			spy(instance, 'validateUniquenessInGroup');
 			instance.runInputValidations({ isDuplicate: false });

--- a/test-unit/src/models/ProductionTeamCredit.test.js
+++ b/test-unit/src/models/ProductionTeamCredit.test.js
@@ -120,10 +120,6 @@ describe('ProductionTeamCredit model', () => {
 				]
 			};
 			const instance = createInstance(props);
-			instance.entities[0].name = 'Sara Gunter';
-			instance.entities[1].name = 'Assistant Stage Managers Ltd';
-			instance.entities[1].members = [createStubInstance(Person)];
-			instance.entities[1].members[0].name = 'Julia Wickham';
 			spy(instance, 'validateName');
 			spy(instance, 'validateUniquenessInGroup');
 			spy(instance, 'validateNamePresenceIfNamedChildren');

--- a/test-unit/src/models/WritingCredit.test.js
+++ b/test-unit/src/models/WritingCredit.test.js
@@ -179,8 +179,6 @@ describe('WritingCredit model', () => {
 				]
 			};
 			const instance = createInstance(props);
-			instance.entities[2].name = 'A Midsummer Night\'s Dream';
-			instance.entities[2].differentiator = '1';
 			spy(instance, 'validateName');
 			spy(instance, 'validateUniquenessInGroup');
 			instance.runInputValidations(


### PR DESCRIPTION
The `runInputValidations` method of some models would previously perform these at several levels of nesting.

E.g. [`ProductionTeamCredit`](https://github.com/andygout/theatrebase-api/blob/dadba93731a16be7a1a09eaa67bb937ee3998474/src/models/ProductionTeamCredit.js) previously performed validation on:
- its top level properties
- its `entities` (i.e. properties nested one level deep)
- (if an `entity` has a `model` of "company") its `entities`' `creditedMembers` (i.e. properties nested two levels deep)

This meant that after instantiating the stub instance, the `entities` then had to be decorated with properties and (where necessary) instances of `creditedMembers` so that they would behave more like real instances for the tests to be able to test what they needed.

The models have since been revised, only going one level of nesting deep (and for that initial level of nesting only calling the instance's `runInputValidations` method rather than actually performing the individual validations). This means that these unit tests can now be completed without this additional property assignment and so this PR removes that.