### PR TITLE
Upgrade Docker Neo4j image version 4.2.7 -> 4.4.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     docker:
       - image: circleci/node:16.8.0
-      - image: neo4j:4.2.7
+      - image: neo4j:4.4.2
         environment:
           NEO4J_AUTH: none
     steps:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     neo4j:
         container_name: neo4j-test
-        image: neo4j:4.2.7
+        image: neo4j:4.4.2
         environment:
             - NEO4J_AUTH=none
         ports:

--- a/src/neo4j/create-indexes.js
+++ b/src/neo4j/create-indexes.js
@@ -47,7 +47,7 @@ export default async () => {
 
 		const modelsWithIndex =
 			indexes
-				.filter(index => index.properties.includes('name'))
+				.filter(index => index.name.startsWith('index') && index.properties?.includes('name'))
 				.map(index => index.labelsOrTypes[0]);
 
 		const modelsToIndex = [...INDEXABLE_MODELS].filter(model => !modelsWithIndex.includes(model));


### PR DESCRIPTION
I have upgraded the version of my Neo4j Desktop to 4.4.2 so this PR makes the corresponding upgrades to the Docker Neo4j images used for the end-to-end tests.

---

My Neo4j Desktop instance states it is the Enterprise version but the reason I use the `4.4.2` image (which seems to be the same as `4.4.2-community` and different to `4.4.2-enterprise`) is because:

> You need to have a valid commercial license in order to use the Enterprise Edition. Using an enterprise Docker image will require you to accept the official Enterprise license agreement.

Ref. [Neo4j Developer: How-To: Run Neo4j in Docker](https://neo4j.com/developer/docker-run-neo4j)

---

This PR also makes some changes in `src/neo4j/create-indexes.js` to accommodate the changes to the index objects returned by the `SHOW INDEXES` command:
- the array of index objects is a mixture of indexes and constraints, so the for sake of specificity it checks that the name starts with `index` (rather than `constraint`)
- `properties` object can be `null` (see below **`SHOW INDEXES` return value** - the entries with `id` 1 and `id` 2) so optional chaining has been applied when checking whether it includes the string `'name'`

#### `SHOW CONSTRAINTS` return value
```
[
	{
		"id": 14,
		"name": "constraint_2ea8895a",
		"type": "UNIQUENESS",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Person"
		],
		"properties": [
			"uuid"
		],
		"ownedIndexId": 13
	},
	{
		"id": 12,
		"name": "constraint_487f8262",
		"type": "UNIQUENESS",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Material"
		],
		"properties": [
			"uuid"
		],
		"ownedIndexId": 11
	},
	{
		"id": 16,
		"name": "constraint_5468ed6e",
		"type": "UNIQUENESS",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Production"
		],
		"properties": [
			"uuid"
		],
		"ownedIndexId": 15
	},
	{
		"id": 4,
		"name": "constraint_7f1555c5",
		"type": "UNIQUENESS",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Award"
		],
		"properties": [
			"uuid"
		],
		"ownedIndexId": 3
	},
	{
		"id": 6,
		"name": "constraint_804c4d9",
		"type": "UNIQUENESS",
		"entityType": "NODE",
		"labelsOrTypes": [
			"AwardCeremony"
		],
		"properties": [
			"uuid"
		],
		"ownedIndexId": 5
	},
	{
		"id": 10,
		"name": "constraint_996e514e",
		"type": "UNIQUENESS",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Company"
		],
		"properties": [
			"uuid"
		],
		"ownedIndexId": 9
	},
	{
		"id": 18,
		"name": "constraint_d892a92f",
		"type": "UNIQUENESS",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Venue"
		],
		"properties": [
			"uuid"
		],
		"ownedIndexId": 17
	},
	{
		"id": 8,
		"name": "constraint_e4b55e8c",
		"type": "UNIQUENESS",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Character"
		],
		"properties": [
			"uuid"
		],
		"ownedIndexId": 7
	}
]
```

#### `SHOW INDEXES` return value
```
[
	{
		"id": 13,
		"name": "constraint_2ea8895a",
		"state": "ONLINE",
		"populationPercent": 100,
		"uniqueness": "UNIQUE",
		"type": "BTREE",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Person"
		],
		"properties": [
			"uuid"
		],
		"indexProvider": "native-btree-1.0"
	},
	{
		"id": 11,
		"name": "constraint_487f8262",
		"state": "ONLINE",
		"populationPercent": 100,
		"uniqueness": "UNIQUE",
		"type": "BTREE",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Material"
		],
		"properties": [
			"uuid"
		],
		"indexProvider": "native-btree-1.0"
	},
	{
		"id": 15,
		"name": "constraint_5468ed6e",
		"state": "ONLINE",
		"populationPercent": 100,
		"uniqueness": "UNIQUE",
		"type": "BTREE",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Production"
		],
		"properties": [
			"uuid"
		],
		"indexProvider": "native-btree-1.0"
	},
	{
		"id": 3,
		"name": "constraint_7f1555c5",
		"state": "ONLINE",
		"populationPercent": 100,
		"uniqueness": "UNIQUE",
		"type": "BTREE",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Award"
		],
		"properties": [
			"uuid"
		],
		"indexProvider": "native-btree-1.0"
	},
	{
		"id": 5,
		"name": "constraint_804c4d9",
		"state": "ONLINE",
		"populationPercent": 100,
		"uniqueness": "UNIQUE",
		"type": "BTREE",
		"entityType": "NODE",
		"labelsOrTypes": [
			"AwardCeremony"
		],
		"properties": [
			"uuid"
		],
		"indexProvider": "native-btree-1.0"
	},
	{
		"id": 9,
		"name": "constraint_996e514e",
		"state": "ONLINE",
		"populationPercent": 100,
		"uniqueness": "UNIQUE",
		"type": "BTREE",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Company"
		],
		"properties": [
			"uuid"
		],
		"indexProvider": "native-btree-1.0"
	},
	{
		"id": 17,
		"name": "constraint_d892a92f",
		"state": "ONLINE",
		"populationPercent": 100,
		"uniqueness": "UNIQUE",
		"type": "BTREE",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Venue"
		],
		"properties": [
			"uuid"
		],
		"indexProvider": "native-btree-1.0"
	},
	{
		"id": 7,
		"name": "constraint_e4b55e8c",
		"state": "ONLINE",
		"populationPercent": 100,
		"uniqueness": "UNIQUE",
		"type": "BTREE",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Character"
		],
		"properties": [
			"uuid"
		],
		"indexProvider": "native-btree-1.0"
	},
	{
		"id": 20,
		"name": "index_2ae6922a",
		"state": "ONLINE",
		"populationPercent": 100,
		"uniqueness": "NONUNIQUE",
		"type": "BTREE",
		"entityType": "NODE",
		"labelsOrTypes": [
			"AwardCeremony"
		],
		"properties": [
			"name"
		],
		"indexProvider": "native-btree-1.0"
	},
	{
		"id": 1,
		"name": "index_343aff4e",
		"state": "ONLINE",
		"populationPercent": 100,
		"uniqueness": "NONUNIQUE",
		"type": "LOOKUP",
		"entityType": "NODE",
		"labelsOrTypes": null,
		"properties": null,
		"indexProvider": "token-lookup-1.0"
	},
	{
		"id": 24,
		"name": "index_5c0607ad",
		"state": "ONLINE",
		"populationPercent": 100,
		"uniqueness": "NONUNIQUE",
		"type": "BTREE",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Person"
		],
		"properties": [
			"name"
		],
		"indexProvider": "native-btree-1.0"
	},
	{
		"id": 19,
		"name": "index_83c91879",
		"state": "ONLINE",
		"populationPercent": 100,
		"uniqueness": "NONUNIQUE",
		"type": "BTREE",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Award"
		],
		"properties": [
			"name"
		],
		"indexProvider": "native-btree-1.0"
	},
	{
		"id": 25,
		"name": "index_8952b7b3",
		"state": "ONLINE",
		"populationPercent": 100,
		"uniqueness": "NONUNIQUE",
		"type": "BTREE",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Venue"
		],
		"properties": [
			"name"
		],
		"indexProvider": "native-btree-1.0"
	},
	{
		"id": 23,
		"name": "index_bf3d1a88",
		"state": "ONLINE",
		"populationPercent": 100,
		"uniqueness": "NONUNIQUE",
		"type": "BTREE",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Material"
		],
		"properties": [
			"name"
		],
		"indexProvider": "native-btree-1.0"
	},
	{
		"id": 21,
		"name": "index_e95cfe92",
		"state": "ONLINE",
		"populationPercent": 100,
		"uniqueness": "NONUNIQUE",
		"type": "BTREE",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Character"
		],
		"properties": [
			"name"
		],
		"indexProvider": "native-btree-1.0"
	},
	{
		"id": 2,
		"name": "index_f7700477",
		"state": "ONLINE",
		"populationPercent": 100,
		"uniqueness": "NONUNIQUE",
		"type": "LOOKUP",
		"entityType": "RELATIONSHIP",
		"labelsOrTypes": null,
		"properties": null,
		"indexProvider": "token-lookup-1.0"
	},
	{
		"id": 22,
		"name": "index_facc95fe",
		"state": "ONLINE",
		"populationPercent": 100,
		"uniqueness": "NONUNIQUE",
		"type": "BTREE",
		"entityType": "NODE",
		"labelsOrTypes": [
			"Company"
		],
		"properties": [
			"name"
		],
		"indexProvider": "native-btree-1.0"
	}
]
```

---

### References:
- [neo4j Tags v4.4.2 | Docker Hub](https://hub.docker.com/_/neo4j?tab=tags&page=1&name=4.4.2)
- [Neo4j Developer: How-To: Run Neo4j in Docker](https://neo4j.com/developer/docker-run-neo4j)