### PR TITLE
Increase end-to-end tests mocha timeout to 15000ms

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "unit-test": "mocha --require @babel/register test-unit/mocha.env.js test-unit/**/*.test.js",
     "int-test": "mocha --require @babel/register test-int/mocha.env.js test-int/**/*.test.js",
     "e2e-test-resources": "docker-compose -f docker/docker-compose.yml up",
-    "e2e-test": "mocha --timeout 10000  --require @babel/register test-e2e/mocha.env.js test-e2e/setup.js test-e2e/**/*.test.js",
+    "e2e-test": "mocha --timeout 15000  --require @babel/register test-e2e/mocha.env.js test-e2e/setup.js test-e2e/**/*.test.js",
     "seed-db": "node db-seeding/seed-db",
     "transfer-env-dev": "node transfer-env-dev",
     "build": "webpack",


### PR DESCRIPTION
The mocha timeout for the end-to-end tests was originally extended in this PR (from the 2,000ms default to 5,000ms): https://github.com/andygout/theatrebase-api/pull/184 and again (from 5,000ms to 10,000ms) in this PR https://github.com/andygout/theatrebase-api/pull/348.

With the increase of end-to-end tests since then, the test suite is again failing some tests owing to timeouts, and so this PR increases the timeout to 15,000ms to allow the tests the time they need to run.

PR description from https://github.com/andygout/theatrebase-api/pull/184:
> End-to-end tests are being flaky: occasionally the second test to run (which is the first that interacts with the Docker-served Neo4j database) will fail owing to:

> `"before all" hook`

> ```
> 1) CRUD (Create, Read, Update, Delete): Characters API CRUD "before all" hook:
>   Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
>    at listOnTimeout (internal/timers.js:551:17)
>    at processTimers (internal/timers.js:494:7)
> ```

> This happens both locally and (more recently) in CircleCI - see here for an example: https://circleci.com/gh/andygout/theatrebase-api/827.

> The general suggestion to fix this issue is to increase the mocha timeout value. The default is 2000ms and this PR increases it to 5000ms.

> My guess is that the Docker-served Neo4j database currently does not have enough time to prepare for requests, so hopefully this extension will allow that to happen.

> ### References:
> - [GitHub - pact-foundation/pact-js - Issues: Tests timeout before pact daemon starts](https://github.com/pact-foundation/pact-js/issues/49#issuecomment-395004092).
> - [Learn.co Help Center: "Error: timeout of 2000ms exceeded"](https://help.learn.co/en/articles/567920-error-timeout-of-2000ms-exceeded).