### PR TITLE
Add nomination customType property

### DIFF
--- a/db-seeding/seeds/award-ceremonies/evening-standard-theatre-awards-2007.json
+++ b/db-seeding/seeds/award-ceremonies/evening-standard-theatre-awards-2007.json
@@ -8,6 +8,7 @@
 			"name": "Best Actor",
 			"nominations": [
 				{
+					"customType": "Longlisted",
 					"entities": [
 						{
 							"name": "Mackenzie Crook"
@@ -20,6 +21,7 @@
 					]
 				},
 				{
+					"customType": "Longlisted",
 					"entities": [
 						{
 							"name": "Lee Evans"
@@ -32,6 +34,7 @@
 					]
 				},
 				{
+					"customType": "Shortlisted",
 					"entities": [
 						{
 							"name": "Mark Rylance"
@@ -44,6 +47,7 @@
 					]
 				},
 				{
+					"customType": "Longlisted",
 					"entities": [
 						{
 							"name": "John Simm"
@@ -74,6 +78,7 @@
 			"name": "Best Actress",
 			"nominations": [
 				{
+					"customType": "Longlisted",
 					"entities": [
 						{
 							"name": "Frances de la Tour"
@@ -99,6 +104,7 @@
 					]
 				},
 				{
+					"customType": "Longlisted",
 					"entities": [
 						{
 							"name": "Lindsay Duncan"
@@ -111,6 +117,7 @@
 					]
 				},
 				{
+					"customType": "Longlisted",
 					"entities": [
 						{
 							"name": "Kate Fleetwood"
@@ -123,6 +130,7 @@
 					]
 				},
 				{
+					"customType": "Longlisted",
 					"entities": [
 						{
 							"name": "Carey Mulligan"
@@ -135,6 +143,7 @@
 					]
 				},
 				{
+					"customType": "Longlisted",
 					"entities": [
 						{
 							"name": "Kristin Scott Thomas"
@@ -147,6 +156,7 @@
 					]
 				},
 				{
+					"customType": "Longlisted",
 					"entities": [
 						{
 							"name": "Fiona Shaw"
@@ -159,6 +169,7 @@
 					]
 				},
 				{
+					"customType": "Shortlisted",
 					"entities": [
 						{
 							"name": "Penelope Wilton"
@@ -189,6 +200,7 @@
 					]
 				},
 				{
+					"customType": "Shortlisted",
 					"productions": [
 						{
 							"uuid": "80fe797f-1408-4b0c-bcd4-7a288ed4d847"
@@ -201,6 +213,7 @@
 					]
 				},
 				{
+					"customType": "Shortlisted",
 					"productions": [
 						{
 							"uuid": "15cd0c78-8fd5-4aa2-9c02-a90bf7ee2fd6"

--- a/db-seeding/seeds/award-ceremonies/evening-standard-theatre-awards-2008.json
+++ b/db-seeding/seeds/award-ceremonies/evening-standard-theatre-awards-2008.json
@@ -21,6 +21,7 @@
 					]
 				},
 				{
+					"customType": "Shortlisted",
 					"entities": [
 						{
 							"name": "Adam Godley"
@@ -69,6 +70,7 @@
 			"name": "Best Play",
 			"nominations": [
 				{
+					"customType": "Shortlisted",
 					"productions": [
 						{
 							"uuid": "269b01df-6f28-42ce-879f-538771a862de"
@@ -81,6 +83,7 @@
 					]
 				},
 				{
+					"customType": "Shortlisted",
 					"productions": [
 						{
 							"uuid": "c45a69fb-fa84-48dd-8822-5eadcdb87e70"

--- a/db-seeding/seeds/award-ceremonies/evening-standard-theatre-awards-2009.json
+++ b/db-seeding/seeds/award-ceremonies/evening-standard-theatre-awards-2009.json
@@ -8,6 +8,7 @@
 			"name": "Best Actor",
 			"nominations": [
 				{
+					"customType": "Longlisted",
 					"entities": [
 						{
 							"name": "Henry Goodman"
@@ -23,6 +24,7 @@
 					]
 				},
 				{
+					"customType": "Longlisted",
 					"entities": [
 						{
 							"name": "David Harewood"
@@ -48,6 +50,7 @@
 					]
 				},
 				{
+					"customType": "Shortlisted",
 					"entities": [
 						{
 							"name": "Ken Stott"
@@ -60,6 +63,7 @@
 					]
 				},
 				{
+					"customType": "Shortlisted",
 					"entities": [
 						{
 							"name": "Samuel West"
@@ -77,6 +81,7 @@
 			"name": "Best Actress",
 			"nominations": [
 				{
+					"customType": "Shortlisted",
 					"entities": [
 						{
 							"name": "Deanna Dunagan"
@@ -89,6 +94,7 @@
 					]
 				},
 				{
+					"customType": "Longlisted",
 					"entities": [
 						{
 							"name": "Mary Elizabeth Mastrantonio"
@@ -101,6 +107,7 @@
 					]
 				},
 				{
+					"customType": "Longlisted",
 					"entities": [
 						{
 							"name": "Amy Morton"
@@ -113,6 +120,7 @@
 					]
 				},
 				{
+					"customType": "Shortlisted",
 					"entities": [
 						{
 							"name": "Juliet Stevenson"
@@ -146,6 +154,7 @@
 			"name": "Best Play",
 			"nominations": [
 				{
+					"customType": "Shortlisted",
 					"productions": [
 						{
 							"uuid": "337b1b99-8a3a-45b6-b535-640452a6f3c1"
@@ -158,6 +167,7 @@
 					]
 				},
 				{
+					"customType": "Shortlisted",
 					"productions": [
 						{
 							"uuid": "02047e75-3d9e-4841-907a-b5fae44f5cd3"
@@ -166,18 +176,6 @@
 					"materials": [
 						{
 							"name": "Enron"
-						}
-					]
-				},
-				{
-					"productions": [
-						{
-							"uuid": "439aed3c-237e-40fa-ae84-bfc05e7bc401"
-						}
-					],
-					"materials": [
-						{
-							"name": "Punk Rock"
 						}
 					]
 				},
@@ -191,6 +189,19 @@
 					"materials": [
 						{
 							"name": "Jerusalem"
+						}
+					]
+				},
+				{
+					"customType": "Shortlisted",
+					"productions": [
+						{
+							"uuid": "439aed3c-237e-40fa-ae84-bfc05e7bc401"
+						}
+					],
+					"materials": [
+						{
+							"name": "Punk Rock"
 						}
 					]
 				}

--- a/db-seeding/seeds/award-ceremonies/susan-smith-blackburn-prize-2007-08.json
+++ b/db-seeding/seeds/award-ceremonies/susan-smith-blackburn-prize-2007-08.json
@@ -8,6 +8,7 @@
 			"name": "Susan Smith Blackburn Prize",
 			"nominations": [
 				{
+					"customType": "Finalist",
 					"materials": [
 						{
 							"name": "Black Crows"
@@ -15,6 +16,7 @@
 					]
 				},
 				{
+					"customType": "Special Commendation",
 					"materials": [
 						{
 							"name": "Girls and Dolls"
@@ -22,6 +24,7 @@
 					]
 				},
 				{
+					"customType": "Finalist",
 					"materials": [
 						{
 							"name": "Boats on a River"
@@ -29,6 +32,7 @@
 					]
 				},
 				{
+					"customType": "Special Commendation",
 					"materials": [
 						{
 							"name": "God's Ear"
@@ -36,6 +40,7 @@
 					]
 				},
 				{
+					"customType": "Finalist",
 					"materials": [
 						{
 							"name": "Hardball"
@@ -51,6 +56,7 @@
 					]
 				},
 				{
+					"customType": "Finalist",
 					"materials": [
 						{
 							"name": "Stick Fly"
@@ -58,6 +64,7 @@
 					]
 				},
 				{
+					"customType": "Finalist",
 					"materials": [
 						{
 							"name": "Stockholm"
@@ -65,6 +72,7 @@
 					]
 				},
 				{
+					"customType": "Finalist",
 					"materials": [
 						{
 							"name": "Strangers, Babies"
@@ -72,6 +80,7 @@
 					]
 				},
 				{
+					"customType": "Special Commendation",
 					"materials": [
 						{
 							"name": "That Face"

--- a/db-seeding/seeds/award-ceremonies/susan-smith-blackburn-prize-2008-09.json
+++ b/db-seeding/seeds/award-ceremonies/susan-smith-blackburn-prize-2008-09.json
@@ -8,6 +8,7 @@
 			"name": "Susan Smith Blackburn Prize",
 			"nominations": [
 				{
+					"customType": "Finalist",
 					"materials": [
 						{
 							"name": "Free Outgoing"
@@ -15,6 +16,7 @@
 					]
 				},
 				{
+					"customType": "Special Commendation",
 					"materials": [
 						{
 							"name": "Happy Now?"
@@ -22,6 +24,7 @@
 					]
 				},
 				{
+					"customType": "Finalist",
 					"materials": [
 						{
 							"name": "What Once We Felt"
@@ -29,6 +32,7 @@
 					]
 				},
 				{
+					"customType": "Finalist",
 					"materials": [
 						{
 							"name": "Inana"
@@ -36,6 +40,7 @@
 					]
 				},
 				{
+					"customType": "Finalist",
 					"materials": [
 						{
 							"name": "Oliver Parker!"
@@ -51,6 +56,7 @@
 					]
 				},
 				{
+					"customType": "Finalist",
 					"materials": [
 						{
 							"name": "Ruined"
@@ -58,6 +64,7 @@
 					]
 				},
 				{
+					"customType": "Finalist",
 					"materials": [
 						{
 							"name": "The Almond and the Seahorse"
@@ -65,6 +72,7 @@
 					]
 				},
 				{
+					"customType": "Finalist",
 					"materials": [
 						{
 							"name": "On the Rocks"
@@ -72,6 +80,7 @@
 					]
 				},
 				{
+					"customType": "Finalist",
 					"materials": [
 						{
 							"name": "Ten Tiny Toes"

--- a/db-seeding/seeds/award-ceremonies/susan-smith-blackburn-prize-2009-10.json
+++ b/db-seeding/seeds/award-ceremonies/susan-smith-blackburn-prize-2009-10.json
@@ -8,6 +8,7 @@
 			"name": "Susan Smith Blackburn Prize",
 			"nominations": [
 				{
+					"customType": "Finalist",
 					"materials": [
 						{
 							"name": "The Aliens"
@@ -23,6 +24,7 @@
 					]
 				},
 				{
+					"customType": "Finalist",
 					"materials": [
 						{
 							"name": "This"
@@ -30,6 +32,7 @@
 					]
 				},
 				{
+					"customType": "Finalist",
 					"materials": [
 						{
 							"name": "It Felt Empty When the Heart Went at First But It Is Alright Now"
@@ -37,6 +40,7 @@
 					]
 				},
 				{
+					"customType": "Finalist",
 					"materials": [
 						{
 							"name": "The Shipment"
@@ -44,6 +48,7 @@
 					]
 				},
 				{
+					"customType": "Finalist",
 					"materials": [
 						{
 							"name": "The Nature of Love"
@@ -51,6 +56,7 @@
 					]
 				},
 				{
+					"customType": "Finalist",
 					"materials": [
 						{
 							"name": "East of Berlin"
@@ -58,6 +64,7 @@
 					]
 				},
 				{
+					"customType": "Finalist",
 					"materials": [
 						{
 							"name": "The Swallowing Dark"
@@ -65,6 +72,7 @@
 					]
 				},
 				{
+					"customType": "Finalist",
 					"materials": [
 						{
 							"name": "Enron"
@@ -72,6 +80,7 @@
 					]
 				},
 				{
+					"customType": "Finalist",
 					"materials": [
 						{
 							"name": "Strandline"

--- a/src/models/Nomination.js
+++ b/src/models/Nomination.js
@@ -10,9 +10,11 @@ export default class Nomination extends Base {
 
 		super(props);
 
-		const { isWinner, entities, productions, materials } = props;
+		const { isWinner, customType, entities, productions, materials } = props;
 
 		this.isWinner = Boolean(isWinner);
+
+		this.customType = customType?.trim() || '';
 
 		this.entities = entities
 			? entities.map(entity => {
@@ -42,6 +44,8 @@ export default class Nomination extends Base {
 	}
 
 	runInputValidations () {
+
+		this.validateCustomType({ isRequired: false });
 
 		const duplicateEntities = getDuplicateEntities(this.entities);
 
@@ -80,6 +84,12 @@ export default class Nomination extends Base {
 			material.validateUniquenessInGroup({ isDuplicate: duplicateMaterialIndices.includes(index) });
 
 		});
+
+	}
+
+	validateCustomType (opts) {
+
+		this.validateStringForProperty('customType', { isRequired: opts.isRequired });
 
 	}
 

--- a/src/neo4j/cypher-queries/award-ceremony.js
+++ b/src/neo4j/cypher-queries/award-ceremony.js
@@ -104,7 +104,8 @@ const getCreateUpdateQuery = action => {
 							[:HAS_NOMINEE {
 								nominationPosition: nomination.position,
 								entityPosition: nomineePersonParam.position,
-								isWinner: nomination.isWinner
+								isWinner: nomination.isWinner,
+								customType: nomination.customType
 							}]->(nomineePerson)
 					)
 
@@ -135,7 +136,8 @@ const getCreateUpdateQuery = action => {
 							[:HAS_NOMINEE {
 								nominationPosition: nomination.position,
 								entityPosition: nomineeCompanyParam.position,
-								isWinner: nomination.isWinner
+								isWinner: nomination.isWinner,
+								customType: nomination.customType
 							}]->(nomineeCompany)
 					)
 
@@ -206,7 +208,8 @@ const getCreateUpdateQuery = action => {
 							[:HAS_NOMINEE {
 								nominationPosition: nomination.position,
 								productionPosition: nomineeProductionParam.position,
-								isWinner: nomination.isWinner
+								isWinner: nomination.isWinner,
+								customType: nomination.customType
 							}]->(existingNomineeProduction)
 					)
 
@@ -237,7 +240,8 @@ const getCreateUpdateQuery = action => {
 							[:HAS_NOMINEE {
 								nominationPosition: nomination.position,
 								materialPosition: nomineeMaterialParam.position,
-								isWinner: nomination.isWinner
+								isWinner: nomination.isWinner,
+								customType: nomination.customType
 							}]->(nomineeMaterial)
 					)
 
@@ -303,6 +307,7 @@ const getEditQuery = () => `
 		category,
 		nomineeRel.nominationPosition AS nominationPosition,
 		nomineeRel.isWinner AS isWinner,
+		nomineeRel.customType AS customType,
 		[nominee IN COLLECT(
 			CASE nominee WHEN NULL
 				THEN null
@@ -321,6 +326,7 @@ const getEditQuery = () => `
 		categoryRel,
 		category,
 		isWinner,
+		customType,
 		[nominee IN nominees WHERE nominee.model = 'PERSON' OR nominee.model = 'COMPANY'] + [{}] AS nomineeEntities,
 		[nominee IN nominees WHERE nominee.model = 'PRODUCTION'] + [{ uuid: '' }] AS nomineeProductions,
 		[nominee IN nominees WHERE nominee.model = 'MATERIAL'] + [{}] AS nomineeMaterials
@@ -331,6 +337,7 @@ const getEditQuery = () => `
 				THEN null
 				ELSE {
 					isWinner: COALESCE(isWinner, false),
+					customType: customType,
 					entities: nomineeEntities,
 					productions: nomineeProductions,
 					materials: nomineeMaterials
@@ -541,6 +548,7 @@ const getShowQuery = () => `
 		category,
 		nomineeRel.nominationPosition AS nominationPosition,
 		nomineeRel.isWinner AS isWinner,
+		nomineeRel.customType AS customType,
 		[nominee IN COLLECT(
 			CASE nominee WHEN NULL
 				THEN null
@@ -570,6 +578,7 @@ const getShowQuery = () => `
 		categoryRel,
 		category,
 		isWinner,
+		customType,
 		[nominee IN nominees WHERE nominee.model = 'PERSON' OR nominee.model = 'COMPANY'] AS nomineeEntities,
 		[nominee IN nominees WHERE nominee.model = 'PRODUCTION'] AS nomineeProductions,
 		[nominee IN nominees WHERE nominee.model = 'MATERIAL'] AS nomineeMaterials
@@ -581,6 +590,7 @@ const getShowQuery = () => `
 				ELSE {
 					model: 'NOMINATION',
 					isWinner: COALESCE(isWinner, false),
+					customType: customType,
 					entities: nomineeEntities,
 					productions: nomineeProductions,
 					materials: nomineeMaterials

--- a/src/neo4j/cypher-queries/company.js
+++ b/src/neo4j/cypher-queries/company.js
@@ -740,6 +740,7 @@ const getShowQuery = () => `
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(nomineeRel.isWinner, false),
+			customType: nomineeRel.customType,
 			members: nominatedMembers,
 			coEntities: coNominatedEntities,
 			productions: nominatedProductions,
@@ -1034,6 +1035,7 @@ const getShowQuery = () => `
 		crewProductions,
 		awards,
 		nomineeRel.isWinner AS isWinner,
+		nomineeRel.customType AS customType,
 		nomineeRel,
 		category,
 		categoryRel,
@@ -1063,6 +1065,7 @@ const getShowQuery = () => `
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(isWinner, false),
+			customType: customType,
 			entities: nominatedEntities,
 			productions: nominatedProductions,
 			materials: nominatedMaterials,
@@ -1380,6 +1383,7 @@ const getShowQuery = () => `
 		awards,
 		subsequentVersionMaterialAwards,
 		nomineeRel.isWinner AS isWinner,
+		nomineeRel.customType AS customType,
 		category,
 		categoryRel,
 		ceremony,
@@ -1409,6 +1413,7 @@ const getShowQuery = () => `
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(isWinner, false),
+			customType: customType,
 			entities: nominatedEntities,
 			productions: nominatedProductions,
 			materials: nominatedMaterials,
@@ -1729,6 +1734,7 @@ const getShowQuery = () => `
 		subsequentVersionMaterialAwards,
 		sourcingMaterialAwards,
 		nomineeRel.isWinner AS isWinner,
+		nomineeRel.customType AS customType,
 		category,
 		categoryRel,
 		ceremony,
@@ -1759,6 +1765,7 @@ const getShowQuery = () => `
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(isWinner, false),
+			customType: customType,
 			entities: nominatedEntities,
 			productions: nominatedProductions,
 			materials: nominatedMaterials,

--- a/src/neo4j/cypher-queries/material.js
+++ b/src/neo4j/cypher-queries/material.js
@@ -758,6 +758,7 @@ const getShowQuery = () => `
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(nomineeRel.isWinner, false),
+			customType: nomineeRel.customType,
 			entities: nominatedEntities,
 			productions: nominatedProductions,
 			coMaterials: coNominatedMaterials
@@ -1039,6 +1040,7 @@ const getShowQuery = () => `
 		productions,
 		awards,
 		nomineeRel.isWinner AS isWinner,
+		nomineeRel.customType AS customType,
 		category,
 		categoryRel,
 		ceremony,
@@ -1066,6 +1068,7 @@ const getShowQuery = () => `
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(isWinner, false),
+			customType: customType,
 			entities: nominatedEntities,
 			productions: nominatedProductions,
 			materials: nominatedMaterials,
@@ -1366,6 +1369,7 @@ const getShowQuery = () => `
 		awards,
 		subsequentVersionMaterialAwards,
 		nomineeRel.isWinner AS isWinner,
+		nomineeRel.customType AS customType,
 		category,
 		categoryRel,
 		ceremony,
@@ -1394,6 +1398,7 @@ const getShowQuery = () => `
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(isWinner, false),
+			customType: customType,
 			entities: nominatedEntities,
 			productions: nominatedProductions,
 			materials: nominatedMaterials,

--- a/src/neo4j/cypher-queries/person.js
+++ b/src/neo4j/cypher-queries/person.js
@@ -964,6 +964,7 @@ const getShowQuery = () => `
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(entityRel.isWinner, false),
+			customType: entityRel.customType,
 			employerCompany: nominatedEmployerCompany,
 			coEntities: coNominatedEntities,
 			productions: nominatedProductions,
@@ -1271,6 +1272,7 @@ const getShowQuery = () => `
 		crewProductions,
 		awards,
 		nomineeRel.isWinner AS isWinner,
+		nomineeRel.customType AS customType,
 		category,
 		categoryRel,
 		ceremony,
@@ -1300,6 +1302,7 @@ const getShowQuery = () => `
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(isWinner, false),
+			customType: customType,
 			entities: nominatedEntities,
 			productions: nominatedProductions,
 			materials: nominatedMaterials,
@@ -1630,6 +1633,7 @@ const getShowQuery = () => `
 		awards,
 		subsequentVersionMaterialAwards,
 		nomineeRel.isWinner AS isWinner,
+		nomineeRel.customType AS customType,
 		category,
 		categoryRel,
 		ceremony,
@@ -1660,6 +1664,7 @@ const getShowQuery = () => `
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(isWinner, false),
+			customType: customType,
 			entities: nominatedEntities,
 			productions: nominatedProductions,
 			materials: nominatedMaterials,
@@ -1993,6 +1998,7 @@ const getShowQuery = () => `
 		subsequentVersionMaterialAwards,
 		sourcingMaterialAwards,
 		nomineeRel.isWinner AS isWinner,
+		nomineeRel.customType AS customType,
 		category,
 		categoryRel,
 		ceremony,
@@ -2024,6 +2030,7 @@ const getShowQuery = () => `
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(isWinner, false),
+			customType: customType,
 			entities: nominatedEntities,
 			productions: nominatedProductions,
 			materials: nominatedMaterials,

--- a/src/neo4j/cypher-queries/production.js
+++ b/src/neo4j/cypher-queries/production.js
@@ -1226,6 +1226,7 @@ const getShowQuery = () => `
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(nomineeRel.isWinner, false),
+			customType: nomineeRel.customType,
 			entities: nominatedEntities,
 			coProductions: coNominatedProductions,
 			materials: nominatedMaterials

--- a/test-e2e/crud/award-ceremonies-api.test.js
+++ b/test-e2e/crud/award-ceremonies-api.test.js
@@ -40,6 +40,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -125,6 +126,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -186,6 +188,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -251,6 +254,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -714,6 +718,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 									]
 								},
 								{
+									customType: 'Special Commendation',
 									materials: [
 										{
 											name: 'The Reporter',
@@ -722,6 +727,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 									]
 								},
 								{
+									customType: 'Finalist',
 									materials: [
 										{
 											name: 'Vernon God Little',
@@ -757,6 +763,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -802,6 +809,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -860,6 +868,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: true,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -911,6 +920,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -976,6 +986,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -1046,6 +1057,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -1081,6 +1093,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -1115,6 +1128,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -1155,6 +1169,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: true,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -1189,6 +1204,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -1224,6 +1240,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -1262,6 +1279,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: true,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -1295,6 +1313,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -1328,6 +1347,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -1363,6 +1383,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: true,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -1397,6 +1418,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: 'Special Commendation',
 								errors: {},
 								entities: [
 									{
@@ -1431,6 +1453,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: 'Finalist',
 								errors: {},
 								entities: [
 									{
@@ -1465,6 +1488,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -1500,6 +1524,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -1535,6 +1560,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -1593,6 +1619,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: null,
 								entities: [
 									{
 										model: 'PERSON',
@@ -1629,6 +1656,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: null,
 								entities: [
 									{
 										model: 'COMPANY',
@@ -1679,6 +1707,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: true,
+								customType: null,
 								entities: [
 									{
 										model: 'PERSON',
@@ -1720,6 +1749,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: null,
 								entities: [
 									{
 										model: 'COMPANY',
@@ -1768,6 +1798,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: null,
 								entities: [
 									{
 										model: 'COMPANY',
@@ -1835,6 +1866,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: null,
 								entities: [
 									{
 										model: 'PERSON',
@@ -1848,6 +1880,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: null,
 								entities: [
 									{
 										model: 'PERSON',
@@ -1866,6 +1899,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: true,
+								customType: null,
 								entities: [
 									{
 										model: 'PERSON',
@@ -1885,6 +1919,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: null,
 								entities: [],
 								productions: [
 									{
@@ -1919,6 +1954,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: true,
+								customType: null,
 								entities: [],
 								productions: [
 									{
@@ -1940,6 +1976,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: null,
 								entities: [],
 								productions: [
 									{
@@ -1967,6 +2004,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: true,
+								customType: null,
 								entities: [],
 								productions: [],
 								materials: [
@@ -1983,6 +2021,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: 'Special Commendation',
 								entities: [],
 								productions: [],
 								materials: [
@@ -1999,6 +2038,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: 'Finalist',
 								entities: [],
 								productions: [],
 								materials: [
@@ -2052,6 +2092,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -2097,6 +2138,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -2155,6 +2197,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: true,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -2206,6 +2249,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -2271,6 +2315,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -2341,6 +2386,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -2376,6 +2422,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -2410,6 +2457,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -2450,6 +2498,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: true,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -2484,6 +2533,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -2519,6 +2569,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -2557,6 +2608,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: true,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -2590,6 +2642,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -2623,6 +2676,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -2658,6 +2712,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: true,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -2692,6 +2747,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: 'Special Commendation',
 								errors: {},
 								entities: [
 									{
@@ -2726,6 +2782,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: 'Finalist',
 								errors: {},
 								entities: [
 									{
@@ -2760,6 +2817,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -2795,6 +2853,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -2830,6 +2889,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -3164,6 +3224,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							name: 'Best Play',
 							nominations: [
 								{
+									customType: 'Shortlisted',
 									materials: [
 										{
 											name: 'England People Very Nice',
@@ -3181,6 +3242,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 									]
 								},
 								{
+									customType: 'Longlisted',
 									materials: [
 										{
 											name: 'Our Class',
@@ -3216,6 +3278,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: true,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -3261,6 +3324,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -3319,6 +3383,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -3370,6 +3435,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -3440,6 +3506,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -3510,6 +3577,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -3545,6 +3613,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -3579,6 +3648,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: true,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -3613,6 +3683,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -3653,6 +3724,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -3688,6 +3760,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -3721,6 +3794,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -3759,6 +3833,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: true,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -3797,6 +3872,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -3832,6 +3908,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: 'Shortlisted',
 								errors: {},
 								entities: [
 									{
@@ -3866,6 +3943,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: true,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -3900,6 +3978,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: 'Longlisted',
 								errors: {},
 								entities: [
 									{
@@ -3934,6 +4013,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -3969,6 +4049,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -4004,6 +4085,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{
@@ -4062,6 +4144,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: true,
+								customType: null,
 								entities: [
 									{
 										model: 'PERSON',
@@ -4098,6 +4181,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: null,
 								entities: [
 									{
 										model: 'COMPANY',
@@ -4148,6 +4232,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: null,
 								entities: [
 									{
 										model: 'PERSON',
@@ -4189,6 +4274,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: null,
 								entities: [
 									{
 										model: 'COMPANY',
@@ -4250,6 +4336,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: null,
 								entities: [
 									{
 										model: 'COMPANY',
@@ -4317,6 +4404,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: null,
 								entities: [
 									{
 										model: 'PERSON',
@@ -4330,6 +4418,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: true,
+								customType: null,
 								entities: [
 									{
 										model: 'PERSON',
@@ -4343,6 +4432,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: null,
 								entities: [
 									{
 										model: 'PERSON',
@@ -4367,6 +4457,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: null,
 								entities: [],
 								productions: [
 									{
@@ -4388,6 +4479,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: null,
 								entities: [],
 								productions: [
 									{
@@ -4422,6 +4514,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: true,
+								customType: null,
 								entities: [],
 								productions: [
 									{
@@ -4462,6 +4555,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: 'Shortlisted',
 								entities: [],
 								productions: [],
 								materials: [
@@ -4478,6 +4572,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: true,
+								customType: null,
 								entities: [],
 								productions: [],
 								materials: [
@@ -4494,6 +4589,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: 'Longlisted',
 								entities: [],
 								productions: [],
 								materials: [
@@ -4552,6 +4648,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
+								customType: '',
 								errors: {},
 								entities: [
 									{

--- a/test-e2e/database-validation-failures/award-ceremonies-api.test.js
+++ b/test-e2e/database-validation-failures/award-ceremonies-api.test.js
@@ -69,6 +69,7 @@ describe('Database validation failures: Award ceremonies API', () => {
 								{
 									model: 'NOMINATION',
 									isWinner: false,
+									customType: '',
 									errors: {},
 									entities: [],
 									productions: [
@@ -180,6 +181,7 @@ describe('Database validation failures: Award ceremonies API', () => {
 								{
 									model: 'NOMINATION',
 									isWinner: false,
+									customType: '',
 									errors: {},
 									entities: [],
 									productions: [

--- a/test-e2e/model-interaction/award-ceremonies-nominated-materials.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-nominated-materials.test.js
@@ -726,6 +726,7 @@ describe('Award ceremonies with nominated materials', () => {
 						name: 'Best Miscellaneous Play',
 						nominations: [
 							{
+								customType: 'Shortlisted',
 								productions: [
 									{
 										uuid: PIYO_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID
@@ -741,6 +742,7 @@ describe('Award ceremonies with nominated materials', () => {
 								]
 							},
 							{
+								customType: 'Longlisted',
 								productions: [
 									{
 										uuid: WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID
@@ -757,6 +759,7 @@ describe('Award ceremonies with nominated materials', () => {
 							},
 							{
 								isWinner: true,
+								customType: 'First Place',
 								productions: [
 									{
 										uuid: XYZZY_OLIVIER_PRODUCTION_UUID
@@ -788,6 +791,7 @@ describe('Award ceremonies with nominated materials', () => {
 						name: 'Best Miscellaneous Play',
 						nominations: [
 							{
+								customType: 'Longlisted',
 								productions: [
 									{
 										uuid: FRED_LYTTELTON_PRODUCTION_UUID
@@ -804,6 +808,7 @@ describe('Award ceremonies with nominated materials', () => {
 							},
 							{
 								isWinner: true,
+								customType: 'First Place',
 								productions: [
 									{
 										uuid: GARPLY_ALMEIDA_PRODUCTION_UUID
@@ -816,6 +821,7 @@ describe('Award ceremonies with nominated materials', () => {
 								]
 							},
 							{
+								customType: 'Shortlisted',
 								productions: [
 									{
 										uuid: PLUGH_LYTTELTON_PRODUCTION_UUID
@@ -849,6 +855,7 @@ describe('Award ceremonies with nominated materials', () => {
 						nominations: [
 							{
 								isWinner: true,
+								customType: 'First Place',
 								productions: [
 									{
 										uuid: HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID
@@ -861,6 +868,7 @@ describe('Award ceremonies with nominated materials', () => {
 								]
 							},
 							{
+								customType: 'Shortlisted',
 								productions: [
 									{
 										uuid: THUD_PLAYHOUSE_PRODUCTION_UUID
@@ -873,6 +881,7 @@ describe('Award ceremonies with nominated materials', () => {
 								]
 							},
 							{
+								customType: 'Longlisted',
 								productions: [
 									{
 										uuid: TUTU_OLD_VIC_PRODUCTION_UUID
@@ -1132,6 +1141,7 @@ describe('Award ceremonies with nominated materials', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: false,
+							customType: 'Shortlisted',
 							entities: [],
 							productions: [
 								{
@@ -1228,6 +1238,7 @@ describe('Award ceremonies with nominated materials', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: false,
+							customType: 'Longlisted',
 							entities: [],
 							productions: [
 								{
@@ -1323,6 +1334,7 @@ describe('Award ceremonies with nominated materials', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: true,
+							customType: 'First Place',
 							entities: [],
 							productions: [
 								{
@@ -1424,6 +1436,7 @@ describe('Award ceremonies with nominated materials', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: false,
+							customType: null,
 							entities: [],
 							productions: [
 								{
@@ -1504,6 +1517,7 @@ describe('Award ceremonies with nominated materials', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: true,
+							customType: null,
 							entities: [],
 							productions: [
 								{
@@ -1571,6 +1585,7 @@ describe('Award ceremonies with nominated materials', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: false,
+							customType: null,
 							entities: [],
 							productions: [
 								{
@@ -1697,6 +1712,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: null,
 											employerCompany: null,
 											coEntities: [],
 											productions: [
@@ -1764,6 +1780,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Longlisted',
 											employerCompany: null,
 											coEntities: [],
 											productions: [
@@ -1846,6 +1863,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: null,
 											members: [],
 											coEntities: [],
 											productions: [
@@ -1913,6 +1931,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Longlisted',
 											members: [],
 											coEntities: [],
 											productions: [
@@ -1995,6 +2014,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: null,
 											employerCompany: null,
 											coEntities: [],
 											productions: [
@@ -2042,6 +2062,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: null,
 											employerCompany: null,
 											coEntities: [],
 											productions: [
@@ -2092,6 +2113,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Shortlisted',
 											employerCompany: null,
 											coEntities: [],
 											productions: [
@@ -2152,6 +2174,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Shortlisted',
 											employerCompany: null,
 											coEntities: [],
 											productions: [
@@ -2217,6 +2240,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: null,
 											members: [],
 											coEntities: [],
 											productions: [
@@ -2271,6 +2295,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Shortlisted',
 											members: [],
 											coEntities: [],
 											productions: [
@@ -2353,6 +2378,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: null,
 											employerCompany: null,
 											coEntities: [],
 											productions: [
@@ -2400,6 +2426,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: null,
 											employerCompany: null,
 											coEntities: [],
 											productions: [
@@ -2447,6 +2474,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: null,
 											employerCompany: null,
 											coEntities: [],
 											productions: [
@@ -2497,6 +2525,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Shortlisted',
 											employerCompany: null,
 											coEntities: [],
 											productions: [
@@ -2557,6 +2586,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: 'First Place',
 											employerCompany: null,
 											coEntities: [],
 											productions: [
@@ -2626,6 +2656,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: null,
 											members: [],
 											coEntities: [],
 											productions: [
@@ -2673,6 +2704,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: null,
 											members: [],
 											coEntities: [],
 											productions: [
@@ -2740,6 +2772,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Longlisted',
 											members: [],
 											coEntities: [],
 											productions: [
@@ -2800,6 +2833,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: 'First Place',
 											members: [],
 											coEntities: [],
 											productions: [
@@ -2869,6 +2903,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: null,
 											entities: [],
 											productions: [
 												{
@@ -2923,6 +2958,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Shortlisted',
 											entities: [],
 											productions: [
 												{
@@ -3007,6 +3043,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: null,
 											entities: [],
 											productions: [
 												{
@@ -3061,6 +3098,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Shortlisted',
 											entities: [],
 											productions: [
 												{
@@ -3146,6 +3184,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: null,
 											entities: [],
 											productions: [
 												{
@@ -3200,6 +3239,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Shortlisted',
 											entities: [],
 											productions: [
 												{
@@ -3283,6 +3323,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: null,
 											entities: [],
 											productions: [
 												{
@@ -3350,6 +3391,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Longlisted',
 											entities: [],
 											productions: [
 												{
@@ -3432,6 +3474,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: null,
 											entities: [],
 											productions: [
 												{
@@ -3499,6 +3542,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Longlisted',
 											entities: [],
 											productions: [
 												{
@@ -3581,6 +3625,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: null,
 											entities: [],
 											productions: [
 												{
@@ -3648,6 +3693,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Longlisted',
 											entities: [],
 											productions: [
 												{
@@ -3730,6 +3776,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: null,
 											employerCompany: null,
 											coEntities: [],
 											productions: [
@@ -3800,6 +3847,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: null,
 											entities: [],
 											productions: [
 												{
@@ -3854,6 +3902,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: 'First Place',
 											entities: [],
 											productions: [
 												{
@@ -3939,6 +3988,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: null,
 											entities: [],
 											productions: [
 												{
@@ -3993,6 +4043,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: 'First Place',
 											entities: [],
 											productions: [
 												{
@@ -4078,6 +4129,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: null,
 											entities: [],
 											productions: [
 												{
@@ -4145,6 +4197,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: 'First Place',
 											entities: [],
 											productions: [
 												{
@@ -4217,6 +4270,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: null,
 											entities: [],
 											productions: [
 												{
@@ -4284,6 +4338,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: 'First Place',
 											entities: [],
 											productions: [
 												{

--- a/test-e2e/model-interaction/award-ceremonies.test.js
+++ b/test-e2e/model-interaction/award-ceremonies.test.js
@@ -881,6 +881,7 @@ describe('Award ceremonies', () => {
 						name: 'Best Miscellaneous Role',
 						nominations: [
 							{
+								customType: 'Longlisted',
 								entities: [
 									{
 										model: 'COMPANY',
@@ -906,6 +907,7 @@ describe('Award ceremonies', () => {
 							},
 							{
 								isWinner: true,
+								customType: 'First Place',
 								entities: [
 									{
 										model: 'COMPANY',
@@ -924,6 +926,7 @@ describe('Award ceremonies', () => {
 								]
 							},
 							{
+								customType: 'Shortlisted',
 								entities: [
 									{
 										model: 'COMPANY',
@@ -973,6 +976,7 @@ describe('Award ceremonies', () => {
 						nominations: [
 							{
 								isWinner: true,
+								customType: 'First Place',
 								entities: [
 									{
 										name: 'John Doe'
@@ -990,6 +994,7 @@ describe('Award ceremonies', () => {
 								]
 							},
 							{
+								customType: 'Shortlisted',
 								entities: [
 									{
 										name: 'Conor Corge'
@@ -1028,6 +1033,7 @@ describe('Award ceremonies', () => {
 						nominations: [
 							{
 								isWinner: true,
+								customType: 'First Place',
 								productions: [
 									{
 										uuid: GARPLY_LYTTELTON_PRODUCTION_UUID
@@ -1035,6 +1041,7 @@ describe('Award ceremonies', () => {
 								]
 							},
 							{
+								customType: 'Longlisted',
 								productions: [
 									{
 										uuid: GRAULT_ALMEIDA_PRODUCTION_UUID
@@ -1042,6 +1049,7 @@ describe('Award ceremonies', () => {
 								]
 							},
 							{
+								customType: 'Shortlisted',
 								productions: [
 									{
 										uuid: WALDO_DORFMAN_PRODUCTION_UUID
@@ -1057,6 +1065,7 @@ describe('Award ceremonies', () => {
 						name: 'Most Remarkable Play',
 						nominations: [
 							{
+								customType: 'Shortlisted',
 								materials: [
 									{
 										name: 'Garply'
@@ -1065,6 +1074,7 @@ describe('Award ceremonies', () => {
 							},
 							{
 								isWinner: true,
+								customType: 'First Place',
 								materials: [
 									{
 										name: 'Grault'
@@ -1072,6 +1082,7 @@ describe('Award ceremonies', () => {
 								]
 							},
 							{
+								customType: 'Longlisted',
 								materials: [
 									{
 										name: 'Waldo'
@@ -1095,6 +1106,7 @@ describe('Award ceremonies', () => {
 						name: 'Best Random Role',
 						nominations: [
 							{
+								customType: 'Longlisted',
 								entities: [
 									{
 										name: 'Jane Roe'
@@ -1103,6 +1115,7 @@ describe('Award ceremonies', () => {
 							},
 							{
 								isWinner: true,
+								customType: 'First Place',
 								entities: [
 									{
 										name: 'John Doe'
@@ -1117,6 +1130,7 @@ describe('Award ceremonies', () => {
 								]
 							},
 							{
+								customType: 'Shortlisted',
 								entities: [
 									{
 										model: 'COMPANY',
@@ -1154,6 +1168,7 @@ describe('Award ceremonies', () => {
 								]
 							},
 							{
+								customType: 'Longlisted',
 								entities: [
 									{
 										model: 'COMPANY',
@@ -1167,6 +1182,7 @@ describe('Award ceremonies', () => {
 						name: 'Best Miscellaneous Role',
 						nominations: [
 							{
+								customType: 'Shortlisted',
 								entities: [
 									{
 										model: 'COMPANY',
@@ -1185,6 +1201,7 @@ describe('Award ceremonies', () => {
 								]
 							},
 							{
+								customType: 'Longlisted',
 								entities: [
 									{
 										name: 'Jane Roe'
@@ -1219,6 +1236,7 @@ describe('Award ceremonies', () => {
 							},
 							{
 								isWinner: true,
+								customType: 'First Place',
 								entities: [
 									{
 										name: 'Conor Corge'
@@ -1266,6 +1284,7 @@ describe('Award ceremonies', () => {
 								]
 							},
 							{
+								customType: 'Shortlisted',
 								entities: [
 									{
 										model: 'COMPANY',
@@ -1289,6 +1308,7 @@ describe('Award ceremonies', () => {
 						name: 'Best Noteworthy Production',
 						nominations: [
 							{
+								customType: 'Shortlisted',
 								productions: [
 									{
 										uuid: PIYO_HAROLD_PINTER_PRODUCTION_UUID
@@ -1297,6 +1317,7 @@ describe('Award ceremonies', () => {
 							},
 							{
 								isWinner: true,
+								customType: 'First Place',
 								productions: [
 									{
 										uuid: THUD_DUKE_OF_YORKS_PRODUCTION_UUID
@@ -1304,6 +1325,7 @@ describe('Award ceremonies', () => {
 								]
 							},
 							{
+								customType: 'Longlisted',
 								productions: [
 									{
 										uuid: XYZZY_DORFMAN_PRODUCTION_UUID
@@ -1319,6 +1341,7 @@ describe('Award ceremonies', () => {
 						name: 'Most Remarkable Play',
 						nominations: [
 							{
+								customType: 'Shortlisted',
 								materials: [
 									{
 										name: 'Thud'
@@ -1326,6 +1349,7 @@ describe('Award ceremonies', () => {
 								]
 							},
 							{
+								customType: 'Longlisted',
 								materials: [
 									{
 										name: 'Wibble'
@@ -1334,6 +1358,7 @@ describe('Award ceremonies', () => {
 							},
 							{
 								isWinner: true,
+								customType: 'First Place',
 								materials: [
 									{
 										name: 'Xyzzy'
@@ -1357,6 +1382,7 @@ describe('Award ceremonies', () => {
 						name: 'Best Miscellaneous Role',
 						nominations: [
 							{
+								customType: 'Special Commendation',
 								entities: [
 									{
 										name: 'John Doe'
@@ -1374,6 +1400,7 @@ describe('Award ceremonies', () => {
 								]
 							},
 							{
+								customType: 'Finalist',
 								entities: [
 									{
 										model: 'COMPANY',
@@ -1404,6 +1431,7 @@ describe('Award ceremonies', () => {
 								]
 							},
 							{
+								customType: 'Finalist',
 								entities: [
 									{
 										model: 'COMPANY',
@@ -1452,6 +1480,7 @@ describe('Award ceremonies', () => {
 							},
 							{
 								isWinner: true,
+								customType: 'Prize Recipient',
 								entities: [
 									{
 										model: 'COMPANY',
@@ -1476,6 +1505,7 @@ describe('Award ceremonies', () => {
 						nominations: [
 							{
 								isWinner: true,
+								customType: 'Prize Recipient',
 								productions: [
 									{
 										uuid: FRED_OLD_VIC_PRODUCTION_UUID
@@ -1483,6 +1513,7 @@ describe('Award ceremonies', () => {
 								]
 							},
 							{
+								customType: 'Finalist',
 								productions: [
 									{
 										uuid: GARPLY_LYTTELTON_PRODUCTION_UUID
@@ -1490,6 +1521,7 @@ describe('Award ceremonies', () => {
 								]
 							},
 							{
+								customType: 'Special Commendation',
 								productions: [
 									{
 										uuid: WALDO_DORFMAN_PRODUCTION_UUID
@@ -1502,6 +1534,7 @@ describe('Award ceremonies', () => {
 						name: 'Most Remarkable Play',
 						nominations: [
 							{
+								customType: 'Special Commendation',
 								materials: [
 									{
 										name: 'Fred'
@@ -1510,6 +1543,7 @@ describe('Award ceremonies', () => {
 							},
 							{
 								isWinner: true,
+								customType: 'Prize Recipient',
 								materials: [
 									{
 										name: 'Garply'
@@ -1520,6 +1554,7 @@ describe('Award ceremonies', () => {
 								]
 							},
 							{
+								customType: 'Finalist',
 								materials: [
 									{
 										name: 'Waldo'
@@ -1587,6 +1622,7 @@ describe('Award ceremonies', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: true,
+							customType: null,
 							entities: [
 								{
 									model: 'PERSON',
@@ -1640,6 +1676,7 @@ describe('Award ceremonies', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: false,
+							customType: null,
 							entities: [
 								{
 									model: 'COMPANY',
@@ -1687,6 +1724,7 @@ describe('Award ceremonies', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: false,
+							customType: null,
 							entities: [
 								{
 									name: 'Stagecraft Ltd',
@@ -1784,6 +1822,7 @@ describe('Award ceremonies', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: false,
+							customType: null,
 							entities: [
 								{
 									model: 'COMPANY',
@@ -1865,6 +1904,7 @@ describe('Award ceremonies', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: false,
+							customType: null,
 							entities: [
 								{
 									model: 'PERSON',
@@ -1878,6 +1918,7 @@ describe('Award ceremonies', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: true,
+							customType: null,
 							entities: [
 								{
 									model: 'PERSON',
@@ -1902,6 +1943,7 @@ describe('Award ceremonies', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: false,
+							customType: null,
 							entities: [
 								{
 									model: 'COMPANY',
@@ -1959,6 +2001,7 @@ describe('Award ceremonies', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: false,
+							customType: null,
 							entities: [
 								{
 									model: 'COMPANY',
@@ -1979,6 +2022,7 @@ describe('Award ceremonies', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: false,
+							customType: null,
 							entities: [],
 							productions: [
 								{
@@ -2000,6 +2044,7 @@ describe('Award ceremonies', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: true,
+							customType: null,
 							entities: [],
 							productions: [
 								{
@@ -2038,6 +2083,7 @@ describe('Award ceremonies', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: false,
+							customType: null,
 							entities: [],
 							productions: [
 								{
@@ -2065,6 +2111,7 @@ describe('Award ceremonies', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: false,
+							customType: null,
 							entities: [],
 							productions: [],
 							materials: [
@@ -2081,6 +2128,7 @@ describe('Award ceremonies', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: false,
+							customType: null,
 							entities: [],
 							productions: [],
 							materials: [
@@ -2105,6 +2153,7 @@ describe('Award ceremonies', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: true,
+							customType: null,
 							entities: [],
 							productions: [],
 							materials: [
@@ -2207,6 +2256,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Special Commendation',
 											employerCompany: null,
 											coEntities: [],
 											productions: [
@@ -2237,6 +2287,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Finalist',
 											employerCompany: null,
 											coEntities: [
 												{
@@ -2319,6 +2370,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: 'First Place',
 											employerCompany: null,
 											coEntities: [],
 											productions: [
@@ -2362,6 +2414,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Longlisted',
 											employerCompany: null,
 											coEntities: [
 												{
@@ -2417,6 +2470,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: 'First Place',
 											employerCompany: null,
 											coEntities: [
 												{
@@ -2443,6 +2497,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Longlisted',
 											employerCompany: null,
 											coEntities: [
 												{
@@ -2542,6 +2597,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: null,
 											employerCompany: null,
 											coEntities: [],
 											productions: [
@@ -2589,6 +2645,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: null,
 											employerCompany: null,
 											coEntities: [
 												{
@@ -2637,6 +2694,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: null,
 											employerCompany: null,
 											coEntities: [
 												{
@@ -2670,6 +2728,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: null,
 											employerCompany: null,
 											coEntities: [
 												{
@@ -2764,6 +2823,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Finalist',
 											members: [],
 											coEntities: [
 												{
@@ -2845,6 +2905,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: 'First Place',
 											members: [],
 											coEntities: [],
 											productions: [
@@ -2892,6 +2953,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: 'First Place',
 											members: [],
 											coEntities: [
 												{
@@ -2917,6 +2979,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Shortlisted',
 											members: [],
 											coEntities: [],
 											productions: [
@@ -2967,6 +3030,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: null,
 											members: [],
 											coEntities: [
 												{
@@ -3014,6 +3078,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: null,
 											members: [],
 											coEntities: [],
 											productions: [],
@@ -3035,6 +3100,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: null,
 											members: [],
 											coEntities: [],
 											productions: [
@@ -3065,6 +3131,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: null,
 											members: [],
 											coEntities: [
 												{
@@ -3158,6 +3225,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Finalist',
 											employerCompany: null,
 											coEntities: [
 												{
@@ -3257,6 +3325,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Shortlisted',
 											employerCompany: null,
 											coEntities: [
 												{
@@ -3327,6 +3396,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Shortlisted',
 											employerCompany: null,
 											coEntities: [
 												{
@@ -3393,6 +3463,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Shortlisted',
 											employerCompany: null,
 											coEntities: [
 												{
@@ -3452,6 +3523,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: 'First Place',
 											employerCompany: null,
 											coEntities: [
 												{
@@ -3547,6 +3619,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: null,
 											employerCompany: null,
 											coEntities: [
 												{
@@ -3645,6 +3718,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: null,
 											employerCompany: null,
 											coEntities: [
 												{
@@ -3711,6 +3785,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: null,
 											employerCompany: null,
 											coEntities: [
 												{
@@ -3834,6 +3909,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Finalist',
 											members: [
 												{
 													model: 'PERSON',
@@ -3932,6 +4008,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Shortlisted',
 											members: [
 												{
 													model: 'PERSON',
@@ -3997,6 +4074,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Shortlisted',
 											members: [
 												{
 													model: 'PERSON',
@@ -4055,6 +4133,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: 'First Place',
 											members: [
 												{
 													model: 'PERSON',
@@ -4149,6 +4228,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: null,
 											members: [
 												{
 													model: 'PERSON',
@@ -4246,6 +4326,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: null,
 											members: [
 												{
 													model: 'PERSON',
@@ -4311,6 +4392,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: null,
 											members: [
 												{
 													model: 'PERSON',
@@ -4433,6 +4515,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Finalist',
 											employerCompany: {
 												model: 'COMPANY',
 												uuid: THEATRICALS_LTD_COMPANY_UUID,
@@ -4531,6 +4614,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Shortlisted',
 											employerCompany: {
 												model: 'COMPANY',
 												uuid: THEATRICALS_LTD_COMPANY_UUID,
@@ -4600,6 +4684,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Shortlisted',
 											employerCompany: {
 												model: 'COMPANY',
 												uuid: THEATRICALS_LTD_COMPANY_UUID,
@@ -4658,6 +4743,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: 'First Place',
 											employerCompany: {
 												model: 'COMPANY',
 												uuid: THEATRICALS_LTD_COMPANY_UUID,
@@ -4752,6 +4838,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: null,
 											employerCompany: {
 												model: 'COMPANY',
 												uuid: THEATRICALS_LTD_COMPANY_UUID,
@@ -4849,6 +4936,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: null,
 											employerCompany: {
 												model: 'COMPANY',
 												uuid: THEATRICALS_LTD_COMPANY_UUID,
@@ -4914,6 +5002,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: null,
 											employerCompany: {
 												model: 'COMPANY',
 												uuid: THEATRICALS_LTD_COMPANY_UUID,
@@ -5036,6 +5125,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Finalist',
 											entities: [
 												{
 													model: 'COMPANY',
@@ -5107,6 +5197,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Finalist',
 											entities: [],
 											coProductions: [],
 											materials: []
@@ -5134,6 +5225,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Shortlisted',
 											entities: [
 												{
 													model: 'PERSON',
@@ -5183,6 +5275,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: 'First Place',
 											entities: [],
 											coProductions: [],
 											materials: []
@@ -5210,6 +5303,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: null,
 											entities: [
 												{
 													model: 'PERSON',
@@ -5245,6 +5339,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: null,
 											entities: [
 												{
 													model: 'COMPANY',
@@ -5330,6 +5425,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: null,
 											entities: [],
 											coProductions: [
 												{
@@ -5386,6 +5482,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Longlisted',
 											entities: [
 												{
 													model: 'PERSON',
@@ -5462,6 +5559,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Longlisted',
 											entities: [],
 											coProductions: [
 												{
@@ -5507,6 +5605,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: null,
 											entities: [
 												{
 													model: 'PERSON',
@@ -5563,6 +5662,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: null,
 											entities: [],
 											coProductions: [
 												{
@@ -5623,6 +5723,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Finalist',
 											entities: [
 												{
 													model: 'COMPANY',
@@ -5704,6 +5805,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: 'Prize Recipient',
 											entities: [],
 											productions: [],
 											coMaterials: [
@@ -5739,6 +5841,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Shortlisted',
 											entities: [
 												{
 													model: 'PERSON',
@@ -5798,6 +5901,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Shortlisted',
 											entities: [],
 											productions: [],
 											coMaterials: []
@@ -5825,6 +5929,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: null,
 											entities: [
 												{
 													model: 'PERSON',
@@ -5869,6 +5974,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: null,
 											entities: [
 												{
 													model: 'COMPANY',
@@ -5963,6 +6069,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: null,
 											entities: [],
 											productions: [],
 											coMaterials: [
@@ -6013,6 +6120,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: 'Longlisted',
 											entities: [
 												{
 													model: 'PERSON',
@@ -6095,6 +6203,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
+											customType: 'First Place',
 											entities: [],
 											productions: [],
 											coMaterials: []
@@ -6122,6 +6231,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: null,
 											entities: [
 												{
 													model: 'PERSON',
@@ -6183,6 +6293,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
+											customType: null,
 											entities: [],
 											productions: [],
 											coMaterials: [

--- a/test-int/input-validation-failures/award-ceremony.test.js
+++ b/test-int/input-validation-failures/award-ceremony.test.js
@@ -367,6 +367,7 @@ describe('Input validation failures: AwardCeremony instance', () => {
 							nominations: [
 								{
 									isWinner: false,
+									customType: '',
 									entities: [
 										{
 											uuid: undefined,
@@ -378,6 +379,71 @@ describe('Input validation failures: AwardCeremony instance', () => {
 									productions: [],
 									materials: [],
 									errors: {}
+								}
+							]
+						}
+					]
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		}
+
+	});
+
+	context('category nomination customType value exceeds maximum limit', () => {
+
+		for (const method of methods) {
+
+			it(`assigns appropriate error (${method} method)`, async () => {
+
+				const instanceProps = {
+					name: '2010',
+					categories: [
+						{
+							name: 'Best Sound Design',
+							nominations: [
+								{
+									customType: ABOVE_MAX_LENGTH_STRING
+								}
+							]
+						}
+					]
+				};
+
+				const instance = new AwardCeremony(instanceProps);
+
+				const result = await instance[method]();
+
+				const expectedResponseBody = {
+					uuid: undefined,
+					name: '2010',
+					hasErrors: true,
+					errors: {},
+					award: {
+						uuid: undefined,
+						name: '',
+						differentiator: '',
+						errors: {}
+					},
+					categories: [
+						{
+							name: 'Best Sound Design',
+							errors: {},
+							nominations: [
+								{
+									isWinner: false,
+									customType: ABOVE_MAX_LENGTH_STRING,
+									entities: [],
+									productions: [],
+									materials: [],
+									errors: {
+										customType: [
+											'Value is too long'
+										]
+									}
 								}
 							]
 						}
@@ -438,6 +504,7 @@ describe('Input validation failures: AwardCeremony instance', () => {
 							nominations: [
 								{
 									isWinner: false,
+									customType: '',
 									entities: [
 										{
 											uuid: undefined,
@@ -514,6 +581,7 @@ describe('Input validation failures: AwardCeremony instance', () => {
 							nominations: [
 								{
 									isWinner: false,
+									customType: '',
 									entities: [
 										{
 											uuid: undefined,
@@ -590,6 +658,7 @@ describe('Input validation failures: AwardCeremony instance', () => {
 							nominations: [
 								{
 									isWinner: false,
+									customType: '',
 									entities: [
 										{
 											uuid: undefined,
@@ -668,6 +737,7 @@ describe('Input validation failures: AwardCeremony instance', () => {
 							nominations: [
 								{
 									isWinner: false,
+									customType: '',
 									entities: [
 										{
 											uuid: undefined,
@@ -764,6 +834,7 @@ describe('Input validation failures: AwardCeremony instance', () => {
 							nominations: [
 								{
 									isWinner: false,
+									customType: '',
 									entities: [
 										{
 											uuid: undefined,
@@ -903,6 +974,7 @@ describe('Input validation failures: AwardCeremony instance', () => {
 							nominations: [
 								{
 									isWinner: false,
+									customType: '',
 									entities: [
 										{
 											uuid: undefined,
@@ -992,6 +1064,7 @@ describe('Input validation failures: AwardCeremony instance', () => {
 							nominations: [
 								{
 									isWinner: false,
+									customType: '',
 									entities: [
 										{
 											uuid: undefined,
@@ -1082,6 +1155,7 @@ describe('Input validation failures: AwardCeremony instance', () => {
 							nominations: [
 								{
 									isWinner: false,
+									customType: '',
 									entities: [
 										{
 											uuid: undefined,
@@ -1165,6 +1239,7 @@ describe('Input validation failures: AwardCeremony instance', () => {
 							nominations: [
 								{
 									isWinner: false,
+									customType: '',
 									entities: [],
 									productions: [
 										{
@@ -1244,6 +1319,7 @@ describe('Input validation failures: AwardCeremony instance', () => {
 							nominations: [
 								{
 									isWinner: false,
+									customType: '',
 									entities: [],
 									productions: [
 										{
@@ -1329,6 +1405,7 @@ describe('Input validation failures: AwardCeremony instance', () => {
 							nominations: [
 								{
 									isWinner: false,
+									customType: '',
 									entities: [
 										{
 											uuid: undefined,
@@ -1405,6 +1482,7 @@ describe('Input validation failures: AwardCeremony instance', () => {
 							nominations: [
 								{
 									isWinner: false,
+									customType: '',
 									entities: [
 										{
 											uuid: undefined,
@@ -1486,6 +1564,7 @@ describe('Input validation failures: AwardCeremony instance', () => {
 							nominations: [
 								{
 									isWinner: false,
+									customType: '',
 									entities: [],
 									productions: [],
 									materials: [

--- a/test-unit/src/models/Nomination.test.js
+++ b/test-unit/src/models/Nomination.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import proxyquire from 'proxyquire';
-import { assert, createStubInstance, stub } from 'sinon';
+import { assert, createStubInstance, spy, stub } from 'sinon';
 
 import { CompanyWithMembers, MaterialBase, Person, ProductionIdentifier } from '../../../src/models';
 
@@ -104,6 +104,45 @@ describe('Nomination model', () => {
 
 				const instance = createInstance({ isWinner: true });
 				expect(instance.isWinner).to.equal(true);
+
+			});
+
+		});
+
+		describe('customType property', () => {
+
+			it('assigns empty string if absent from props', () => {
+
+				const instance = createInstance({});
+				expect(instance.customType).to.equal('');
+
+			});
+
+			it('assigns empty string if included in props but value is empty string', () => {
+
+				const instance = createInstance({ customType: '' });
+				expect(instance.customType).to.equal('');
+
+			});
+
+			it('assigns empty string if included in props but value is whitespace-only string', () => {
+
+				const instance = createInstance({ customType: ' ' });
+				expect(instance.customType).to.equal('');
+
+			});
+
+			it('assigns value if included in props and is string with length', () => {
+
+				const instance = createInstance({ customType: 'Shortlisted' });
+				expect(instance.customType).to.equal('Shortlisted');
+
+			});
+
+			it('trims value before assigning', () => {
+
+				const instance = createInstance({ customType: ' Shortlisted ' });
+				expect(instance.customType).to.equal('Shortlisted');
 
 			});
 
@@ -233,6 +272,7 @@ describe('Nomination model', () => {
 		it('calls instance\'s validate methods and associated models\' validate methods', () => {
 
 			const props = {
+				customType: 'Shortlisted',
 				entities: [
 					{
 						name: 'Simon Baker'
@@ -254,8 +294,10 @@ describe('Nomination model', () => {
 				]
 			};
 			const instance = createInstance(props);
+			spy(instance, 'validateCustomType');
 			instance.runInputValidations();
 			assert.callOrder(
+				instance.validateCustomType,
 				stubs.getDuplicateEntityInfoModule.getDuplicateEntities,
 				instance.entities[0].validateName,
 				instance.entities[0].validateDifferentiator,
@@ -274,6 +316,8 @@ describe('Nomination model', () => {
 				instance.materials[0].validateDifferentiator,
 				instance.materials[0].validateUniquenessInGroup
 			);
+			expect(instance.validateCustomType.calledOnce).to.be.true;
+			expect(instance.validateCustomType.calledWithExactly({ isRequired: false })).to.be.true;
 			expect(stubs.getDuplicateEntityInfoModule.getDuplicateEntities.calledOnce).to.be.true;
 			expect(stubs.getDuplicateEntityInfoModule.getDuplicateEntities.calledWithExactly(
 				instance.entities
@@ -323,6 +367,22 @@ describe('Nomination model', () => {
 			expect(instance.materials[0].validateUniquenessInGroup.calledOnce).to.be.true;
 			expect(instance.materials[0].validateUniquenessInGroup.calledWithExactly(
 				{ isDuplicate: false }
+			)).to.be.true;
+
+		});
+
+	});
+
+	describe('validateCustomType method', () => {
+
+		it('will call validateStringForProperty method', () => {
+
+			const instance = createInstance({ customType: 'Shortlisted' });
+			spy(instance, 'validateStringForProperty');
+			instance.validateCustomType({ isRequired: false });
+			expect(instance.validateStringForProperty.calledOnce).to.be.true;
+			expect(instance.validateStringForProperty.calledWithExactly(
+				'customType', { isRequired: false }
 			)).to.be.true;
 
 		});


### PR DESCRIPTION
Some award ceremonies don't use just 'winner' and 'nominee/nomination' to distinguish the different honours bestowed to recipients, e.g.

- Evening Standard Theatre Awards:
  - Longlisted
  - Shortlisted
  - Winner
- Susan Smith Blackburn Prize:
  - Finalist
  - Special Commendation
  - Winner

There may also be award ceremonies that use different terms for their winners, e.g. 'First Prize', 'Second Prize', 'Third Prize', etc.

This PR allows nominations to be given a `customType` property which can employed by the front-end to be displayed instead of the default 'Nomination' and 'Winner' text.

N.B. Several contrived companies/materials/people/productions have been used for the purposes of demonstration.

---

#### Wordsmith Award 2008 (award ceremony)
<img width="887" alt="wordsmith-award-2008-award-ceremony" src="https://user-images.githubusercontent.com/10484515/161835854-e0582fa8-bd94-4b3c-9e76-f574dda1cb8b.png">

---

#### Xyzzy at National Theatre: Olivier Theatre (production) - direct nominations
<img width="658" alt="xyzzy-olivier-theatre-production" src="https://user-images.githubusercontent.com/10484515/161835870-f4ada7b2-30c3-41e3-90a4-dc3f46b57c8f.png">

---

#### Fred (material) - direct nominations
<img width="738" alt="fred-material" src="https://user-images.githubusercontent.com/10484515/161836057-5fbaac63-cedb-4774-8d0c-e4ed2f83547f.png">

---

#### John Doe (person) - direct nominations
<img width="861" alt="john-doe-person" src="https://user-images.githubusercontent.com/10484515/161835893-2d0a473d-6318-402b-89bf-e135b81a6c72.png">

---

#### Playwrights Ltd (company) - direct nominations
<img width="863" alt="playwrights-ltd-company" src="https://user-images.githubusercontent.com/10484515/161835912-aa92d67a-52fb-46b2-bad5-bb1086062a9a.png">

---

#### Plugh (original version) (material) - subsequent versions have nominations
<img width="859" alt="plugh-original-version-material" src="https://user-images.githubusercontent.com/10484515/161835922-6a858dd3-a236-491f-9cbb-72fadbec4e5a.png">

---

#### Francis Flob (person) - subsequent versions of their work have nominations
<img width="858" alt="francis-flob-person" src="https://user-images.githubusercontent.com/10484515/161835936-545414be-85f1-4129-8527-fcbd54f1b0ed.png">

---

#### Curtain Up Ltd (company) - subsequent versions of their work have nominations
<img width="854" alt="curtain-up-ltd-company" src="https://user-images.githubusercontent.com/10484515/161835959-89c09313-e740-4b29-9dbc-e4b7db497aed.png">

---

#### Waldo (material) - materials that used it as source material have nominations
<img width="935" alt="waldo-material" src="https://user-images.githubusercontent.com/10484515/161835970-18f913e0-c0da-4db3-9003-6ff18bec1efe.png">

---

#### Jane Roe (person) - materials that used their work as source material have nominations
<img width="938" alt="jane-roe-person" src="https://user-images.githubusercontent.com/10484515/161835984-876e591f-4439-42da-a0df-5aea70bde80a.png">

---

#### Fictioneers Ltd (company) - materials that used their work as source material have nominations
<img width="942" alt="fictioneers-ltd-company" src="https://user-images.githubusercontent.com/10484515/161836022-ec225155-b321-4955-ba77-35810087883e.png">

---

#### Talyse Tata (person) - materials to which they have granted rights have nominations
<img width="917" alt="talyse-tata-person" src="https://user-images.githubusercontent.com/10484515/161837966-14e6f40f-8be5-4369-bbe8-3c875149584e.png">

----

#### Cinerights Ltd (company) - materials to which they have granted rights have nominations
<img width="913" alt="cinerights-ltd-company" src="https://user-images.githubusercontent.com/10484515/161837994-a0c44d77-79cc-4dc9-8580-6fe0a9cdfee7.png">