### PR TITLE
Add nomination type property in getShowQuery responses

### DIFF
--- a/src/neo4j/cypher-queries/award-ceremony.js
+++ b/src/neo4j/cypher-queries/award-ceremony.js
@@ -590,7 +590,7 @@ const getShowQuery = () => `
 				ELSE {
 					model: 'NOMINATION',
 					isWinner: COALESCE(isWinner, false),
-					customType: customType,
+					type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
 					entities: nomineeEntities,
 					productions: nomineeProductions,
 					materials: nomineeMaterials

--- a/src/neo4j/cypher-queries/company.js
+++ b/src/neo4j/cypher-queries/company.js
@@ -740,7 +740,7 @@ const getShowQuery = () => `
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(nomineeRel.isWinner, false),
-			customType: nomineeRel.customType,
+			type: COALESCE(nomineeRel.customType, CASE WHEN nomineeRel.isWinner THEN 'Winner' ELSE 'Nomination' END),
 			members: nominatedMembers,
 			coEntities: coNominatedEntities,
 			productions: nominatedProductions,
@@ -1065,7 +1065,7 @@ const getShowQuery = () => `
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(isWinner, false),
-			customType: customType,
+			type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
 			entities: nominatedEntities,
 			productions: nominatedProductions,
 			materials: nominatedMaterials,
@@ -1413,7 +1413,7 @@ const getShowQuery = () => `
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(isWinner, false),
-			customType: customType,
+			type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
 			entities: nominatedEntities,
 			productions: nominatedProductions,
 			materials: nominatedMaterials,
@@ -1765,7 +1765,7 @@ const getShowQuery = () => `
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(isWinner, false),
-			customType: customType,
+			type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
 			entities: nominatedEntities,
 			productions: nominatedProductions,
 			materials: nominatedMaterials,

--- a/src/neo4j/cypher-queries/material.js
+++ b/src/neo4j/cypher-queries/material.js
@@ -758,7 +758,7 @@ const getShowQuery = () => `
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(nomineeRel.isWinner, false),
-			customType: nomineeRel.customType,
+			type: COALESCE(nomineeRel.customType, CASE WHEN nomineeRel.isWinner THEN 'Winner' ELSE 'Nomination' END),
 			entities: nominatedEntities,
 			productions: nominatedProductions,
 			coMaterials: coNominatedMaterials
@@ -1068,7 +1068,7 @@ const getShowQuery = () => `
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(isWinner, false),
-			customType: customType,
+			type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
 			entities: nominatedEntities,
 			productions: nominatedProductions,
 			materials: nominatedMaterials,
@@ -1398,7 +1398,7 @@ const getShowQuery = () => `
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(isWinner, false),
-			customType: customType,
+			type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
 			entities: nominatedEntities,
 			productions: nominatedProductions,
 			materials: nominatedMaterials,

--- a/src/neo4j/cypher-queries/person.js
+++ b/src/neo4j/cypher-queries/person.js
@@ -964,7 +964,7 @@ const getShowQuery = () => `
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(entityRel.isWinner, false),
-			customType: entityRel.customType,
+			type: COALESCE(entityRel.customType, CASE WHEN entityRel.isWinner THEN 'Winner' ELSE 'Nomination' END),
 			employerCompany: nominatedEmployerCompany,
 			coEntities: coNominatedEntities,
 			productions: nominatedProductions,
@@ -1302,7 +1302,7 @@ const getShowQuery = () => `
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(isWinner, false),
-			customType: customType,
+			type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
 			entities: nominatedEntities,
 			productions: nominatedProductions,
 			materials: nominatedMaterials,
@@ -1664,7 +1664,7 @@ const getShowQuery = () => `
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(isWinner, false),
-			customType: customType,
+			type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
 			entities: nominatedEntities,
 			productions: nominatedProductions,
 			materials: nominatedMaterials,
@@ -2030,7 +2030,7 @@ const getShowQuery = () => `
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(isWinner, false),
-			customType: customType,
+			type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
 			entities: nominatedEntities,
 			productions: nominatedProductions,
 			materials: nominatedMaterials,

--- a/src/neo4j/cypher-queries/production.js
+++ b/src/neo4j/cypher-queries/production.js
@@ -1226,7 +1226,7 @@ const getShowQuery = () => `
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(nomineeRel.isWinner, false),
-			customType: nomineeRel.customType,
+			type: COALESCE(nomineeRel.customType, CASE WHEN nomineeRel.isWinner THEN 'Winner' ELSE 'Nomination' END),
 			entities: nominatedEntities,
 			coProductions: coNominatedProductions,
 			materials: nominatedMaterials

--- a/test-e2e/crud/award-ceremonies-api.test.js
+++ b/test-e2e/crud/award-ceremonies-api.test.js
@@ -1619,7 +1619,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
-								customType: null,
+								type: 'Nomination',
 								entities: [
 									{
 										model: 'PERSON',
@@ -1656,7 +1656,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
-								customType: null,
+								type: 'Nomination',
 								entities: [
 									{
 										model: 'COMPANY',
@@ -1707,7 +1707,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: true,
-								customType: null,
+								type: 'Winner',
 								entities: [
 									{
 										model: 'PERSON',
@@ -1749,7 +1749,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
-								customType: null,
+								type: 'Nomination',
 								entities: [
 									{
 										model: 'COMPANY',
@@ -1798,7 +1798,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
-								customType: null,
+								type: 'Nomination',
 								entities: [
 									{
 										model: 'COMPANY',
@@ -1866,7 +1866,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
-								customType: null,
+								type: 'Nomination',
 								entities: [
 									{
 										model: 'PERSON',
@@ -1880,7 +1880,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
-								customType: null,
+								type: 'Nomination',
 								entities: [
 									{
 										model: 'PERSON',
@@ -1899,7 +1899,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: true,
-								customType: null,
+								type: 'Winner',
 								entities: [
 									{
 										model: 'PERSON',
@@ -1919,7 +1919,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
-								customType: null,
+								type: 'Nomination',
 								entities: [],
 								productions: [
 									{
@@ -1954,7 +1954,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: true,
-								customType: null,
+								type: 'Winner',
 								entities: [],
 								productions: [
 									{
@@ -1976,7 +1976,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
-								customType: null,
+								type: 'Nomination',
 								entities: [],
 								productions: [
 									{
@@ -2004,7 +2004,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: true,
-								customType: null,
+								type: 'Winner',
 								entities: [],
 								productions: [],
 								materials: [
@@ -2021,7 +2021,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
-								customType: 'Special Commendation',
+								type: 'Special Commendation',
 								entities: [],
 								productions: [],
 								materials: [
@@ -2038,7 +2038,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
-								customType: 'Finalist',
+								type: 'Finalist',
 								entities: [],
 								productions: [],
 								materials: [
@@ -4144,7 +4144,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: true,
-								customType: null,
+								type: 'Winner',
 								entities: [
 									{
 										model: 'PERSON',
@@ -4181,7 +4181,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
-								customType: null,
+								type: 'Nomination',
 								entities: [
 									{
 										model: 'COMPANY',
@@ -4232,7 +4232,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
-								customType: null,
+								type: 'Nomination',
 								entities: [
 									{
 										model: 'PERSON',
@@ -4274,7 +4274,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
-								customType: null,
+								type: 'Nomination',
 								entities: [
 									{
 										model: 'COMPANY',
@@ -4336,7 +4336,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
-								customType: null,
+								type: 'Nomination',
 								entities: [
 									{
 										model: 'COMPANY',
@@ -4404,7 +4404,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
-								customType: null,
+								type: 'Nomination',
 								entities: [
 									{
 										model: 'PERSON',
@@ -4418,7 +4418,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: true,
-								customType: null,
+								type: 'Winner',
 								entities: [
 									{
 										model: 'PERSON',
@@ -4432,7 +4432,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
-								customType: null,
+								type: 'Nomination',
 								entities: [
 									{
 										model: 'PERSON',
@@ -4457,7 +4457,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
-								customType: null,
+								type: 'Nomination',
 								entities: [],
 								productions: [
 									{
@@ -4479,7 +4479,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
-								customType: null,
+								type: 'Nomination',
 								entities: [],
 								productions: [
 									{
@@ -4514,7 +4514,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: true,
-								customType: null,
+								type: 'Winner',
 								entities: [],
 								productions: [
 									{
@@ -4555,7 +4555,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
-								customType: 'Shortlisted',
+								type: 'Shortlisted',
 								entities: [],
 								productions: [],
 								materials: [
@@ -4572,7 +4572,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: true,
-								customType: null,
+								type: 'Winner',
 								entities: [],
 								productions: [],
 								materials: [
@@ -4589,7 +4589,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 							{
 								model: 'NOMINATION',
 								isWinner: false,
-								customType: 'Longlisted',
+								type: 'Longlisted',
 								entities: [],
 								productions: [],
 								materials: [

--- a/test-e2e/model-interaction/award-ceremonies-nominated-materials.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-nominated-materials.test.js
@@ -1141,7 +1141,7 @@ describe('Award ceremonies with nominated materials', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: false,
-							customType: 'Shortlisted',
+							type: 'Shortlisted',
 							entities: [],
 							productions: [
 								{
@@ -1238,7 +1238,7 @@ describe('Award ceremonies with nominated materials', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: false,
-							customType: 'Longlisted',
+							type: 'Longlisted',
 							entities: [],
 							productions: [
 								{
@@ -1334,7 +1334,7 @@ describe('Award ceremonies with nominated materials', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: true,
-							customType: 'First Place',
+							type: 'First Place',
 							entities: [],
 							productions: [
 								{
@@ -1436,7 +1436,7 @@ describe('Award ceremonies with nominated materials', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: false,
-							customType: null,
+							type: 'Nomination',
 							entities: [],
 							productions: [
 								{
@@ -1517,7 +1517,7 @@ describe('Award ceremonies with nominated materials', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: true,
-							customType: null,
+							type: 'Winner',
 							entities: [],
 							productions: [
 								{
@@ -1585,7 +1585,7 @@ describe('Award ceremonies with nominated materials', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: false,
-							customType: null,
+							type: 'Nomination',
 							entities: [],
 							productions: [
 								{
@@ -1712,7 +1712,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: null,
+											type: 'Winner',
 											employerCompany: null,
 											coEntities: [],
 											productions: [
@@ -1780,7 +1780,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Longlisted',
+											type: 'Longlisted',
 											employerCompany: null,
 											coEntities: [],
 											productions: [
@@ -1863,7 +1863,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: null,
+											type: 'Winner',
 											members: [],
 											coEntities: [],
 											productions: [
@@ -1931,7 +1931,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Longlisted',
+											type: 'Longlisted',
 											members: [],
 											coEntities: [],
 											productions: [
@@ -2014,7 +2014,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: null,
+											type: 'Nomination',
 											employerCompany: null,
 											coEntities: [],
 											productions: [
@@ -2062,7 +2062,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: null,
+											type: 'Winner',
 											employerCompany: null,
 											coEntities: [],
 											productions: [
@@ -2113,7 +2113,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Shortlisted',
+											type: 'Shortlisted',
 											employerCompany: null,
 											coEntities: [],
 											productions: [
@@ -2174,7 +2174,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Shortlisted',
+											type: 'Shortlisted',
 											employerCompany: null,
 											coEntities: [],
 											productions: [
@@ -2240,7 +2240,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: null,
+											type: 'Nomination',
 											members: [],
 											coEntities: [],
 											productions: [
@@ -2295,7 +2295,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Shortlisted',
+											type: 'Shortlisted',
 											members: [],
 											coEntities: [],
 											productions: [
@@ -2378,7 +2378,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: null,
+											type: 'Nomination',
 											employerCompany: null,
 											coEntities: [],
 											productions: [
@@ -2426,7 +2426,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: null,
+											type: 'Winner',
 											employerCompany: null,
 											coEntities: [],
 											productions: [
@@ -2474,7 +2474,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: null,
+											type: 'Nomination',
 											employerCompany: null,
 											coEntities: [],
 											productions: [
@@ -2525,7 +2525,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Shortlisted',
+											type: 'Shortlisted',
 											employerCompany: null,
 											coEntities: [],
 											productions: [
@@ -2586,7 +2586,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: 'First Place',
+											type: 'First Place',
 											employerCompany: null,
 											coEntities: [],
 											productions: [
@@ -2656,7 +2656,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: null,
+											type: 'Nomination',
 											members: [],
 											coEntities: [],
 											productions: [
@@ -2704,7 +2704,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: null,
+											type: 'Nomination',
 											members: [],
 											coEntities: [],
 											productions: [
@@ -2772,7 +2772,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Longlisted',
+											type: 'Longlisted',
 											members: [],
 											coEntities: [],
 											productions: [
@@ -2833,7 +2833,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: 'First Place',
+											type: 'First Place',
 											members: [],
 											coEntities: [],
 											productions: [
@@ -2903,7 +2903,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: null,
+											type: 'Winner',
 											entities: [],
 											productions: [
 												{
@@ -2958,7 +2958,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Shortlisted',
+											type: 'Shortlisted',
 											entities: [],
 											productions: [
 												{
@@ -3043,7 +3043,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: null,
+											type: 'Winner',
 											entities: [],
 											productions: [
 												{
@@ -3098,7 +3098,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Shortlisted',
+											type: 'Shortlisted',
 											entities: [],
 											productions: [
 												{
@@ -3184,7 +3184,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: null,
+											type: 'Winner',
 											entities: [],
 											productions: [
 												{
@@ -3239,7 +3239,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Shortlisted',
+											type: 'Shortlisted',
 											entities: [],
 											productions: [
 												{
@@ -3323,7 +3323,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: null,
+											type: 'Nomination',
 											entities: [],
 											productions: [
 												{
@@ -3391,7 +3391,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Longlisted',
+											type: 'Longlisted',
 											entities: [],
 											productions: [
 												{
@@ -3474,7 +3474,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: null,
+											type: 'Nomination',
 											entities: [],
 											productions: [
 												{
@@ -3542,7 +3542,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Longlisted',
+											type: 'Longlisted',
 											entities: [],
 											productions: [
 												{
@@ -3625,7 +3625,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: null,
+											type: 'Nomination',
 											entities: [],
 											productions: [
 												{
@@ -3693,7 +3693,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Longlisted',
+											type: 'Longlisted',
 											entities: [],
 											productions: [
 												{
@@ -3776,7 +3776,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: null,
+											type: 'Winner',
 											employerCompany: null,
 											coEntities: [],
 											productions: [
@@ -3847,7 +3847,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: null,
+											type: 'Nomination',
 											entities: [],
 											productions: [
 												{
@@ -3902,7 +3902,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: 'First Place',
+											type: 'First Place',
 											entities: [],
 											productions: [
 												{
@@ -3988,7 +3988,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: null,
+											type: 'Nomination',
 											entities: [],
 											productions: [
 												{
@@ -4043,7 +4043,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: 'First Place',
+											type: 'First Place',
 											entities: [],
 											productions: [
 												{
@@ -4129,7 +4129,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: null,
+											type: 'Nomination',
 											entities: [],
 											productions: [
 												{
@@ -4197,7 +4197,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: 'First Place',
+											type: 'First Place',
 											entities: [],
 											productions: [
 												{
@@ -4270,7 +4270,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: null,
+											type: 'Nomination',
 											entities: [],
 											productions: [
 												{
@@ -4338,7 +4338,7 @@ describe('Award ceremonies with nominated materials', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: 'First Place',
+											type: 'First Place',
 											entities: [],
 											productions: [
 												{

--- a/test-e2e/model-interaction/award-ceremonies.test.js
+++ b/test-e2e/model-interaction/award-ceremonies.test.js
@@ -1622,7 +1622,7 @@ describe('Award ceremonies', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: true,
-							customType: null,
+							type: 'Winner',
 							entities: [
 								{
 									model: 'PERSON',
@@ -1676,7 +1676,7 @@ describe('Award ceremonies', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: false,
-							customType: null,
+							type: 'Nomination',
 							entities: [
 								{
 									model: 'COMPANY',
@@ -1724,7 +1724,7 @@ describe('Award ceremonies', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: false,
-							customType: null,
+							type: 'Nomination',
 							entities: [
 								{
 									name: 'Stagecraft Ltd',
@@ -1822,7 +1822,7 @@ describe('Award ceremonies', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: false,
-							customType: null,
+							type: 'Nomination',
 							entities: [
 								{
 									model: 'COMPANY',
@@ -1904,7 +1904,7 @@ describe('Award ceremonies', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: false,
-							customType: null,
+							type: 'Nomination',
 							entities: [
 								{
 									model: 'PERSON',
@@ -1918,7 +1918,7 @@ describe('Award ceremonies', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: true,
-							customType: null,
+							type: 'Winner',
 							entities: [
 								{
 									model: 'PERSON',
@@ -1943,7 +1943,7 @@ describe('Award ceremonies', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: false,
-							customType: null,
+							type: 'Nomination',
 							entities: [
 								{
 									model: 'COMPANY',
@@ -2001,7 +2001,7 @@ describe('Award ceremonies', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: false,
-							customType: null,
+							type: 'Nomination',
 							entities: [
 								{
 									model: 'COMPANY',
@@ -2022,7 +2022,7 @@ describe('Award ceremonies', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: false,
-							customType: null,
+							type: 'Nomination',
 							entities: [],
 							productions: [
 								{
@@ -2044,7 +2044,7 @@ describe('Award ceremonies', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: true,
-							customType: null,
+							type: 'Winner',
 							entities: [],
 							productions: [
 								{
@@ -2083,7 +2083,7 @@ describe('Award ceremonies', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: false,
-							customType: null,
+							type: 'Nomination',
 							entities: [],
 							productions: [
 								{
@@ -2111,7 +2111,7 @@ describe('Award ceremonies', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: false,
-							customType: null,
+							type: 'Nomination',
 							entities: [],
 							productions: [],
 							materials: [
@@ -2128,7 +2128,7 @@ describe('Award ceremonies', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: false,
-							customType: null,
+							type: 'Nomination',
 							entities: [],
 							productions: [],
 							materials: [
@@ -2153,7 +2153,7 @@ describe('Award ceremonies', () => {
 						{
 							model: 'NOMINATION',
 							isWinner: true,
-							customType: null,
+							type: 'Winner',
 							entities: [],
 							productions: [],
 							materials: [
@@ -2256,7 +2256,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Special Commendation',
+											type: 'Special Commendation',
 											employerCompany: null,
 											coEntities: [],
 											productions: [
@@ -2287,7 +2287,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Finalist',
+											type: 'Finalist',
 											employerCompany: null,
 											coEntities: [
 												{
@@ -2370,7 +2370,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: 'First Place',
+											type: 'First Place',
 											employerCompany: null,
 											coEntities: [],
 											productions: [
@@ -2414,7 +2414,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Longlisted',
+											type: 'Longlisted',
 											employerCompany: null,
 											coEntities: [
 												{
@@ -2470,7 +2470,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: 'First Place',
+											type: 'First Place',
 											employerCompany: null,
 											coEntities: [
 												{
@@ -2497,7 +2497,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Longlisted',
+											type: 'Longlisted',
 											employerCompany: null,
 											coEntities: [
 												{
@@ -2597,7 +2597,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: null,
+											type: 'Winner',
 											employerCompany: null,
 											coEntities: [],
 											productions: [
@@ -2645,7 +2645,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: null,
+											type: 'Nomination',
 											employerCompany: null,
 											coEntities: [
 												{
@@ -2694,7 +2694,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: null,
+											type: 'Winner',
 											employerCompany: null,
 											coEntities: [
 												{
@@ -2728,7 +2728,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: null,
+											type: 'Nomination',
 											employerCompany: null,
 											coEntities: [
 												{
@@ -2823,7 +2823,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Finalist',
+											type: 'Finalist',
 											members: [],
 											coEntities: [
 												{
@@ -2905,7 +2905,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: 'First Place',
+											type: 'First Place',
 											members: [],
 											coEntities: [],
 											productions: [
@@ -2953,7 +2953,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: 'First Place',
+											type: 'First Place',
 											members: [],
 											coEntities: [
 												{
@@ -2979,7 +2979,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Shortlisted',
+											type: 'Shortlisted',
 											members: [],
 											coEntities: [],
 											productions: [
@@ -3030,7 +3030,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: null,
+											type: 'Nomination',
 											members: [],
 											coEntities: [
 												{
@@ -3078,7 +3078,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: null,
+											type: 'Nomination',
 											members: [],
 											coEntities: [],
 											productions: [],
@@ -3100,7 +3100,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: null,
+											type: 'Nomination',
 											members: [],
 											coEntities: [],
 											productions: [
@@ -3131,7 +3131,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: null,
+											type: 'Nomination',
 											members: [],
 											coEntities: [
 												{
@@ -3225,7 +3225,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Finalist',
+											type: 'Finalist',
 											employerCompany: null,
 											coEntities: [
 												{
@@ -3325,7 +3325,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Shortlisted',
+											type: 'Shortlisted',
 											employerCompany: null,
 											coEntities: [
 												{
@@ -3396,7 +3396,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Shortlisted',
+											type: 'Shortlisted',
 											employerCompany: null,
 											coEntities: [
 												{
@@ -3463,7 +3463,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Shortlisted',
+											type: 'Shortlisted',
 											employerCompany: null,
 											coEntities: [
 												{
@@ -3523,7 +3523,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: 'First Place',
+											type: 'First Place',
 											employerCompany: null,
 											coEntities: [
 												{
@@ -3619,7 +3619,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: null,
+											type: 'Nomination',
 											employerCompany: null,
 											coEntities: [
 												{
@@ -3718,7 +3718,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: null,
+											type: 'Nomination',
 											employerCompany: null,
 											coEntities: [
 												{
@@ -3785,7 +3785,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: null,
+											type: 'Winner',
 											employerCompany: null,
 											coEntities: [
 												{
@@ -3909,7 +3909,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Finalist',
+											type: 'Finalist',
 											members: [
 												{
 													model: 'PERSON',
@@ -4008,7 +4008,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Shortlisted',
+											type: 'Shortlisted',
 											members: [
 												{
 													model: 'PERSON',
@@ -4074,7 +4074,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Shortlisted',
+											type: 'Shortlisted',
 											members: [
 												{
 													model: 'PERSON',
@@ -4133,7 +4133,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: 'First Place',
+											type: 'First Place',
 											members: [
 												{
 													model: 'PERSON',
@@ -4228,7 +4228,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: null,
+											type: 'Nomination',
 											members: [
 												{
 													model: 'PERSON',
@@ -4326,7 +4326,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: null,
+											type: 'Nomination',
 											members: [
 												{
 													model: 'PERSON',
@@ -4392,7 +4392,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: null,
+											type: 'Winner',
 											members: [
 												{
 													model: 'PERSON',
@@ -4515,7 +4515,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Finalist',
+											type: 'Finalist',
 											employerCompany: {
 												model: 'COMPANY',
 												uuid: THEATRICALS_LTD_COMPANY_UUID,
@@ -4614,7 +4614,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Shortlisted',
+											type: 'Shortlisted',
 											employerCompany: {
 												model: 'COMPANY',
 												uuid: THEATRICALS_LTD_COMPANY_UUID,
@@ -4684,7 +4684,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Shortlisted',
+											type: 'Shortlisted',
 											employerCompany: {
 												model: 'COMPANY',
 												uuid: THEATRICALS_LTD_COMPANY_UUID,
@@ -4743,7 +4743,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: 'First Place',
+											type: 'First Place',
 											employerCompany: {
 												model: 'COMPANY',
 												uuid: THEATRICALS_LTD_COMPANY_UUID,
@@ -4838,7 +4838,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: null,
+											type: 'Nomination',
 											employerCompany: {
 												model: 'COMPANY',
 												uuid: THEATRICALS_LTD_COMPANY_UUID,
@@ -4936,7 +4936,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: null,
+											type: 'Nomination',
 											employerCompany: {
 												model: 'COMPANY',
 												uuid: THEATRICALS_LTD_COMPANY_UUID,
@@ -5002,7 +5002,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: null,
+											type: 'Winner',
 											employerCompany: {
 												model: 'COMPANY',
 												uuid: THEATRICALS_LTD_COMPANY_UUID,
@@ -5125,7 +5125,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Finalist',
+											type: 'Finalist',
 											entities: [
 												{
 													model: 'COMPANY',
@@ -5197,7 +5197,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Finalist',
+											type: 'Finalist',
 											entities: [],
 											coProductions: [],
 											materials: []
@@ -5225,7 +5225,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Shortlisted',
+											type: 'Shortlisted',
 											entities: [
 												{
 													model: 'PERSON',
@@ -5275,7 +5275,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: 'First Place',
+											type: 'First Place',
 											entities: [],
 											coProductions: [],
 											materials: []
@@ -5303,7 +5303,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: null,
+											type: 'Winner',
 											entities: [
 												{
 													model: 'PERSON',
@@ -5339,7 +5339,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: null,
+											type: 'Nomination',
 											entities: [
 												{
 													model: 'COMPANY',
@@ -5425,7 +5425,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: null,
+											type: 'Winner',
 											entities: [],
 											coProductions: [
 												{
@@ -5482,7 +5482,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Longlisted',
+											type: 'Longlisted',
 											entities: [
 												{
 													model: 'PERSON',
@@ -5559,7 +5559,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Longlisted',
+											type: 'Longlisted',
 											entities: [],
 											coProductions: [
 												{
@@ -5605,7 +5605,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: null,
+											type: 'Nomination',
 											entities: [
 												{
 													model: 'PERSON',
@@ -5662,7 +5662,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: null,
+											type: 'Winner',
 											entities: [],
 											coProductions: [
 												{
@@ -5723,7 +5723,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Finalist',
+											type: 'Finalist',
 											entities: [
 												{
 													model: 'COMPANY',
@@ -5805,7 +5805,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: 'Prize Recipient',
+											type: 'Prize Recipient',
 											entities: [],
 											productions: [],
 											coMaterials: [
@@ -5841,7 +5841,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Shortlisted',
+											type: 'Shortlisted',
 											entities: [
 												{
 													model: 'PERSON',
@@ -5901,7 +5901,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Shortlisted',
+											type: 'Shortlisted',
 											entities: [],
 											productions: [],
 											coMaterials: []
@@ -5929,7 +5929,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: null,
+											type: 'Winner',
 											entities: [
 												{
 													model: 'PERSON',
@@ -5974,7 +5974,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: null,
+											type: 'Nomination',
 											entities: [
 												{
 													model: 'COMPANY',
@@ -6069,7 +6069,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: null,
+											type: 'Nomination',
 											entities: [],
 											productions: [],
 											coMaterials: [
@@ -6120,7 +6120,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: 'Longlisted',
+											type: 'Longlisted',
 											entities: [
 												{
 													model: 'PERSON',
@@ -6203,7 +6203,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: true,
-											customType: 'First Place',
+											type: 'First Place',
 											entities: [],
 											productions: [],
 											coMaterials: []
@@ -6231,7 +6231,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: null,
+											type: 'Nomination',
 											entities: [
 												{
 													model: 'PERSON',
@@ -6293,7 +6293,7 @@ describe('Award ceremonies', () => {
 										{
 											model: 'NOMINATION',
 											isWinner: false,
-											customType: null,
+											type: 'Nomination',
 											entities: [],
 											productions: [],
 											coMaterials: [


### PR DESCRIPTION
This PR applies logic in the model 'show' Cypher queries so that the nomination `type` value is calculated based on its `customType` and `isWinner` values.

This allows the front-end to passively display the `type` value rather than have to calculate the value to display itself.