### PR TITLE
Refactor Cypher query variable length path usage

### DIFF
--- a/src/neo4j/cypher-queries/material.js
+++ b/src/neo4j/cypher-queries/material.js
@@ -553,7 +553,7 @@ const getShowQuery = () => `
 			END
 		) AS characterGroups
 
-	OPTIONAL MATCH (material)<-[:USES_SOURCE_MATERIAL|PRODUCTION_OF*1..2]-(production:Production)
+	OPTIONAL MATCH (material)<-[:USES_SOURCE_MATERIAL*0..1]-(:Material)<-[:PRODUCTION_OF]-(production:Production)
 
 	WITH
 		material,
@@ -615,7 +615,8 @@ const getShowQuery = () => `
 		characterGroups,
 		productions
 
-	OPTIONAL MATCH path=(material)-[:HAS_NOMINEE|HAS_SUB_MATERIAL*1..2]-(category:AwardCeremonyCategory)
+	OPTIONAL MATCH (material)-[:HAS_SUB_MATERIAL*0..1]-(materialLinkedToCategory:Material)
+		<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
 		<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
 
 	WITH
@@ -623,12 +624,12 @@ const getShowQuery = () => `
 		relatedMaterials,
 		characterGroups,
 		productions,
+		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		HEAD([rel IN RELATIONSHIPS(path) WHERE TYPE(rel) = 'HAS_NOMINEE']) AS nomineeRel,
-		CASE SIZE([node in NODES(path) WHERE HEAD(LABELS(node)) = "Material"]) WHEN 2
-			THEN LAST([node in NODES(path) WHERE HEAD(LABELS(node)) = "Material"])
+		CASE WHEN material <> materialLinkedToCategory
+			THEN materialLinkedToCategory
 			ELSE null
 		END AS recipientMaterial
 

--- a/src/neo4j/cypher-queries/venue.js
+++ b/src/neo4j/cypher-queries/venue.js
@@ -96,15 +96,13 @@ const getShowQuery = () => `
 			END
 		) AS subVenues
 
-	OPTIONAL MATCH path=
-		(venue)-[:HAS_SUB_VENUE*0..1]->(subVenueForProduction:Venue)<-[:PLAYS_AT]-(production:Production)
+	OPTIONAL MATCH (venue)-[:HAS_SUB_VENUE*0..1]->(venueLinkedToProduction:Venue)<-[:PLAYS_AT]-(production:Production)
 
 	WITH
 		venue,
 		surVenue,
 		subVenues,
-		subVenueForProduction,
-		LENGTH(path) AS venueToProductionPathLength,
+		venueLinkedToProduction,
 		production
 		ORDER BY production.startDate DESC, production.name
 
@@ -124,8 +122,8 @@ const getShowQuery = () => `
 					.name,
 					.startDate,
 					.endDate,
-					subVenue: CASE venueToProductionPathLength WHEN 2
-						THEN subVenueForProduction { model: 'VENUE', .uuid, .name }
+					subVenue: CASE WHEN venue <> venueLinkedToProduction
+						THEN venueLinkedToProduction { model: 'VENUE', .uuid, .name }
 						ELSE null
 					END
 				}


### PR DESCRIPTION
This PR refactors the usage of variable length path in Cypher queries to:
- (where possible) remove the use of `path=` to avoid having to perform search operations on the relationships extracted from the path in order to find a specific relationship to which to create a reference
- convert `*1..2` relationship patterns that search for multiple relationship types to the more specific usage of the `*0..1` relationship pattern that search for a single relationship type (checking that there is a single instance of it or no instance whatsoever) - this greater specificity reduces the potential for unintended matches