### PR TITLE
Amend DATABASE_URL value in .env-dev file

### DIFF
--- a/.env-dev
+++ b/.env-dev
@@ -1,3 +1,3 @@
 DATABASE_PASSWORD=theatrebase
-DATABASE_URL=bolt://localhost:11006
+DATABASE_URL=neo4j://localhost:7687
 DATABASE_USERNAME=neo4j


### PR DESCRIPTION
This change is required to allow the app to connect to the Neo4j Desktop database instance, as detailed in the link:

> I had a look through the documentation ([here](https://neo4j.com/docs/driver-manual/current/client-applications/?_gl=1*8n23nz*_ga*MTUxNTM5NjMzNy4xNjYwNzY1MTE3*_ga_DL38Q8KGQC*MTY2MDc2NTExNy4xLjEuMTY2MDc2NTU1NS4wLjAuMA..#driver-connection-uris)) and changed my NEO4J_URI from `bolt://SO.ME.IP.ADDRESS:7687` to `neo4j://MYDOMAIN.COM:7687` and all is working as expected now.

### References:
- [Neo4j Community: Server certificate is not trusted](https://community.neo4j.com/t5/neo4j-graph-platform/server-certificate-is-not-trusted/td-p/30192)