### PR TITLE
Upgrade mocha ^3.2.0 -> ^10.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "eslint": "^7.5.0",
     "eslint-plugin-no-only-tests": "^2.4.0",
     "lintspaces-cli": "^0.6.0",
-    "mocha": "^3.2.0",
+    "mocha": "^10.0.0",
     "node-fetch": "^2.6.0",
     "node-mocks-http": "^1.6.6",
     "nodemon": "^1.11.0",

--- a/src/app.js
+++ b/src/app.js
@@ -36,3 +36,4 @@ process.on('SIGINT', shutDown);
 
 // Export for end-to-end tests.
 export default app;
+export { shutDown };

--- a/test-e2e/setup.js
+++ b/test-e2e/setup.js
@@ -1,10 +1,17 @@
 import createNeo4jConstraints from '../src/neo4j/create-constraints';
 import createNeo4jIndexes from '../src/neo4j/create-indexes';
+import { shutDown } from '../src/app';
 
 before(async () => {
 
 	await createNeo4jConstraints();
 
 	await createNeo4jIndexes();
+
+});
+
+after(() => {
+
+	shutDown();
 
 });


### PR DESCRIPTION
This PR upgrades `mocha` to the current latest version and makes the necessary migratory changes.

### References:
- [GitHub: mochajs/mocha - releases - v4.0.0](https://github.com/mochajs/mocha/releases/tag/v4.0.0)
  - > By default, Mocha will no longer force the process to exit once all tests complete. This means any test code (or code under test) which would normally prevent `node` from exiting will do so when run in Mocha.
- [Stack Overflow: Mocha not exiting after test](https://stackoverflow.com/questions/50372866/mocha-not-exiting-after-test#answer-52143003)
- [GitHub: chaijs/chai-http - Issues - Http Server not closing after tests](https://github.com/chaijs/chai-http/issues/178)
- [GitHub: mochajs/mocha - Issues - Do not force exit of a process (by default)](https://github.com/mochajs/mocha/issues/2879)