### PR TITLE
Retain subject uuid value in subject instance results

### DIFF
--- a/src/neo4j/cypher-queries/company.js
+++ b/src/neo4j/cypher-queries/company.js
@@ -53,14 +53,7 @@ const getShowQuery = () => `
 			COLLECT(
 				CASE sourceMaterialWriter WHEN NULL
 					THEN null
-					ELSE sourceMaterialWriter {
-						model: TOUPPER(HEAD(LABELS(sourceMaterialWriter))),
-						uuid: CASE sourceMaterialWriter.uuid WHEN company.uuid
-							THEN null
-							ELSE sourceMaterialWriter.uuid
-						END,
-						.name
-					}
+					ELSE sourceMaterialWriter { model: TOUPPER(HEAD(LABELS(sourceMaterialWriter))), .uuid, .name }
 				END
 			) AS sourceMaterialWriters
 
@@ -99,7 +92,7 @@ const getShowQuery = () => `
 					THEN null
 					ELSE entity {
 						model: TOUPPER(HEAD(LABELS(entity))),
-						uuid: CASE entity.uuid WHEN company.uuid THEN null ELSE entity.uuid END,
+						.uuid,
 						.name,
 						.format,
 						.year,
@@ -186,12 +179,7 @@ const getShowQuery = () => `
 		[entity IN COLLECT(
 			CASE entity WHEN NULL
 				THEN null
-				ELSE entity {
-					model: TOUPPER(HEAD(LABELS(entity))),
-					uuid: CASE entity.uuid WHEN company.uuid THEN null ELSE entity.uuid END,
-					.name,
-					members: creditedMembers
-				}
+				ELSE entity { model: TOUPPER(HEAD(LABELS(entity))), .uuid, .name, members: creditedMembers }
 			END
 		) | CASE entity.model WHEN 'COMPANY'
 			THEN entity
@@ -934,12 +922,7 @@ const getShowQuery = () => `
 		[nominatedEntity IN COLLECT(
 			CASE nominatedEntity WHEN NULL
 				THEN null
-				ELSE nominatedEntity {
-					.model,
-					uuid: CASE nominatedEntity.uuid WHEN company.uuid THEN null ELSE nominatedEntity.uuid END,
-					.name,
-					members: nominatedMembers
-				}
+				ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
 			END
 		) | CASE nominatedEntity.model WHEN 'COMPANY'
 			THEN nominatedEntity
@@ -1309,12 +1292,7 @@ const getShowQuery = () => `
 		[nominatedEntity IN COLLECT(
 			CASE nominatedEntity WHEN NULL
 				THEN null
-				ELSE nominatedEntity {
-					.model,
-					uuid: CASE nominatedEntity.uuid WHEN company.uuid THEN null ELSE nominatedEntity.uuid END,
-					.name,
-					members: nominatedMembers
-				}
+				ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
 			END
 		) | CASE nominatedEntity.model WHEN 'COMPANY'
 			THEN nominatedEntity
@@ -1689,12 +1667,7 @@ const getShowQuery = () => `
 		[nominatedEntity IN COLLECT(
 			CASE nominatedEntity WHEN NULL
 				THEN null
-				ELSE nominatedEntity {
-					.model,
-					uuid: CASE nominatedEntity.uuid WHEN company.uuid THEN null ELSE nominatedEntity.uuid END,
-					.name,
-					members: nominatedMembers
-				}
+				ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
 			END
 		) | CASE nominatedEntity.model WHEN 'COMPANY'
 			THEN nominatedEntity

--- a/src/neo4j/cypher-queries/material.js
+++ b/src/neo4j/cypher-queries/material.js
@@ -400,14 +400,7 @@ const getShowQuery = () => `
 			COLLECT(
 				CASE sourceMaterialWriter WHEN NULL
 					THEN null
-					ELSE sourceMaterialWriter {
-						model: TOUPPER(HEAD(LABELS(sourceMaterialWriter))),
-						uuid: CASE sourceMaterialWriter.uuid WHEN material.uuid
-							THEN null
-							ELSE sourceMaterialWriter.uuid
-						END,
-						.name
-					}
+					ELSE sourceMaterialWriter { model: TOUPPER(HEAD(LABELS(sourceMaterialWriter))), .uuid, .name }
 				END
 			) AS sourceMaterialWriters
 
@@ -451,7 +444,7 @@ const getShowQuery = () => `
 					THEN null
 					ELSE entity {
 						model: TOUPPER(HEAD(LABELS(entity))),
-						uuid: CASE entity.uuid WHEN material.uuid THEN null ELSE entity.uuid END,
+						.uuid,
 						.name,
 						.format,
 						.year,
@@ -1149,13 +1142,7 @@ const getShowQuery = () => `
 		COLLECT(
 			CASE nominatedMaterial WHEN NULL
 				THEN null
-				ELSE nominatedMaterial {
-					model: 'MATERIAL',
-					uuid: CASE nominatedMaterial.uuid WHEN material.uuid THEN null ELSE nominatedMaterial.uuid END,
-					.name,
-					.format,
-					.year
-				}
+				ELSE nominatedMaterial { model: 'MATERIAL', .uuid, .name, .format, .year }
 			END
 		) AS nominatedMaterials
 		ORDER BY nomineeRel.nominationPosition, nomineeRel.materialPosition
@@ -1499,13 +1486,7 @@ const getShowQuery = () => `
 		COLLECT(
 			CASE nominatedMaterial WHEN NULL
 				THEN null
-				ELSE nominatedMaterial {
-					model: 'MATERIAL',
-					uuid: CASE nominatedMaterial.uuid WHEN material.uuid THEN null ELSE nominatedMaterial.uuid END,
-					.name,
-					.format,
-					.year
-				}
+				ELSE nominatedMaterial { model: 'MATERIAL', .uuid, .name, .format, .year }
 			END
 		) AS nominatedMaterials
 		ORDER BY nomineeRel.nominationPosition, nomineeRel.materialPosition

--- a/src/neo4j/cypher-queries/person.js
+++ b/src/neo4j/cypher-queries/person.js
@@ -53,14 +53,7 @@ const getShowQuery = () => `
 			COLLECT(
 				CASE sourceMaterialWriter WHEN NULL
 					THEN null
-					ELSE sourceMaterialWriter {
-						model: TOUPPER(HEAD(LABELS(sourceMaterialWriter))),
-						uuid: CASE sourceMaterialWriter.uuid WHEN person.uuid
-							THEN null
-							ELSE sourceMaterialWriter.uuid
-						END,
-						.name
-					}
+					ELSE sourceMaterialWriter { model: TOUPPER(HEAD(LABELS(sourceMaterialWriter))), .uuid, .name }
 				END
 			) AS sourceMaterialWriters
 
@@ -99,7 +92,7 @@ const getShowQuery = () => `
 					THEN null
 					ELSE entity {
 						model: TOUPPER(HEAD(LABELS(entity))),
-						uuid: CASE entity.uuid WHEN person.uuid THEN null ELSE entity.uuid END,
+						.uuid,
 						.name,
 						.format,
 						.year,
@@ -175,23 +168,14 @@ const getShowQuery = () => `
 			ORDER BY creditedMember.memberPosition
 
 		WITH person, materials, production, entityRel, entity,
-			COLLECT(DISTINCT(creditedMember {
-				model: 'PERSON',
-				uuid: CASE creditedMember.uuid WHEN person.uuid THEN null ELSE creditedMember.uuid END,
-				.name
-			})) AS creditedMembers
+			COLLECT(DISTINCT(creditedMember { model: 'PERSON', .uuid, .name })) AS creditedMembers
 		ORDER BY entityRel.creditPosition, entityRel.entityPosition
 
 	WITH person, materials, production, entityRel.credit AS producerCreditName,
 		[entity IN COLLECT(
 			CASE entity WHEN NULL
 				THEN null
-				ELSE entity {
-					model: TOUPPER(HEAD(LABELS(entity))),
-					uuid: CASE entity.uuid WHEN person.uuid THEN null ELSE entity.uuid END,
-					.name,
-					members: creditedMembers
-				}
+				ELSE entity { model: TOUPPER(HEAD(LABELS(entity))), .uuid, .name, members: creditedMembers }
 			END
 		) | CASE entity.model WHEN 'COMPANY'
 			THEN entity
@@ -1166,12 +1150,7 @@ const getShowQuery = () => `
 		[nominatedEntity IN COLLECT(
 			CASE nominatedEntity WHEN NULL
 				THEN null
-				ELSE nominatedEntity {
-					.model,
-					uuid: CASE nominatedEntity.uuid WHEN person.uuid THEN null ELSE nominatedEntity.uuid END,
-					.name,
-					members: nominatedMembers
-				}
+				ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
 			END
 		) | CASE nominatedEntity.model WHEN 'COMPANY'
 			THEN nominatedEntity
@@ -1554,12 +1533,7 @@ const getShowQuery = () => `
 		[nominatedEntity IN COLLECT(
 			CASE nominatedEntity WHEN NULL
 				THEN null
-				ELSE nominatedEntity {
-					.model,
-					uuid: CASE nominatedEntity.uuid WHEN person.uuid THEN null ELSE nominatedEntity.uuid END,
-					.name,
-					members: nominatedMembers
-				}
+				ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
 			END
 		) | CASE nominatedEntity.model WHEN 'COMPANY'
 			THEN nominatedEntity
@@ -1948,12 +1922,7 @@ const getShowQuery = () => `
 		[nominatedEntity IN COLLECT(
 			CASE nominatedEntity WHEN NULL
 				THEN null
-				ELSE nominatedEntity {
-					.model,
-					uuid: CASE nominatedEntity.uuid WHEN person.uuid THEN null ELSE nominatedEntity.uuid END,
-					.name,
-					members: nominatedMembers
-				}
+				ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
 			END
 		) | CASE nominatedEntity.model WHEN 'COMPANY'
 			THEN nominatedEntity

--- a/test-e2e/model-interaction/material-with-multi-credited-entities.test.js
+++ b/test-e2e/model-interaction/material-with-multi-credited-entities.test.js
@@ -128,7 +128,7 @@ describe('Materials with entities credited multiple times', () => {
 
 	describe('Person', () => {
 
-		it('includes materials they have written (in which their uuid is nullified), with corresponding writers', () => {
+		it('includes materials they have written, with corresponding writers', () => {
 
 			const expectedMaterials = [
 				{
@@ -145,7 +145,7 @@ describe('Materials with entities credited multiple times', () => {
 							entities: [
 								{
 									model: 'PERSON',
-									uuid: null,
+									uuid: FERDINAND_FOO_PERSON_UUID,
 									name: 'Ferdinand Foo'
 								},
 								{
@@ -161,7 +161,7 @@ describe('Materials with entities credited multiple times', () => {
 							entities: [
 								{
 									model: 'PERSON',
-									uuid: null,
+									uuid: FERDINAND_FOO_PERSON_UUID,
 									name: 'Ferdinand Foo'
 								},
 								{
@@ -185,7 +185,7 @@ describe('Materials with entities credited multiple times', () => {
 
 	describe('Company', () => {
 
-		it('includes materials it has written (in which its uuid is nullified), with corresponding writers', () => {
+		it('includes materials it has written, with corresponding writers', () => {
 
 			const expectedMaterials = [
 				{
@@ -207,7 +207,7 @@ describe('Materials with entities credited multiple times', () => {
 								},
 								{
 									model: 'COMPANY',
-									uuid: null,
+									uuid: STAGECRAFT_LTD_COMPANY_UUID,
 									name: 'Stagecraft Ltd'
 								}
 							]
@@ -223,7 +223,7 @@ describe('Materials with entities credited multiple times', () => {
 								},
 								{
 									model: 'COMPANY',
-									uuid: null,
+									uuid: STAGECRAFT_LTD_COMPANY_UUID,
 									name: 'Stagecraft Ltd'
 								}
 							]

--- a/test-e2e/model-interaction/material-with-multi-sub-material-versions.test.js
+++ b/test-e2e/model-interaction/material-with-multi-sub-material-versions.test.js
@@ -273,7 +273,7 @@ describe('Materials with multiple sub-material versions', () => {
 
 	describe('Aeschylus (person)', () => {
 
-		it('includes subsequent versions of materials they originally wrote (in which their uuid is nullified), with corresponding sur-material', () => {
+		it('includes subsequent versions of materials they originally wrote, with corresponding sur-material', () => {
 
 			const expectedSubsequentVersionMaterials = [
 				{
@@ -294,7 +294,7 @@ describe('Materials with multiple sub-material versions', () => {
 							entities: [
 								{
 									model: 'PERSON',
-									uuid: null,
+									uuid: AESCHYLUS_PERSON_UUID,
 									name: 'Aeschylus'
 								},
 								{
@@ -334,7 +334,7 @@ describe('Materials with multiple sub-material versions', () => {
 
 	describe('The Fathers of Tragedy (company)', () => {
 
-		it('includes subsequent versions of materials it originally wrote (in which its uuid is nullified), with corresponding sur-material', () => {
+		it('includes subsequent versions of materials it originally wrote, with corresponding sur-material', () => {
 
 			const expectedSubsequentVersionMaterials = [
 				{
@@ -360,7 +360,7 @@ describe('Materials with multiple sub-material versions', () => {
 								},
 								{
 									model: 'COMPANY',
-									uuid: null,
+									uuid: THE_FATHERS_OF_TRAGEDY_COMPANY_UUID,
 									name: 'The Fathers of Tragedy'
 								}
 							]

--- a/test-e2e/model-interaction/material-with-multi-versions.test.js
+++ b/test-e2e/model-interaction/material-with-multi-versions.test.js
@@ -498,7 +498,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 
 	describe('Henrik Ibsen (person)', () => {
 
-		it('includes materials they have written (in which their uuid is nullified)', () => {
+		it('includes materials they have written', () => {
 
 			const expectedMaterials = [
 				{
@@ -515,7 +515,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 							entities: [
 								{
 									model: 'PERSON',
-									uuid: null,
+									uuid: HENRIK_IBSEN_PERSON_UUID,
 									name: 'Henrik Ibsen'
 								},
 								{
@@ -541,7 +541,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 							entities: [
 								{
 									model: 'PERSON',
-									uuid: null,
+									uuid: HENRIK_IBSEN_PERSON_UUID,
 									name: 'Henrik Ibsen'
 								},
 								{
@@ -561,7 +561,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 
 		});
 
-		it('includes subsequent versions of materials they originally wrote (in which their uuid is nullified), with corresponding writers', () => {
+		it('includes subsequent versions of materials they originally wrote, with corresponding writers', () => {
 
 			const expectedSubsequentVersionMaterials = [
 				{
@@ -578,7 +578,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 							entities: [
 								{
 									model: 'PERSON',
-									uuid: null,
+									uuid: HENRIK_IBSEN_PERSON_UUID,
 									name: 'Henrik Ibsen'
 								},
 								{
@@ -636,7 +636,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 							entities: [
 								{
 									model: 'PERSON',
-									uuid: null,
+									uuid: HENRIK_IBSEN_PERSON_UUID,
 									name: 'Henrik Ibsen'
 								},
 								{
@@ -694,7 +694,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 							entities: [
 								{
 									model: 'PERSON',
-									uuid: null,
+									uuid: HENRIK_IBSEN_PERSON_UUID,
 									name: 'Henrik Ibsen'
 								},
 								{
@@ -729,7 +729,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 
 	describe('Gerry Bamman (person)', () => {
 
-		it('includes materials they have written (in which their uuid is nullified), with corresponding writers', () => {
+		it('includes materials they have written, with corresponding writers', () => {
 
 			const expectedMaterials = [
 				{
@@ -762,7 +762,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 							entities: [
 								{
 									model: 'PERSON',
-									uuid: null,
+									uuid: GERRY_BAMMAN_PERSON_UUID,
 									name: 'Gerry Bamman'
 								},
 								{
@@ -820,7 +820,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 							entities: [
 								{
 									model: 'PERSON',
-									uuid: null,
+									uuid: GERRY_BAMMAN_PERSON_UUID,
 									name: 'Gerry Bamman'
 								},
 								{
@@ -860,7 +860,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 
 	describe('Ibsen Theatre Company (company)', () => {
 
-		it('includes materials it has written (in which its uuid is nullified)', () => {
+		it('includes materials it has written', () => {
 
 			const expectedMaterials = [
 				{
@@ -882,7 +882,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								},
 								{
 									model: 'COMPANY',
-									uuid: null,
+									uuid: IBSEN_THEATRE_COMPANY_UUID,
 									name: 'Ibsen Theatre Company'
 								}
 							]
@@ -908,7 +908,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								},
 								{
 									model: 'COMPANY',
-									uuid: null,
+									uuid: IBSEN_THEATRE_COMPANY_UUID,
 									name: 'Ibsen Theatre Company'
 								}
 							]
@@ -923,7 +923,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 
 		});
 
-		it('includes subsequent versions of materials it originally wrote (in which its uuid is nullified), with corresponding writers', () => {
+		it('includes subsequent versions of materials it originally wrote, with corresponding writers', () => {
 
 			const expectedSubsequentVersionMaterials = [
 				{
@@ -945,7 +945,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								},
 								{
 									model: 'COMPANY',
-									uuid: null,
+									uuid: IBSEN_THEATRE_COMPANY_UUID,
 									name: 'Ibsen Theatre Company'
 								}
 							]
@@ -1003,7 +1003,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								},
 								{
 									model: 'COMPANY',
-									uuid: null,
+									uuid: IBSEN_THEATRE_COMPANY_UUID,
 									name: 'Ibsen Theatre Company'
 								}
 							]
@@ -1061,7 +1061,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								},
 								{
 									model: 'COMPANY',
-									uuid: null,
+									uuid: IBSEN_THEATRE_COMPANY_UUID,
 									name: 'Ibsen Theatre Company'
 								}
 							]
@@ -1091,7 +1091,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 
 	describe('Bamman Theatre Company (company)', () => {
 
-		it('includes materials it has written (in which its uuid is nullified), with corresponding writers', () => {
+		it('includes materials it has written, with corresponding writers', () => {
 
 			const expectedMaterials = [
 				{
@@ -1129,7 +1129,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								},
 								{
 									model: 'COMPANY',
-									uuid: null,
+									uuid: BAMMAN_THEATRE_COMPANY_UUID,
 									name: 'Bamman Theatre Company'
 								},
 								{
@@ -1187,7 +1187,7 @@ describe('Materials with multiple versions and multiple writer credits', () => {
 								},
 								{
 									model: 'COMPANY',
-									uuid: null,
+									uuid: BAMMAN_THEATRE_COMPANY_UUID,
 									name: 'Bamman Theatre Company'
 								},
 								{

--- a/test-e2e/model-interaction/material-with-rights-grantor.test.js
+++ b/test-e2e/model-interaction/material-with-rights-grantor.test.js
@@ -106,86 +106,7 @@ describe('Materials with rights grantor credits', () => {
 
 	describe('StudioCanal (company)', () => {
 
-		it('includes materials for which it has a rights grantor credit (in which its uuid is nullified)', () => {
-
-			const expectedRightsGrantorMaterials = [
-				{
-					model: 'MATERIAL',
-					uuid: THE_LADYKILLERS_PLAY_MATERIAL_UUID,
-					name: 'The Ladykillers',
-					format: 'play',
-					year: 2011,
-					surMaterial: null,
-					writingCredits: [
-						{
-							model: 'WRITING_CREDIT',
-							name: 'by',
-							entities: [
-								{
-									model: 'PERSON',
-									uuid: GRAHAM_LINEHAN_PERSON_UUID,
-									name: 'Graham Linehan'
-								}
-							]
-						},
-						{
-							model: 'WRITING_CREDIT',
-							name: 'from',
-							entities: [
-								{
-									model: 'MATERIAL',
-									uuid: THE_LADYKILLERS_SCREENPLAY_MATERIAL_UUID,
-									name: 'The Ladykillers',
-									format: 'motion picture screenplay',
-									year: 1955,
-									surMaterial: null,
-									writingCredits: [
-										{
-											model: 'WRITING_CREDIT',
-											name: 'by',
-											entities: [
-												{
-													model: 'PERSON',
-													uuid: WILLIAM_ROSE_PERSON_UUID,
-													name: 'William Rose'
-												}
-											]
-										}
-									]
-								}
-							]
-						},
-						{
-							model: 'WRITING_CREDIT',
-							name: 'by special arrangement with',
-							entities: [
-								{
-									model: 'COMPANY',
-									uuid: null,
-									name: 'StudioCanal'
-								},
-								{
-									model: 'PERSON',
-									uuid: ALISON_MEESE_PERSON_UUID,
-									name: 'Alison Meese'
-								}
-							]
-						}
-					]
-				}
-			];
-
-			const { rightsGrantorMaterials } = studioCanalCompany.body;
-
-			expect(rightsGrantorMaterials).to.deep.equal(expectedRightsGrantorMaterials);
-
-		});
-
-	});
-
-	describe('Alison Meese (person)', () => {
-
-		it('includes materials for which they have a rights grantor credit (in which their uuid is nullified)', () => {
+		it('includes materials for which it has a rights grantor credit', () => {
 
 			const expectedRightsGrantorMaterials = [
 				{
@@ -245,7 +166,86 @@ describe('Materials with rights grantor credits', () => {
 								},
 								{
 									model: 'PERSON',
-									uuid: null,
+									uuid: ALISON_MEESE_PERSON_UUID,
+									name: 'Alison Meese'
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { rightsGrantorMaterials } = studioCanalCompany.body;
+
+			expect(rightsGrantorMaterials).to.deep.equal(expectedRightsGrantorMaterials);
+
+		});
+
+	});
+
+	describe('Alison Meese (person)', () => {
+
+		it('includes materials for which they have a rights grantor credit', () => {
+
+			const expectedRightsGrantorMaterials = [
+				{
+					model: 'MATERIAL',
+					uuid: THE_LADYKILLERS_PLAY_MATERIAL_UUID,
+					name: 'The Ladykillers',
+					format: 'play',
+					year: 2011,
+					surMaterial: null,
+					writingCredits: [
+						{
+							model: 'WRITING_CREDIT',
+							name: 'by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: GRAHAM_LINEHAN_PERSON_UUID,
+									name: 'Graham Linehan'
+								}
+							]
+						},
+						{
+							model: 'WRITING_CREDIT',
+							name: 'from',
+							entities: [
+								{
+									model: 'MATERIAL',
+									uuid: THE_LADYKILLERS_SCREENPLAY_MATERIAL_UUID,
+									name: 'The Ladykillers',
+									format: 'motion picture screenplay',
+									year: 1955,
+									surMaterial: null,
+									writingCredits: [
+										{
+											model: 'WRITING_CREDIT',
+											name: 'by',
+											entities: [
+												{
+													model: 'PERSON',
+													uuid: WILLIAM_ROSE_PERSON_UUID,
+													name: 'William Rose'
+												}
+											]
+										}
+									]
+								}
+							]
+						},
+						{
+							model: 'WRITING_CREDIT',
+							name: 'by special arrangement with',
+							entities: [
+								{
+									model: 'COMPANY',
+									uuid: STUDIOCANAL_COMPANY_UUID,
+									name: 'StudioCanal'
+								},
+								{
+									model: 'PERSON',
+									uuid: ALISON_MEESE_PERSON_UUID,
 									name: 'Alison Meese'
 								}
 							]

--- a/test-e2e/model-interaction/material-with-source-material.test.js
+++ b/test-e2e/model-interaction/material-with-source-material.test.js
@@ -391,7 +391,7 @@ describe('Materials with source material', () => {
 
 	describe('A Midsummer Night\'s Dream (material)', () => {
 
-		it('includes materials that used it as source material (in which its uuid is nullified), with corresponding writers', () => {
+		it('includes materials that used it as source material, with corresponding writers', () => {
 
 			const expectedSourcingMaterials = [
 				{
@@ -424,7 +424,7 @@ describe('Materials with source material', () => {
 							entities: [
 								{
 									model: 'MATERIAL',
-									uuid: null,
+									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
 									name: 'A Midsummer Night\'s Dream',
 									format: 'play',
 									year: 1595,
@@ -482,7 +482,7 @@ describe('Materials with source material', () => {
 							entities: [
 								{
 									model: 'MATERIAL',
-									uuid: null,
+									uuid: A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID,
 									name: 'A Midsummer Night\'s Dream',
 									format: 'play',
 									year: 1595,
@@ -726,7 +726,7 @@ describe('Materials with source material', () => {
 							entities: [
 								{
 									model: 'MATERIAL',
-									uuid: null,
+									uuid: A_MOORISH_CAPTAIN_MATERIAL_UUID,
 									name: 'A Moorish Captain',
 									format: 'tale',
 									year: 1565,
@@ -874,7 +874,7 @@ describe('Materials with source material', () => {
 											entities: [
 												{
 													model: 'PERSON',
-													uuid: null,
+													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
 													name: 'William Shakespeare'
 												},
 												{
@@ -932,7 +932,7 @@ describe('Materials with source material', () => {
 											entities: [
 												{
 													model: 'PERSON',
-													uuid: null,
+													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
 													name: 'William Shakespeare'
 												},
 												{
@@ -978,7 +978,7 @@ describe('Materials with source material', () => {
 							entities: [
 								{
 									model: 'PERSON',
-									uuid: null,
+									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
 									name: 'William Shakespeare'
 								},
 								{
@@ -1004,7 +1004,7 @@ describe('Materials with source material', () => {
 							entities: [
 								{
 									model: 'PERSON',
-									uuid: null,
+									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
 									name: 'William Shakespeare'
 								},
 								{
@@ -1032,7 +1032,7 @@ describe('Materials with source material', () => {
 											entities: [
 												{
 													model: 'PERSON',
-													uuid: null,
+													uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
 													name: 'William Shakespeare'
 												},
 												{
@@ -1060,7 +1060,7 @@ describe('Materials with source material', () => {
 
 	describe('Rona Munro (person)', () => {
 
-		it('includes materials they have written (in which their uuid is nullified), with corresponding writers', () => {
+		it('includes materials they have written, with corresponding writers', () => {
 
 			const expectedMaterials = [
 				{
@@ -1077,7 +1077,7 @@ describe('Materials with source material', () => {
 							entities: [
 								{
 									model: 'PERSON',
-									uuid: null,
+									uuid: RONA_MUNRO_PERSON_UUID,
 									name: 'Rona Munro'
 								},
 								{
@@ -1133,7 +1133,7 @@ describe('Materials with source material', () => {
 
 	describe('Steven Berkoff (person)', () => {
 
-		it('includes materials they have written (in which their uuid is nullified), with corresponding writers', () => {
+		it('includes materials they have written, with corresponding writers', () => {
 
 			const expectedMaterials = [
 				{
@@ -1150,7 +1150,7 @@ describe('Materials with source material', () => {
 							entities: [
 								{
 									model: 'PERSON',
-									uuid: null,
+									uuid: STEVEN_BERKOFF_PERSON_UUID,
 									name: 'Steven Berkoff'
 								},
 								{
@@ -1240,7 +1240,7 @@ describe('Materials with source material', () => {
 												},
 												{
 													model: 'COMPANY',
-													uuid: null,
+													uuid: THE_KINGS_MEN_COMPANY_UUID,
 													name: 'The King\'s Men'
 												}
 											]
@@ -1298,7 +1298,7 @@ describe('Materials with source material', () => {
 												},
 												{
 													model: 'COMPANY',
-													uuid: null,
+													uuid: THE_KINGS_MEN_COMPANY_UUID,
 													name: 'The King\'s Men'
 												}
 											]
@@ -1344,7 +1344,7 @@ describe('Materials with source material', () => {
 								},
 								{
 									model: 'COMPANY',
-									uuid: null,
+									uuid: THE_KINGS_MEN_COMPANY_UUID,
 									name: 'The King\'s Men'
 								}
 							]
@@ -1370,7 +1370,7 @@ describe('Materials with source material', () => {
 								},
 								{
 									model: 'COMPANY',
-									uuid: null,
+									uuid: THE_KINGS_MEN_COMPANY_UUID,
 									name: 'The King\'s Men'
 								}
 							]
@@ -1398,7 +1398,7 @@ describe('Materials with source material', () => {
 												},
 												{
 													model: 'COMPANY',
-													uuid: null,
+													uuid: THE_KINGS_MEN_COMPANY_UUID,
 													name: 'The King\'s Men'
 												}
 											]
@@ -1421,7 +1421,7 @@ describe('Materials with source material', () => {
 
 	describe('Royal Shakespeare Company (company)', () => {
 
-		it('includes materials it has written (in which its uuid is nullified), with corresponding writers', () => {
+		it('includes materials it has written, with corresponding writers', () => {
 
 			const expectedMaterials = [
 				{
@@ -1443,7 +1443,7 @@ describe('Materials with source material', () => {
 								},
 								{
 									model: 'COMPANY',
-									uuid: null,
+									uuid: ROYAL_SHAKESPEARE_COMPANY_UUID,
 									name: 'Royal Shakespeare Company'
 								}
 							]
@@ -1494,7 +1494,7 @@ describe('Materials with source material', () => {
 
 	describe('East Productions (company)', () => {
 
-		it('includes materials it has written (in which its uuid is nullified), with corresponding writers', () => {
+		it('includes materials it has written, with corresponding writers', () => {
 
 			const expectedMaterials = [
 				{
@@ -1516,7 +1516,7 @@ describe('Materials with source material', () => {
 								},
 								{
 									model: 'COMPANY',
-									uuid: null,
+									uuid: EAST_PRODUCTIONS_COMPANY_UUID,
 									name: 'East Productions'
 								}
 							]

--- a/test-e2e/model-interaction/material-with-source-sub-material.test.js
+++ b/test-e2e/model-interaction/material-with-source-sub-material.test.js
@@ -220,7 +220,7 @@ describe('Materials with source sub-material', () => {
 
 	describe('Bring Up the Bodies (novel) (material)', () => {
 
-		it('includes materials that used it as source material (in which its uuid is nullified), with corresponding sur-material', () => {
+		it('includes materials that used it as source material, with corresponding sur-material', () => {
 
 			const expectedSourcingMaterials = [
 				{
@@ -257,7 +257,7 @@ describe('Materials with source sub-material', () => {
 							entities: [
 								{
 									model: 'MATERIAL',
-									uuid: null,
+									uuid: BRING_UP_THE_BODIES_NOVEL_MATERIAL_UUID,
 									name: 'Bring Up the Bodies',
 									format: 'novel',
 									year: 2012,
@@ -421,7 +421,7 @@ describe('Materials with source sub-material', () => {
 											entities: [
 												{
 													model: 'PERSON',
-													uuid: null,
+													uuid: HILARY_MANTEL_PERSON_UUID,
 													name: 'Hilary Mantel'
 												},
 												{
@@ -449,7 +449,7 @@ describe('Materials with source sub-material', () => {
 
 	describe('Mike Poulton (person)', () => {
 
-		it('includes materials they have written (in which their uuid is nullified), with corresponding sur-materials', () => {
+		it('includes materials they have written, with corresponding sur-materials', () => {
 
 			const expectedMaterials = [
 				{
@@ -470,7 +470,7 @@ describe('Materials with source sub-material', () => {
 							entities: [
 								{
 									model: 'PERSON',
-									uuid: null,
+									uuid: MIKE_POULTON_PERSON_UUID,
 									name: 'Mike Poulton'
 								},
 								{
@@ -588,7 +588,7 @@ describe('Materials with source sub-material', () => {
 												},
 												{
 													model: 'COMPANY',
-													uuid: null,
+													uuid: THE_MANTEL_GROUP_COMPANY_UUID,
 													name: 'The Mantel Group'
 												}
 											]
@@ -611,7 +611,7 @@ describe('Materials with source sub-material', () => {
 
 	describe('Royal Shakespeare Company (company)', () => {
 
-		it('includes materials it has written (in which its uuid is nullified), with corresponding sur-material', () => {
+		it('includes materials it has written, with corresponding sur-material', () => {
 
 			const expectedMaterials = [
 				{
@@ -637,7 +637,7 @@ describe('Materials with source sub-material', () => {
 								},
 								{
 									model: 'COMPANY',
-									uuid: null,
+									uuid: ROYAL_SHAKESPEARE_COMPANY_UUID,
 									name: 'Royal Shakespeare Company'
 								}
 							]

--- a/test-e2e/model-interaction/material-with-sub-materials.test.js
+++ b/test-e2e/model-interaction/material-with-sub-materials.test.js
@@ -616,7 +616,7 @@ describe('Material with sub-materials', () => {
 							entities: [
 								{
 									model: 'PERSON',
-									uuid: null,
+									uuid: TOM_STOPPARD_PERSON_UUID,
 									name: 'Tom Stoppard'
 								},
 								{
@@ -646,7 +646,7 @@ describe('Material with sub-materials', () => {
 							entities: [
 								{
 									model: 'PERSON',
-									uuid: null,
+									uuid: TOM_STOPPARD_PERSON_UUID,
 									name: 'Tom Stoppard'
 								},
 								{
@@ -676,7 +676,7 @@ describe('Material with sub-materials', () => {
 							entities: [
 								{
 									model: 'PERSON',
-									uuid: null,
+									uuid: TOM_STOPPARD_PERSON_UUID,
 									name: 'Tom Stoppard'
 								},
 								{
@@ -726,7 +726,7 @@ describe('Material with sub-materials', () => {
 								},
 								{
 									model: 'COMPANY',
-									uuid: null,
+									uuid: THE_STRÄUSSLER_GROUP_COMPANY_UUID,
 									name: 'The Sträussler Group'
 								}
 							]
@@ -756,7 +756,7 @@ describe('Material with sub-materials', () => {
 								},
 								{
 									model: 'COMPANY',
-									uuid: null,
+									uuid: THE_STRÄUSSLER_GROUP_COMPANY_UUID,
 									name: 'The Sträussler Group'
 								}
 							]
@@ -786,7 +786,7 @@ describe('Material with sub-materials', () => {
 								},
 								{
 									model: 'COMPANY',
-									uuid: null,
+									uuid: THE_STRÄUSSLER_GROUP_COMPANY_UUID,
 									name: 'The Sträussler Group'
 								}
 							]

--- a/test-e2e/model-interaction/prods-with-producers.test.js
+++ b/test-e2e/model-interaction/prods-with-producers.test.js
@@ -896,7 +896,7 @@ describe('Productions with producer', () => {
 							entities: [
 								{
 									model: 'PERSON',
-									uuid: null,
+									uuid: ROBERT_FOX_PERSON_UUID,
 									name: 'Robert Fox'
 								}
 							]
@@ -1015,7 +1015,7 @@ describe('Productions with producer', () => {
 							entities: [
 								{
 									model: 'PERSON',
-									uuid: null,
+									uuid: ROBERT_FOX_PERSON_UUID,
 									name: 'Robert Fox'
 								}
 							]
@@ -1137,7 +1137,7 @@ describe('Productions with producer', () => {
 							entities: [
 								{
 									model: 'PERSON',
-									uuid: null,
+									uuid: ROBERT_FOX_PERSON_UUID,
 									name: 'Robert Fox'
 								}
 							]
@@ -1283,7 +1283,7 @@ describe('Productions with producer', () => {
 							entities: [
 								{
 									model: 'PERSON',
-									uuid: null,
+									uuid: ERIC_ABRAHAM_PERSON_UUID,
 									name: 'Eric Abraham'
 								}
 							]
@@ -1339,7 +1339,7 @@ describe('Productions with producer', () => {
 								},
 								{
 									model: 'PERSON',
-									uuid: null,
+									uuid: ERIC_ABRAHAM_PERSON_UUID,
 									name: 'Eric Abraham'
 								},
 								{
@@ -1432,7 +1432,7 @@ describe('Productions with producer', () => {
 							entities: [
 								{
 									model: 'PERSON',
-									uuid: null,
+									uuid: ERIC_ABRAHAM_PERSON_UUID,
 									name: 'Eric Abraham'
 								},
 								{
@@ -1517,7 +1517,7 @@ describe('Productions with producer', () => {
 							entities: [
 								{
 									model: 'PERSON',
-									uuid: null,
+									uuid: ERIC_ABRAHAM_PERSON_UUID,
 									name: 'Eric Abraham'
 								},
 								{
@@ -1688,7 +1688,7 @@ describe('Productions with producer', () => {
 								},
 								{
 									model: 'PERSON',
-									uuid: null,
+									uuid: ERIC_ABRAHAM_PERSON_UUID,
 									name: 'Eric Abraham'
 								}
 							]
@@ -1810,7 +1810,7 @@ describe('Productions with producer', () => {
 									members: [
 										{
 											model: 'PERSON',
-											uuid: null,
+											uuid: MATTHEW_BYAM_SHAW_PERSON_UUID,
 											name: 'Matthew Byam Shaw'
 										},
 										{
@@ -1868,7 +1868,7 @@ describe('Productions with producer', () => {
 									members: [
 										{
 											model: 'PERSON',
-											uuid: null,
+											uuid: MATTHEW_BYAM_SHAW_PERSON_UUID,
 											name: 'Matthew Byam Shaw'
 										}
 									]
@@ -1930,7 +1930,7 @@ describe('Productions with producer', () => {
 										},
 										{
 											model: 'PERSON',
-											uuid: null,
+											uuid: MATTHEW_BYAM_SHAW_PERSON_UUID,
 											name: 'Matthew Byam Shaw'
 										},
 										{
@@ -2015,7 +2015,7 @@ describe('Productions with producer', () => {
 										},
 										{
 											model: 'PERSON',
-											uuid: null,
+											uuid: MATTHEW_BYAM_SHAW_PERSON_UUID,
 											name: 'Matthew Byam Shaw'
 										},
 										{
@@ -2132,7 +2132,7 @@ describe('Productions with producer', () => {
 									members: [
 										{
 											model: 'PERSON',
-											uuid: null,
+											uuid: MATTHEW_BYAM_SHAW_PERSON_UUID,
 											name: 'Matthew Byam Shaw'
 										},
 										{
@@ -2267,7 +2267,7 @@ describe('Productions with producer', () => {
 									members: [
 										{
 											model: 'PERSON',
-											uuid: null,
+											uuid: ROGER_CHAPMAN_PERSON_UUID,
 											name: 'Roger Chapman'
 										},
 										{
@@ -2357,7 +2357,7 @@ describe('Productions with producer', () => {
 							entities: [
 								{
 									model: 'COMPANY',
-									uuid: null,
+									uuid: SONIA_FRIEDMAN_PRODUCTIONS_COMPANY_UUID,
 									name: 'Sonia Friedman Productions',
 									members: []
 								}
@@ -2483,7 +2483,7 @@ describe('Productions with producer', () => {
 							entities: [
 								{
 									model: 'COMPANY',
-									uuid: null,
+									uuid: SONIA_FRIEDMAN_PRODUCTIONS_COMPANY_UUID,
 									name: 'Sonia Friedman Productions',
 									members: []
 								}
@@ -2587,7 +2587,7 @@ describe('Productions with producer', () => {
 							entities: [
 								{
 									model: 'COMPANY',
-									uuid: null,
+									uuid: SONIA_FRIEDMAN_PRODUCTIONS_COMPANY_UUID,
 									name: 'Sonia Friedman Productions',
 									members: []
 								}
@@ -2599,7 +2599,7 @@ describe('Productions with producer', () => {
 							entities: [
 								{
 									model: 'COMPANY',
-									uuid: null,
+									uuid: SONIA_FRIEDMAN_PRODUCTIONS_COMPANY_UUID,
 									name: 'Sonia Friedman Productions',
 									members: []
 								}
@@ -2756,7 +2756,7 @@ describe('Productions with producer', () => {
 								},
 								{
 									model: 'COMPANY',
-									uuid: null,
+									uuid: ROYAL_COURT_THEATRE_COMPANY_UUID,
 									name: 'Royal Court Theatre',
 									members: [
 										{
@@ -2876,7 +2876,7 @@ describe('Productions with producer', () => {
 								},
 								{
 									model: 'COMPANY',
-									uuid: null,
+									uuid: ROYAL_COURT_THEATRE_COMPANY_UUID,
 									name: 'Royal Court Theatre',
 									members: [
 										{
@@ -2961,7 +2961,7 @@ describe('Productions with producer', () => {
 								},
 								{
 									model: 'COMPANY',
-									uuid: null,
+									uuid: ROYAL_COURT_THEATRE_COMPANY_UUID,
 									name: 'Royal Court Theatre',
 									members: [
 										{
@@ -3072,7 +3072,7 @@ describe('Productions with producer', () => {
 							entities: [
 								{
 									model: 'COMPANY',
-									uuid: null,
+									uuid: ROYAL_COURT_THEATRE_COMPANY_UUID,
 									name: 'Royal Court Theatre',
 									members: [
 										{
@@ -3244,7 +3244,7 @@ describe('Productions with producer', () => {
 								},
 								{
 									model: 'COMPANY',
-									uuid: null,
+									uuid: PLAYFUL_PRODUCTIONS_COMPANY_UUID,
 									name: 'Playful Productions',
 									members: [
 										{
@@ -3302,7 +3302,7 @@ describe('Productions with producer', () => {
 							entities: [
 								{
 									model: 'COMPANY',
-									uuid: null,
+									uuid: PLAYFUL_PRODUCTIONS_COMPANY_UUID,
 									name: 'Playful Productions',
 									members: [
 										{
@@ -3359,7 +3359,7 @@ describe('Productions with producer', () => {
 								},
 								{
 									model: 'COMPANY',
-									uuid: null,
+									uuid: PLAYFUL_PRODUCTIONS_COMPANY_UUID,
 									name: 'Playful Productions',
 									members: [
 										{
@@ -3444,7 +3444,7 @@ describe('Productions with producer', () => {
 								},
 								{
 									model: 'COMPANY',
-									uuid: null,
+									uuid: PLAYFUL_PRODUCTIONS_COMPANY_UUID,
 									name: 'Playful Productions',
 									members: [
 										{
@@ -3566,7 +3566,7 @@ describe('Productions with producer', () => {
 								},
 								{
 									model: 'COMPANY',
-									uuid: null,
+									uuid: PLAYFUL_PRODUCTIONS_COMPANY_UUID,
 									name: 'Playful Productions',
 									members: [
 										{

--- a/test-e2e/model-interaction/sub-material-with-rights-grantor.test.js
+++ b/test-e2e/model-interaction/sub-material-with-rights-grantor.test.js
@@ -166,94 +166,7 @@ describe('Sub-materials with rights grantor credits', () => {
 
 	describe('C S Lewis Society (company)', () => {
 
-		it('includes materials for which it has a rights grantor credit (in which its uuid is nullified), with corresponding sur-material', () => {
-
-			const expectedRightsGrantorMaterials = [
-				{
-					model: 'MATERIAL',
-					uuid: THE_LION_THE_WITCH_AND_THE_WARDROBE_PLAY_MATERIAL_UUID,
-					name: 'The Lion, the Witch and the Wardrobe',
-					format: 'play',
-					year: 2017,
-					surMaterial: {
-						model: 'MATERIAL',
-						uuid: THE_CHRONICLES_OF_NARNIA_PLAYS_MATERIAL_UUID,
-						name: 'The Chronicles of Narnia'
-					},
-					writingCredits: [
-						{
-							model: 'WRITING_CREDIT',
-							name: 'by',
-							entities: [
-								{
-									model: 'PERSON',
-									uuid: ADAM_PECK_PERSON_UUID,
-									name: 'Adam Peck'
-								}
-							]
-						},
-						{
-							model: 'WRITING_CREDIT',
-							name: 'based on',
-							entities: [
-								{
-									model: 'MATERIAL',
-									uuid: THE_LION_THE_WITCH_AND_THE_WARDROBE_NOVEL_MATERIAL_UUID,
-									name: 'The Lion, the Witch and the Wardrobe',
-									format: 'novel',
-									year: 1950,
-									surMaterial: {
-										model: 'MATERIAL',
-										uuid: THE_CHRONICLES_OF_NARNIA_SERIES_OF_NOVELS_MATERIAL_UUID,
-										name: 'The Chronicles of Narnia'
-									},
-									writingCredits: [
-										{
-											model: 'WRITING_CREDIT',
-											name: 'by',
-											entities: [
-												{
-													model: 'PERSON',
-													uuid: C_S_LEWIS_PERSON_UUID,
-													name: 'C S Lewis'
-												}
-											]
-										}
-									]
-								}
-							]
-						},
-						{
-							model: 'WRITING_CREDIT',
-							name: 'by special arrangement with',
-							entities: [
-								{
-									model: 'COMPANY',
-									uuid: null,
-									name: 'C S Lewis Society'
-								},
-								{
-									model: 'PERSON',
-									uuid: SARAH_SELDEN_PERSON_UUID,
-									name: 'Sarah Selden'
-								}
-							]
-						}
-					]
-				}
-			];
-
-			const { rightsGrantorMaterials } = cSLewisSocietyCompany.body;
-
-			expect(rightsGrantorMaterials).to.deep.equal(expectedRightsGrantorMaterials);
-
-		});
-
-	});
-
-	describe('Sarah Selden (person)', () => {
-
-		it('includes materials for which they have a rights grantor credit (in which their uuid is nullified), with corresponding sur-material', () => {
+		it('includes materials for which it has a rights grantor credit, with corresponding sur-material', () => {
 
 			const expectedRightsGrantorMaterials = [
 				{
@@ -321,7 +234,94 @@ describe('Sub-materials with rights grantor credits', () => {
 								},
 								{
 									model: 'PERSON',
-									uuid: null,
+									uuid: SARAH_SELDEN_PERSON_UUID,
+									name: 'Sarah Selden'
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { rightsGrantorMaterials } = cSLewisSocietyCompany.body;
+
+			expect(rightsGrantorMaterials).to.deep.equal(expectedRightsGrantorMaterials);
+
+		});
+
+	});
+
+	describe('Sarah Selden (person)', () => {
+
+		it('includes materials for which they have a rights grantor credit, with corresponding sur-material', () => {
+
+			const expectedRightsGrantorMaterials = [
+				{
+					model: 'MATERIAL',
+					uuid: THE_LION_THE_WITCH_AND_THE_WARDROBE_PLAY_MATERIAL_UUID,
+					name: 'The Lion, the Witch and the Wardrobe',
+					format: 'play',
+					year: 2017,
+					surMaterial: {
+						model: 'MATERIAL',
+						uuid: THE_CHRONICLES_OF_NARNIA_PLAYS_MATERIAL_UUID,
+						name: 'The Chronicles of Narnia'
+					},
+					writingCredits: [
+						{
+							model: 'WRITING_CREDIT',
+							name: 'by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: ADAM_PECK_PERSON_UUID,
+									name: 'Adam Peck'
+								}
+							]
+						},
+						{
+							model: 'WRITING_CREDIT',
+							name: 'based on',
+							entities: [
+								{
+									model: 'MATERIAL',
+									uuid: THE_LION_THE_WITCH_AND_THE_WARDROBE_NOVEL_MATERIAL_UUID,
+									name: 'The Lion, the Witch and the Wardrobe',
+									format: 'novel',
+									year: 1950,
+									surMaterial: {
+										model: 'MATERIAL',
+										uuid: THE_CHRONICLES_OF_NARNIA_SERIES_OF_NOVELS_MATERIAL_UUID,
+										name: 'The Chronicles of Narnia'
+									},
+									writingCredits: [
+										{
+											model: 'WRITING_CREDIT',
+											name: 'by',
+											entities: [
+												{
+													model: 'PERSON',
+													uuid: C_S_LEWIS_PERSON_UUID,
+													name: 'C S Lewis'
+												}
+											]
+										}
+									]
+								}
+							]
+						},
+						{
+							model: 'WRITING_CREDIT',
+							name: 'by special arrangement with',
+							entities: [
+								{
+									model: 'COMPANY',
+									uuid: C_S_LEWIS_SOCIETY_COMPANY_UUID,
+									name: 'C S Lewis Society'
+								},
+								{
+									model: 'PERSON',
+									uuid: SARAH_SELDEN_PERSON_UUID,
 									name: 'Sarah Selden'
 								}
 							]


### PR DESCRIPTION
The subject of a query can include itself in its results, e.g. William Shakespeare appears as the credited writer of the materials he wrote, and also as the credited source material writer of materials that use his work as source material:

<img width="893" alt="Screenshot 2022-10-28 at 19 32 58" src="https://user-images.githubusercontent.com/10484515/198708150-cf58a08f-50bd-4b9d-b3d8-9d6e05a42958.png">

On the front-end it does not make sense for those instances of William Shakespeare to be links to the same page. Currently, this is solved by the Cypher query setting the `uuid` value to `null` in these scenarios and the front-end taking that as a directive to instead display the `name` value as plain text rather than a link.

Ultimately, it is better that a payload contains all the necessary information relating to associated instances, even if it happens to be the same as the subject instance, and it should not necessarily cater too heavily to the needs of the front-end, e.g. in future this API might serve other consumers for whom it is necessary to have the `uuid` values are all associated instances.

There are some useful approaches the front-end can take to identifying whether to display an instance `name` as plain text or a link, and these are implemented in the below PRs:
- https://github.com/andygout/theatrebase-spa/pull/165
- https://github.com/andygout/theatrebase-ssr/pull/199