### PR TITLE
Add surMaterial property to nominated co-materials

### DIFF
--- a/src/neo4j/cypher-queries/material.js
+++ b/src/neo4j/cypher-queries/material.js
@@ -825,6 +825,8 @@ const getShowQuery = () => `
 			coNominatedMaterial.uuid <> material.uuid AND
 			NOT (material)-[:HAS_SUB_MATERIAL]-(coNominatedMaterial)
 
+	OPTIONAL MATCH (coNominatedMaterial)<-[:HAS_SUB_MATERIAL]-(coNominatedMaterialSurMaterial:Material)
+
 	WITH
 		material,
 		relatedMaterials,
@@ -839,7 +841,8 @@ const getShowQuery = () => `
 		nominatedEntities,
 		nominatedProductions,
 		coNominatedMaterialRel,
-		coNominatedMaterial
+		coNominatedMaterial,
+		coNominatedMaterialSurMaterial
 		ORDER BY coNominatedMaterialRel.materialPosition
 
 	WITH
@@ -858,7 +861,17 @@ const getShowQuery = () => `
 		COLLECT(
 			CASE coNominatedMaterial WHEN NULL
 				THEN null
-				ELSE coNominatedMaterial { model: 'MATERIAL', .uuid, .name, .format, .year }
+				ELSE coNominatedMaterial {
+					model: 'MATERIAL',
+					.uuid,
+					.name,
+					.format,
+					.year,
+					surMaterial: CASE coNominatedMaterialSurMaterial WHEN NULL
+						THEN null
+						ELSE coNominatedMaterialSurMaterial { model: 'MATERIAL', .uuid, .name }
+					END
+				}
 			END
 		) AS coNominatedMaterials
 		ORDER BY nomineeRel.nominationPosition

--- a/test-e2e/model-interaction/award-ceremonies-with-sub-materials-sub-prods.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-sub-materials-sub-prods.test.js
@@ -13,32 +13,34 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 
 	const ROYAL_COURT_THEATRE_VENUE_UUID = '2';
 	const JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID = '3';
-	const SUB_WALDO_MATERIAL_UUID = '6';
-	const SUR_WALDO_MATERIAL_UUID = '11';
-	const SUB_WIBBLE_MATERIAL_UUID = '17';
-	const SUR_WIBBLE_MATERIAL_UUID = '24';
-	const SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID = '28';
-	const SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID = '31';
-	const SUB_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID = '34';
-	const DUKE_OF_YORKS_THEATRE_VENUE_UUID = '36';
-	const SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID = '37';
-	const LAURENCE_OLIVIER_AWARDS_TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID = '46';
-	const LAURENCE_OLIVIER_AWARDS_AWARD_UUID = '47';
-	const CONOR_CORGE_PERSON_UUID = '48';
-	const STAGECRAFT_LTD_COMPANY_UUID = '49';
-	const FERDINAND_FOO_PERSON_UUID = '50';
-	const EVENING_STANDARD_THEATRE_AWARDS_TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID = '58';
-	const EVENING_STANDARD_THEATRE_AWARDS_AWARD_UUID = '59';
+	const SUB_HOGE_MATERIAL_UUID = '6';
+	const SUR_HOGE_MATERIAL_UUID = '11';
+	const SUB_WALDO_MATERIAL_UUID = '16';
+	const SUR_WALDO_MATERIAL_UUID = '21';
+	const SUB_WIBBLE_MATERIAL_UUID = '27';
+	const SUR_WIBBLE_MATERIAL_UUID = '34';
+	const SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID = '38';
+	const NOËL_COWARD_THEATRE_VENUE_UUID = '40';
+	const SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID = '41';
+	const SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID = '44';
+	const SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID = '47';
+	const LAURENCE_OLIVIER_AWARDS_TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID = '57';
+	const LAURENCE_OLIVIER_AWARDS_AWARD_UUID = '58';
+	const CONOR_CORGE_PERSON_UUID = '59';
+	const STAGECRAFT_LTD_COMPANY_UUID = '60';
+	const FERDINAND_FOO_PERSON_UUID = '61';
+	const EVENING_STANDARD_THEATRE_AWARDS_TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID = '71';
+	const EVENING_STANDARD_THEATRE_AWARDS_AWARD_UUID = '72';
 
 	let laurenceOlivierAwards2020AwardCeremony;
 	let eveningStandardTheatreAwards2019AwardCeremony;
 	let conorCorgePerson;
 	let stagecraftLtdCompany;
 	let ferdinandFooPerson;
+	let subHogeNoëlCowardProduction;
+	let surHogeNoëlCowardProduction;
 	let subWibbleJerwoodTheatreUpstairsProduction;
 	let surWibbleJerwoodTheatreUpstairsProduction;
-	let subWibbleDukeOfYorksProduction;
-	let surWibbleDukeOfYorksProduction;
 	let subWibbleMaterial;
 	let surWibbleMaterial;
 
@@ -59,6 +61,27 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 				subVenues: [
 					{
 						name: 'Jerwood Theatre Upstairs'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sub-Hoge',
+				format: 'play',
+				year: '2019'
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sur-Hoge',
+				format: 'collection of plays',
+				year: '2019',
+				subMaterials: [
+					{
+						name: 'Sub-Hoge'
 					}
 				]
 			});
@@ -130,6 +153,33 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 		await chai.request(app)
 			.post('/productions')
 			.send({
+				name: 'Sub-Hoge',
+				startDate: '2019-05-01',
+				endDate: '2019-05-31',
+				venue: {
+					name: 'Noël Coward Theatre'
+				}
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sur-Hoge',
+				startDate: '2019-05-01',
+				endDate: '2019-05-31',
+				venue: {
+					name: 'Noël Coward Theatre'
+				},
+				subProductions: [
+					{
+						uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
 				name: 'Sub-Wibble',
 				startDate: '2019-06-01',
 				endDate: '2019-06-30',
@@ -150,33 +200,6 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 				subProductions: [
 					{
 						uuid: SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID
-					}
-				]
-			});
-
-		await chai.request(app)
-			.post('/productions')
-			.send({
-				name: 'Sub-Wibble',
-				startDate: '2019-08-01',
-				endDate: '2019-08-31',
-				venue: {
-					name: 'Duke of York\'s Theatre'
-				}
-			});
-
-		await chai.request(app)
-			.post('/productions')
-			.send({
-				name: 'Sur-Wibble',
-				startDate: '2019-08-01',
-				endDate: '2019-08-31',
-				venue: {
-					name: 'Duke of York\'s Theatre'
-				},
-				subProductions: [
-					{
-						uuid: SUB_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID
 					}
 				]
 			});
@@ -209,13 +232,16 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 								],
 								productions: [
 									{
-										uuid: SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID
+										uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID
 									},
 									{
-										uuid: SUB_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID
+										uuid: SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID
 									}
 								],
 								materials: [
+									{
+										name: 'Sub-Hoge'
+									},
 									{
 										name: 'Sub-Wibble'
 									}
@@ -255,13 +281,16 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 								],
 								productions: [
 									{
-										uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID
+										uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID
 									},
 									{
-										uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID
+										uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID
 									}
 								],
 								materials: [
+									{
+										name: 'Sur-Hoge'
+									},
 									{
 										name: 'Sur-Wibble'
 									}
@@ -287,17 +316,17 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 		ferdinandFooPerson = await chai.request(app)
 			.get(`/people/${FERDINAND_FOO_PERSON_UUID}`);
 
+		subHogeNoëlCowardProduction = await chai.request(app)
+			.get(`/productions/${SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID}`);
+
+		surHogeNoëlCowardProduction = await chai.request(app)
+			.get(`/productions/${SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID}`);
+
 		subWibbleJerwoodTheatreUpstairsProduction = await chai.request(app)
 			.get(`/productions/${SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID}`);
 
 		surWibbleJerwoodTheatreUpstairsProduction = await chai.request(app)
 			.get(`/productions/${SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID}`);
-
-		subWibbleDukeOfYorksProduction = await chai.request(app)
-			.get(`/productions/${SUB_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID}`);
-
-		surWibbleDukeOfYorksProduction = await chai.request(app)
-			.get(`/productions/${SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID}`);
 
 		subWibbleMaterial = await chai.request(app)
 			.get(`/materials/${SUB_WIBBLE_MATERIAL_UUID}`);
@@ -348,6 +377,24 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 							productions: [
 								{
 									model: 'PRODUCTION',
+									uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+									name: 'Sub-Hoge',
+									startDate: '2019-05-01',
+									endDate: '2019-05-31',
+									venue: {
+										model: 'VENUE',
+										uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+										name: 'Noël Coward Theatre',
+										surVenue: null
+									},
+									surProduction: {
+										model: 'PRODUCTION',
+										uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+										name: 'Sur-Hoge'
+									}
+								},
+								{
+									model: 'PRODUCTION',
 									uuid: SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
 									name: 'Sub-Wibble',
 									startDate: '2019-06-01',
@@ -367,27 +414,22 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 										uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
 										name: 'Sur-Wibble'
 									}
-								},
-								{
-									model: 'PRODUCTION',
-									uuid: SUB_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-									name: 'Sub-Wibble',
-									startDate: '2019-08-01',
-									endDate: '2019-08-31',
-									venue: {
-										model: 'VENUE',
-										uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
-										name: 'Duke of York\'s Theatre',
-										surVenue: null
-									},
-									surProduction: {
-										model: 'PRODUCTION',
-										uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-										name: 'Sur-Wibble'
-									}
 								}
 							],
 							materials: [
+								{
+									model: 'MATERIAL',
+									uuid: SUB_HOGE_MATERIAL_UUID,
+									name: 'Sub-Hoge',
+									format: 'play',
+									year: 2019,
+									surMaterial: {
+										model: 'MATERIAL',
+										uuid: SUR_HOGE_MATERIAL_UUID,
+										name: 'Sur-Hoge'
+									},
+									writingCredits: []
+								},
 								{
 									model: 'MATERIAL',
 									uuid: SUB_WIBBLE_MATERIAL_UUID,
@@ -470,6 +512,20 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 							productions: [
 								{
 									model: 'PRODUCTION',
+									uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+									name: 'Sur-Hoge',
+									startDate: '2019-05-01',
+									endDate: '2019-05-31',
+									venue: {
+										model: 'VENUE',
+										uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+										name: 'Noël Coward Theatre',
+										surVenue: null
+									},
+									surProduction: null
+								},
+								{
+									model: 'PRODUCTION',
 									uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
 									name: 'Sur-Wibble',
 									startDate: '2019-06-01',
@@ -485,23 +541,18 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 										}
 									},
 									surProduction: null
-								},
-								{
-									model: 'PRODUCTION',
-									uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-									name: 'Sur-Wibble',
-									startDate: '2019-08-01',
-									endDate: '2019-08-31',
-									venue: {
-										model: 'VENUE',
-										uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
-										name: 'Duke of York\'s Theatre',
-										surVenue: null
-									},
-									surProduction: null
 								}
 							],
 							materials: [
+								{
+									model: 'MATERIAL',
+									uuid: SUR_HOGE_MATERIAL_UUID,
+									name: 'Sur-Hoge',
+									format: 'collection of plays',
+									year: 2019,
+									surMaterial: null,
+									writingCredits: []
+								},
 								{
 									model: 'MATERIAL',
 									uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -582,6 +633,20 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 											productions: [
 												{
 													model: 'PRODUCTION',
+													uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sur-Hoge',
+													startDate: '2019-05-01',
+													endDate: '2019-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
 													uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
 													name: 'Sur-Wibble',
 													startDate: '2019-06-01',
@@ -597,23 +662,17 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 														}
 													},
 													surProduction: null
-												},
-												{
-													model: 'PRODUCTION',
-													uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-													name: 'Sur-Wibble',
-													startDate: '2019-08-01',
-													endDate: '2019-08-31',
-													venue: {
-														model: 'VENUE',
-														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
-														name: 'Duke of York\'s Theatre',
-														surVenue: null
-													},
-													surProduction: null
 												}
 											],
 											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_HOGE_MATERIAL_UUID,
+													name: 'Sur-Hoge',
+													format: 'collection of plays',
+													year: 2019,
+													surMaterial: null
+												},
 												{
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -666,6 +725,24 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 											productions: [
 												{
 													model: 'PRODUCTION',
+													uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sub-Hoge',
+													startDate: '2019-05-01',
+													endDate: '2019-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Sur-Hoge'
+													}
+												},
+												{
+													model: 'PRODUCTION',
 													uuid: SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
 													name: 'Sub-Wibble',
 													startDate: '2019-06-01',
@@ -685,27 +762,21 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
 														name: 'Sur-Wibble'
 													}
-												},
-												{
-													model: 'PRODUCTION',
-													uuid: SUB_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-													name: 'Sub-Wibble',
-													startDate: '2019-08-01',
-													endDate: '2019-08-31',
-													venue: {
-														model: 'VENUE',
-														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
-														name: 'Duke of York\'s Theatre',
-														surVenue: null
-													},
-													surProduction: {
-														model: 'PRODUCTION',
-														uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
-													}
 												}
 											],
 											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_HOGE_MATERIAL_UUID,
+													name: 'Sub-Hoge',
+													format: 'play',
+													year: 2019,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_HOGE_MATERIAL_UUID,
+														name: 'Sur-Hoge'
+													}
+												},
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_MATERIAL_UUID,
@@ -776,6 +847,20 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 											productions: [
 												{
 													model: 'PRODUCTION',
+													uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sur-Hoge',
+													startDate: '2019-05-01',
+													endDate: '2019-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
 													uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
 													name: 'Sur-Wibble',
 													startDate: '2019-06-01',
@@ -791,23 +876,17 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 														}
 													},
 													surProduction: null
-												},
-												{
-													model: 'PRODUCTION',
-													uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-													name: 'Sur-Wibble',
-													startDate: '2019-08-01',
-													endDate: '2019-08-31',
-													venue: {
-														model: 'VENUE',
-														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
-														name: 'Duke of York\'s Theatre',
-														surVenue: null
-													},
-													surProduction: null
 												}
 											],
 											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_HOGE_MATERIAL_UUID,
+													name: 'Sur-Hoge',
+													format: 'collection of plays',
+													year: 2019,
+													surMaterial: null
+												},
 												{
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -859,6 +938,24 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 											productions: [
 												{
 													model: 'PRODUCTION',
+													uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sub-Hoge',
+													startDate: '2019-05-01',
+													endDate: '2019-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Sur-Hoge'
+													}
+												},
+												{
+													model: 'PRODUCTION',
 													uuid: SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
 													name: 'Sub-Wibble',
 													startDate: '2019-06-01',
@@ -878,27 +975,21 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
 														name: 'Sur-Wibble'
 													}
-												},
-												{
-													model: 'PRODUCTION',
-													uuid: SUB_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-													name: 'Sub-Wibble',
-													startDate: '2019-08-01',
-													endDate: '2019-08-31',
-													venue: {
-														model: 'VENUE',
-														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
-														name: 'Duke of York\'s Theatre',
-														surVenue: null
-													},
-													surProduction: {
-														model: 'PRODUCTION',
-														uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
-													}
 												}
 											],
 											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_HOGE_MATERIAL_UUID,
+													name: 'Sub-Hoge',
+													format: 'play',
+													year: 2019,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_HOGE_MATERIAL_UUID,
+														name: 'Sur-Hoge'
+													}
+												},
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_MATERIAL_UUID,
@@ -968,6 +1059,20 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 											productions: [
 												{
 													model: 'PRODUCTION',
+													uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sur-Hoge',
+													startDate: '2019-05-01',
+													endDate: '2019-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
 													uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
 													name: 'Sur-Wibble',
 													startDate: '2019-06-01',
@@ -983,23 +1088,17 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 														}
 													},
 													surProduction: null
-												},
-												{
-													model: 'PRODUCTION',
-													uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-													name: 'Sur-Wibble',
-													startDate: '2019-08-01',
-													endDate: '2019-08-31',
-													venue: {
-														model: 'VENUE',
-														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
-														name: 'Duke of York\'s Theatre',
-														surVenue: null
-													},
-													surProduction: null
 												}
 											],
 											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_HOGE_MATERIAL_UUID,
+													name: 'Sur-Hoge',
+													format: 'collection of plays',
+													year: 2019,
+													surMaterial: null
+												},
 												{
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -1050,6 +1149,24 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 											productions: [
 												{
 													model: 'PRODUCTION',
+													uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sub-Hoge',
+													startDate: '2019-05-01',
+													endDate: '2019-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Sur-Hoge'
+													}
+												},
+												{
+													model: 'PRODUCTION',
 													uuid: SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
 													name: 'Sub-Wibble',
 													startDate: '2019-06-01',
@@ -1069,27 +1186,21 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
 														name: 'Sur-Wibble'
 													}
-												},
-												{
-													model: 'PRODUCTION',
-													uuid: SUB_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-													name: 'Sub-Wibble',
-													startDate: '2019-08-01',
-													endDate: '2019-08-31',
-													venue: {
-														model: 'VENUE',
-														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
-														name: 'Duke of York\'s Theatre',
-														surVenue: null
-													},
-													surProduction: {
-														model: 'PRODUCTION',
-														uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
-													}
 												}
 											],
 											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_HOGE_MATERIAL_UUID,
+													name: 'Sub-Hoge',
+													format: 'play',
+													year: 2019,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_HOGE_MATERIAL_UUID,
+														name: 'Sur-Hoge'
+													}
+												},
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_MATERIAL_UUID,
@@ -1113,6 +1224,416 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 			];
 
 			const { awards } = ferdinandFooPerson.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+
+		});
+
+	});
+
+	describe('Sub-Hoge at Noël Coward Theatre (production)', () => {
+
+		it('includes its and its sur-production\'s award nominations, in the latter case specifying the recipient', () => {
+
+			const expectedAwards = [
+				{
+					model: 'AWARD',
+					uuid: EVENING_STANDARD_THEATRE_AWARDS_AWARD_UUID,
+					name: 'Evening Standard Theatre Awards',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: EVENING_STANDARD_THEATRE_AWARDS_TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID,
+							name: '2019',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Role',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: true,
+											type: 'Winner',
+											recipientProduction: {
+												model: 'PRODUCTION',
+												uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+												name: 'Sur-Hoge',
+												startDate: '2019-05-01',
+												endDate: '2019-05-31',
+												venue: {
+													model: 'VENUE',
+													uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+													name: 'Noël Coward Theatre',
+													surVenue: null
+												}
+											},
+											entities: [
+												{
+													model: 'PERSON',
+													uuid: CONOR_CORGE_PERSON_UUID,
+													name: 'Conor Corge'
+												},
+												{
+													model: 'COMPANY',
+													uuid: STAGECRAFT_LTD_COMPANY_UUID,
+													name: 'Stagecraft Ltd',
+													members: [
+														{
+															model: 'PERSON',
+															uuid: FERDINAND_FOO_PERSON_UUID,
+															name: 'Ferdinand Foo'
+														}
+													]
+												}
+											],
+											coProductions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sur-Wibble',
+													startDate: '2019-06-01',
+													endDate: '2019-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: null
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_HOGE_MATERIAL_UUID,
+													name: 'Sur-Hoge',
+													format: 'collection of plays',
+													year: 2019,
+													surMaterial: null
+												},
+												{
+													model: 'MATERIAL',
+													uuid: SUR_WIBBLE_MATERIAL_UUID,
+													name: 'Sur-Wibble',
+													format: 'trilogy of plays',
+													year: 2019,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: LAURENCE_OLIVIER_AWARDS_AWARD_UUID,
+					name: 'Laurence Olivier Awards',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: LAURENCE_OLIVIER_AWARDS_TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID,
+							name: '2020',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Role',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											recipientProduction: null,
+											entities: [
+												{
+													model: 'PERSON',
+													uuid: CONOR_CORGE_PERSON_UUID,
+													name: 'Conor Corge'
+												},
+												{
+													model: 'COMPANY',
+													uuid: STAGECRAFT_LTD_COMPANY_UUID,
+													name: 'Stagecraft Ltd',
+													members: [
+														{
+															model: 'PERSON',
+															uuid: FERDINAND_FOO_PERSON_UUID,
+															name: 'Ferdinand Foo'
+														}
+													]
+												}
+											],
+											coProductions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sub-Wibble',
+													startDate: '2019-06-01',
+													endDate: '2019-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+														name: 'Sur-Wibble'
+													}
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_HOGE_MATERIAL_UUID,
+													name: 'Sub-Hoge',
+													format: 'play',
+													year: 2019,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_HOGE_MATERIAL_UUID,
+														name: 'Sur-Hoge'
+													}
+												},
+												{
+													model: 'MATERIAL',
+													uuid: SUB_WIBBLE_MATERIAL_UUID,
+													name: 'Sub-Wibble',
+													format: 'play',
+													year: 2019,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble'
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards } = subHogeNoëlCowardProduction.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+
+		});
+
+	});
+
+	describe('Sur-Hoge at Noël Coward Theatre (production)', () => {
+
+		it('includes its and its sub-productions\' award nominations, in the latter case specifying the recipient', () => {
+
+			const expectedAwards = [
+				{
+					model: 'AWARD',
+					uuid: EVENING_STANDARD_THEATRE_AWARDS_AWARD_UUID,
+					name: 'Evening Standard Theatre Awards',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: EVENING_STANDARD_THEATRE_AWARDS_TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID,
+							name: '2019',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Role',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: true,
+											type: 'Winner',
+											recipientProduction: null,
+											entities: [
+												{
+													model: 'PERSON',
+													uuid: CONOR_CORGE_PERSON_UUID,
+													name: 'Conor Corge'
+												},
+												{
+													model: 'COMPANY',
+													uuid: STAGECRAFT_LTD_COMPANY_UUID,
+													name: 'Stagecraft Ltd',
+													members: [
+														{
+															model: 'PERSON',
+															uuid: FERDINAND_FOO_PERSON_UUID,
+															name: 'Ferdinand Foo'
+														}
+													]
+												}
+											],
+											coProductions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sur-Wibble',
+													startDate: '2019-06-01',
+													endDate: '2019-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: null
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_HOGE_MATERIAL_UUID,
+													name: 'Sur-Hoge',
+													format: 'collection of plays',
+													year: 2019,
+													surMaterial: null
+												},
+												{
+													model: 'MATERIAL',
+													uuid: SUR_WIBBLE_MATERIAL_UUID,
+													name: 'Sur-Wibble',
+													format: 'trilogy of plays',
+													year: 2019,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: LAURENCE_OLIVIER_AWARDS_AWARD_UUID,
+					name: 'Laurence Olivier Awards',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: LAURENCE_OLIVIER_AWARDS_TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID,
+							name: '2020',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Role',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											recipientProduction: {
+												model: 'PRODUCTION',
+												uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+												name: 'Sub-Hoge',
+												startDate: '2019-05-01',
+												endDate: '2019-05-31',
+												venue: {
+													model: 'VENUE',
+													uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+													name: 'Noël Coward Theatre',
+													surVenue: null
+												}
+											},
+											entities: [
+												{
+													model: 'PERSON',
+													uuid: CONOR_CORGE_PERSON_UUID,
+													name: 'Conor Corge'
+												},
+												{
+													model: 'COMPANY',
+													uuid: STAGECRAFT_LTD_COMPANY_UUID,
+													name: 'Stagecraft Ltd',
+													members: [
+														{
+															model: 'PERSON',
+															uuid: FERDINAND_FOO_PERSON_UUID,
+															name: 'Ferdinand Foo'
+														}
+													]
+												}
+											],
+											coProductions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sub-Wibble',
+													startDate: '2019-06-01',
+													endDate: '2019-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+														name: 'Sur-Wibble'
+													}
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_HOGE_MATERIAL_UUID,
+													name: 'Sub-Hoge',
+													format: 'play',
+													year: 2019,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_HOGE_MATERIAL_UUID,
+														name: 'Sur-Hoge'
+													}
+												},
+												{
+													model: 'MATERIAL',
+													uuid: SUB_WIBBLE_MATERIAL_UUID,
+													name: 'Sub-Wibble',
+													format: 'play',
+													year: 2019,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble'
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards } = surHogeNoëlCowardProduction.body;
 
 			expect(awards).to.deep.equal(expectedAwards);
 
@@ -1182,20 +1703,28 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 											coProductions: [
 												{
 													model: 'PRODUCTION',
-													uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-													name: 'Sur-Wibble',
-													startDate: '2019-08-01',
-													endDate: '2019-08-31',
+													uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sur-Hoge',
+													startDate: '2019-05-01',
+													endDate: '2019-05-31',
 													venue: {
 														model: 'VENUE',
-														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
-														name: 'Duke of York\'s Theatre',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
 														surVenue: null
 													},
 													surProduction: null
 												}
 											],
 											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_HOGE_MATERIAL_UUID,
+													name: 'Sur-Hoge',
+													format: 'collection of plays',
+													year: 2019,
+													surMaterial: null
+												},
 												{
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -1253,24 +1782,36 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 											coProductions: [
 												{
 													model: 'PRODUCTION',
-													uuid: SUB_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-													name: 'Sub-Wibble',
-													startDate: '2019-08-01',
-													endDate: '2019-08-31',
+													uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sub-Hoge',
+													startDate: '2019-05-01',
+													endDate: '2019-05-31',
 													venue: {
 														model: 'VENUE',
-														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
-														name: 'Duke of York\'s Theatre',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
 														surVenue: null
 													},
 													surProduction: {
 														model: 'PRODUCTION',
-														uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Sur-Hoge'
 													}
 												}
 											],
 											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_HOGE_MATERIAL_UUID,
+													name: 'Sub-Hoge',
+													format: 'play',
+													year: 2019,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_HOGE_MATERIAL_UUID,
+														name: 'Sur-Hoge'
+													}
+												},
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_MATERIAL_UUID,
@@ -1347,20 +1888,28 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 											coProductions: [
 												{
 													model: 'PRODUCTION',
-													uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-													name: 'Sur-Wibble',
-													startDate: '2019-08-01',
-													endDate: '2019-08-31',
+													uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sur-Hoge',
+													startDate: '2019-05-01',
+													endDate: '2019-05-31',
 													venue: {
 														model: 'VENUE',
-														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
-														name: 'Duke of York\'s Theatre',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
 														surVenue: null
 													},
 													surProduction: null
 												}
 											],
 											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_HOGE_MATERIAL_UUID,
+													name: 'Sur-Hoge',
+													format: 'collection of plays',
+													year: 2019,
+													surMaterial: null
+												},
 												{
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -1434,24 +1983,36 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 											coProductions: [
 												{
 													model: 'PRODUCTION',
-													uuid: SUB_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-													name: 'Sub-Wibble',
-													startDate: '2019-08-01',
-													endDate: '2019-08-31',
+													uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sub-Hoge',
+													startDate: '2019-05-01',
+													endDate: '2019-05-31',
 													venue: {
 														model: 'VENUE',
-														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
-														name: 'Duke of York\'s Theatre',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
 														surVenue: null
 													},
 													surProduction: {
 														model: 'PRODUCTION',
-														uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Sur-Hoge'
 													}
 												}
 											],
 											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_HOGE_MATERIAL_UUID,
+													name: 'Sub-Hoge',
+													format: 'play',
+													year: 2019,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_HOGE_MATERIAL_UUID,
+														name: 'Sur-Hoge'
+													}
+												},
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_MATERIAL_UUID,
@@ -1475,376 +2036,6 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 			];
 
 			const { awards } = surWibbleJerwoodTheatreUpstairsProduction.body;
-
-			expect(awards).to.deep.equal(expectedAwards);
-
-		});
-
-	});
-
-	describe('Sub-Wibble at Duke of York\'s Theatre (production)', () => {
-
-		it('includes its and its sur-production\'s award nominations, in the latter case specifying the recipient', () => {
-
-			const expectedAwards = [
-				{
-					model: 'AWARD',
-					uuid: EVENING_STANDARD_THEATRE_AWARDS_AWARD_UUID,
-					name: 'Evening Standard Theatre Awards',
-					ceremonies: [
-						{
-							model: 'AWARD_CEREMONY',
-							uuid: EVENING_STANDARD_THEATRE_AWARDS_TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID,
-							name: '2019',
-							categories: [
-								{
-									model: 'AWARD_CEREMONY_CATEGORY',
-									name: 'Best Random Role',
-									nominations: [
-										{
-											model: 'NOMINATION',
-											isWinner: true,
-											type: 'Winner',
-											recipientProduction: {
-												model: 'PRODUCTION',
-												uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-												name: 'Sur-Wibble',
-												startDate: '2019-08-01',
-												endDate: '2019-08-31',
-												venue: {
-													model: 'VENUE',
-													uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
-													name: 'Duke of York\'s Theatre',
-													surVenue: null
-												}
-											},
-											entities: [
-												{
-													model: 'PERSON',
-													uuid: CONOR_CORGE_PERSON_UUID,
-													name: 'Conor Corge'
-												},
-												{
-													model: 'COMPANY',
-													uuid: STAGECRAFT_LTD_COMPANY_UUID,
-													name: 'Stagecraft Ltd',
-													members: [
-														{
-															model: 'PERSON',
-															uuid: FERDINAND_FOO_PERSON_UUID,
-															name: 'Ferdinand Foo'
-														}
-													]
-												}
-											],
-											coProductions: [
-												{
-													model: 'PRODUCTION',
-													uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-													name: 'Sur-Wibble',
-													startDate: '2019-06-01',
-													endDate: '2019-06-30',
-													venue: {
-														model: 'VENUE',
-														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
-														name: 'Jerwood Theatre Upstairs',
-														surVenue: {
-															model: 'VENUE',
-															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
-															name: 'Royal Court Theatre'
-														}
-													},
-													surProduction: null
-												}
-											],
-											materials: [
-												{
-													model: 'MATERIAL',
-													uuid: SUR_WIBBLE_MATERIAL_UUID,
-													name: 'Sur-Wibble',
-													format: 'trilogy of plays',
-													year: 2019,
-													surMaterial: null
-												}
-											]
-										}
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'AWARD',
-					uuid: LAURENCE_OLIVIER_AWARDS_AWARD_UUID,
-					name: 'Laurence Olivier Awards',
-					ceremonies: [
-						{
-							model: 'AWARD_CEREMONY',
-							uuid: LAURENCE_OLIVIER_AWARDS_TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID,
-							name: '2020',
-							categories: [
-								{
-									model: 'AWARD_CEREMONY_CATEGORY',
-									name: 'Best Miscellaneous Role',
-									nominations: [
-										{
-											model: 'NOMINATION',
-											isWinner: false,
-											type: 'Nomination',
-											recipientProduction: null,
-											entities: [
-												{
-													model: 'PERSON',
-													uuid: CONOR_CORGE_PERSON_UUID,
-													name: 'Conor Corge'
-												},
-												{
-													model: 'COMPANY',
-													uuid: STAGECRAFT_LTD_COMPANY_UUID,
-													name: 'Stagecraft Ltd',
-													members: [
-														{
-															model: 'PERSON',
-															uuid: FERDINAND_FOO_PERSON_UUID,
-															name: 'Ferdinand Foo'
-														}
-													]
-												}
-											],
-											coProductions: [
-												{
-													model: 'PRODUCTION',
-													uuid: SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-													name: 'Sub-Wibble',
-													startDate: '2019-06-01',
-													endDate: '2019-06-30',
-													venue: {
-														model: 'VENUE',
-														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
-														name: 'Jerwood Theatre Upstairs',
-														surVenue: {
-															model: 'VENUE',
-															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
-															name: 'Royal Court Theatre'
-														}
-													},
-													surProduction: {
-														model: 'PRODUCTION',
-														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
-													}
-												}
-											],
-											materials: [
-												{
-													model: 'MATERIAL',
-													uuid: SUB_WIBBLE_MATERIAL_UUID,
-													name: 'Sub-Wibble',
-													format: 'play',
-													year: 2019,
-													surMaterial: {
-														model: 'MATERIAL',
-														uuid: SUR_WIBBLE_MATERIAL_UUID,
-														name: 'Sur-Wibble'
-													}
-												}
-											]
-										}
-									]
-								}
-							]
-						}
-					]
-				}
-			];
-
-			const { awards } = subWibbleDukeOfYorksProduction.body;
-
-			expect(awards).to.deep.equal(expectedAwards);
-
-		});
-
-	});
-
-	describe('Sur-Wibble at Duke of York\'s Theatre (production)', () => {
-
-		it('includes its and its sub-productions\' award nominations, in the latter case specifying the recipient', () => {
-
-			const expectedAwards = [
-				{
-					model: 'AWARD',
-					uuid: EVENING_STANDARD_THEATRE_AWARDS_AWARD_UUID,
-					name: 'Evening Standard Theatre Awards',
-					ceremonies: [
-						{
-							model: 'AWARD_CEREMONY',
-							uuid: EVENING_STANDARD_THEATRE_AWARDS_TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID,
-							name: '2019',
-							categories: [
-								{
-									model: 'AWARD_CEREMONY_CATEGORY',
-									name: 'Best Random Role',
-									nominations: [
-										{
-											model: 'NOMINATION',
-											isWinner: true,
-											type: 'Winner',
-											recipientProduction: null,
-											entities: [
-												{
-													model: 'PERSON',
-													uuid: CONOR_CORGE_PERSON_UUID,
-													name: 'Conor Corge'
-												},
-												{
-													model: 'COMPANY',
-													uuid: STAGECRAFT_LTD_COMPANY_UUID,
-													name: 'Stagecraft Ltd',
-													members: [
-														{
-															model: 'PERSON',
-															uuid: FERDINAND_FOO_PERSON_UUID,
-															name: 'Ferdinand Foo'
-														}
-													]
-												}
-											],
-											coProductions: [
-												{
-													model: 'PRODUCTION',
-													uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-													name: 'Sur-Wibble',
-													startDate: '2019-06-01',
-													endDate: '2019-06-30',
-													venue: {
-														model: 'VENUE',
-														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
-														name: 'Jerwood Theatre Upstairs',
-														surVenue: {
-															model: 'VENUE',
-															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
-															name: 'Royal Court Theatre'
-														}
-													},
-													surProduction: null
-												}
-											],
-											materials: [
-												{
-													model: 'MATERIAL',
-													uuid: SUR_WIBBLE_MATERIAL_UUID,
-													name: 'Sur-Wibble',
-													format: 'trilogy of plays',
-													year: 2019,
-													surMaterial: null
-												}
-											]
-										}
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'AWARD',
-					uuid: LAURENCE_OLIVIER_AWARDS_AWARD_UUID,
-					name: 'Laurence Olivier Awards',
-					ceremonies: [
-						{
-							model: 'AWARD_CEREMONY',
-							uuid: LAURENCE_OLIVIER_AWARDS_TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID,
-							name: '2020',
-							categories: [
-								{
-									model: 'AWARD_CEREMONY_CATEGORY',
-									name: 'Best Miscellaneous Role',
-									nominations: [
-										{
-											model: 'NOMINATION',
-											isWinner: false,
-											type: 'Nomination',
-											recipientProduction: {
-												model: 'PRODUCTION',
-												uuid: SUB_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-												name: 'Sub-Wibble',
-												startDate: '2019-08-01',
-												endDate: '2019-08-31',
-												venue: {
-													model: 'VENUE',
-													uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
-													name: 'Duke of York\'s Theatre',
-													surVenue: null
-												}
-											},
-											entities: [
-												{
-													model: 'PERSON',
-													uuid: CONOR_CORGE_PERSON_UUID,
-													name: 'Conor Corge'
-												},
-												{
-													model: 'COMPANY',
-													uuid: STAGECRAFT_LTD_COMPANY_UUID,
-													name: 'Stagecraft Ltd',
-													members: [
-														{
-															model: 'PERSON',
-															uuid: FERDINAND_FOO_PERSON_UUID,
-															name: 'Ferdinand Foo'
-														}
-													]
-												}
-											],
-											coProductions: [
-												{
-													model: 'PRODUCTION',
-													uuid: SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-													name: 'Sub-Wibble',
-													startDate: '2019-06-01',
-													endDate: '2019-06-30',
-													venue: {
-														model: 'VENUE',
-														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
-														name: 'Jerwood Theatre Upstairs',
-														surVenue: {
-															model: 'VENUE',
-															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
-															name: 'Royal Court Theatre'
-														}
-													},
-													surProduction: {
-														model: 'PRODUCTION',
-														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
-													}
-												}
-											],
-											materials: [
-												{
-													model: 'MATERIAL',
-													uuid: SUB_WIBBLE_MATERIAL_UUID,
-													name: 'Sub-Wibble',
-													format: 'play',
-													year: 2019,
-													surMaterial: {
-														model: 'MATERIAL',
-														uuid: SUR_WIBBLE_MATERIAL_UUID,
-														name: 'Sur-Wibble'
-													}
-												}
-											]
-										}
-									]
-								}
-							]
-						}
-					]
-				}
-			];
-
-			const { awards } = surWibbleDukeOfYorksProduction.body;
 
 			expect(awards).to.deep.equal(expectedAwards);
 
@@ -1904,6 +2095,20 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 											productions: [
 												{
 													model: 'PRODUCTION',
+													uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sur-Hoge',
+													startDate: '2019-05-01',
+													endDate: '2019-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
 													uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
 													name: 'Sur-Wibble',
 													startDate: '2019-06-01',
@@ -1919,23 +2124,18 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 														}
 													},
 													surProduction: null
-												},
-												{
-													model: 'PRODUCTION',
-													uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-													name: 'Sur-Wibble',
-													startDate: '2019-08-01',
-													endDate: '2019-08-31',
-													venue: {
-														model: 'VENUE',
-														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
-														name: 'Duke of York\'s Theatre',
-														surVenue: null
-													},
-													surProduction: null
 												}
 											],
-											coMaterials: []
+											coMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_HOGE_MATERIAL_UUID,
+													name: 'Sur-Hoge',
+													format: 'collection of plays',
+													year: 2019,
+													surMaterial: null
+												}
+											]
 										}
 									]
 								}
@@ -1984,6 +2184,24 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 											productions: [
 												{
 													model: 'PRODUCTION',
+													uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sub-Hoge',
+													startDate: '2019-05-01',
+													endDate: '2019-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Sur-Hoge'
+													}
+												},
+												{
+													model: 'PRODUCTION',
 													uuid: SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
 													name: 'Sub-Wibble',
 													startDate: '2019-06-01',
@@ -2003,27 +2221,22 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
 														name: 'Sur-Wibble'
 													}
-												},
-												{
-													model: 'PRODUCTION',
-													uuid: SUB_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-													name: 'Sub-Wibble',
-													startDate: '2019-08-01',
-													endDate: '2019-08-31',
-													venue: {
-														model: 'VENUE',
-														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
-														name: 'Duke of York\'s Theatre',
-														surVenue: null
-													},
-													surProduction: {
-														model: 'PRODUCTION',
-														uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
-													}
 												}
 											],
-											coMaterials: []
+											coMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_HOGE_MATERIAL_UUID,
+													name: 'Sub-Hoge',
+													format: 'play',
+													year: 2019,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_HOGE_MATERIAL_UUID,
+														name: 'Sur-Hoge'
+													}
+												}
+											]
 										}
 									]
 								}
@@ -2087,6 +2300,20 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 											productions: [
 												{
 													model: 'PRODUCTION',
+													uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sur-Hoge',
+													startDate: '2019-05-01',
+													endDate: '2019-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
 													uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
 													name: 'Sur-Wibble',
 													startDate: '2019-06-01',
@@ -2102,23 +2329,18 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 														}
 													},
 													surProduction: null
-												},
-												{
-													model: 'PRODUCTION',
-													uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-													name: 'Sur-Wibble',
-													startDate: '2019-08-01',
-													endDate: '2019-08-31',
-													venue: {
-														model: 'VENUE',
-														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
-														name: 'Duke of York\'s Theatre',
-														surVenue: null
-													},
-													surProduction: null
 												}
 											],
-											coMaterials: []
+											coMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_HOGE_MATERIAL_UUID,
+													name: 'Sur-Hoge',
+													format: 'collection of plays',
+													year: 2019,
+													surMaterial: null
+												}
+											]
 										}
 									]
 								}
@@ -2173,6 +2395,24 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 											productions: [
 												{
 													model: 'PRODUCTION',
+													uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sub-Hoge',
+													startDate: '2019-05-01',
+													endDate: '2019-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Sur-Hoge'
+													}
+												},
+												{
+													model: 'PRODUCTION',
 													uuid: SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
 													name: 'Sub-Wibble',
 													startDate: '2019-06-01',
@@ -2192,27 +2432,22 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
 														name: 'Sur-Wibble'
 													}
-												},
-												{
-													model: 'PRODUCTION',
-													uuid: SUB_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-													name: 'Sub-Wibble',
-													startDate: '2019-08-01',
-													endDate: '2019-08-31',
-													venue: {
-														model: 'VENUE',
-														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
-														name: 'Duke of York\'s Theatre',
-														surVenue: null
-													},
-													surProduction: {
-														model: 'PRODUCTION',
-														uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
-													}
 												}
 											],
-											coMaterials: []
+											coMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_HOGE_MATERIAL_UUID,
+													name: 'Sub-Hoge',
+													format: 'play',
+													year: 2019,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_HOGE_MATERIAL_UUID,
+														name: 'Sur-Hoge'
+													}
+												}
+											]
 										}
 									]
 								}

--- a/test-e2e/model-interaction/award-ceremonies.test.js
+++ b/test-e2e/model-interaction/award-ceremonies.test.js
@@ -6490,7 +6490,8 @@ describe('Award ceremonies', () => {
 													uuid: PLUGH_MATERIAL_UUID,
 													name: 'Plugh',
 													format: 'play',
-													year: 2019
+													year: 2019,
+													surMaterial: null
 												}
 											]
 										}
@@ -6764,7 +6765,8 @@ describe('Award ceremonies', () => {
 													uuid: WALDO_MATERIAL_UUID,
 													name: 'Waldo',
 													format: 'play',
-													year: 2019
+													year: 2019,
+													surMaterial: null
 												}
 											]
 										}
@@ -6880,7 +6882,8 @@ describe('Award ceremonies', () => {
 													uuid: HOGE_MATERIAL_UUID,
 													name: 'Hoge',
 													format: 'play',
-													year: 2017
+													year: 2017,
+													surMaterial: null
 												}
 											]
 										}
@@ -6997,7 +7000,8 @@ describe('Award ceremonies', () => {
 													uuid: THUD_MATERIAL_UUID,
 													name: 'Thud',
 													format: 'play',
-													year: 2017
+													year: 2017,
+													surMaterial: null
 												}
 											]
 										}


### PR DESCRIPTION
This PR adds makes changes to the material Cypher 'show' query so that nominated co-materials will include their sur-material where applicable.

It also adds a test case in `test-e2e/model-interaction/award-ceremonies-with-sub-materials-sub-prods.test.js` to capture this aspect of the query, which also included some updating of the test case productions so that each material had a respective production (i.e. Sur-Wibble and Sub-Wibble at the Duke of York's Theatre were replaced with Sur-Hoge and Sub-Hoge at the Noël Coward Theatre).