### PR TITLE
Fix deprecated Cypher query features

### DIFF
--- a/src/neo4j/cypher-queries/award-ceremony.js
+++ b/src/neo4j/cypher-queries/award-ceremony.js
@@ -308,12 +308,22 @@ const getEditQuery = () => `
 		nomineeRel.nominationPosition AS nominationPosition,
 		nomineeRel.isWinner AS isWinner,
 		nomineeRel.customType AS customType,
-		[nominee IN COLLECT(
+		COLLECT(
 			CASE nominee WHEN NULL
 				THEN null
 				ELSE nominee { .model, .uuid, .name, .differentiator, members: nominatedMembers }
 			END
-		) | CASE nominee.model
+		) AS nominees
+
+	WITH
+		ceremony,
+		award,
+		categoryRel,
+		category,
+		nominationPosition,
+		isWinner,
+		customType,
+		[nominee IN nominees | CASE nominee.model
 			WHEN 'COMPANY' THEN nominee { .model, .name, .differentiator, .members }
 			WHEN 'PERSON' THEN nominee { .model, .name, .differentiator }
 			WHEN 'PRODUCTION' THEN nominee { .model, .uuid }
@@ -474,7 +484,7 @@ const getShowQuery = () => `
 		surProduction,
 		surMaterial,
 		entityRel.credit AS writingCreditName,
-		[entity IN COLLECT(
+		COLLECT(
 			CASE entity WHEN NULL
 				THEN null
 				ELSE entity {
@@ -490,7 +500,21 @@ const getShowQuery = () => `
 					writingCredits: sourceMaterialWritingCredits
 				}
 			END
-		) | CASE entity.model WHEN 'MATERIAL'
+		) AS entities
+
+	WITH
+		ceremony,
+		award,
+		categoryRel,
+		category,
+		nomineeRel,
+		nominee,
+		venue,
+		surVenue,
+		surProduction,
+		surMaterial,
+		writingCreditName,
+		[entity IN entities | CASE entity.model WHEN 'MATERIAL'
 			THEN entity
 			ELSE entity { .model, .uuid, .name }
 		END] AS entities
@@ -581,7 +605,7 @@ const getShowQuery = () => `
 		nomineeRel.nominationPosition AS nominationPosition,
 		nomineeRel.isWinner AS isWinner,
 		nomineeRel.customType AS customType,
-		[nominee IN COLLECT(
+		COLLECT(
 			CASE nominee WHEN NULL
 				THEN null
 				ELSE nominee {
@@ -599,7 +623,17 @@ const getShowQuery = () => `
 					.writingCredits
 				}
 			END
-		) | CASE nominee.model
+		) AS nominees
+
+	WITH
+		ceremony,
+		award,
+		categoryRel,
+		category,
+		nominationPosition,
+		isWinner,
+		customType,
+		[nominee IN nominees | CASE nominee.model
 			WHEN 'COMPANY' THEN nominee { .model, .uuid, .name, .members }
 			WHEN 'PERSON' THEN nominee { .model, .uuid, .name }
 			WHEN 'PRODUCTION' THEN nominee { .model, .uuid, .name, .startDate, .endDate, .venue, .surProduction }

--- a/src/neo4j/cypher-queries/character.js
+++ b/src/neo4j/cypher-queries/character.js
@@ -51,7 +51,7 @@ const getShowQuery = () => `
 		ORDER BY entityRel.creditPosition, entityRel.entityPosition
 
 	WITH character, materialRel, material, entityRel.credit AS writingCreditName,
-		[entity IN COLLECT(
+		COLLECT(
 			CASE entity WHEN NULL
 				THEN null
 				ELSE entity {
@@ -67,7 +67,10 @@ const getShowQuery = () => `
 					writingCredits: sourceMaterialWritingCredits
 				}
 			END
-		) | CASE entity.model WHEN 'MATERIAL'
+		) AS entities
+
+	WITH character, materialRel, material, writingCreditName,
+		[entity IN entities | CASE entity.model WHEN 'MATERIAL'
 			THEN entity
 			ELSE entity { .model, .uuid, .name }
 		END] AS entities
@@ -117,7 +120,7 @@ const getShowQuery = () => `
 		) AS materials
 
 	OPTIONAL MATCH (character)<-[variantNamedDepiction:DEPICTS]-(:Material)
-		WHERE EXISTS(variantNamedDepiction.displayName)
+		WHERE variantNamedDepiction.displayName IS NOT NULL
 
 	WITH character, materials, variantNamedDepiction
 		ORDER BY variantNamedDepiction.displayName

--- a/src/neo4j/cypher-queries/venue.js
+++ b/src/neo4j/cypher-queries/venue.js
@@ -97,8 +97,10 @@ const getShowQuery = () => `
 		) AS subVenues
 
 	OPTIONAL MATCH (venue)-[:HAS_SUB_VENUE*0..1]->(venueLinkedToProduction:Venue)<-[:PLAYS_AT]-(production:Production)
-		WHERE NOT (venue)-[:HAS_SUB_VENUE*0..1]->(venueLinkedToProduction)<-[:PLAYS_AT]-(:Production)
-			<-[:HAS_SUB_PRODUCTION]-(production)
+		WHERE NOT EXISTS(
+			(venue)-[:HAS_SUB_VENUE*0..1]->(venueLinkedToProduction)
+			<-[:PLAYS_AT]-(:Production)<-[:HAS_SUB_PRODUCTION]-(production)
+		)
 
 	OPTIONAL MATCH (production)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
@@ -142,7 +144,7 @@ const getShowQuery = () => `
 
 const getListQuery = () => `
 	MATCH (venue:Venue)
-		WHERE NOT (:Venue)-[:HAS_SUB_VENUE]->(venue)
+		WHERE NOT EXISTS((:Venue)-[:HAS_SUB_VENUE]->(venue))
 
 	OPTIONAL MATCH (venue)-[subVenueRel:HAS_SUB_VENUE]->(subVenue:Venue)
 

--- a/test-unit/src/neo4j/cypher-queries/production.test.js
+++ b/test-unit/src/neo4j/cypher-queries/production.test.js
@@ -68,7 +68,7 @@ describe('Cypher Queries Production module', () => {
 				MATCH (production:Production { uuid: $uuid })
 
 				OPTIONAL MATCH (production)-[relationship]-()
-					WHERE NOT (production)<-[relationship:HAS_SUB_PRODUCTION]-(:Production)
+					WHERE NOT EXISTS((production)<-[relationship:HAS_SUB_PRODUCTION]-(:Production))
 
 				DELETE relationship
 


### PR DESCRIPTION
When writing Cypher queries in the Neo4j browser, it will provide feedback when the query is using a feature that has been deprecated, e.g.

<img width="1373" alt="Screenshot 2022-12-21 at 17 12 45" src="https://user-images.githubusercontent.com/10484515/208964643-0efc9d4a-c9a7-44f0-b13e-b1d2c9119e70.png">

This PR fixes all the deprecated features, which include:

### 1
`This feature is deprecated and will be removed in future versions.`
`Aggregation column contains implicit grouping expressions. Aggregation expressions with implicit grouping keys are deprecated and will be removed in a future version. For example, in 'RETURN n.a, n.a + n.b + count(*)' the aggregation expression 'n.a + n.b + count(*)' includes the implicit grouping key 'n.b', and this expression is now deprecated. It may be possible to rewrite the query by extracting these grouping/aggregation expressions into a preceding WITH clause.`

#### References
- [Neo4j Community: Getting a warning when using collect](https://community.neo4j.com/t5/neo4j-graph-platform/getting-a-warning-when-using-collect/m-p/29613)

---

### 2
`This feature is deprecated and will be removed in future versions.`
``Coercion of list to boolean is deprecated. Please consider using `NOT isEmpty(…)` instead.``

#### References:
- [Neo4j Community: Coercion of list to boolean is deprecated](https://community.neo4j.com/t5/neo4j-graph-platform/coercion-of-list-to-boolean-is-deprecated/td-p/22911)
- [Neo4j Docs: `exists()`](https://neo4j.com/docs/cypher-manual/current/functions/predicate/#functions-exists)

---

### 3
`This feature is deprecated and will be removed in future versions.`
``The property existence syntax `… exists(variable.property)` is deprecated, please use `variable.property IS NOT NULL` instead.``