### PR TITLE
Fix production create/update Cypher query to handle non-existent sub-productions

### DIFF
--- a/src/neo4j/cypher-queries/production.js
+++ b/src/neo4j/cypher-queries/production.js
@@ -73,7 +73,7 @@ const getCreateUpdateQuery = action => {
 
 				OPTIONAL MATCH (existingSubProduction:Production { uuid: subProductionParam.uuid })
 
-				FOREACH (item IN CASE subProductionParam WHEN NULL THEN [] ELSE [1] END |
+				FOREACH (item IN CASE existingSubProduction WHEN NULL THEN [] ELSE [1] END |
 					CREATE (production)-[:HAS_SUB_PRODUCTION { position: subProductionParam.position }]->
 						(existingSubProduction)
 				)


### PR DESCRIPTION
The section of the production create/update Cypher query that sets the production's relationships with its sub-productions will fail if a non-existent production is provided as a sub-production.

The Prepare As Params module will remove productions with empty string UUID values, so the validations performed prior to running the query should prevent this from happening, but while it is possible to write the query to be more defensive it makes sense to do so and also keeps things consistent with other queries that perform a similar purpose, e.g. award ceremony create/update Cypher query for setting a category's relationships with its nominee productions.