### PR TITLE
Modify Prepare As Params module to remove productions with empty string UUID values

### DIFF
--- a/src/lib/prepare-as-params.js
+++ b/src/lib/prepare-as-params.js
@@ -32,6 +32,7 @@ const REQUIRES_NAMED_CHILDREN_KEYS = new Set([
 ]);
 
 const REQUIRES_NON_EMPTY_UUID_KEYS = new Set([
+	PRODUCTIONS,
 	SUB_PRODUCTIONS
 ]);
 
@@ -57,6 +58,7 @@ export const prepareAsParams = instance => {
 
 	const hasUuidIfRequired = key => item =>
 		!REQUIRES_NON_EMPTY_UUID_KEYS.has(key) ||
+		!Object.prototype.hasOwnProperty.call(item, 'uuid') ||
 		Boolean(item.uuid);
 
 	const applyPositionPropertyAndRecurseObject = (item, index, array) => {

--- a/test-unit/src/lib/prepare-as-params.test.js
+++ b/test-unit/src/lib/prepare-as-params.test.js
@@ -536,15 +536,21 @@ describe('Prepare As Params module', () => {
 			it('retains objects only if they have a non-empty uuid value', () => {
 
 				const instance = {
-					subProductions: [
+					productions: [
 						{ uuid: '' },
 						{ uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' },
+						{ uuid: '' }
+					],
+					subProductions: [
+						{ uuid: '' },
+						{ uuid: 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy' },
 						{ uuid: '' }
 					]
 				};
 				const result = prepareAsParams(instance);
 				expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
 				expect(stubs.neo4jInt.notCalled).to.be.true;
+				expect(result.productions.length).to.equal(1);
 				expect(result.subProductions.length).to.equal(1);
 
 			});
@@ -902,7 +908,12 @@ describe('Prepare As Params module', () => {
 			it('retains objects only if they have a non-empty uuid value', () => {
 
 				const instance = {
-					production: {
+					foo: {
+						productions: [
+							{ uuid: '' },
+							{ uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' },
+							{ uuid: '' }
+						],
 						subProductions: [
 							{ uuid: '' },
 							{ uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' },
@@ -913,7 +924,8 @@ describe('Prepare As Params module', () => {
 				const result = prepareAsParams(instance);
 				expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
 				expect(stubs.neo4jInt.notCalled).to.be.true;
-				expect(result.production.subProductions.length).to.equal(1);
+				expect(result.foo.productions.length).to.equal(1);
+				expect(result.foo.subProductions.length).to.equal(1);
 
 			});
 
@@ -1314,11 +1326,20 @@ describe('Prepare As Params module', () => {
 			it('retains objects only if they have a non-empty uuid value', () => {
 
 				const instance = {
+					nominations: [
+						{
+							productions: [
+								{ uuid: '' },
+								{ uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' },
+								{ uuid: '' }
+							]
+						}
+					],
 					productions: [
 						{
 							subProductions: [
 								{ uuid: '' },
-								{ uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' },
+								{ uuid: 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy' },
 								{ uuid: '' }
 							]
 						}
@@ -1327,6 +1348,7 @@ describe('Prepare As Params module', () => {
 				const result = prepareAsParams(instance);
 				expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
 				expect(stubs.neo4jInt.notCalled).to.be.true;
+				expect(result.nominations[0].productions.length).to.equal(1);
 				expect(result.productions[0].subProductions.length).to.equal(1);
 
 			});


### PR DESCRIPTION
Currently, award ceremonies submitted via the CMS will include an additional item at the end of its nominated productions with an empty string UUID value.

The Prepare As Params module then replaces those empty string values with newly-generated UUIDs, which are obviously not those of pre-existing productions.

The award ceremony create/update Cypher query has been written to defensively ignore non-existing productions, though it is ultimately better that only the intended params are provided to the query, and so this PR modifies the Prepare As Params module to ensure that, like productions' sub-productions, nominated productions with empty string UUID values are removed rather than assigned a newly-generated UUID.