### PR TITLE
Abstract validateNoAssociationWithSelf method

### DIFF
--- a/src/models/Entity.js
+++ b/src/models/Entity.js
@@ -18,6 +18,11 @@ const DIFFERENTIATOR_EXEMPT_MODELS = new Set([
 	MODELS.PRODUCTION_IDENTIFIER
 ]);
 
+const ASSOCIATION_WITH_SELF_NON_EMPTY_COMPARISON_KEYS = new Set([
+	'uuid',
+	'name'
+]);
+
 export default class Entity extends Base {
 
 	constructor (props = {}) {
@@ -52,17 +57,18 @@ export default class Entity extends Base {
 
 	}
 
-	validateNoAssociationWithSelf (associationName, associationDifferentiator) {
+	validateNoAssociationWithSelf (association) {
 
-		const hasAssociationWithSelf =
-			Boolean(associationName) &&
-			this.name === associationName &&
-			this.differentiator === associationDifferentiator;
+		const hasAssociationWithSelf = Object.entries(association).every(([key, value]) =>
+			(ASSOCIATION_WITH_SELF_NON_EMPTY_COMPARISON_KEYS.has(key) ? Boolean(value) : true) &&
+			this[key] === value
+		);
 
 		if (hasAssociationWithSelf) {
 
-			this.addPropertyError('name', 'Instance cannot form association with itself');
-			this.addPropertyError('differentiator', 'Instance cannot form association with itself');
+			for (const key of Object.keys(association)) {
+				this.addPropertyError(key, 'Instance cannot form association with itself');
+			}
 
 		}
 

--- a/src/models/Material.js
+++ b/src/models/Material.js
@@ -52,7 +52,9 @@ export default class Material extends MaterialBase {
 
 		this.originalVersionMaterial.validateDifferentiator();
 
-		this.originalVersionMaterial.validateNoAssociationWithSelf(this.name, this.differentiator);
+		this.originalVersionMaterial.validateNoAssociationWithSelf(
+			{ name: this.name, differentiator: this.differentiator }
+		);
 
 		const duplicateWritingCreditIndices = getDuplicateNameIndices(this.writingCredits);
 
@@ -71,7 +73,7 @@ export default class Material extends MaterialBase {
 
 			subMaterial.validateDifferentiator();
 
-			subMaterial.validateNoAssociationWithSelf(this.name, this.differentiator);
+			subMaterial.validateNoAssociationWithSelf({ name: this.name, differentiator: this.differentiator });
 
 			subMaterial.validateUniquenessInGroup({ isDuplicate: duplicateSubMaterialIndices.includes(index) });
 

--- a/src/models/Production.js
+++ b/src/models/Production.js
@@ -93,7 +93,7 @@ export default class Production extends Entity {
 
 			subProduction.validateUuid();
 
-			subProduction.validateNoAssociationWithSelf(this.uuid);
+			subProduction.validateNoAssociationWithSelf({ uuid: this.uuid });
 
 			subProduction.validateUniquenessInGroup(
 				{ isDuplicate: duplicateSubProductionIdentifierIndices.includes(index), properties: new Set(['uuid']) }

--- a/src/models/ProductionIdentifier.js
+++ b/src/models/ProductionIdentifier.js
@@ -23,18 +23,6 @@ export default class ProductionIdentifier extends Entity {
 
 	}
 
-	validateNoAssociationWithSelf (associationUuid) {
-
-		const hasAssociationWithSelf = this.uuid === associationUuid;
-
-		if (hasAssociationWithSelf) {
-
-			this.addPropertyError('uuid', 'Instance cannot form association with itself');
-
-		}
-
-	}
-
 	async runDatabaseValidations () {
 
 		if (this.uuid) {

--- a/src/models/Venue.js
+++ b/src/models/Venue.js
@@ -29,7 +29,7 @@ export default class Venue extends VenueBase {
 
 			subVenue.validateDifferentiator();
 
-			subVenue.validateNoAssociationWithSelf(this.name, this.differentiator);
+			subVenue.validateNoAssociationWithSelf({ name: this.name, differentiator: this.differentiator });
 
 			subVenue.validateUniquenessInGroup({ isDuplicate: duplicateSubVenueIndices.includes(index) });
 

--- a/src/models/WritingCredit.js
+++ b/src/models/WritingCredit.js
@@ -52,7 +52,9 @@ export default class WritingCredit extends Base {
 
 			if (entity.model === MODELS.MATERIAL) {
 
-				entity.validateNoAssociationWithSelf(opts.subject.name, opts.subject.differentiator);
+				entity.validateNoAssociationWithSelf(
+					{ name: opts.subject.name, differentiator: opts.subject.differentiator }
+				);
 
 			}
 

--- a/test-unit/src/models/Entity.test.js
+++ b/test-unit/src/models/Entity.test.js
@@ -231,29 +231,91 @@ describe('Entity model', () => {
 
 		context('valid data', () => {
 
-			context('association has name value of empty string', () => {
+			context('name and differentiator comparison', () => {
 
-				it('will not add properties to errors property', () => {
+				context('association has name value of empty string', () => {
 
-					const instance = new Entity({ name: 'National Theatre' });
-					instance.differentiator = '';
-					spy(instance, 'addPropertyError');
-					instance.validateNoAssociationWithSelf('', '');
-					expect(instance.addPropertyError.notCalled).to.be.true;
+					it('will not add properties to errors property', () => {
+
+						const instance = new Entity({ name: 'National Theatre' });
+						instance.differentiator = '';
+						spy(instance, 'addPropertyError');
+						instance.validateNoAssociationWithSelf({ name: '', differentiator: '' });
+						expect(instance.addPropertyError.notCalled).to.be.true;
+
+					});
+
+				});
+
+				context('association name and differentiator combination different to instance name and differentiator combination', () => {
+
+					it('will not add properties to errors property', () => {
+
+						const instance = new Entity({ name: 'Olivier Theatre' });
+						instance.differentiator = '';
+						spy(instance, 'addPropertyError');
+						instance.validateNoAssociationWithSelf({ name: 'National Theatre', differentiator: '' });
+						expect(instance.addPropertyError.notCalled).to.be.true;
+
+					});
+
+				});
+
+				context('instance and association have empty name and differentiator values', () => {
+
+					it('will not add properties to errors property', () => {
+
+						const instance = new Entity({ name: '', differentiator: '' });
+						instance.differentiator = '';
+						spy(instance, 'addPropertyError');
+						instance.validateNoAssociationWithSelf({ name: '', differentiator: '' });
+						expect(instance.addPropertyError.notCalled).to.be.true;
+
+					});
+
+				});
+
+				context('instance and association have matching non-empty differentiator value but empty name value', () => {
+
+					it('will not add properties to errors property', () => {
+
+						const instance = new Entity({ name: '', differentiator: '1' });
+						instance.differentiator = '';
+						spy(instance, 'addPropertyError');
+						instance.validateNoAssociationWithSelf({ name: '', differentiator: '1' });
+						expect(instance.addPropertyError.notCalled).to.be.true;
+
+					});
 
 				});
 
 			});
 
-			context('association name and differentiator combination different to instance name and differentiator combination', () => {
+			context('uuid comparison', () => {
 
-				it('will not add properties to errors property', () => {
+				context('association has not yet been assigned uuid value', () => {
 
-					const instance = new Entity({ name: 'Olivier Theatre' });
-					instance.differentiator = '';
-					spy(instance, 'addPropertyError');
-					instance.validateNoAssociationWithSelf('National Theatre', '');
-					expect(instance.addPropertyError.notCalled).to.be.true;
+					it('will not add properties to errors property', () => {
+
+						const instance = new ProductionIdentifier({ uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' });
+						spy(instance, 'addPropertyError');
+						instance.validateNoAssociationWithSelf({ uuid: undefined });
+						expect(instance.addPropertyError.notCalled).to.be.true;
+
+					});
+
+				});
+
+				context('association uuid different to instance uuid', () => {
+
+					it('will not add properties to errors property', () => {
+
+						const instance = new ProductionIdentifier({ uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' });
+						spy(instance, 'addPropertyError');
+						instance.validateNoAssociationWithSelf({ uuid: 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy' });
+						expect(instance.addPropertyError.notCalled).to.be.true;
+
+					});
 
 				});
 
@@ -263,21 +325,42 @@ describe('Entity model', () => {
 
 		context('invalid data', () => {
 
-			it('adds properties whose values are arrays to errors property', () => {
+			context('name and differentiator comparison', () => {
 
-				const instance = new Entity({ name: 'National Theatre' });
-				instance.differentiator = '';
-				spy(instance, 'addPropertyError');
-				instance.validateNoAssociationWithSelf('National Theatre', '');
-				expect(instance.addPropertyError.calledTwice).to.be.true;
-				expect(instance.addPropertyError.firstCall.calledWithExactly(
-					'name',
-					'Instance cannot form association with itself'
-				)).to.be.true;
-				expect(instance.addPropertyError.secondCall.calledWithExactly(
-					'differentiator',
-					'Instance cannot form association with itself'
-				)).to.be.true;
+				it('adds properties whose values are arrays to errors property', () => {
+
+					const instance = new Entity({ name: 'National Theatre' });
+					instance.differentiator = '';
+					spy(instance, 'addPropertyError');
+					instance.validateNoAssociationWithSelf({ name: 'National Theatre', differentiator: '' });
+					expect(instance.addPropertyError.calledTwice).to.be.true;
+					expect(instance.addPropertyError.firstCall.calledWithExactly(
+						'name',
+						'Instance cannot form association with itself'
+					)).to.be.true;
+					expect(instance.addPropertyError.secondCall.calledWithExactly(
+						'differentiator',
+						'Instance cannot form association with itself'
+					)).to.be.true;
+
+				});
+
+			});
+
+			context('uuid comparison', () => {
+
+				it('adds properties whose values are arrays to errors property', () => {
+
+					const instance = new ProductionIdentifier({ uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' });
+					spy(instance, 'addPropertyError');
+					instance.validateNoAssociationWithSelf({ uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' });
+					expect(instance.addPropertyError.calledOnce).to.be.true;
+					expect(instance.addPropertyError.calledWithExactly(
+						'uuid',
+						'Instance cannot form association with itself'
+					)).to.be.true;
+
+				});
 
 			});
 

--- a/test-unit/src/models/Material.test.js
+++ b/test-unit/src/models/Material.test.js
@@ -382,7 +382,7 @@ describe('Material model', () => {
 			expect(instance.subMaterials[0].validateDifferentiator.calledWithExactly()).to.be.true;
 			expect(instance.subMaterials[0].validateNoAssociationWithSelf.calledOnce).to.be.true;
 			expect(instance.subMaterials[0].validateNoAssociationWithSelf.calledWithExactly(
-				'The Tragedy of Hamlet, Prince of Denmark', '1'
+				{ name: 'The Tragedy of Hamlet, Prince of Denmark', differentiator: '1' }
 			)).to.be.true;
 			expect(instance.subMaterials[0].validateUniquenessInGroup.calledOnce).to.be.true;
 			expect(instance.subMaterials[0].validateUniquenessInGroup.calledWithExactly(

--- a/test-unit/src/models/Production.test.js
+++ b/test-unit/src/models/Production.test.js
@@ -511,7 +511,7 @@ describe('Production model', () => {
 			expect(instance.subProductions[0].validateUuid.calledWithExactly()).to.be.true;
 			expect(instance.subProductions[0].validateNoAssociationWithSelf.calledOnce).to.be.true;
 			expect(instance.subProductions[0].validateNoAssociationWithSelf.calledWithExactly(
-				'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+				{ uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' }
 			)).to.be.true;
 			expect(instance.subProductions[0].validateUniquenessInGroup.calledOnce).to.be.true;
 			expect(instance.subProductions[0].validateUniquenessInGroup.calledWithExactly(

--- a/test-unit/src/models/ProductionIdentifier.test.js
+++ b/test-unit/src/models/ProductionIdentifier.test.js
@@ -19,57 +19,6 @@ describe('ProductionIdentifier model', () => {
 
 	});
 
-	describe('validateNoAssociationWithSelf method', () => {
-
-		context('valid data', () => {
-
-			context('association has not yet been assigned uuid value', () => {
-
-				it('will not add properties to errors property', () => {
-
-					const instance = new ProductionIdentifier({ uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' });
-					spy(instance, 'addPropertyError');
-					instance.validateNoAssociationWithSelf(undefined);
-					expect(instance.addPropertyError.notCalled).to.be.true;
-
-				});
-
-			});
-
-			context('association uuid different to instance uuid', () => {
-
-				it('will not add properties to errors property', () => {
-
-					const instance = new ProductionIdentifier({ uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' });
-					spy(instance, 'addPropertyError');
-					instance.validateNoAssociationWithSelf('yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy');
-					expect(instance.addPropertyError.notCalled).to.be.true;
-
-				});
-
-			});
-
-		});
-
-		context('invalid data', () => {
-
-			it('adds properties whose values are arrays to errors property', () => {
-
-				const instance = new ProductionIdentifier({ uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' });
-				spy(instance, 'addPropertyError');
-				instance.validateNoAssociationWithSelf('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
-				expect(instance.addPropertyError.calledOnce).to.be.true;
-				expect(instance.addPropertyError.calledWithExactly(
-					'uuid',
-					'Instance cannot form association with itself'
-				)).to.be.true;
-
-			});
-
-		});
-
-	});
-
 	describe('runDatabaseValidations method', () => {
 
 		context('confirmExistenceInDatabase method resolves (i.e. production uuid exists in database)', () => {

--- a/test-unit/src/models/Venue.test.js
+++ b/test-unit/src/models/Venue.test.js
@@ -107,7 +107,7 @@ describe('Venue model', () => {
 			expect(instance.subVenues[0].validateDifferentiator.calledWithExactly()).to.be.true;
 			expect(instance.subVenues[0].validateNoAssociationWithSelf.calledOnce).to.be.true;
 			expect(instance.subVenues[0].validateNoAssociationWithSelf.calledWithExactly(
-				'National Theatre', ''
+				{ name: 'National Theatre', differentiator: '' }
 			)).to.be.true;
 			expect(instance.subVenues[0].validateUniquenessInGroup.calledOnce).to.be.true;
 			expect(instance.subVenues[0].validateUniquenessInGroup.calledWithExactly(

--- a/test-unit/src/models/WritingCredit.test.js
+++ b/test-unit/src/models/WritingCredit.test.js
@@ -227,7 +227,7 @@ describe('WritingCredit model', () => {
 			expect(instance.entities[2].validateUniquenessInGroup.calledWithExactly({ isDuplicate: false })).to.be.true;
 			expect(instance.entities[2].validateNoAssociationWithSelf.calledOnce).to.be.true;
 			expect(instance.entities[2].validateNoAssociationWithSelf.calledWithExactly(
-				'The Indian Boy', '1'
+				{ name: 'The Indian Boy', differentiator: '1' }
 			)).to.be.true;
 
 		});


### PR DESCRIPTION
There are currently multiple versions of the `validateNoAssociationWithSelf` method: in the `Entity` and `ProductionIdentifier` classes respectively, which each compare different properties.

This PR abstracts this method so that there is only one version of it in the `Entity` class (of which the `ProductionIdentifier` class is an extension). The argument is an object of the association properties to be compared against the instance. The comparison is then conducted and, if necessary, errors are attached to the properties in question.

The last wrinkle is that a `name` and `differentiator` comparison is deemed valid if the `differentiator` values alone are non-empty strings (while the `name` values are empty strings), so this scenario is still handled.