### PR TITLE
Switch Chai expectations to Sinon assertions

### DIFF
--- a/test-unit/src/controllers/award-ceremonies.test.js
+++ b/test-unit/src/controllers/award-ceremonies.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import proxyquire from 'proxyquire';
-import { createStubInstance, stub } from 'sinon';
+import { assert, createStubInstance, stub } from 'sinon';
 
 import { AwardCeremony } from '../../../src/models';
 
@@ -54,10 +54,11 @@ describe('Award ceremonies controller', () => {
 		it('calls sendJsonResponse module', () => {
 
 			expect(callFunction('newRoute')).to.equal('sendJsonResponse response');
-			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledOnce).to.be.true;
-			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledWithExactly(
+			assert.calledOnce(stubs.sendJsonResponseModule.sendJsonResponse);
+			assert.calledWithExactly(
+				stubs.sendJsonResponseModule.sendJsonResponse,
 				stubs.response, stubs.models.AwardCeremony() // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 
 		});
 
@@ -68,10 +69,11 @@ describe('Award ceremonies controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('createRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.AwardCeremony(), 'CREATE' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -83,10 +85,11 @@ describe('Award ceremonies controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('editRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.AwardCeremony(), 'EDIT' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -98,10 +101,11 @@ describe('Award ceremonies controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('updateRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.AwardCeremony(), 'UPDATE' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -113,10 +117,11 @@ describe('Award ceremonies controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('deleteRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.AwardCeremony(), 'DELETE' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -128,10 +133,11 @@ describe('Award ceremonies controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('showRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.AwardCeremony(), 'SHOW' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -143,10 +149,11 @@ describe('Award ceremonies controller', () => {
 		it('calls callStaticListMethod module', async () => {
 
 			const result = await callFunction('listRoute');
-			expect(stubs.callClassMethodsModule.callStaticListMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callStaticListMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callStaticListMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callStaticListMethod,
 				stubs.response, stubs.next, stubs.models.AwardCeremony, 'AWARD_CEREMONY'
-			)).to.be.true;
+			);
 			expect(result).to.equal('callStaticListMethod response');
 
 		});

--- a/test-unit/src/controllers/awards.test.js
+++ b/test-unit/src/controllers/awards.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import proxyquire from 'proxyquire';
-import { createStubInstance, stub } from 'sinon';
+import { assert, createStubInstance, stub } from 'sinon';
 
 import { Award } from '../../../src/models';
 
@@ -54,10 +54,11 @@ describe('Awards controller', () => {
 		it('calls sendJsonResponse module', () => {
 
 			expect(callFunction('newRoute')).to.equal('sendJsonResponse response');
-			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledOnce).to.be.true;
-			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledWithExactly(
+			assert.calledOnce(stubs.sendJsonResponseModule.sendJsonResponse);
+			assert.calledWithExactly(
+				stubs.sendJsonResponseModule.sendJsonResponse,
 				stubs.response, stubs.models.Award() // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 
 		});
 
@@ -68,10 +69,11 @@ describe('Awards controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('createRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Award(), 'CREATE' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -83,10 +85,11 @@ describe('Awards controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('editRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Award(), 'EDIT' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -98,10 +101,11 @@ describe('Awards controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('updateRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Award(), 'UPDATE' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -113,10 +117,11 @@ describe('Awards controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('deleteRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Award(), 'DELETE' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -128,10 +133,11 @@ describe('Awards controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('showRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Award(), 'SHOW' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -143,10 +149,11 @@ describe('Awards controller', () => {
 		it('calls callStaticListMethod module', async () => {
 
 			const result = await callFunction('listRoute');
-			expect(stubs.callClassMethodsModule.callStaticListMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callStaticListMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callStaticListMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callStaticListMethod,
 				stubs.response, stubs.next, stubs.models.Award, 'AWARD'
-			)).to.be.true;
+			);
 			expect(result).to.equal('callStaticListMethod response');
 
 		});

--- a/test-unit/src/controllers/characters.test.js
+++ b/test-unit/src/controllers/characters.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import proxyquire from 'proxyquire';
-import { createStubInstance, stub } from 'sinon';
+import { assert, createStubInstance, stub } from 'sinon';
 
 import { Character } from '../../../src/models';
 
@@ -54,11 +54,11 @@ describe('Characters controller', () => {
 		it('calls sendJsonResponse module', () => {
 
 			expect(callFunction('newRoute')).to.equal('sendJsonResponse response');
-			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledOnce).to.be.true;
-			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledWithExactly(
-				stubs.response,
-				stubs.models.Character() // eslint-disable-line new-cap
-			)).to.be.true;
+			assert.calledOnce(stubs.sendJsonResponseModule.sendJsonResponse);
+			assert.calledWithExactly(
+				stubs.sendJsonResponseModule.sendJsonResponse,
+				stubs.response, stubs.models.Character() // eslint-disable-line new-cap
+			);
 
 		});
 
@@ -69,10 +69,11 @@ describe('Characters controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('createRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Character(), 'CREATE' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -84,10 +85,11 @@ describe('Characters controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('editRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Character(), 'EDIT' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -99,10 +101,11 @@ describe('Characters controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('updateRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Character(), 'UPDATE' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -114,10 +117,11 @@ describe('Characters controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('deleteRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Character(), 'DELETE' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -129,10 +133,11 @@ describe('Characters controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('showRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Character(), 'SHOW' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -144,10 +149,11 @@ describe('Characters controller', () => {
 		it('calls callStaticListMethod module', async () => {
 
 			const result = await callFunction('listRoute');
-			expect(stubs.callClassMethodsModule.callStaticListMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callStaticListMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callStaticListMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callStaticListMethod,
 				stubs.response, stubs.next, stubs.models.Character, 'CHARACTER'
-			)).to.be.true;
+			);
 			expect(result).to.equal('callStaticListMethod response');
 
 		});

--- a/test-unit/src/controllers/companies.test.js
+++ b/test-unit/src/controllers/companies.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import proxyquire from 'proxyquire';
-import { createStubInstance, stub } from 'sinon';
+import { assert, createStubInstance, stub } from 'sinon';
 
 import { Company } from '../../../src/models';
 
@@ -54,10 +54,11 @@ describe('Companies controller', () => {
 		it('calls sendJsonResponse module', () => {
 
 			expect(callFunction('newRoute')).to.equal('sendJsonResponse response');
-			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledOnce).to.be.true;
-			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledWithExactly(
+			assert.calledOnce(stubs.sendJsonResponseModule.sendJsonResponse);
+			assert.calledWithExactly(
+				stubs.sendJsonResponseModule.sendJsonResponse,
 				stubs.response, stubs.models.Company() // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 
 		});
 
@@ -68,10 +69,11 @@ describe('Companies controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('createRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Company(), 'CREATE' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -83,10 +85,11 @@ describe('Companies controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('editRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Company(), 'EDIT' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -98,10 +101,11 @@ describe('Companies controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('updateRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Company(), 'UPDATE' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -113,10 +117,11 @@ describe('Companies controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('deleteRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Company(), 'DELETE' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -128,10 +133,11 @@ describe('Companies controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('showRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Company(), 'SHOW' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -143,10 +149,11 @@ describe('Companies controller', () => {
 		it('calls callStaticListMethod module', async () => {
 
 			const result = await callFunction('listRoute');
-			expect(stubs.callClassMethodsModule.callStaticListMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callStaticListMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callStaticListMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callStaticListMethod,
 				stubs.response, stubs.next, stubs.models.Company, 'COMPANY'
-			)).to.be.true;
+			);
 			expect(result).to.equal('callStaticListMethod response');
 
 		});

--- a/test-unit/src/controllers/materials.test.js
+++ b/test-unit/src/controllers/materials.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import proxyquire from 'proxyquire';
-import { createStubInstance, stub } from 'sinon';
+import { assert, createStubInstance, stub } from 'sinon';
 
 import { Material } from '../../../src/models';
 
@@ -54,10 +54,11 @@ describe('Materials controller', () => {
 		it('calls sendJsonResponse module', () => {
 
 			expect(callFunction('newRoute')).to.equal('sendJsonResponse response');
-			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledOnce).to.be.true;
-			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledWithExactly(
+			assert.calledOnce(stubs.sendJsonResponseModule.sendJsonResponse);
+			assert.calledWithExactly(
+				stubs.sendJsonResponseModule.sendJsonResponse,
 				stubs.response, stubs.models.Material() // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 
 		});
 
@@ -68,10 +69,11 @@ describe('Materials controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('createRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Material(), 'CREATE' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -83,10 +85,11 @@ describe('Materials controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('editRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Material(), 'EDIT' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -98,10 +101,11 @@ describe('Materials controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('updateRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Material(), 'UPDATE' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -113,10 +117,11 @@ describe('Materials controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('deleteRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Material(), 'DELETE' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -128,10 +133,11 @@ describe('Materials controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('showRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Material(), 'SHOW' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -143,10 +149,11 @@ describe('Materials controller', () => {
 		it('calls callStaticListMethod module', async () => {
 
 			const result = await callFunction('listRoute');
-			expect(stubs.callClassMethodsModule.callStaticListMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callStaticListMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callStaticListMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callStaticListMethod,
 				stubs.response, stubs.next, stubs.models.Material, 'MATERIAL'
-			)).to.be.true;
+			);
 			expect(result).to.equal('callStaticListMethod response');
 
 		});

--- a/test-unit/src/controllers/people.test.js
+++ b/test-unit/src/controllers/people.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import proxyquire from 'proxyquire';
-import { createStubInstance, stub } from 'sinon';
+import { assert, createStubInstance, stub } from 'sinon';
 
 import { Person } from '../../../src/models';
 
@@ -54,10 +54,11 @@ describe('People controller', () => {
 		it('calls sendJsonResponse module', () => {
 
 			expect(callFunction('newRoute')).to.equal('sendJsonResponse response');
-			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledOnce).to.be.true;
-			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledWithExactly(
+			assert.calledOnce(stubs.sendJsonResponseModule.sendJsonResponse);
+			assert.calledWithExactly(
+				stubs.sendJsonResponseModule.sendJsonResponse,
 				stubs.response, stubs.models.Person() // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 
 		});
 
@@ -68,10 +69,11 @@ describe('People controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('createRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Person(), 'CREATE' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -83,10 +85,11 @@ describe('People controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('editRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Person(), 'EDIT' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -98,10 +101,11 @@ describe('People controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('updateRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Person(), 'UPDATE' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -113,10 +117,11 @@ describe('People controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('deleteRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Person(), 'DELETE' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -128,10 +133,11 @@ describe('People controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('showRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Person(), 'SHOW' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -143,10 +149,11 @@ describe('People controller', () => {
 		it('calls callStaticListMethod module', async () => {
 
 			const result = await callFunction('listRoute');
-			expect(stubs.callClassMethodsModule.callStaticListMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callStaticListMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callStaticListMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callStaticListMethod,
 				stubs.response, stubs.next, stubs.models.Person, 'PERSON'
-			)).to.be.true;
+			);
 			expect(result).to.equal('callStaticListMethod response');
 
 		});

--- a/test-unit/src/controllers/productions.test.js
+++ b/test-unit/src/controllers/productions.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import proxyquire from 'proxyquire';
-import { createStubInstance, stub } from 'sinon';
+import { assert, createStubInstance, stub } from 'sinon';
 
 import { Production } from '../../../src/models';
 
@@ -54,11 +54,11 @@ describe('Productions controller', () => {
 		it('calls sendJsonResponse module', () => {
 
 			expect(callFunction('newRoute')).to.equal('sendJsonResponse response');
-			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledOnce).to.be.true;
-			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledWithExactly(
-				stubs.response,
-				stubs.models.Production() // eslint-disable-line new-cap
-			)).to.be.true;
+			assert.calledOnce(stubs.sendJsonResponseModule.sendJsonResponse);
+			assert.calledWithExactly(
+				stubs.sendJsonResponseModule.sendJsonResponse,
+				stubs.response, stubs.models.Production() // eslint-disable-line new-cap
+			);
 
 		});
 
@@ -69,10 +69,11 @@ describe('Productions controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('createRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Production(), 'CREATE' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -84,10 +85,11 @@ describe('Productions controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('editRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Production(), 'EDIT' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -99,10 +101,11 @@ describe('Productions controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('updateRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Production(), 'UPDATE' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -114,10 +117,11 @@ describe('Productions controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('deleteRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Production(), 'DELETE' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -129,10 +133,11 @@ describe('Productions controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('showRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Production(), 'SHOW' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -144,10 +149,11 @@ describe('Productions controller', () => {
 		it('calls callStaticListMethod module', async () => {
 
 			const result = await callFunction('listRoute');
-			expect(stubs.callClassMethodsModule.callStaticListMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callStaticListMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callStaticListMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callStaticListMethod,
 				stubs.response, stubs.next, stubs.models.Production, 'PRODUCTION'
-			)).to.be.true;
+			);
 			expect(result).to.equal('callStaticListMethod response');
 
 		});

--- a/test-unit/src/controllers/venues.test.js
+++ b/test-unit/src/controllers/venues.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import proxyquire from 'proxyquire';
-import { createStubInstance, stub } from 'sinon';
+import { assert, createStubInstance, stub } from 'sinon';
 
 import { Venue } from '../../../src/models';
 
@@ -54,10 +54,11 @@ describe('Venues controller', () => {
 		it('calls sendJsonResponse module', () => {
 
 			expect(callFunction('newRoute')).to.equal('sendJsonResponse response');
-			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledOnce).to.be.true;
-			expect(stubs.sendJsonResponseModule.sendJsonResponse.calledWithExactly(
+			assert.calledOnce(stubs.sendJsonResponseModule.sendJsonResponse);
+			assert.calledWithExactly(
+				stubs.sendJsonResponseModule.sendJsonResponse,
 				stubs.response, stubs.models.Venue() // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 
 		});
 
@@ -68,10 +69,11 @@ describe('Venues controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('createRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Venue(), 'CREATE' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -83,10 +85,11 @@ describe('Venues controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('editRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Venue(), 'EDIT' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -98,10 +101,11 @@ describe('Venues controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('updateRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Venue(), 'UPDATE' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -113,10 +117,11 @@ describe('Venues controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('deleteRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Venue(), 'DELETE' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -128,10 +133,11 @@ describe('Venues controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('showRoute');
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callInstanceMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Venue(), 'SHOW' // eslint-disable-line new-cap
-			)).to.be.true;
+			);
 			expect(result).to.equal('callInstanceMethod response');
 
 		});
@@ -143,10 +149,11 @@ describe('Venues controller', () => {
 		it('calls callStaticListMethod module', async () => {
 
 			const result = await callFunction('listRoute');
-			expect(stubs.callClassMethodsModule.callStaticListMethod.calledOnce).to.be.true;
-			expect(stubs.callClassMethodsModule.callStaticListMethod.calledWithExactly(
+			assert.calledOnce(stubs.callClassMethodsModule.callStaticListMethod);
+			assert.calledWithExactly(
+				stubs.callClassMethodsModule.callStaticListMethod,
 				stubs.response, stubs.next, stubs.models.Venue, 'VENUE'
-			)).to.be.true;
+			);
 			expect(result).to.equal('callStaticListMethod response');
 
 		});

--- a/test-unit/src/lib/call-class-methods.test.js
+++ b/test-unit/src/lib/call-class-methods.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import httpMocks from 'node-mocks-http';
-import { createSandbox } from 'sinon';
+import { assert, createSandbox } from 'sinon';
 
 import * as callClassMethods from '../../../src/lib/call-class-methods';
 import * as sendJsonResponseModule from '../../../src/lib/send-json-response';
@@ -50,9 +50,9 @@ describe('Call Class Methods module', () => {
 				const instanceMethodResponse = { property: 'value' };
 				sandbox.stub(character, method).callsFake(() => { return Promise.resolve(instanceMethodResponse); });
 				const result = await callClassMethods.callInstanceMethod(stubs.response, stubs.next, character, method);
-				expect(stubs.sendJsonResponse.calledOnce).to.be.true;
-				expect(stubs.sendJsonResponse.calledWithExactly(stubs.response, instanceMethodResponse)).to.be.true;
-				expect(stubs.next.notCalled).to.be.true;
+				assert.calledOnce(stubs.sendJsonResponse);
+				assert.calledWithExactly(stubs.sendJsonResponse, stubs.response, instanceMethodResponse);
+				assert.notCalled(stubs.next);
 				expect(result).to.equal('sendJsonResponse response');
 
 			});
@@ -65,9 +65,9 @@ describe('Call Class Methods module', () => {
 
 				sandbox.stub(character, method).callsFake(() => { return Promise.reject(error); });
 				await callClassMethods.callInstanceMethod(stubs.response, stubs.next, character, method);
-				expect(stubs.next.calledOnce).to.be.true;
-				expect(stubs.next.calledWithExactly(error)).to.be.true;
-				expect(stubs.sendJsonResponse.notCalled).to.be.true;
+				assert.calledOnce(stubs.next);
+				assert.calledWithExactly(stubs.next, error);
+				assert.notCalled(stubs.sendJsonResponse);
 
 			});
 
@@ -81,8 +81,8 @@ describe('Call Class Methods module', () => {
 				await callClassMethods.callInstanceMethod(stubs.response, stubs.next, character, method);
 				expect(stubs.response.statusCode).to.equal(404);
 				expect(stubs.response._getData()).to.equal('Not Found'); // eslint-disable-line no-underscore-dangle
-				expect(stubs.sendJsonResponse.notCalled).to.be.true;
-				expect(stubs.next.notCalled).to.be.true;
+				assert.notCalled(stubs.sendJsonResponse);
+				assert.notCalled(stubs.next);
 
 			});
 
@@ -108,11 +108,12 @@ describe('Call Class Methods module', () => {
 				sandbox.stub(Character, method).callsFake(() => { return Promise.resolve(staticListMethodResponse); });
 				const result =
 					await callClassMethods.callStaticListMethod(stubs.response, stubs.next, Character, 'character');
-				expect(stubs.sendJsonResponse.calledOnce).to.be.true;
-				expect(stubs.sendJsonResponse.calledWithExactly(
+				assert.calledOnce(stubs.sendJsonResponse);
+				assert.calledWithExactly(
+					stubs.sendJsonResponse,
 					stubs.response, staticListMethodResponse
-				)).to.be.true;
-				expect(stubs.next.notCalled).to.be.true;
+				);
+				assert.notCalled(stubs.next);
 				expect(result).to.equal('sendJsonResponse response');
 
 			});
@@ -125,9 +126,9 @@ describe('Call Class Methods module', () => {
 
 				sandbox.stub(Character, method).callsFake(() => { return Promise.reject(error); });
 				await callClassMethods.callStaticListMethod(stubs.response, stubs.next, Character, 'character');
-				expect(stubs.next.calledOnce).to.be.true;
-				expect(stubs.next.calledWithExactly(error)).to.be.true;
-				expect(stubs.sendJsonResponse.notCalled).to.be.true;
+				assert.calledOnce(stubs.next);
+				assert.calledWithExactly(stubs.next, error);
+				assert.notCalled(stubs.sendJsonResponse);
 
 			});
 

--- a/test-unit/src/lib/prepare-as-params.test.js
+++ b/test-unit/src/lib/prepare-as-params.test.js
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
 
 import { expect } from 'chai';
-import { createSandbox } from 'sinon';
+import { assert, createSandbox } from 'sinon';
 import neo4j from 'neo4j-driver';
 
 import { prepareAsParams } from '../../../src/lib/prepare-as-params';
@@ -81,8 +81,8 @@ describe('Prepare As Params module', () => {
 
 			const instance = { uuid: '' };
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.calledOnce(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result.uuid).to.equal('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
 
 		});
@@ -91,8 +91,8 @@ describe('Prepare As Params module', () => {
 
 			const instance = { uuid: undefined };
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.calledOnce(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result.uuid).to.equal('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
 
 		});
@@ -101,8 +101,8 @@ describe('Prepare As Params module', () => {
 
 			const instance = { uuid: 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy' };
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.notCalled(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result.uuid).to.equal('yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy');
 
 		});
@@ -111,8 +111,8 @@ describe('Prepare As Params module', () => {
 
 			const instance = { foo: 'bar' };
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.notCalled(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result.foo).to.equal('bar');
 
 		});
@@ -121,8 +121,8 @@ describe('Prepare As Params module', () => {
 
 			const instance = { foo: '' };
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.notCalled(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result.foo).to.equal(null);
 
 		});
@@ -131,8 +131,8 @@ describe('Prepare As Params module', () => {
 
 			const instance = { foo: false };
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.notCalled(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result.foo).to.equal(null);
 
 		});
@@ -141,8 +141,8 @@ describe('Prepare As Params module', () => {
 
 			const instance = { foo: '' };
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.notCalled(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result).not.to.have.property('position');
 
 		});
@@ -163,8 +163,8 @@ describe('Prepare As Params module', () => {
 
 			const instance = { venue: { uuid: '' } };
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.calledOnce(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result.venue.uuid).to.equal('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
 
 		});
@@ -173,8 +173,8 @@ describe('Prepare As Params module', () => {
 
 			const instance = { venue: { uuid: undefined } };
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.calledOnce(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result.venue.uuid).to.equal('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
 
 		});
@@ -183,8 +183,8 @@ describe('Prepare As Params module', () => {
 
 			const instance = { venue: { uuid: 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy' } };
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.notCalled(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result.venue.uuid).to.equal('yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy');
 
 		});
@@ -193,8 +193,8 @@ describe('Prepare As Params module', () => {
 
 			const instance = { venue: { foo: 'bar' } };
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.notCalled(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result.venue.foo).to.equal('bar');
 
 		});
@@ -203,8 +203,8 @@ describe('Prepare As Params module', () => {
 
 			const instance = { venue: { foo: '' } };
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.notCalled(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result.venue.foo).to.equal(null);
 
 		});
@@ -213,8 +213,8 @@ describe('Prepare As Params module', () => {
 
 			const instance = { venue: { foo: false } };
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.notCalled(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result.venue.foo).to.equal(null);
 
 		});
@@ -223,8 +223,8 @@ describe('Prepare As Params module', () => {
 
 			const instance = { venue: { uuid: '' } };
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.calledOnce(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result.venue).not.to.have.property('position');
 
 		});
@@ -245,8 +245,8 @@ describe('Prepare As Params module', () => {
 
 			const instance = { cast: [{ uuid: '', name: 'David Calder' }] };
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.calledOnce(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result.cast[0].uuid).to.equal('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
 
 		});
@@ -255,8 +255,8 @@ describe('Prepare As Params module', () => {
 
 			const instance = { cast: [{ uuid: undefined, name: 'David Calder' }] };
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.calledOnce(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result.cast[0].uuid).to.equal('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
 
 		});
@@ -265,8 +265,8 @@ describe('Prepare As Params module', () => {
 
 			const instance = { cast: [{ uuid: 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy', name: 'David Calder' }] };
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.notCalled(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result.cast[0].uuid).to.equal('yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy');
 
 		});
@@ -275,8 +275,8 @@ describe('Prepare As Params module', () => {
 
 			const instance = { cast: [{ foo: 'bar', name: 'David Calder' }] };
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.notCalled(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result.cast[0].foo).to.equal('bar');
 
 		});
@@ -285,8 +285,8 @@ describe('Prepare As Params module', () => {
 
 			const instance = { cast: [{ foo: '', name: 'David Calder' }] };
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.notCalled(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result.cast[0].foo).to.equal(null);
 
 		});
@@ -295,8 +295,8 @@ describe('Prepare As Params module', () => {
 
 			const instance = { cast: [{ foo: false, name: 'David Calder' }] };
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.notCalled(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result.cast[0].foo).to.equal(null);
 
 		});
@@ -307,8 +307,8 @@ describe('Prepare As Params module', () => {
 
 				const instance = { cast: [{ uuid: '', name: 'David Calder' }] };
 				const result = prepareAsParams(instance);
-				expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
-				expect(stubs.neo4jInt.notCalled).to.be.true;
+				assert.calledOnce(stubs.cryptoRandomUUID);
+				assert.notCalled(stubs.neo4jInt);
 				expect(result.cast[0]).to.not.have.property('position');
 
 			});
@@ -329,10 +329,10 @@ describe('Prepare As Params module', () => {
 
 				const instance = { cast: [{ uuid: '', name: 'David Calder' }, { uuid: '', name: 'Ruth Negga' }] };
 				const result = prepareAsParams(instance);
-				expect(stubs.cryptoRandomUUID.calledTwice).to.be.true;
-				expect(stubs.neo4jInt.calledTwice).to.be.true;
-				expect(stubs.neo4jInt.getCall(0).calledWithExactly(0)).to.be.true;
-				expect(stubs.neo4jInt.getCall(1).calledWithExactly(1)).to.be.true;
+				assert.calledTwice(stubs.cryptoRandomUUID);
+				assert.calledTwice(stubs.neo4jInt);
+				assert.calledWithExactly(stubs.neo4jInt.getCall(0), 0);
+				assert.calledWithExactly(stubs.neo4jInt.getCall(1), 1);
 				expect(result.cast[0]).to.have.property('position');
 				expect(result.cast[0].position).to.equal(0);
 				expect(result.cast[1]).to.have.property('position');
@@ -361,8 +361,8 @@ describe('Prepare As Params module', () => {
 
 				const instance = { cast: [{ uuid: '', name: '' }, { uuid: '', name: 'David Calder' }] };
 				const result = prepareAsParams(instance);
-				expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
-				expect(stubs.neo4jInt.notCalled).to.be.true;
+				assert.calledOnce(stubs.cryptoRandomUUID);
+				assert.notCalled(stubs.neo4jInt);
 				expect(result.cast.length).to.equal(1);
 				expect(result.cast[0].name).to.equal('David Calder');
 				expect(result.cast[0]).to.not.have.property('position');
@@ -384,8 +384,8 @@ describe('Prepare As Params module', () => {
 					]
 				};
 				const result = prepareAsParams(instance);
-				expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-				expect(stubs.neo4jInt.notCalled).to.be.true;
+				assert.notCalled(stubs.cryptoRandomUUID);
+				assert.notCalled(stubs.neo4jInt);
 				expect(result.productions.length).to.equal(1);
 				expect(result.productions[0]).to.not.have.property('name');
 				expect(result.productions[0]).to.not.have.property('position');
@@ -416,8 +416,8 @@ describe('Prepare As Params module', () => {
 					]
 				};
 				const result = prepareAsParams(instance);
-				expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-				expect(stubs.neo4jInt.notCalled).to.be.true;
+				assert.notCalled(stubs.cryptoRandomUUID);
+				assert.notCalled(stubs.neo4jInt);
 				expect(result.characterGroups.length).to.equal(1);
 				expect(result.characterGroups[0].name).to.be.null;
 				expect(result.characterGroups[0]).to.not.have.property('position');
@@ -486,7 +486,7 @@ describe('Prepare As Params module', () => {
 					]
 				};
 				const result = prepareAsParams(instance);
-				expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
+				assert.notCalled(stubs.cryptoRandomUUID);
 				expect(stubs.neo4jInt.callCount).to.equal(4);
 				expect(result.characterGroups.length).to.equal(1);
 				expect(result.characterGroups[0]).to.not.have.property('position');
@@ -523,8 +523,8 @@ describe('Prepare As Params module', () => {
 					]
 				};
 				const result = prepareAsParams(instance);
-				expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-				expect(stubs.neo4jInt.calledThrice).to.be.true;
+				assert.notCalled(stubs.cryptoRandomUUID);
+				assert.calledThrice(stubs.neo4jInt);
 				expect(result.cast.length).to.equal(3);
 
 			});
@@ -548,8 +548,8 @@ describe('Prepare As Params module', () => {
 					]
 				};
 				const result = prepareAsParams(instance);
-				expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-				expect(stubs.neo4jInt.notCalled).to.be.true;
+				assert.notCalled(stubs.cryptoRandomUUID);
+				assert.notCalled(stubs.neo4jInt);
 				expect(result.productions.length).to.equal(1);
 				expect(result.subProductions.length).to.equal(1);
 
@@ -591,8 +591,8 @@ describe('Prepare As Params module', () => {
 
 			const instance = { production: { cast: [{ uuid: '', name: 'David Calder' }] } };
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.calledOnce(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result.production.cast[0].uuid).to.equal('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
 
 		});
@@ -601,8 +601,8 @@ describe('Prepare As Params module', () => {
 
 			const instance = { production: { cast: [{ uuid: undefined, name: 'David Calder' }] } };
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.calledOnce(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result.production.cast[0].uuid).to.equal('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
 
 		});
@@ -620,8 +620,8 @@ describe('Prepare As Params module', () => {
 				}
 			};
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.notCalled(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result.production.cast[0].uuid).to.equal('yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy');
 
 		});
@@ -630,8 +630,8 @@ describe('Prepare As Params module', () => {
 
 			const instance = { production: { cast: [{ foo: 'bar', name: 'David Calder' }] } };
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.notCalled(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result.production.cast[0].foo).to.equal('bar');
 
 		});
@@ -640,8 +640,8 @@ describe('Prepare As Params module', () => {
 
 			const instance = { production: { cast: [{ foo: '', name: 'David Calder' }] } };
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.notCalled(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result.production.cast[0].foo).to.equal(null);
 
 		});
@@ -650,8 +650,8 @@ describe('Prepare As Params module', () => {
 
 			const instance = { production: { cast: [{ foo: false, name: 'David Calder' }] } };
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.notCalled(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result.production.cast[0].foo).to.equal(null);
 
 		});
@@ -662,8 +662,8 @@ describe('Prepare As Params module', () => {
 
 				const instance = { production: { cast: [{ uuid: '', name: 'David Calder' }] } };
 				const result = prepareAsParams(instance);
-				expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
-				expect(stubs.neo4jInt.notCalled).to.be.true;
+				assert.calledOnce(stubs.cryptoRandomUUID);
+				assert.notCalled(stubs.neo4jInt);
 				expect(result.production.cast[0]).to.not.have.property('position');
 
 			});
@@ -691,10 +691,10 @@ describe('Prepare As Params module', () => {
 					}
 				};
 				const result = prepareAsParams(instance);
-				expect(stubs.cryptoRandomUUID.calledTwice).to.be.true;
-				expect(stubs.neo4jInt.calledTwice).to.be.true;
-				expect(stubs.neo4jInt.getCall(0).calledWithExactly(0)).to.be.true;
-				expect(stubs.neo4jInt.getCall(1).calledWithExactly(1)).to.be.true;
+				assert.calledTwice(stubs.cryptoRandomUUID);
+				assert.calledTwice(stubs.neo4jInt);
+				assert.calledWithExactly(stubs.neo4jInt.getCall(0), 0);
+				assert.calledWithExactly(stubs.neo4jInt.getCall(1), 1);
 				expect(result.production.cast[0]).to.have.property('position');
 				expect(result.production.cast[0].position).to.equal(0);
 				expect(result.production.cast[1]).to.have.property('position');
@@ -725,8 +725,8 @@ describe('Prepare As Params module', () => {
 
 				const instance = { production: { cast: [{ uuid: '', name: '' }, { uuid: '', name: 'David Calder' }] } };
 				const result = prepareAsParams(instance);
-				expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
-				expect(stubs.neo4jInt.notCalled).to.be.true;
+				assert.calledOnce(stubs.cryptoRandomUUID);
+				assert.notCalled(stubs.neo4jInt);
 				expect(result.production.cast.length).to.equal(1);
 				expect(result.production.cast[0].name).to.equal('David Calder');
 				expect(result.production.cast[0]).to.not.have.property('position');
@@ -750,8 +750,8 @@ describe('Prepare As Params module', () => {
 					}
 				};
 				const result = prepareAsParams(instance);
-				expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-				expect(stubs.neo4jInt.notCalled).to.be.true;
+				assert.notCalled(stubs.cryptoRandomUUID);
+				assert.notCalled(stubs.neo4jInt);
 				expect(result.foo.productions.length).to.equal(1);
 				expect(result.foo.productions[0]).to.not.have.property('name');
 				expect(result.foo.productions[0]).to.not.have.property('position');
@@ -784,8 +784,8 @@ describe('Prepare As Params module', () => {
 					}
 				};
 				const result = prepareAsParams(instance);
-				expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-				expect(stubs.neo4jInt.notCalled).to.be.true;
+				assert.notCalled(stubs.cryptoRandomUUID);
+				assert.notCalled(stubs.neo4jInt);
 				expect(result.foo.characterGroups.length).to.equal(1);
 				expect(result.foo.characterGroups[0].name).to.be.null;
 				expect(result.foo.characterGroups[0]).to.not.have.property('position');
@@ -856,7 +856,7 @@ describe('Prepare As Params module', () => {
 					}
 				};
 				const result = prepareAsParams(instance);
-				expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
+				assert.notCalled(stubs.cryptoRandomUUID);
 				expect(stubs.neo4jInt.callCount).to.equal(4);
 				expect(result.foo.characterGroups.length).to.equal(1);
 				expect(result.foo.characterGroups[0]).to.not.have.property('position');
@@ -895,8 +895,8 @@ describe('Prepare As Params module', () => {
 					}
 				};
 				const result = prepareAsParams(instance);
-				expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-				expect(stubs.neo4jInt.calledThrice).to.be.true;
+				assert.notCalled(stubs.cryptoRandomUUID);
+				assert.calledThrice(stubs.neo4jInt);
 				expect(result.production.cast.length).to.equal(3);
 
 			});
@@ -922,8 +922,8 @@ describe('Prepare As Params module', () => {
 					}
 				};
 				const result = prepareAsParams(instance);
-				expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-				expect(stubs.neo4jInt.notCalled).to.be.true;
+				assert.notCalled(stubs.cryptoRandomUUID);
+				assert.notCalled(stubs.neo4jInt);
 				expect(result.foo.productions.length).to.equal(1);
 				expect(result.foo.subProductions.length).to.equal(1);
 
@@ -967,8 +967,8 @@ describe('Prepare As Params module', () => {
 
 			const instance = { cast: [{ name: 'David Calder', roles: [{ uuid: '', name: 'Polonius' }] }] };
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.calledOnce(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result.cast[0].roles[0].uuid).to.equal('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
 
 		});
@@ -977,8 +977,8 @@ describe('Prepare As Params module', () => {
 
 			const instance = { cast: [{ name: 'David Calder', roles: [{ uuid: undefined, name: 'Polonius' }] }] };
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.calledOnce(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result.cast[0].roles[0].uuid).to.equal('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
 
 		});
@@ -999,8 +999,8 @@ describe('Prepare As Params module', () => {
 				]
 			};
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.notCalled(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result.cast[0].roles[0].uuid).to.equal('yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy');
 
 		});
@@ -1009,8 +1009,8 @@ describe('Prepare As Params module', () => {
 
 			const instance = { cast: [{ name: 'David Calder', roles: [{ foo: 'bar', name: 'Polonius' }] }] };
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.notCalled(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result.cast[0].roles[0].foo).to.equal('bar');
 
 		});
@@ -1019,8 +1019,8 @@ describe('Prepare As Params module', () => {
 
 			const instance = { cast: [{ name: 'David Calder', roles: [{ foo: '', name: 'Polonius' }] }] };
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.notCalled(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result.cast[0].roles[0].foo).to.equal(null);
 
 		});
@@ -1029,8 +1029,8 @@ describe('Prepare As Params module', () => {
 
 			const instance = { cast: [{ name: 'David Calder', roles: [{ foo: false, name: 'Polonius' }] }] };
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-			expect(stubs.neo4jInt.notCalled).to.be.true;
+			assert.notCalled(stubs.cryptoRandomUUID);
+			assert.notCalled(stubs.neo4jInt);
 			expect(result.cast[0].roles[0].foo).to.equal(null);
 
 		});
@@ -1041,8 +1041,8 @@ describe('Prepare As Params module', () => {
 
 				const instance = { cast: [{ name: 'David Calder', roles: [{ uuid: '', name: 'Polonius' }] }] };
 				const result = prepareAsParams(instance);
-				expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
-				expect(stubs.neo4jInt.notCalled).to.be.true;
+				assert.calledOnce(stubs.cryptoRandomUUID);
+				assert.notCalled(stubs.neo4jInt);
 				expect(result.cast[0]).to.not.have.property('position');
 				expect(result.cast[0].roles[0]).to.not.have.property('position');
 
@@ -1083,10 +1083,10 @@ describe('Prepare As Params module', () => {
 					]
 				};
 				const result = prepareAsParams(instance);
-				expect(stubs.cryptoRandomUUID.calledTwice).to.be.true;
-				expect(stubs.neo4jInt.calledTwice).to.be.true;
-				expect(stubs.neo4jInt.getCall(0).calledWithExactly(0)).to.be.true;
-				expect(stubs.neo4jInt.getCall(1).calledWithExactly(1)).to.be.true;
+				assert.calledTwice(stubs.cryptoRandomUUID);
+				assert.calledTwice(stubs.neo4jInt);
+				assert.calledWithExactly(stubs.neo4jInt.getCall(0), 0);
+				assert.calledWithExactly(stubs.neo4jInt.getCall(1), 1);
 				expect(result.cast[0]).to.not.have.property('position');
 				expect(result.cast[0].roles[0]).to.have.property('position');
 				expect(result.cast[0].roles[0].position).to.equal(0);
@@ -1131,8 +1131,8 @@ describe('Prepare As Params module', () => {
 					]
 				};
 				const result = prepareAsParams(instance);
-				expect(stubs.cryptoRandomUUID.calledOnce).to.be.true;
-				expect(stubs.neo4jInt.notCalled).to.be.true;
+				assert.calledOnce(stubs.cryptoRandomUUID);
+				assert.notCalled(stubs.neo4jInt);
 				expect(result.cast[0].roles.length).to.equal(1);
 				expect(result.cast[0].roles[0].name).to.equal('Polonius');
 				expect(result.cast[0].roles[0]).to.not.have.property('position');
@@ -1159,8 +1159,8 @@ describe('Prepare As Params module', () => {
 					]
 				};
 				const result = prepareAsParams(instance);
-				expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-				expect(stubs.neo4jInt.notCalled).to.be.true;
+				assert.notCalled(stubs.cryptoRandomUUID);
+				assert.notCalled(stubs.neo4jInt);
 				expect(result.foos[0].productions.length).to.equal(1);
 				expect(result.foos[0].productions[0]).to.not.have.property('name');
 				expect(result.foos[0].productions[0]).to.not.have.property('position');
@@ -1196,8 +1196,8 @@ describe('Prepare As Params module', () => {
 					]
 				};
 				const result = prepareAsParams(instance);
-				expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-				expect(stubs.neo4jInt.notCalled).to.be.true;
+				assert.notCalled(stubs.cryptoRandomUUID);
+				assert.notCalled(stubs.neo4jInt);
 				expect(result.foos[0].characterGroups.length).to.equal(1);
 				expect(result.foos[0].characterGroups[0].name).to.be.null;
 				expect(result.foos[0].characterGroups[0]).to.not.have.property('position');
@@ -1271,7 +1271,7 @@ describe('Prepare As Params module', () => {
 					]
 				};
 				const result = prepareAsParams(instance);
-				expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
+				assert.notCalled(stubs.cryptoRandomUUID);
 				expect(stubs.neo4jInt.callCount).to.equal(4);
 				expect(result.foos[0].characterGroups.length).to.equal(1);
 				expect(result.foos[0].characterGroups[0]).to.not.have.property('position');
@@ -1313,8 +1313,8 @@ describe('Prepare As Params module', () => {
 					]
 				};
 				const result = prepareAsParams(instance);
-				expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-				expect(stubs.neo4jInt.calledThrice).to.be.true;
+				assert.notCalled(stubs.cryptoRandomUUID);
+				assert.calledThrice(stubs.neo4jInt);
 				expect(result.productions[0].cast.length).to.equal(3);
 
 			});
@@ -1346,8 +1346,8 @@ describe('Prepare As Params module', () => {
 					]
 				};
 				const result = prepareAsParams(instance);
-				expect(stubs.cryptoRandomUUID.notCalled).to.be.true;
-				expect(stubs.neo4jInt.notCalled).to.be.true;
+				assert.notCalled(stubs.cryptoRandomUUID);
+				assert.notCalled(stubs.neo4jInt);
 				expect(result.nominations[0].productions.length).to.equal(1);
 				expect(result.productions[0].subProductions.length).to.equal(1);
 

--- a/test-unit/src/models/AwardCeremony.test.js
+++ b/test-unit/src/models/AwardCeremony.test.js
@@ -152,18 +152,19 @@ describe('AwardCeremony model', () => {
 				stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices,
 				instance.categories[0].runInputValidations
 			);
-			expect(instance.validateName.calledOnce).to.be.true;
-			expect(instance.validateName.calledWithExactly({ isRequired: true })).to.be.true;
-			expect(instance.award.validateName.calledOnce).to.be.true;
-			expect(instance.award.validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.award.validateDifferentiator.calledOnce).to.be.true;
-			expect(instance.award.validateDifferentiator.calledWithExactly()).to.be.true;
-			expect(stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices.calledOnce).to.be.true;
-			expect(stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices.calledWithExactly(
+			assert.calledOnce(instance.validateName);
+			assert.calledWithExactly(instance.validateName, { isRequired: true });
+			assert.calledOnce(instance.award.validateName);
+			assert.calledWithExactly(instance.award.validateName, { isRequired: false });
+			assert.calledOnce(instance.award.validateDifferentiator);
+			assert.calledWithExactly(instance.award.validateDifferentiator);
+			assert.calledOnce(stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices);
+			assert.calledWithExactly(
+				stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices,
 				instance.categories
-			)).to.be.true;
-			expect(instance.categories[0].runInputValidations.calledOnce).to.be.true;
-			expect(instance.categories[0].runInputValidations.calledWithExactly({ isDuplicate: false })).to.be.true;
+			);
+			assert.calledOnce(instance.categories[0].runInputValidations);
+			assert.calledWithExactly(instance.categories[0].runInputValidations, { isDuplicate: false });
 
 		});
 
@@ -184,10 +185,10 @@ describe('AwardCeremony model', () => {
 			const instance = createInstance(props);
 			spy(instance, 'validateAwardContextualUniquenessInDatabase');
 			await instance.runDatabaseValidations();
-			expect(instance.validateAwardContextualUniquenessInDatabase.calledOnce).to.be.true;
-			expect(instance.validateAwardContextualUniquenessInDatabase.calledWithExactly()).to.be.true;
-			expect(instance.categories[0].runDatabaseValidations.calledOnce).to.be.true;
-			expect(instance.categories[0].runDatabaseValidations.calledWithExactly()).to.be.true;
+			assert.calledOnce(instance.validateAwardContextualUniquenessInDatabase);
+			assert.calledWithExactly(instance.validateAwardContextualUniquenessInDatabase);
+			assert.calledOnce(instance.categories[0].runDatabaseValidations);
+			assert.calledWithExactly(instance.categories[0].runDatabaseValidations);
 
 		});
 
@@ -208,13 +209,13 @@ describe('AwardCeremony model', () => {
 					stubs.cypherQueriesModule.getAwardContextualDuplicateRecordCountQuery,
 					stubs.neo4jQueryModule.neo4jQuery
 				);
-				expect(stubs.prepareAsParamsModule.prepareAsParams.calledOnce).to.be.true;
-				expect(stubs.prepareAsParamsModule.prepareAsParams.calledWithExactly(instance)).to.be.true;
-				expect(stubs.cypherQueriesModule.getAwardContextualDuplicateRecordCountQuery.calledOnce).to.be.true;
-				expect(stubs.cypherQueriesModule.getAwardContextualDuplicateRecordCountQuery.calledWithExactly())
-					.to.be.true;
-				expect(stubs.neo4jQueryModule.neo4jQuery.calledOnce).to.be.true;
-				expect(stubs.neo4jQueryModule.neo4jQuery.calledWithExactly(
+				assert.calledOnce(stubs.prepareAsParamsModule.prepareAsParams);
+				assert.calledWithExactly(stubs.prepareAsParamsModule.prepareAsParams, instance);
+				assert.calledOnce(stubs.cypherQueriesModule.getAwardContextualDuplicateRecordCountQuery);
+				assert.calledWithExactly(stubs.cypherQueriesModule.getAwardContextualDuplicateRecordCountQuery);
+				assert.calledOnce(stubs.neo4jQueryModule.neo4jQuery);
+				assert.calledWithExactly(
+					stubs.neo4jQueryModule.neo4jQuery,
 					{
 						query: 'getAwardContextualDuplicateRecordCountQuery response',
 						params: {
@@ -226,9 +227,9 @@ describe('AwardCeremony model', () => {
 							}
 						}
 					}
-				)).to.be.true;
-				expect(instance.addPropertyError.notCalled).to.be.true;
-				expect(instance.award.addPropertyError.notCalled).to.be.true;
+				);
+				assert.notCalled(instance.addPropertyError);
+				assert.notCalled(instance.award.addPropertyError);
 
 			});
 
@@ -248,13 +249,13 @@ describe('AwardCeremony model', () => {
 					stubs.neo4jQueryModule.neo4jQuery,
 					instance.addPropertyError
 				);
-				expect(stubs.prepareAsParamsModule.prepareAsParams.calledOnce).to.be.true;
-				expect(stubs.prepareAsParamsModule.prepareAsParams.calledWithExactly(instance)).to.be.true;
-				expect(stubs.cypherQueriesModule.getAwardContextualDuplicateRecordCountQuery.calledOnce).to.be.true;
-				expect(stubs.cypherQueriesModule.getAwardContextualDuplicateRecordCountQuery.calledWithExactly())
-					.to.be.true;
-				expect(stubs.neo4jQueryModule.neo4jQuery.calledOnce).to.be.true;
-				expect(stubs.neo4jQueryModule.neo4jQuery.calledWithExactly(
+				assert.calledOnce(stubs.prepareAsParamsModule.prepareAsParams);
+				assert.calledWithExactly(stubs.prepareAsParamsModule.prepareAsParams, instance);
+				assert.calledOnce(stubs.cypherQueriesModule.getAwardContextualDuplicateRecordCountQuery);
+				assert.calledWithExactly(stubs.cypherQueriesModule.getAwardContextualDuplicateRecordCountQuery);
+				assert.calledOnce(stubs.neo4jQueryModule.neo4jQuery);
+				assert.calledWithExactly(
+					stubs.neo4jQueryModule.neo4jQuery,
 					{
 						query: 'getAwardContextualDuplicateRecordCountQuery response',
 						params: {
@@ -266,18 +267,21 @@ describe('AwardCeremony model', () => {
 							}
 						}
 					}
-				)).to.be.true;
-				expect(instance.addPropertyError.calledOnce).to.be.true;
-				expect(instance.addPropertyError.calledWithExactly(
+				);
+				assert.calledOnce(instance.addPropertyError);
+				assert.calledWithExactly(
+					instance.addPropertyError,
 					'name', 'Award ceremony already exists for given award'
-				)).to.be.true;
-				expect(instance.award.addPropertyError.calledTwice).to.be.true;
-				expect(instance.award.addPropertyError.firstCall.calledWithExactly(
+				);
+				assert.calledTwice(instance.award.addPropertyError);
+				assert.calledWithExactly(
+					instance.award.addPropertyError.firstCall,
 					'name', 'Award ceremony already exists for given award'
-				)).to.be.true;
-				expect(instance.award.addPropertyError.secondCall.calledWithExactly(
+				);
+				assert.calledWithExactly(
+					instance.award.addPropertyError.secondCall,
 					'differentiator', 'Award ceremony already exists for given award'
-				)).to.be.true;
+				);
 
 			});
 

--- a/test-unit/src/models/AwardCeremonyCategory.test.js
+++ b/test-unit/src/models/AwardCeremonyCategory.test.js
@@ -57,14 +57,14 @@ describe('AwardCeremonyCategory model', () => {
 				instance.validateNamePresenceIfNamedChildren,
 				instance.nominations[0].runInputValidations
 			);
-			expect(instance.validateName.calledOnce).to.be.true;
-			expect(instance.validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.validateUniquenessInGroup.calledOnce).to.be.true;
-			expect(instance.validateUniquenessInGroup.calledWithExactly({ isDuplicate: false })).to.be.true;
-			expect(instance.validateNamePresenceIfNamedChildren.calledOnce).to.be.true;
-			expect(instance.validateNamePresenceIfNamedChildren.calledWithExactly([])).to.be.true;
-			expect(instance.nominations[0].runInputValidations.calledOnce).to.be.true;
-			expect(instance.nominations[0].runInputValidations.calledWithExactly()).to.be.true;
+			assert.calledOnce(instance.validateName);
+			assert.calledWithExactly(instance.validateName, { isRequired: false });
+			assert.calledOnce(instance.validateUniquenessInGroup);
+			assert.calledWithExactly(instance.validateUniquenessInGroup, { isDuplicate: false });
+			assert.calledOnce(instance.validateNamePresenceIfNamedChildren);
+			assert.calledWithExactly(instance.validateNamePresenceIfNamedChildren, []);
+			assert.calledOnce(instance.nominations[0].runInputValidations);
+			assert.calledWithExactly(instance.nominations[0].runInputValidations);
 
 		});
 
@@ -80,8 +80,8 @@ describe('AwardCeremonyCategory model', () => {
 			const instance = new AwardCeremonyCategory(props);
 			spy(instance.nominations[0], 'runDatabaseValidations');
 			await instance.runDatabaseValidations();
-			expect(instance.nominations[0].runDatabaseValidations.calledOnce).to.be.true;
-			expect(instance.nominations[0].runDatabaseValidations.calledWithExactly()).to.be.true;
+			assert.calledOnce(instance.nominations[0].runDatabaseValidations);
+			assert.calledWithExactly(instance.nominations[0].runDatabaseValidations);
 
 		});
 

--- a/test-unit/src/models/Base.test.js
+++ b/test-unit/src/models/Base.test.js
@@ -116,8 +116,11 @@ describe('Base model', () => {
 
 			spy(instance, 'validateStringForProperty');
 			instance.validateName({ isRequired: false });
-			expect(instance.validateStringForProperty.calledOnce).to.be.true;
-			expect(instance.validateStringForProperty.calledWithExactly('name', { isRequired: false })).to.be.true;
+			assert.calledOnce(instance.validateStringForProperty);
+			assert.calledWithExactly(
+				instance.validateStringForProperty,
+				'name', { isRequired: false }
+			);
 
 		});
 
@@ -129,8 +132,11 @@ describe('Base model', () => {
 
 			spy(instance, 'validateStringForProperty');
 			instance.validateQualifier();
-			expect(instance.validateStringForProperty.calledOnce).to.be.true;
-			expect(instance.validateStringForProperty.calledWithExactly('qualifier', { isRequired: false })).to.be.true;
+			assert.calledOnce(instance.validateStringForProperty);
+			assert.calledWithExactly(
+				instance.validateStringForProperty,
+				'qualifier', { isRequired: false }
+			);
 
 		});
 
@@ -144,9 +150,12 @@ describe('Base model', () => {
 
 				spy(instance, 'addPropertyError');
 				instance.validateStringForProperty('name', { isRequired: false });
-				expect(stubs.validateString.calledOnce).to.be.true;
-				expect(stubs.validateString.calledWithExactly(instance.name, { isRequired: false })).to.be.true;
-				expect(instance.addPropertyError.notCalled).to.be.true;
+				assert.calledOnce(stubs.validateString);
+				assert.calledWithExactly(
+					stubs.validateString,
+					instance.name, { isRequired: false }
+				);
+				assert.notCalled(instance.addPropertyError);
 
 			});
 
@@ -163,10 +172,16 @@ describe('Base model', () => {
 					stubs.validateString,
 					instance.addPropertyError
 				);
-				expect(stubs.validateString.calledOnce).to.be.true;
-				expect(stubs.validateString.calledWithExactly(instance.name, { isRequired: true })).to.be.true;
-				expect(instance.addPropertyError.calledOnce).to.be.true;
-				expect(instance.addPropertyError.calledWithExactly('name', 'Value is too short')).to.be.true;
+				assert.calledOnce(stubs.validateString);
+				assert.calledWithExactly(
+					stubs.validateString,
+					instance.name, { isRequired: true }
+				);
+				assert.calledOnce(instance.addPropertyError);
+				assert.calledWithExactly(
+					instance.addPropertyError,
+					'name', 'Value is too short'
+				);
 
 			});
 
@@ -183,7 +198,7 @@ describe('Base model', () => {
 				spy(instance, 'addPropertyError');
 				const opts = { isDuplicate: false };
 				instance.validateUniquenessInGroup(opts);
-				expect(instance.addPropertyError.notCalled).to.be.true;
+				assert.notCalled(instance.addPropertyError);
 
 			});
 
@@ -198,10 +213,11 @@ describe('Base model', () => {
 					spy(instance, 'addPropertyError');
 					const opts = { isDuplicate: true };
 					instance.validateUniquenessInGroup(opts);
-					expect(instance.addPropertyError.calledOnce).to.be.true;
-					expect(instance.addPropertyError.calledWithExactly(
+					assert.calledOnce(instance.addPropertyError);
+					assert.calledWithExactly(
+						instance.addPropertyError,
 						'name', 'This item has been duplicated within the group'
-					)).to.be.true;
+					);
 
 				});
 
@@ -215,13 +231,15 @@ describe('Base model', () => {
 					spy(instance, 'addPropertyError');
 					const opts = { isDuplicate: true };
 					instance.validateUniquenessInGroup(opts);
-					expect(instance.addPropertyError.calledTwice).to.be.true;
-					expect(instance.addPropertyError.firstCall.calledWithExactly(
+					assert.calledTwice(instance.addPropertyError);
+					assert.calledWithExactly(
+						instance.addPropertyError.firstCall,
 						'name', 'This item has been duplicated within the group'
-					)).to.be.true;
-					expect(instance.addPropertyError.secondCall.calledWithExactly(
+					);
+					assert.calledWithExactly(
+						instance.addPropertyError.secondCall,
 						'underlyingName', 'This item has been duplicated within the group'
-					)).to.be.true;
+					);
 
 				});
 
@@ -235,13 +253,15 @@ describe('Base model', () => {
 					spy(instance, 'addPropertyError');
 					const opts = { isDuplicate: true };
 					instance.validateUniquenessInGroup(opts);
-					expect(instance.addPropertyError.calledTwice).to.be.true;
-					expect(instance.addPropertyError.firstCall.calledWithExactly(
+					assert.calledTwice(instance.addPropertyError);
+					assert.calledWithExactly(
+						instance.addPropertyError.firstCall,
 						'name', 'This item has been duplicated within the group'
-					)).to.be.true;
-					expect(instance.addPropertyError.secondCall.calledWithExactly(
+					);
+					assert.calledWithExactly(
+						instance.addPropertyError.secondCall,
 						'characterName', 'This item has been duplicated within the group'
-					)).to.be.true;
+					);
 
 				});
 
@@ -255,13 +275,15 @@ describe('Base model', () => {
 					spy(instance, 'addPropertyError');
 					const opts = { isDuplicate: true };
 					instance.validateUniquenessInGroup(opts);
-					expect(instance.addPropertyError.calledTwice).to.be.true;
-					expect(instance.addPropertyError.firstCall.calledWithExactly(
+					assert.calledTwice(instance.addPropertyError);
+					assert.calledWithExactly(
+						instance.addPropertyError.firstCall,
 						'name', 'This item has been duplicated within the group'
-					)).to.be.true;
-					expect(instance.addPropertyError.secondCall.calledWithExactly(
+					);
+					assert.calledWithExactly(
+						instance.addPropertyError.secondCall,
 						'differentiator', 'This item has been duplicated within the group'
-					)).to.be.true;
+					);
 
 				});
 
@@ -275,13 +297,15 @@ describe('Base model', () => {
 					spy(instance, 'addPropertyError');
 					const opts = { isDuplicate: true };
 					instance.validateUniquenessInGroup(opts);
-					expect(instance.addPropertyError.calledTwice).to.be.true;
-					expect(instance.addPropertyError.firstCall.calledWithExactly(
+					assert.calledTwice(instance.addPropertyError);
+					assert.calledWithExactly(
+						instance.addPropertyError.firstCall,
 						'name', 'This item has been duplicated within the group'
-					)).to.be.true;
-					expect(instance.addPropertyError.secondCall.calledWithExactly(
+					);
+					assert.calledWithExactly(
+						instance.addPropertyError.secondCall,
 						'characterDifferentiator', 'This item has been duplicated within the group'
-					)).to.be.true;
+					);
 
 				});
 
@@ -295,13 +319,15 @@ describe('Base model', () => {
 					spy(instance, 'addPropertyError');
 					const opts = { isDuplicate: true };
 					instance.validateUniquenessInGroup(opts);
-					expect(instance.addPropertyError.calledTwice).to.be.true;
-					expect(instance.addPropertyError.firstCall.calledWithExactly(
+					assert.calledTwice(instance.addPropertyError);
+					assert.calledWithExactly(
+						instance.addPropertyError.firstCall,
 						'name', 'This item has been duplicated within the group'
-					)).to.be.true;
-					expect(instance.addPropertyError.secondCall.calledWithExactly(
+					);
+					assert.calledWithExactly(
+						instance.addPropertyError.secondCall,
 						'qualifier', 'This item has been duplicated within the group'
-					)).to.be.true;
+					);
 
 				});
 
@@ -314,10 +340,11 @@ describe('Base model', () => {
 					spy(instance, 'addPropertyError');
 					const opts = { isDuplicate: true };
 					instance.validateUniquenessInGroup(opts);
-					expect(instance.addPropertyError.calledOnce).to.be.true;
-					expect(instance.addPropertyError.calledWithExactly(
+					assert.calledOnce(instance.addPropertyError);
+					assert.calledWithExactly(
+						instance.addPropertyError,
 						'name', 'This item has been duplicated within the group'
-					)).to.be.true;
+					);
 
 				});
 
@@ -334,18 +361,22 @@ describe('Base model', () => {
 					const opts = { isDuplicate: true };
 					instance.validateUniquenessInGroup(opts);
 					expect(instance.addPropertyError.callCount).to.equal(4);
-					expect(instance.addPropertyError.firstCall.calledWithExactly(
+					assert.calledWithExactly(
+						instance.addPropertyError.firstCall,
 						'name', 'This item has been duplicated within the group'
-					)).to.be.true;
-					expect(instance.addPropertyError.secondCall.calledWithExactly(
+					);
+					assert.calledWithExactly(
+						instance.addPropertyError.secondCall,
 						'differentiator', 'This item has been duplicated within the group'
-					)).to.be.true;
-					expect(instance.addPropertyError.thirdCall.calledWithExactly(
+					);
+					assert.calledWithExactly(
+						instance.addPropertyError.thirdCall,
 						'characterDifferentiator', 'This item has been duplicated within the group'
-					)).to.be.true;
-					expect(instance.addPropertyError.getCall(3).calledWithExactly(
+					);
+					assert.calledWithExactly(
+						instance.addPropertyError.getCall(3),
 						'qualifier', 'This item has been duplicated within the group'
-					)).to.be.true;
+					);
 
 				});
 
@@ -359,10 +390,11 @@ describe('Base model', () => {
 					spy(instance, 'addPropertyError');
 					const opts = { isDuplicate: true, properties: new Set(['uuid']) };
 					instance.validateUniquenessInGroup(opts);
-					expect(instance.addPropertyError.calledOnce).to.be.true;
-					expect(instance.addPropertyError.calledWithExactly(
+					assert.calledOnce(instance.addPropertyError);
+					assert.calledWithExactly(
+						instance.addPropertyError,
 						'uuid', 'This item has been duplicated within the group'
-					)).to.be.true;
+					);
 
 				});
 
@@ -383,7 +415,7 @@ describe('Base model', () => {
 					const instance = new Base({ name: '' });
 					spy(instance, 'addPropertyError');
 					instance.validateNamePresenceIfNamedChildren([{ name: '' }]);
-					expect(instance.addPropertyError.notCalled).to.be.true;
+					assert.notCalled(instance.addPropertyError);
 
 				});
 
@@ -396,7 +428,7 @@ describe('Base model', () => {
 					const instance = new Base({ name: 'Foo' });
 					spy(instance, 'addPropertyError');
 					instance.validateNamePresenceIfNamedChildren([{ name: '' }]);
-					expect(instance.addPropertyError.notCalled).to.be.true;
+					assert.notCalled(instance.addPropertyError);
 				});
 
 			});
@@ -408,7 +440,7 @@ describe('Base model', () => {
 					const instance = new Base({ name: 'Foo' });
 					spy(instance, 'addPropertyError');
 					instance.validateNamePresenceIfNamedChildren([{ name: 'Bar' }]);
-					expect(instance.addPropertyError.notCalled).to.be.true;
+					assert.notCalled(instance.addPropertyError);
 
 				});
 
@@ -423,11 +455,11 @@ describe('Base model', () => {
 				const instance = new Base({ name: '' });
 				spy(instance, 'addPropertyError');
 				instance.validateNamePresenceIfNamedChildren([{ name: 'Bar' }]);
-				expect(instance.addPropertyError.calledOnce).to.be.true;
-				expect(instance.addPropertyError.calledWithExactly(
-					'name',
-					'Name is required if named children exist'
-				)).to.be.true;
+				assert.calledOnce(instance.addPropertyError);
+				assert.calledWithExactly(
+					instance.addPropertyError,
+					'name', 'Name is required if named children exist'
+				);
 
 			});
 

--- a/test-unit/src/models/CastMember.test.js
+++ b/test-unit/src/models/CastMember.test.js
@@ -110,28 +110,29 @@ describe('CastMember model', () => {
 				instance.roles[0].validateRoleNameCharacterNameDisparity,
 				instance.roles[0].validateUniquenessInGroup
 			);
-			expect(instance.validateName.calledOnce).to.be.true;
-			expect(instance.validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.validateDifferentiator.calledOnce).to.be.true;
-			expect(instance.validateDifferentiator.calledWithExactly()).to.be.true;
-			expect(instance.validateUniquenessInGroup.calledOnce).to.be.true;
-			expect(instance.validateUniquenessInGroup.calledWithExactly({ isDuplicate: false })).to.be.true;
-			expect(instance.validateNamePresenceIfNamedChildren.calledOnce).to.be.true;
-			expect(instance.validateNamePresenceIfNamedChildren.calledWithExactly(instance.roles)).to.be.true;
-			expect(stubs.getDuplicateIndicesModule.getDuplicateRoleIndices.calledOnce).to.be.true;
-			expect(stubs.getDuplicateIndicesModule.getDuplicateRoleIndices.calledWithExactly(
+			assert.calledOnce(instance.validateName);
+			assert.calledWithExactly(instance.validateName, { isRequired: false });
+			assert.calledOnce(instance.validateDifferentiator);
+			assert.calledWithExactly(instance.validateDifferentiator);
+			assert.calledOnce(instance.validateUniquenessInGroup);
+			assert.calledWithExactly(instance.validateUniquenessInGroup, { isDuplicate: false });
+			assert.calledOnce(instance.validateNamePresenceIfNamedChildren);
+			assert.calledWithExactly(instance.validateNamePresenceIfNamedChildren, instance.roles);
+			assert.calledOnce(stubs.getDuplicateIndicesModule.getDuplicateRoleIndices);
+			assert.calledWithExactly(
+				stubs.getDuplicateIndicesModule.getDuplicateRoleIndices,
 				instance.roles
-			)).to.be.true;
-			expect(instance.roles[0].validateName.calledOnce).to.be.true;
-			expect(instance.roles[0].validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.roles[0].validateCharacterName.calledOnce).to.be.true;
-			expect(instance.roles[0].validateCharacterName.calledWithExactly()).to.be.true;
-			expect(instance.roles[0].validateQualifier.calledOnce).to.be.true;
-			expect(instance.roles[0].validateQualifier.calledWithExactly()).to.be.true;
-			expect(instance.roles[0].validateRoleNameCharacterNameDisparity.calledOnce).to.be.true;
-			expect(instance.roles[0].validateRoleNameCharacterNameDisparity.calledWithExactly()).to.be.true;
-			expect(instance.roles[0].validateUniquenessInGroup.calledOnce).to.be.true;
-			expect(instance.roles[0].validateUniquenessInGroup.calledWithExactly({ isDuplicate: false })).to.be.true;
+			);
+			assert.calledOnce(instance.roles[0].validateName);
+			assert.calledWithExactly(instance.roles[0].validateName, { isRequired: false });
+			assert.calledOnce(instance.roles[0].validateCharacterName);
+			assert.calledWithExactly(instance.roles[0].validateCharacterName);
+			assert.calledOnce(instance.roles[0].validateQualifier);
+			assert.calledWithExactly(instance.roles[0].validateQualifier);
+			assert.calledOnce(instance.roles[0].validateRoleNameCharacterNameDisparity);
+			assert.calledWithExactly(instance.roles[0].validateRoleNameCharacterNameDisparity);
+			assert.calledOnce(instance.roles[0].validateUniquenessInGroup);
+			assert.calledWithExactly(instance.roles[0].validateUniquenessInGroup, { isDuplicate: false });
 
 		});
 

--- a/test-unit/src/models/CharacterDepiction.test.js
+++ b/test-unit/src/models/CharacterDepiction.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { spy } from 'sinon';
+import { assert, spy } from 'sinon';
 
 import CharacterDepiction from '../../../src/models/CharacterDepiction';
 
@@ -94,10 +94,11 @@ describe('CharacterDepiction model', () => {
 			const instance = new CharacterDepiction({ name: 'Prince Hal', underlyingName: 'King Henry V' });
 			spy(instance, 'validateStringForProperty');
 			instance.validateUnderlyingName();
-			expect(instance.validateStringForProperty.calledOnce).to.be.true;
-			expect(instance.validateStringForProperty.calledWithExactly(
+			assert.calledOnce(instance.validateStringForProperty);
+			assert.calledWithExactly(
+				instance.validateStringForProperty,
 				'underlyingName', { isRequired: false }
-			)).to.be.true;
+			);
 
 		});
 
@@ -114,7 +115,7 @@ describe('CharacterDepiction model', () => {
 					const instance = new CharacterDepiction({ name: 'Prince Hal', underlyingName: '' });
 					spy(instance, 'addPropertyError');
 					instance.validateCharacterNameUnderlyingNameDisparity();
-					expect(instance.addPropertyError.notCalled).to.be.true;
+					assert.notCalled(instance.addPropertyError);
 
 				});
 
@@ -127,7 +128,7 @@ describe('CharacterDepiction model', () => {
 					const instance = new CharacterDepiction({ name: 'Prince Hal', underlyingName: 'King Henry V' });
 					spy(instance, 'addPropertyError');
 					instance.validateCharacterNameUnderlyingNameDisparity();
-					expect(instance.addPropertyError.notCalled).to.be.true;
+					assert.notCalled(instance.addPropertyError);
 
 				});
 
@@ -140,7 +141,7 @@ describe('CharacterDepiction model', () => {
 					const instance = new CharacterDepiction({ name: '', underlyingName: '' });
 					spy(instance, 'addPropertyError');
 					instance.validateCharacterNameUnderlyingNameDisparity();
-					expect(instance.addPropertyError.notCalled).to.be.true;
+					assert.notCalled(instance.addPropertyError);
 
 				});
 
@@ -155,11 +156,11 @@ describe('CharacterDepiction model', () => {
 				const instance = new CharacterDepiction({ name: 'King Henry V', underlyingName: 'King Henry V' });
 				spy(instance, 'addPropertyError');
 				instance.validateCharacterNameUnderlyingNameDisparity();
-				expect(instance.addPropertyError.calledOnce).to.be.true;
-				expect(instance.addPropertyError.calledWithExactly(
-					'underlyingName',
-					'Underlying name is only required if different from character name'
-				)).to.be.true;
+				assert.calledOnce(instance.addPropertyError);
+				assert.calledWithExactly(
+					instance.addPropertyError,
+					'underlyingName', 'Underlying name is only required if different from character name'
+				);
 
 			});
 

--- a/test-unit/src/models/CharacterGroup.test.js
+++ b/test-unit/src/models/CharacterGroup.test.js
@@ -107,26 +107,25 @@ describe('CharacterGroup model', () => {
 				instance.characters[0].validateCharacterNameUnderlyingNameDisparity,
 				instance.characters[0].validateUniquenessInGroup
 			);
-			expect(instance.validateName.calledOnce).to.be.true;
-			expect(instance.validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(stubs.getDuplicateIndicesModule.getDuplicateCharacterIndices.calledOnce).to.be.true;
-			expect(stubs.getDuplicateIndicesModule.getDuplicateCharacterIndices.calledWithExactly(
+			assert.calledOnce(instance.validateName);
+			assert.calledWithExactly(instance.validateName, { isRequired: false });
+			assert.calledOnce(stubs.getDuplicateIndicesModule.getDuplicateCharacterIndices);
+			assert.calledWithExactly(
+				stubs.getDuplicateIndicesModule.getDuplicateCharacterIndices,
 				instance.characters
-			)).to.be.true;
-			expect(instance.characters[0].validateName.calledOnce).to.be.true;
-			expect(instance.characters[0].validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.characters[0].validateUnderlyingName.calledOnce).to.be.true;
-			expect(instance.characters[0].validateUnderlyingName.calledWithExactly()).to.be.true;
-			expect(instance.characters[0].validateDifferentiator.calledOnce).to.be.true;
-			expect(instance.characters[0].validateDifferentiator.calledWithExactly()).to.be.true;
-			expect(instance.characters[0].validateQualifier.calledOnce).to.be.true;
-			expect(instance.characters[0].validateQualifier.calledWithExactly()).to.be.true;
-			expect(instance.characters[0].validateCharacterNameUnderlyingNameDisparity.calledOnce).to.be.true;
-			expect(instance.characters[0].validateCharacterNameUnderlyingNameDisparity.calledWithExactly()).to.be.true;
-			expect(instance.characters[0].validateUniquenessInGroup.calledOnce).to.be.true;
-			expect(instance.characters[0].validateUniquenessInGroup.calledWithExactly(
-				{ isDuplicate: false }
-			)).to.be.true;
+			);
+			assert.calledOnce(instance.characters[0].validateName);
+			assert.calledWithExactly(instance.characters[0].validateName, { isRequired: false });
+			assert.calledOnce(instance.characters[0].validateUnderlyingName);
+			assert.calledWithExactly(instance.characters[0].validateUnderlyingName);
+			assert.calledOnce(instance.characters[0].validateDifferentiator);
+			assert.calledWithExactly(instance.characters[0].validateDifferentiator);
+			assert.calledOnce(instance.characters[0].validateQualifier);
+			assert.calledWithExactly(instance.characters[0].validateQualifier);
+			assert.calledOnce(instance.characters[0].validateCharacterNameUnderlyingNameDisparity);
+			assert.calledWithExactly(instance.characters[0].validateCharacterNameUnderlyingNameDisparity);
+			assert.calledOnce(instance.characters[0].validateUniquenessInGroup);
+			assert.calledWithExactly(instance.characters[0].validateUniquenessInGroup, { isDuplicate: false });
 
 		});
 

--- a/test-unit/src/models/CompanyWithMembers.test.js
+++ b/test-unit/src/models/CompanyWithMembers.test.js
@@ -102,17 +102,18 @@ describe('CompanyWithMembers model', () => {
 				stubs.getDuplicateEntityInfoModule.isEntityInArray,
 				instance.members[0].validateUniquenessInGroup
 			);
-			expect(instance.validateNamePresenceIfNamedChildren.calledOnce).to.be.true;
-			expect(instance.members[0].validateName.calledOnce).to.be.true;
-			expect(instance.members[0].validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.members[0].validateDifferentiator.calledOnce).to.be.true;
-			expect(instance.members[0].validateDifferentiator.calledWithExactly()).to.be.true;
-			expect(stubs.getDuplicateEntityInfoModule.isEntityInArray.calledOnce).to.be.true;
-			expect(stubs.getDuplicateEntityInfoModule.isEntityInArray.calledWithExactly(
+			assert.calledOnce(instance.validateNamePresenceIfNamedChildren);
+			assert.calledOnce(instance.members[0].validateName);
+			assert.calledWithExactly(instance.members[0].validateName, { isRequired: false });
+			assert.calledOnce(instance.members[0].validateDifferentiator);
+			assert.calledWithExactly(instance.members[0].validateDifferentiator);
+			assert.calledOnce(stubs.getDuplicateEntityInfoModule.isEntityInArray);
+			assert.calledWithExactly(
+				stubs.getDuplicateEntityInfoModule.isEntityInArray,
 				instance.members[0], []
-			)).to.be.true;
-			expect(instance.members[0].validateUniquenessInGroup.calledOnce).to.be.true;
-			expect(instance.members[0].validateUniquenessInGroup.calledWithExactly({ isDuplicate: false })).to.be.true;
+			);
+			assert.calledOnce(instance.members[0].validateUniquenessInGroup);
+			assert.calledWithExactly(instance.members[0].validateUniquenessInGroup, { isDuplicate: false });
 
 		});
 

--- a/test-unit/src/models/Entity.test.js
+++ b/test-unit/src/models/Entity.test.js
@@ -203,10 +203,10 @@ describe('Entity model', () => {
 			spy(instance, 'validateName');
 			spy(instance, 'validateDifferentiator');
 			instance.runInputValidations();
-			expect(instance.validateName.calledOnce).to.be.true;
-			expect(instance.validateName.calledWithExactly({ isRequired: true })).to.be.true;
-			expect(instance.validateDifferentiator.calledOnce).to.be.true;
-			expect(instance.validateDifferentiator.calledWithExactly()).to.be.true;
+			assert.calledOnce(instance.validateName);
+			assert.calledWithExactly(instance.validateName, { isRequired: true });
+			assert.calledOnce(instance.validateDifferentiator);
+			assert.calledWithExactly(instance.validateDifferentiator);
 
 		});
 
@@ -218,10 +218,11 @@ describe('Entity model', () => {
 
 			spy(instance, 'validateStringForProperty');
 			instance.validateDifferentiator();
-			expect(instance.validateStringForProperty.calledOnce).to.be.true;
-			expect(instance.validateStringForProperty.calledWithExactly(
-				'differentiator', { isRequired: false })
-			).to.be.true;
+			assert.calledOnce(instance.validateStringForProperty);
+			assert.calledWithExactly(
+				instance.validateStringForProperty,
+				'differentiator', { isRequired: false }
+			);
 
 		});
 
@@ -241,7 +242,7 @@ describe('Entity model', () => {
 						instance.differentiator = '';
 						spy(instance, 'addPropertyError');
 						instance.validateNoAssociationWithSelf({ name: '', differentiator: '' });
-						expect(instance.addPropertyError.notCalled).to.be.true;
+						assert.notCalled(instance.addPropertyError);
 
 					});
 
@@ -255,7 +256,7 @@ describe('Entity model', () => {
 						instance.differentiator = '';
 						spy(instance, 'addPropertyError');
 						instance.validateNoAssociationWithSelf({ name: 'National Theatre', differentiator: '' });
-						expect(instance.addPropertyError.notCalled).to.be.true;
+						assert.notCalled(instance.addPropertyError);
 
 					});
 
@@ -269,7 +270,7 @@ describe('Entity model', () => {
 						instance.differentiator = '';
 						spy(instance, 'addPropertyError');
 						instance.validateNoAssociationWithSelf({ name: '', differentiator: '' });
-						expect(instance.addPropertyError.notCalled).to.be.true;
+						assert.notCalled(instance.addPropertyError);
 
 					});
 
@@ -283,7 +284,7 @@ describe('Entity model', () => {
 						instance.differentiator = '';
 						spy(instance, 'addPropertyError');
 						instance.validateNoAssociationWithSelf({ name: '', differentiator: '1' });
-						expect(instance.addPropertyError.notCalled).to.be.true;
+						assert.notCalled(instance.addPropertyError);
 
 					});
 
@@ -300,7 +301,7 @@ describe('Entity model', () => {
 						const instance = new ProductionIdentifier({ uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' });
 						spy(instance, 'addPropertyError');
 						instance.validateNoAssociationWithSelf({ uuid: undefined });
-						expect(instance.addPropertyError.notCalled).to.be.true;
+						assert.notCalled(instance.addPropertyError);
 
 					});
 
@@ -313,7 +314,7 @@ describe('Entity model', () => {
 						const instance = new ProductionIdentifier({ uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' });
 						spy(instance, 'addPropertyError');
 						instance.validateNoAssociationWithSelf({ uuid: 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy' });
-						expect(instance.addPropertyError.notCalled).to.be.true;
+						assert.notCalled(instance.addPropertyError);
 
 					});
 
@@ -333,15 +334,15 @@ describe('Entity model', () => {
 					instance.differentiator = '';
 					spy(instance, 'addPropertyError');
 					instance.validateNoAssociationWithSelf({ name: 'National Theatre', differentiator: '' });
-					expect(instance.addPropertyError.calledTwice).to.be.true;
-					expect(instance.addPropertyError.firstCall.calledWithExactly(
-						'name',
-						'Instance cannot form association with itself'
-					)).to.be.true;
-					expect(instance.addPropertyError.secondCall.calledWithExactly(
-						'differentiator',
-						'Instance cannot form association with itself'
-					)).to.be.true;
+					assert.calledTwice(instance.addPropertyError);
+					assert.calledWithExactly(
+						instance.addPropertyError.firstCall,
+						'name', 'Instance cannot form association with itself'
+					);
+					assert.calledWithExactly(
+						instance.addPropertyError.secondCall,
+						'differentiator', 'Instance cannot form association with itself'
+					);
 
 				});
 
@@ -354,11 +355,11 @@ describe('Entity model', () => {
 					const instance = new ProductionIdentifier({ uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' });
 					spy(instance, 'addPropertyError');
 					instance.validateNoAssociationWithSelf({ uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' });
-					expect(instance.addPropertyError.calledOnce).to.be.true;
-					expect(instance.addPropertyError.calledWithExactly(
-						'uuid',
-						'Instance cannot form association with itself'
-					)).to.be.true;
+					assert.calledOnce(instance.addPropertyError);
+					assert.calledWithExactly(
+						instance.addPropertyError,
+						'uuid', 'Instance cannot form association with itself'
+					);
 
 				});
 
@@ -376,8 +377,8 @@ describe('Entity model', () => {
 
 				spy(instance, 'validateUniquenessInDatabase');
 				await instance.runDatabaseValidations();
-				expect(instance.validateUniquenessInDatabase.calledOnce).to.be.true;
-				expect(instance.validateUniquenessInDatabase.calledWithExactly()).to.be.true;
+				assert.calledOnce(instance.validateUniquenessInDatabase);
+				assert.calledWithExactly(instance.validateUniquenessInDatabase);
 
 			});
 
@@ -390,7 +391,7 @@ describe('Entity model', () => {
 				const instance = new Production();
 				spy(instance, 'validateUniquenessInDatabase');
 				await instance.runDatabaseValidations();
-				expect(instance.validateUniquenessInDatabase.notCalled).to.be.true;
+				assert.notCalled(instance.validateUniquenessInDatabase);
 
 			});
 
@@ -417,12 +418,13 @@ describe('Entity model', () => {
 					stubs.sharedQueries.getDuplicateRecordCountQuery,
 					stubs.neo4jQuery
 				);
-				expect(stubs.prepareAsParams.calledOnce).to.be.true;
-				expect(stubs.prepareAsParams.calledWithExactly(instance)).to.be.true;
-				expect(stubs.sharedQueries.getDuplicateRecordCountQuery.calledOnce).to.be.true;
-				expect(stubs.sharedQueries.getDuplicateRecordCountQuery.calledWithExactly(instance.model)).to.be.true;
-				expect(stubs.neo4jQuery.calledOnce).to.be.true;
-				expect(stubs.neo4jQuery.calledWithExactly(
+				assert.calledOnce(stubs.prepareAsParams);
+				assert.calledWithExactly(stubs.prepareAsParams, instance);
+				assert.calledOnce(stubs.sharedQueries.getDuplicateRecordCountQuery);
+				assert.calledWithExactly(stubs.sharedQueries.getDuplicateRecordCountQuery, instance.model);
+				assert.calledOnce(stubs.neo4jQuery);
+				assert.calledWithExactly(
+					stubs.neo4jQuery,
 					{
 						query: 'getDuplicateRecordCountQuery response',
 						params: {
@@ -431,8 +433,8 @@ describe('Entity model', () => {
 							differentiator: 'DIFFERENTIATOR_VALUE'
 						}
 					}
-				)).to.be.true;
-				expect(instance.addPropertyError.notCalled).to.be.true;
+				);
+				assert.notCalled(instance.addPropertyError);
 
 			});
 
@@ -456,12 +458,13 @@ describe('Entity model', () => {
 					stubs.neo4jQuery,
 					instance.addPropertyError
 				);
-				expect(stubs.prepareAsParams.calledOnce).to.be.true;
-				expect(stubs.prepareAsParams.calledWithExactly(instance)).to.be.true;
-				expect(stubs.sharedQueries.getDuplicateRecordCountQuery.calledOnce).to.be.true;
-				expect(stubs.sharedQueries.getDuplicateRecordCountQuery.calledWithExactly(instance.model)).to.be.true;
-				expect(stubs.neo4jQuery.calledOnce).to.be.true;
-				expect(stubs.neo4jQuery.calledWithExactly(
+				assert.calledOnce(stubs.prepareAsParams);
+				assert.calledWithExactly(stubs.prepareAsParams, instance);
+				assert.calledOnce(stubs.sharedQueries.getDuplicateRecordCountQuery);
+				assert.calledWithExactly(stubs.sharedQueries.getDuplicateRecordCountQuery, instance.model);
+				assert.calledOnce(stubs.neo4jQuery);
+				assert.calledWithExactly(
+					stubs.neo4jQuery,
 					{
 						query: 'getDuplicateRecordCountQuery response',
 						params: {
@@ -470,14 +473,16 @@ describe('Entity model', () => {
 							differentiator: 'DIFFERENTIATOR_VALUE'
 						}
 					}
-				)).to.be.true;
-				expect(instance.addPropertyError.calledTwice).to.be.true;
-				expect(instance.addPropertyError.firstCall.calledWithExactly(
+				);
+				assert.calledTwice(instance.addPropertyError);
+				assert.calledWithExactly(
+					instance.addPropertyError.firstCall,
 					'name', 'Name and differentiator combination already exists'
-				)).to.be.true;
-				expect(instance.addPropertyError.secondCall.calledWithExactly(
+				);
+				assert.calledWithExactly(
+					instance.addPropertyError.secondCall,
 					'differentiator', 'Name and differentiator combination already exists'
-				)).to.be.true;
+				);
 
 			});
 
@@ -490,8 +495,8 @@ describe('Entity model', () => {
 		it('will call hasErrors function and assign its return value to the instance\'s hasErrors property', () => {
 
 			instance.setErrorStatus();
-			expect(stubs.hasErrors.calledOnce).to.be.true;
-			expect(stubs.hasErrors.calledWithExactly(instance)).to.be.true;
+			assert.calledOnce(stubs.hasErrors);
+			assert.calledWithExactly(stubs.hasErrors, instance);
 			expect(instance.hasErrors).to.be.false;
 
 		});
@@ -511,12 +516,13 @@ describe('Entity model', () => {
 					stubs.sharedQueries.getExistenceQuery,
 					stubs.neo4jQuery
 				);
-				expect(stubs.sharedQueries.getExistenceQuery.calledOnce).to.be.true;
-				expect(stubs.sharedQueries.getExistenceQuery.calledWithExactly(instance.model)).to.be.true;
-				expect(stubs.neo4jQuery.calledOnce).to.be.true;
-				expect(stubs.neo4jQuery.calledWithExactly(
+				assert.calledOnce(stubs.sharedQueries.getExistenceQuery);
+				assert.calledWithExactly(stubs.sharedQueries.getExistenceQuery, instance.model);
+				assert.calledOnce(stubs.neo4jQuery);
+				assert.calledWithExactly(
+					stubs.neo4jQuery,
 					{ query: 'getExistenceQuery response', params: { uuid: instance.uuid } }
-				)).to.be.true;
+				);
 
 			});
 
@@ -533,12 +539,13 @@ describe('Entity model', () => {
 					stubs.sharedQueries.getExistenceQuery,
 					stubs.neo4jQuery
 				);
-				expect(stubs.sharedQueries.getExistenceQuery.calledOnce).to.be.true;
-				expect(stubs.sharedQueries.getExistenceQuery.calledWithExactly(model)).to.be.true;
-				expect(stubs.neo4jQuery.calledOnce).to.be.true;
-				expect(stubs.neo4jQuery.calledWithExactly(
+				assert.calledOnce(stubs.sharedQueries.getExistenceQuery);
+				assert.calledWithExactly(stubs.sharedQueries.getExistenceQuery, model);
+				assert.calledOnce(stubs.neo4jQuery);
+				assert.calledWithExactly(
+					stubs.neo4jQuery,
 					{ query: 'getExistenceQuery response', params: { uuid: instance.uuid } }
-				)).to.be.true;
+				);
 
 			});
 
@@ -572,19 +579,20 @@ describe('Entity model', () => {
 					stubs.prepareAsParams,
 					stubs.neo4jQuery
 				);
-				expect(instance.runInputValidations.calledOnce).to.be.true;
-				expect(instance.runInputValidations.calledWithExactly()).to.be.true;
-				expect(instance.runDatabaseValidations.calledOnce).to.be.true;
-				expect(instance.runDatabaseValidations.calledWithExactly()).to.be.true;
-				expect(instance.setErrorStatus.calledOnce).to.be.true;
-				expect(instance.setErrorStatus.calledWithExactly()).to.be.true;
-				expect(stubs.sharedQueries.getCreateQuery.calledOnce).to.be.true;
-				expect(stubs.sharedQueries.getCreateQuery.calledWithExactly(instance.model)).to.be.true;
-				expect(stubs.prepareAsParams.calledTwice).to.be.true;
-				expect(stubs.prepareAsParams.firstCall.calledWithExactly(instance)).to.be.true;
-				expect(stubs.prepareAsParams.secondCall.calledWithExactly(instance)).to.be.true;
-				expect(stubs.neo4jQuery.calledTwice).to.be.true;
-				expect(stubs.neo4jQuery.firstCall.calledWithExactly(
+				assert.calledOnce(instance.runInputValidations);
+				assert.calledWithExactly(instance.runInputValidations);
+				assert.calledOnce(instance.runDatabaseValidations);
+				assert.calledWithExactly(instance.runDatabaseValidations);
+				assert.calledOnce(instance.setErrorStatus);
+				assert.calledWithExactly(instance.setErrorStatus);
+				assert.calledOnce(stubs.sharedQueries.getCreateQuery);
+				assert.calledWithExactly(stubs.sharedQueries.getCreateQuery, instance.model);
+				assert.calledTwice(stubs.prepareAsParams);
+				assert.calledWithExactly(stubs.prepareAsParams.firstCall, instance);
+				assert.calledWithExactly(stubs.prepareAsParams.secondCall, instance);
+				assert.calledTwice(stubs.neo4jQuery);
+				assert.calledWithExactly(
+					stubs.neo4jQuery.firstCall,
 					{
 						query: 'getDuplicateRecordCountQuery response',
 						params: {
@@ -593,12 +601,13 @@ describe('Entity model', () => {
 							differentiator: 'DIFFERENTIATOR_VALUE'
 						}
 					}
-				)).to.be.true;
-				expect(stubs.neo4jQuery.secondCall.calledWithExactly(
+				);
+				assert.calledWithExactly(
+					stubs.neo4jQuery.secondCall,
 					{ query: 'getCreateQuery response', params: 'prepareAsParams response' }
-				)).to.be.true;
-				expect(instance.constructor.calledOnce).to.be.true;
-				expect(instance.constructor.calledWithExactly(neo4jQueryMockResponse)).to.be.true;
+				);
+				assert.calledOnce(instance.constructor);
+				assert.calledWithExactly(instance.constructor, neo4jQueryMockResponse);
 				expect(result instanceof Entity).to.be.true;
 
 			});
@@ -625,19 +634,20 @@ describe('Entity model', () => {
 					stubs.prepareAsParams,
 					stubs.neo4jQuery
 				);
-				expect(instance.runInputValidations.calledOnce).to.be.true;
-				expect(instance.runInputValidations.calledWithExactly()).to.be.true;
-				expect(instance.runDatabaseValidations.calledOnce).to.be.true;
-				expect(instance.runDatabaseValidations.calledWithExactly()).to.be.true;
-				expect(instance.setErrorStatus.calledOnce).to.be.true;
-				expect(instance.setErrorStatus.calledWithExactly()).to.be.true;
-				expect(stubs.sharedQueries.getUpdateQuery.calledOnce).to.be.true;
-				expect(stubs.sharedQueries.getUpdateQuery.calledWithExactly(instance.model)).to.be.true;
-				expect(stubs.prepareAsParams.calledTwice).to.be.true;
-				expect(stubs.prepareAsParams.firstCall.calledWithExactly(instance)).to.be.true;
-				expect(stubs.prepareAsParams.secondCall.calledWithExactly(instance)).to.be.true;
-				expect(stubs.neo4jQuery.calledTwice).to.be.true;
-				expect(stubs.neo4jQuery.firstCall.calledWithExactly(
+				assert.calledOnce(instance.runInputValidations);
+				assert.calledWithExactly(instance.runInputValidations);
+				assert.calledOnce(instance.runDatabaseValidations);
+				assert.calledWithExactly(instance.runDatabaseValidations);
+				assert.calledOnce(instance.setErrorStatus);
+				assert.calledWithExactly(instance.setErrorStatus);
+				assert.calledOnce(stubs.sharedQueries.getUpdateQuery);
+				assert.calledWithExactly(stubs.sharedQueries.getUpdateQuery, instance.model);
+				assert.calledTwice(stubs.prepareAsParams);
+				assert.calledWithExactly(stubs.prepareAsParams.firstCall, instance);
+				assert.calledWithExactly(stubs.prepareAsParams.secondCall, instance);
+				assert.calledTwice(stubs.neo4jQuery);
+				assert.calledWithExactly(
+					stubs.neo4jQuery.firstCall,
 					{
 						query: 'getDuplicateRecordCountQuery response',
 						params: {
@@ -646,12 +656,13 @@ describe('Entity model', () => {
 							differentiator: 'DIFFERENTIATOR_VALUE'
 						}
 					}
-				)).to.be.true;
-				expect(stubs.neo4jQuery.secondCall.calledWithExactly(
+				);
+				assert.calledWithExactly(
+					stubs.neo4jQuery.secondCall,
 					{ query: 'getUpdateQuery response', params: 'prepareAsParams response' }
-				)).to.be.true;
-				expect(instance.constructor.calledOnce).to.be.true;
-				expect(instance.constructor.calledWithExactly(neo4jQueryMockResponse)).to.be.true;
+				);
+				assert.calledOnce(instance.constructor);
+				assert.calledWithExactly(instance.constructor, neo4jQueryMockResponse);
 				expect(result instanceof Entity).to.be.true;
 
 			});
@@ -681,17 +692,18 @@ describe('Entity model', () => {
 					instance.runDatabaseValidations,
 					instance.setErrorStatus
 				);
-				expect(instance.runInputValidations.calledOnce).to.be.true;
-				expect(instance.runInputValidations.calledWithExactly()).to.be.true;
-				expect(instance.runDatabaseValidations.calledOnce).to.be.true;
-				expect(instance.runDatabaseValidations.calledWithExactly()).to.be.true;
-				expect(instance.setErrorStatus.calledOnce).to.be.true;
-				expect(instance.setErrorStatus.calledWithExactly()).to.be.true;
-				expect(getCreateUpdateQueryStub.notCalled).to.be.true;
-				expect(stubs.prepareAsParams.calledOnce).to.be.true;
-				expect(stubs.prepareAsParams.calledWithExactly(instance)).to.be.true;
-				expect(stubs.neo4jQuery.calledOnce).to.be.true;
-				expect(stubs.neo4jQuery.calledWithExactly(
+				assert.calledOnce(instance.runInputValidations);
+				assert.calledWithExactly(instance.runInputValidations);
+				assert.calledOnce(instance.runDatabaseValidations);
+				assert.calledWithExactly(instance.runDatabaseValidations);
+				assert.calledOnce(instance.setErrorStatus);
+				assert.calledWithExactly(instance.setErrorStatus);
+				assert.notCalled(getCreateUpdateQueryStub);
+				assert.calledOnce(stubs.prepareAsParams);
+				assert.calledWithExactly(stubs.prepareAsParams, instance);
+				assert.calledOnce(stubs.neo4jQuery);
+				assert.calledWithExactly(
+					stubs.neo4jQuery,
 					{
 						query: 'getDuplicateRecordCountQuery response',
 						params: {
@@ -700,8 +712,8 @@ describe('Entity model', () => {
 							differentiator: 'DIFFERENTIATOR_VALUE'
 						}
 					}
-				)).to.be.true;
-				expect(instance.constructor.notCalled).to.be.true;
+				);
+				assert.notCalled(instance.constructor);
 				expect(result).to.deep.equal(instance);
 				expect(result).to.deep.equal({
 					model: 'VENUE',
@@ -727,8 +739,8 @@ describe('Entity model', () => {
 				instance.model = 'PRODUCTION';
 				spy(instance, 'createUpdate');
 				await instance.create();
-				expect(instance.createUpdate.calledOnce).to.be.true;
-				expect(instance.createUpdate.calledWithExactly(stubs.getCreateQueries[instance.model])).to.be.true;
+				assert.calledOnce(instance.createUpdate);
+				assert.calledWithExactly(instance.createUpdate, stubs.getCreateQueries[instance.model]);
 
 			});
 
@@ -740,8 +752,8 @@ describe('Entity model', () => {
 
 				spy(instance, 'createUpdate');
 				await instance.create();
-				expect(instance.createUpdate.calledOnce).to.be.true;
-				expect(instance.createUpdate.calledWithExactly(stubs.sharedQueries.getCreateQuery)).to.be.true;
+				assert.calledOnce(instance.createUpdate);
+				assert.calledWithExactly(instance.createUpdate, stubs.sharedQueries.getCreateQuery);
 
 			});
 
@@ -758,15 +770,16 @@ describe('Entity model', () => {
 				instance.model = 'PRODUCTION';
 				spy(instance, 'constructor');
 				const result = await instance.edit();
-				expect(stubs.getEditQueries[instance.model].calledOnce).to.be.true;
-				expect(stubs.getEditQueries[instance.model].calledWithExactly()).to.be.true;
-				expect(stubs.sharedQueries.getEditQuery.notCalled).to.be.true;
-				expect(stubs.neo4jQuery.calledOnce).to.be.true;
-				expect(stubs.neo4jQuery.calledWithExactly(
+				assert.calledOnce(stubs.getEditQueries[instance.model]);
+				assert.calledWithExactly(stubs.getEditQueries[instance.model]);
+				assert.notCalled(stubs.sharedQueries.getEditQuery);
+				assert.calledOnce(stubs.neo4jQuery);
+				assert.calledWithExactly(
+					stubs.neo4jQuery,
 					{ query: 'getEditProductionQuery response', params: { uuid: instance.uuid } }
-				)).to.be.true;
-				expect(instance.constructor.calledOnce).to.be.true;
-				expect(instance.constructor.calledWithExactly(neo4jQueryMockResponse)).to.be.true;
+				);
+				assert.calledOnce(instance.constructor);
+				assert.calledWithExactly(instance.constructor, neo4jQueryMockResponse);
 				expect(result instanceof Entity).to.be.true;
 
 			});
@@ -779,15 +792,16 @@ describe('Entity model', () => {
 
 				spy(instance, 'constructor');
 				const result = await instance.edit();
-				expect(stubs.sharedQueries.getEditQuery.calledOnce).to.be.true;
-				expect(stubs.sharedQueries.getEditQuery.calledWithExactly(instance.model)).to.be.true;
-				expect(stubs.getEditQueries.PRODUCTION.notCalled).to.be.true;
-				expect(stubs.neo4jQuery.calledOnce).to.be.true;
-				expect(stubs.neo4jQuery.calledWithExactly(
+				assert.calledOnce(stubs.sharedQueries.getEditQuery);
+				assert.calledWithExactly(stubs.sharedQueries.getEditQuery, instance.model);
+				assert.notCalled(stubs.getEditQueries.PRODUCTION);
+				assert.calledOnce(stubs.neo4jQuery);
+				assert.calledWithExactly(
+					stubs.neo4jQuery,
 					{ query: 'getEditQuery response', params: { uuid: instance.uuid } }
-				)).to.be.true;
-				expect(instance.constructor.calledOnce).to.be.true;
-				expect(instance.constructor.calledWithExactly(neo4jQueryMockResponse)).to.be.true;
+				);
+				assert.calledOnce(instance.constructor);
+				assert.calledWithExactly(instance.constructor, neo4jQueryMockResponse);
 				expect(result instanceof Entity).to.be.true;
 
 			});
@@ -808,10 +822,10 @@ describe('Entity model', () => {
 					spy(instance, 'confirmExistenceInDatabase');
 					spy(instance, 'createUpdate');
 					await instance.update();
-					expect(instance.confirmExistenceInDatabase.calledOnce).to.be.true;
-					expect(instance.confirmExistenceInDatabase.calledWithExactly()).to.be.true;
-					expect(instance.createUpdate.calledOnce).to.be.true;
-					expect(instance.createUpdate.calledWithExactly(stubs.getUpdateQueries[instance.model])).to.be.true;
+					assert.calledOnce(instance.confirmExistenceInDatabase);
+					assert.calledWithExactly(instance.confirmExistenceInDatabase);
+					assert.calledOnce(instance.createUpdate);
+					assert.calledWithExactly(instance.createUpdate, stubs.getUpdateQueries[instance.model]);
 
 				});
 
@@ -824,10 +838,10 @@ describe('Entity model', () => {
 					spy(instance, 'confirmExistenceInDatabase');
 					spy(instance, 'createUpdate');
 					await instance.update();
-					expect(instance.confirmExistenceInDatabase.calledOnce).to.be.true;
-					expect(instance.confirmExistenceInDatabase.calledWithExactly()).to.be.true;
-					expect(instance.createUpdate.calledOnce).to.be.true;
-					expect(instance.createUpdate.calledWithExactly(stubs.sharedQueries.getUpdateQuery)).to.be.true;
+					assert.calledOnce(instance.confirmExistenceInDatabase);
+					assert.calledWithExactly(instance.confirmExistenceInDatabase);
+					assert.calledOnce(instance.createUpdate);
+					assert.calledWithExactly(instance.createUpdate, stubs.sharedQueries.getUpdateQuery);
 
 				});
 
@@ -861,18 +875,20 @@ describe('Entity model', () => {
 						stubs.sharedQueries.getDeleteQuery,
 						stubs.neo4jQuery
 					);
-					expect(stubs.sharedQueries.getDeleteQuery.calledOnce).to.be.true;
-					expect(stubs.sharedQueries.getDeleteQuery.calledWithExactly(instance.model)).to.be.true;
-					expect(stubs.neo4jQuery.calledOnce).to.be.true;
-					expect(stubs.neo4jQuery.calledWithExactly(
+					assert.calledOnce(stubs.sharedQueries.getDeleteQuery);
+					assert.calledWithExactly(stubs.sharedQueries.getDeleteQuery, instance.model);
+					assert.calledOnce(stubs.neo4jQuery);
+					assert.calledWithExactly(
+						stubs.neo4jQuery,
 						{ query: 'getDeleteQuery response', params: { uuid: instance.uuid } }
-					)).to.be.true;
-					expect(instance.constructor.calledOnce).to.be.true;
-					expect(instance.constructor.calledWithExactly(
+					);
+					assert.calledOnce(instance.constructor);
+					assert.calledWithExactly(
+						instance.constructor,
 						{ name: 'Almeida Theatre', differentiator: null }
-					)).to.be.true;
-					expect(instance.addPropertyError.notCalled).to.be.true;
-					expect(instance.setErrorStatus.notCalled).to.be.true;
+					);
+					assert.notCalled(instance.addPropertyError);
+					assert.notCalled(instance.setErrorStatus);
 					expect(result instanceof Entity).to.be.true;
 					expect(result).to.deep.equal({
 						uuid: undefined,
@@ -905,16 +921,17 @@ describe('Entity model', () => {
 						stubs.sharedQueries.getDeleteQuery,
 						stubs.neo4jQuery
 					);
-					expect(stubs.sharedQueries.getDeleteQuery.calledOnce).to.be.true;
-					expect(stubs.sharedQueries.getDeleteQuery.calledWithExactly(instance.model)).to.be.true;
-					expect(stubs.neo4jQuery.calledOnce).to.be.true;
-					expect(stubs.neo4jQuery.calledWithExactly(
+					assert.calledOnce(stubs.sharedQueries.getDeleteQuery);
+					assert.calledWithExactly(stubs.sharedQueries.getDeleteQuery, instance.model);
+					assert.calledOnce(stubs.neo4jQuery);
+					assert.calledWithExactly(
+						stubs.neo4jQuery,
 						{ query: 'getDeleteQuery response', params: { uuid: instance.uuid } }
-					)).to.be.true;
-					expect(instance.constructor.calledOnce).to.be.true;
-					expect(instance.constructor.calledWithExactly({ name: 'Hamlet' })).to.be.true;
-					expect(instance.addPropertyError.notCalled).to.be.true;
-					expect(instance.setErrorStatus.notCalled).to.be.true;
+					);
+					assert.calledOnce(instance.constructor);
+					assert.calledWithExactly(instance.constructor, { name: 'Hamlet' });
+					assert.notCalled(instance.addPropertyError);
+					assert.notCalled(instance.setErrorStatus);
 					expect(result instanceof Production).to.be.true;
 					expect(result).to.deep.equal({
 						uuid: undefined,
@@ -971,17 +988,21 @@ describe('Entity model', () => {
 						stubs.sharedQueries.getDeleteQuery,
 						stubs.neo4jQuery
 					);
-					expect(stubs.sharedQueries.getDeleteQuery.calledOnce).to.be.true;
-					expect(stubs.sharedQueries.getDeleteQuery.calledWithExactly(instance.model)).to.be.true;
-					expect(stubs.neo4jQuery.calledOnce).to.be.true;
-					expect(stubs.neo4jQuery.calledWithExactly(
+					assert.calledOnce(stubs.sharedQueries.getDeleteQuery);
+					assert.calledWithExactly(stubs.sharedQueries.getDeleteQuery, instance.model);
+					assert.calledOnce(stubs.neo4jQuery);
+					assert.calledWithExactly(
+						stubs.neo4jQuery,
 						{ query: 'getDeleteQuery response', params: { uuid: instance.uuid } }
-					)).to.be.true;
-					expect(instance.constructor.notCalled).to.be.true;
-					expect(instance.addPropertyError.calledOnce).to.be.true;
-					expect(instance.addPropertyError.calledWithExactly('associations', 'Production')).to.be.true;
-					expect(instance.setErrorStatus.calledOnce).to.be.true;
-					expect(instance.setErrorStatus.calledWithExactly()).to.be.true;
+					);
+					assert.notCalled(instance.constructor);
+					assert.calledOnce(instance.addPropertyError);
+					assert.calledWithExactly(
+						instance.addPropertyError,
+						'associations', 'Production'
+					);
+					assert.calledOnce(instance.setErrorStatus);
+					assert.calledWithExactly(instance.setErrorStatus);
 					expect(result).to.deep.equal(instance);
 					expect(result).to.deep.equal({
 						uuid: undefined,
@@ -1020,17 +1041,21 @@ describe('Entity model', () => {
 						stubs.sharedQueries.getDeleteQuery,
 						stubs.neo4jQuery
 					);
-					expect(stubs.sharedQueries.getDeleteQuery.calledOnce).to.be.true;
-					expect(stubs.sharedQueries.getDeleteQuery.calledWithExactly(instance.model)).to.be.true;
-					expect(stubs.neo4jQuery.calledOnce).to.be.true;
-					expect(stubs.neo4jQuery.calledWithExactly(
+					assert.calledOnce(stubs.sharedQueries.getDeleteQuery);
+					assert.calledWithExactly(stubs.sharedQueries.getDeleteQuery, instance.model);
+					assert.calledOnce(stubs.neo4jQuery);
+					assert.calledWithExactly(
+						stubs.neo4jQuery,
 						{ query: 'getDeleteQuery response', params: { uuid: instance.uuid } }
-					)).to.be.true;
-					expect(instance.constructor.notCalled).to.be.true;
-					expect(instance.addPropertyError.calledOnce).to.be.true;
-					expect(instance.addPropertyError.calledWithExactly('associations', 'Venue')).to.be.true;
-					expect(instance.setErrorStatus.calledOnce).to.be.true;
-					expect(instance.setErrorStatus.calledWithExactly()).to.be.true;
+					);
+					assert.notCalled(instance.constructor);
+					assert.calledOnce(instance.addPropertyError);
+					assert.calledWithExactly(
+						instance.addPropertyError,
+						'associations', 'Venue'
+					);
+					assert.calledOnce(instance.setErrorStatus);
+					assert.calledWithExactly(instance.setErrorStatus);
 					expect(result).to.deep.equal(instance);
 					expect(result).to.deep.equal({
 						uuid: undefined,
@@ -1077,12 +1102,13 @@ describe('Entity model', () => {
 
 			instance.model = 'VENUE';
 			const result = await instance.show();
-			expect(stubs.getShowQueries.VENUE.calledOnce).to.be.true;
-			expect(stubs.getShowQueries.VENUE.calledWithExactly()).to.be.true;
-			expect(stubs.neo4jQuery.calledOnce).to.be.true;
-			expect(stubs.neo4jQuery.calledWithExactly(
+			assert.calledOnce(stubs.getShowQueries.VENUE);
+			assert.calledWithExactly(stubs.getShowQueries.VENUE);
+			assert.calledOnce(stubs.neo4jQuery);
+			assert.calledWithExactly(
+				stubs.neo4jQuery,
 				{ query: 'getShowVenueQuery response', params: { uuid: instance.uuid } }
-			)).to.be.true;
+			);
 			expect(result).to.deep.equal(neo4jQueryMockResponse);
 
 		});
@@ -1094,12 +1120,13 @@ describe('Entity model', () => {
 		it('gets list data', async () => {
 
 			const result = await Entity.list('model');
-			expect(stubs.sharedQueries.getListQuery.calledOnce).to.be.true;
-			expect(stubs.sharedQueries.getListQuery.calledWithExactly('model')).to.be.true;
-			expect(stubs.neo4jQuery.calledOnce).to.be.true;
-			expect(stubs.neo4jQuery.calledWithExactly(
+			assert.calledOnce(stubs.sharedQueries.getListQuery);
+			assert.calledWithExactly(stubs.sharedQueries.getListQuery, 'model');
+			assert.calledOnce(stubs.neo4jQuery);
+			assert.calledWithExactly(
+				stubs.neo4jQuery,
 				{ query: 'getListQuery response' }, { isOptionalResult: true, isArrayResult: true }
-			)).to.be.true;
+			);
 			expect(result).to.deep.equal(neo4jQueryMockResponse);
 
 		});

--- a/test-unit/src/models/Material.test.js
+++ b/test-unit/src/models/Material.test.js
@@ -343,27 +343,30 @@ describe('Material model', () => {
 				stubs.getDuplicateIndicesModule.getDuplicateNameIndices,
 				instance.characterGroups[0].runInputValidations
 			);
-			expect(instance.validateName.calledOnce).to.be.true;
-			expect(instance.validateName.calledWithExactly({ isRequired: true })).to.be.true;
-			expect(instance.validateDifferentiator.calledOnce).to.be.true;
-			expect(instance.validateDifferentiator.calledWithExactly()).to.be.true;
-			expect(instance.validateFormat.calledOnce).to.be.true;
-			expect(instance.validateFormat.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.validateYear.calledOnce).to.be.true;
-			expect(instance.validateYear.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.originalVersionMaterial.validateName.calledOnce).to.be.true;
-			expect(instance.originalVersionMaterial.validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.originalVersionMaterial.validateDifferentiator.calledOnce).to.be.true;
-			expect(instance.originalVersionMaterial.validateDifferentiator.calledWithExactly()).to.be.true;
-			expect(stubs.getDuplicateIndicesModule.getDuplicateNameIndices.calledTwice).to.be.true;
-			expect(stubs.getDuplicateIndicesModule.getDuplicateNameIndices
-				.firstCall.calledWithExactly(instance.writingCredits)
-			).to.be.true;
-			expect(stubs.getDuplicateIndicesModule.getDuplicateNameIndices
-				.secondCall.calledWithExactly(instance.characterGroups)
-			).to.be.true;
-			expect(instance.writingCredits[0].runInputValidations.calledOnce).to.be.true;
-			expect(instance.writingCredits[0].runInputValidations.calledWithExactly(
+			assert.calledOnce(instance.validateName);
+			assert.calledWithExactly(instance.validateName, { isRequired: true });
+			assert.calledOnce(instance.validateDifferentiator);
+			assert.calledWithExactly(instance.validateDifferentiator);
+			assert.calledOnce(instance.validateFormat);
+			assert.calledWithExactly(instance.validateFormat, { isRequired: false });
+			assert.calledOnce(instance.validateYear);
+			assert.calledWithExactly(instance.validateYear, { isRequired: false });
+			assert.calledOnce(instance.originalVersionMaterial.validateName);
+			assert.calledWithExactly(instance.originalVersionMaterial.validateName, { isRequired: false });
+			assert.calledOnce(instance.originalVersionMaterial.validateDifferentiator);
+			assert.calledWithExactly(instance.originalVersionMaterial.validateDifferentiator);
+			assert.calledTwice(stubs.getDuplicateIndicesModule.getDuplicateNameIndices);
+			assert.calledWithExactly(
+				stubs.getDuplicateIndicesModule.getDuplicateNameIndices.firstCall,
+				instance.writingCredits
+			);
+			assert.calledWithExactly(
+				stubs.getDuplicateIndicesModule.getDuplicateNameIndices.secondCall,
+				instance.characterGroups
+			);
+			assert.calledOnce(instance.writingCredits[0].runInputValidations);
+			assert.calledWithExactly(
+				instance.writingCredits[0].runInputValidations,
 				{
 					isDuplicate: false,
 					subject: {
@@ -371,27 +374,31 @@ describe('Material model', () => {
 						differentiator: '1'
 					}
 				}
-			)).to.be.true;
-			expect(stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices.calledOnce).to.be.true;
-			expect(stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices.calledWithExactly(
+			);
+			assert.calledOnce(stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices);
+			assert.calledWithExactly(
+				stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices,
 				instance.subMaterials
-			)).to.be.true;
-			expect(instance.subMaterials[0].validateName.calledOnce).to.be.true;
-			expect(instance.subMaterials[0].validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.subMaterials[0].validateDifferentiator.calledOnce).to.be.true;
-			expect(instance.subMaterials[0].validateDifferentiator.calledWithExactly()).to.be.true;
-			expect(instance.subMaterials[0].validateNoAssociationWithSelf.calledOnce).to.be.true;
-			expect(instance.subMaterials[0].validateNoAssociationWithSelf.calledWithExactly(
+			);
+			assert.calledOnce(instance.subMaterials[0].validateName);
+			assert.calledWithExactly(instance.subMaterials[0].validateName, { isRequired: false });
+			assert.calledOnce(instance.subMaterials[0].validateDifferentiator);
+			assert.calledWithExactly(instance.subMaterials[0].validateDifferentiator);
+			assert.calledOnce(instance.subMaterials[0].validateNoAssociationWithSelf);
+			assert.calledWithExactly(
+				instance.subMaterials[0].validateNoAssociationWithSelf,
 				{ name: 'The Tragedy of Hamlet, Prince of Denmark', differentiator: '1' }
-			)).to.be.true;
-			expect(instance.subMaterials[0].validateUniquenessInGroup.calledOnce).to.be.true;
-			expect(instance.subMaterials[0].validateUniquenessInGroup.calledWithExactly(
+			);
+			assert.calledOnce(instance.subMaterials[0].validateUniquenessInGroup);
+			assert.calledWithExactly(
+				instance.subMaterials[0].validateUniquenessInGroup,
 				{ isDuplicate: false }
-			)).to.be.true;
-			expect(instance.characterGroups[0].runInputValidations.calledOnce).to.be.true;
-			expect(instance.characterGroups[0].runInputValidations.calledWithExactly(
+			);
+			assert.calledOnce(instance.characterGroups[0].runInputValidations);
+			assert.calledWithExactly(
+				instance.characterGroups[0].runInputValidations,
 				{ isDuplicate: false }
-			)).to.be.true;
+			);
 
 		});
 
@@ -404,8 +411,11 @@ describe('Material model', () => {
 			const instance = createInstance({ name: 'The Tragedy of Hamlet, Prince of Denmark', format: 'play' });
 			spy(instance, 'validateStringForProperty');
 			instance.validateFormat({ isRequired: false });
-			expect(instance.validateStringForProperty.calledOnce).to.be.true;
-			expect(instance.validateStringForProperty.calledWithExactly('format', { isRequired: false })).to.be.true;
+			assert.calledOnce(instance.validateStringForProperty);
+			assert.calledWithExactly(
+				instance.validateStringForProperty,
+				'format', { isRequired: false }
+			);
 
 		});
 
@@ -420,8 +430,8 @@ describe('Material model', () => {
 				const instance = createInstance({ name: 'The Caretaker', year: '' });
 				spy(instance, 'addPropertyError');
 				instance.validateYear();
-				expect(stubs.isValidYearModule.isValidYear.notCalled).to.be.true;
-				expect(instance.addPropertyError.notCalled).to.be.true;
+				assert.notCalled(stubs.isValidYearModule.isValidYear);
+				assert.notCalled(instance.addPropertyError);
 
 			});
 
@@ -434,12 +444,13 @@ describe('Material model', () => {
 				const instance = createInstance({ name: 'The Caretaker', year: 'Nineteen Fifty-Nine' });
 				spy(instance, 'addPropertyError');
 				instance.validateYear();
-				expect(stubs.isValidYearModule.isValidYear.calledOnce).to.be.true;
-				expect(stubs.isValidYearModule.isValidYear.calledWithExactly('Nineteen Fifty-Nine')).to.be.true;
-				expect(instance.addPropertyError.calledOnce).to.be.true;
-				expect(instance.addPropertyError.calledWithExactly(
+				assert.calledOnce(stubs.isValidYearModule.isValidYear);
+				assert.calledWithExactly(stubs.isValidYearModule.isValidYear, 'Nineteen Fifty-Nine');
+				assert.calledOnce(instance.addPropertyError);
+				assert.calledWithExactly(
+					instance.addPropertyError,
 					'year', 'Value must be a valid year'
-				)).to.be.true;
+				);
 
 			});
 
@@ -452,9 +463,9 @@ describe('Material model', () => {
 				const instance = createInstance({ name: 'The Caretaker', year: 1959 });
 				spy(instance, 'addPropertyError');
 				instance.validateYear();
-				expect(stubs.isValidYearModule.isValidYear.calledOnce).to.be.true;
-				expect(stubs.isValidYearModule.isValidYear.calledWithExactly(1959)).to.be.true;
-				expect(instance.addPropertyError.notCalled).to.be.true;
+				assert.calledOnce(stubs.isValidYearModule.isValidYear);
+				assert.calledWithExactly(stubs.isValidYearModule.isValidYear, 1959);
+				assert.notCalled(instance.addPropertyError);
 
 			});
 

--- a/test-unit/src/models/Nomination.test.js
+++ b/test-unit/src/models/Nomination.test.js
@@ -316,57 +316,65 @@ describe('Nomination model', () => {
 				instance.materials[0].validateDifferentiator,
 				instance.materials[0].validateUniquenessInGroup
 			);
-			expect(instance.validateCustomType.calledOnce).to.be.true;
-			expect(instance.validateCustomType.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(stubs.getDuplicateEntityInfoModule.getDuplicateEntities.calledOnce).to.be.true;
-			expect(stubs.getDuplicateEntityInfoModule.getDuplicateEntities.calledWithExactly(
+			assert.calledOnce(instance.validateCustomType);
+			assert.calledWithExactly(instance.validateCustomType, { isRequired: false });
+			assert.calledOnce(stubs.getDuplicateEntityInfoModule.getDuplicateEntities);
+			assert.calledWithExactly(
+				stubs.getDuplicateEntityInfoModule.getDuplicateEntities,
 				instance.entities
-			)).to.be.true;
-			expect(instance.entities[0].validateName.calledOnce).to.be.true;
-			expect(instance.entities[0].validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.entities[0].validateDifferentiator.calledOnce).to.be.true;
-			expect(instance.entities[0].validateDifferentiator.calledWithExactly()).to.be.true;
-			expect(stubs.getDuplicateEntityInfoModule.isEntityInArray.calledTwice).to.be.true;
-			expect(stubs.getDuplicateEntityInfoModule.isEntityInArray.getCall(0).calledWithExactly(
+			);
+			assert.calledOnce(instance.entities[0].validateName);
+			assert.calledWithExactly(instance.entities[0].validateName, { isRequired: false });
+			assert.calledOnce(instance.entities[0].validateDifferentiator);
+			assert.calledWithExactly(instance.entities[0].validateDifferentiator);
+			assert.calledTwice(stubs.getDuplicateEntityInfoModule.isEntityInArray);
+			assert.calledWithExactly(
+				stubs.getDuplicateEntityInfoModule.isEntityInArray.getCall(0),
 				instance.entities[0], 'getDuplicateEntities response'
-			)).to.be.true;
-			expect(instance.entities[0].validateUniquenessInGroup.calledOnce).to.be.true;
-			expect(instance.entities[0].validateUniquenessInGroup.calledWithExactly({ isDuplicate: false })).to.be.true;
-			expect(instance.entities[1].validateName.calledOnce).to.be.true;
-			expect(instance.entities[1].validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.entities[1].validateDifferentiator.calledOnce).to.be.true;
-			expect(instance.entities[1].validateDifferentiator.calledWithExactly()).to.be.true;
-			expect(stubs.getDuplicateEntityInfoModule.isEntityInArray.getCall(1).calledWithExactly(
+			);
+			assert.calledOnce(instance.entities[0].validateUniquenessInGroup);
+			assert.calledWithExactly(instance.entities[0].validateUniquenessInGroup, { isDuplicate: false });
+			assert.calledOnce(instance.entities[1].validateName);
+			assert.calledWithExactly(instance.entities[1].validateName, { isRequired: false });
+			assert.calledOnce(instance.entities[1].validateDifferentiator);
+			assert.calledWithExactly(instance.entities[1].validateDifferentiator);
+			assert.calledWithExactly(
+				stubs.getDuplicateEntityInfoModule.isEntityInArray.getCall(1),
 				instance.entities[1], 'getDuplicateEntities response'
-			)).to.be.true;
-			expect(instance.entities[1].validateUniquenessInGroup.calledOnce).to.be.true;
-			expect(instance.entities[1].validateUniquenessInGroup.calledWithExactly({ isDuplicate: false })).to.be.true;
-			expect(instance.entities[1].runInputValidations.calledOnce).to.be.true;
-			expect(instance.entities[1].runInputValidations.calledWithExactly(
+			);
+			assert.calledOnce(instance.entities[1].validateUniquenessInGroup);
+			assert.calledWithExactly(instance.entities[1].validateUniquenessInGroup, { isDuplicate: false });
+			assert.calledOnce(instance.entities[1].runInputValidations);
+			assert.calledWithExactly(
+				instance.entities[1].runInputValidations,
 				{ duplicateEntities: 'getDuplicateEntities response' }
-			)).to.be.true;
-			expect(stubs.getDuplicateIndicesModule.getDuplicateProductionIdentifierIndices.calledOnce).to.be.true;
-			expect(stubs.getDuplicateIndicesModule.getDuplicateProductionIdentifierIndices.calledWithExactly(
+			);
+			assert.calledOnce(stubs.getDuplicateIndicesModule.getDuplicateProductionIdentifierIndices);
+			assert.calledWithExactly(
+				stubs.getDuplicateIndicesModule.getDuplicateProductionIdentifierIndices,
 				instance.productions
-			)).to.be.true;
-			expect(instance.productions[0].validateUuid.calledOnce).to.be.true;
-			expect(instance.productions[0].validateUuid.calledWithExactly()).to.be.true;
-			expect(instance.productions[0].validateUniquenessInGroup.calledOnce).to.be.true;
-			expect(instance.productions[0].validateUniquenessInGroup.calledWithExactly(
+			);
+			assert.calledOnce(instance.productions[0].validateUuid);
+			assert.calledWithExactly(instance.productions[0].validateUuid);
+			assert.calledOnce(instance.productions[0].validateUniquenessInGroup);
+			assert.calledWithExactly(
+				instance.productions[0].validateUniquenessInGroup,
 				{ isDuplicate: false, properties: new Set(['uuid']) }
-			)).to.be.true;
-			expect(stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices.calledOnce).to.be.true;
-			expect(stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices.calledWithExactly(
+			);
+			assert.calledOnce(stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices);
+			assert.calledWithExactly(
+				stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices,
 				instance.materials
-			)).to.be.true;
-			expect(instance.materials[0].validateName.calledOnce).to.be.true;
-			expect(instance.materials[0].validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.materials[0].validateDifferentiator.calledOnce).to.be.true;
-			expect(instance.materials[0].validateDifferentiator.calledWithExactly()).to.be.true;
-			expect(instance.materials[0].validateUniquenessInGroup.calledOnce).to.be.true;
-			expect(instance.materials[0].validateUniquenessInGroup.calledWithExactly(
+			);
+			assert.calledOnce(instance.materials[0].validateName);
+			assert.calledWithExactly(instance.materials[0].validateName, { isRequired: false });
+			assert.calledOnce(instance.materials[0].validateDifferentiator);
+			assert.calledWithExactly(instance.materials[0].validateDifferentiator);
+			assert.calledOnce(instance.materials[0].validateUniquenessInGroup);
+			assert.calledWithExactly(
+				instance.materials[0].validateUniquenessInGroup,
 				{ isDuplicate: false }
-			)).to.be.true;
+			);
 
 		});
 
@@ -379,10 +387,11 @@ describe('Nomination model', () => {
 			const instance = createInstance({ customType: 'Shortlisted' });
 			spy(instance, 'validateStringForProperty');
 			instance.validateCustomType({ isRequired: false });
-			expect(instance.validateStringForProperty.calledOnce).to.be.true;
-			expect(instance.validateStringForProperty.calledWithExactly(
+			assert.calledOnce(instance.validateStringForProperty);
+			assert.calledWithExactly(
+				instance.validateStringForProperty,
 				'customType', { isRequired: false }
-			)).to.be.true;
+			);
 
 		});
 
@@ -401,8 +410,8 @@ describe('Nomination model', () => {
 			};
 			const instance = createInstance(props);
 			await instance.runDatabaseValidations();
-			expect(instance.productions[0].runDatabaseValidations.calledOnce).to.be.true;
-			expect(instance.productions[0].runDatabaseValidations.calledWithExactly()).to.be.true;
+			assert.calledOnce(instance.productions[0].runDatabaseValidations);
+			assert.calledWithExactly(instance.productions[0].runDatabaseValidations);
 
 		});
 

--- a/test-unit/src/models/ProducerCredit.test.js
+++ b/test-unit/src/models/ProducerCredit.test.js
@@ -137,37 +137,41 @@ describe('ProducerCredit model', () => {
 				instance.entities[1].validateUniquenessInGroup,
 				instance.entities[1].runInputValidations
 			);
-			expect(instance.validateName.calledOnce).to.be.true;
-			expect(instance.validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.validateUniquenessInGroup.calledOnce).to.be.true;
-			expect(instance.validateUniquenessInGroup.calledWithExactly({ isDuplicate: false })).to.be.true;
-			expect(stubs.getDuplicateEntityInfoModule.getDuplicateEntities.calledOnce).to.be.true;
-			expect(stubs.getDuplicateEntityInfoModule.getDuplicateEntities.calledWithExactly(
+			assert.calledOnce(instance.validateName);
+			assert.calledWithExactly(instance.validateName, { isRequired: false });
+			assert.calledOnce(instance.validateUniquenessInGroup);
+			assert.calledWithExactly(instance.validateUniquenessInGroup, { isDuplicate: false });
+			assert.calledOnce(stubs.getDuplicateEntityInfoModule.getDuplicateEntities);
+			assert.calledWithExactly(
+				stubs.getDuplicateEntityInfoModule.getDuplicateEntities,
 				instance.entities
-			)).to.be.true;
-			expect(instance.entities[0].validateName.calledOnce).to.be.true;
-			expect(instance.entities[0].validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.entities[0].validateDifferentiator.calledOnce).to.be.true;
-			expect(instance.entities[0].validateDifferentiator.calledWithExactly()).to.be.true;
-			expect(stubs.getDuplicateEntityInfoModule.isEntityInArray.calledTwice).to.be.true;
-			expect(stubs.getDuplicateEntityInfoModule.isEntityInArray.getCall(0).calledWithExactly(
+			);
+			assert.calledOnce(instance.entities[0].validateName);
+			assert.calledWithExactly(instance.entities[0].validateName, { isRequired: false });
+			assert.calledOnce(instance.entities[0].validateDifferentiator);
+			assert.calledWithExactly(instance.entities[0].validateDifferentiator);
+			assert.calledTwice(stubs.getDuplicateEntityInfoModule.isEntityInArray);
+			assert.calledWithExactly(
+				stubs.getDuplicateEntityInfoModule.isEntityInArray.getCall(0),
 				instance.entities[0], 'getDuplicateEntities response'
-			)).to.be.true;
-			expect(instance.entities[0].validateUniquenessInGroup.calledOnce).to.be.true;
-			expect(instance.entities[0].validateUniquenessInGroup.calledWithExactly({ isDuplicate: false })).to.be.true;
-			expect(instance.entities[1].validateName.calledOnce).to.be.true;
-			expect(instance.entities[1].validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.entities[1].validateDifferentiator.calledOnce).to.be.true;
-			expect(instance.entities[1].validateDifferentiator.calledWithExactly()).to.be.true;
-			expect(stubs.getDuplicateEntityInfoModule.isEntityInArray.getCall(1).calledWithExactly(
+			);
+			assert.calledOnce(instance.entities[0].validateUniquenessInGroup);
+			assert.calledWithExactly(instance.entities[0].validateUniquenessInGroup, { isDuplicate: false });
+			assert.calledOnce(instance.entities[1].validateName);
+			assert.calledWithExactly(instance.entities[1].validateName, { isRequired: false });
+			assert.calledOnce(instance.entities[1].validateDifferentiator);
+			assert.calledWithExactly(instance.entities[1].validateDifferentiator);
+			assert.calledWithExactly(
+				stubs.getDuplicateEntityInfoModule.isEntityInArray.getCall(1),
 				instance.entities[1], 'getDuplicateEntities response'
-			)).to.be.true;
-			expect(instance.entities[1].validateUniquenessInGroup.calledOnce).to.be.true;
-			expect(instance.entities[1].validateUniquenessInGroup.calledWithExactly({ isDuplicate: false })).to.be.true;
-			expect(instance.entities[1].runInputValidations.calledOnce).to.be.true;
-			expect(instance.entities[1].runInputValidations.calledWithExactly(
+			);
+			assert.calledOnce(instance.entities[1].validateUniquenessInGroup);
+			assert.calledWithExactly(instance.entities[1].validateUniquenessInGroup, { isDuplicate: false });
+			assert.calledOnce(instance.entities[1].runInputValidations);
+			assert.calledWithExactly(
+				instance.entities[1].runInputValidations,
 				{ duplicateEntities: 'getDuplicateEntities response' }
-			)).to.be.true;
+			);
 
 		});
 

--- a/test-unit/src/models/Production.test.js
+++ b/test-unit/src/models/Production.test.js
@@ -491,58 +491,73 @@ describe('Production model', () => {
 				stubs.getDuplicateIndicesModule.getDuplicateNameIndices,
 				instance.crewCredits[0].runInputValidations
 			);
-			expect(instance.validateName.calledOnce).to.be.true;
-			expect(instance.validateName.calledWithExactly({ isRequired: true })).to.be.true;
-			expect(instance.validateDates.calledOnce).to.be.true;
-			expect(instance.validateDates.calledWithExactly()).to.be.true;
-			expect(instance.material.validateName.calledOnce).to.be.true;
-			expect(instance.material.validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.material.validateDifferentiator.calledOnce).to.be.true;
-			expect(instance.material.validateDifferentiator.calledWithExactly()).to.be.true;
-			expect(instance.venue.validateName.calledOnce).to.be.true;
-			expect(instance.venue.validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.venue.validateDifferentiator.calledOnce).to.be.true;
-			expect(instance.venue.validateDifferentiator.calledWithExactly()).to.be.true;
-			expect(stubs.getDuplicateIndicesModule.getDuplicateProductionIdentifierIndices.calledOnce).to.be.true;
-			expect(stubs.getDuplicateIndicesModule.getDuplicateProductionIdentifierIndices.calledWithExactly(
+			assert.calledOnce(instance.validateName);
+			assert.calledWithExactly(instance.validateName, { isRequired: true });
+			assert.calledOnce(instance.validateDates);
+			assert.calledWithExactly(instance.validateDates);
+			assert.calledOnce(instance.material.validateName);
+			assert.calledWithExactly(instance.material.validateName, { isRequired: false });
+			assert.calledOnce(instance.material.validateDifferentiator);
+			assert.calledWithExactly(instance.material.validateDifferentiator);
+			assert.calledOnce(instance.venue.validateName);
+			assert.calledWithExactly(instance.venue.validateName, { isRequired: false });
+			assert.calledOnce(instance.venue.validateDifferentiator);
+			assert.calledWithExactly(instance.venue.validateDifferentiator);
+			assert.calledOnce(stubs.getDuplicateIndicesModule.getDuplicateProductionIdentifierIndices);
+			assert.calledWithExactly(
+				stubs.getDuplicateIndicesModule.getDuplicateProductionIdentifierIndices,
 				instance.subProductions
-			)).to.be.true;
-			expect(instance.subProductions[0].validateUuid.calledOnce).to.be.true;
-			expect(instance.subProductions[0].validateUuid.calledWithExactly()).to.be.true;
-			expect(instance.subProductions[0].validateNoAssociationWithSelf.calledOnce).to.be.true;
-			expect(instance.subProductions[0].validateNoAssociationWithSelf.calledWithExactly(
+			);
+			assert.calledOnce(instance.subProductions[0].validateUuid);
+			assert.calledWithExactly(instance.subProductions[0].validateUuid);
+			assert.calledOnce(instance.subProductions[0].validateNoAssociationWithSelf);
+			assert.calledWithExactly(
+				instance.subProductions[0].validateNoAssociationWithSelf,
 				{ uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' }
-			)).to.be.true;
-			expect(instance.subProductions[0].validateUniquenessInGroup.calledOnce).to.be.true;
-			expect(instance.subProductions[0].validateUniquenessInGroup.calledWithExactly(
+			);
+			assert.calledOnce(instance.subProductions[0].validateUniquenessInGroup);
+			assert.calledWithExactly(
+				instance.subProductions[0].validateUniquenessInGroup,
 				{ isDuplicate: false, properties: new Set(['uuid']) }
-			)).to.be.true;
-			expect(stubs.getDuplicateIndicesModule.getDuplicateNameIndices.calledThrice).to.be.true;
-			expect(stubs.getDuplicateIndicesModule.getDuplicateNameIndices.getCall(0).calledWithExactly(
+			);
+			assert.calledThrice(stubs.getDuplicateIndicesModule.getDuplicateNameIndices);
+			assert.calledWithExactly(
+				stubs.getDuplicateIndicesModule.getDuplicateNameIndices.getCall(0),
 				instance.producerCredits
-			)).to.be.true;
-			expect(instance.producerCredits[0].runInputValidations.calledOnce).to.be.true;
-			expect(instance.producerCredits[0].runInputValidations.calledWithExactly(
+			);
+			assert.calledOnce(instance.producerCredits[0].runInputValidations);
+			assert.calledWithExactly(
+				instance.producerCredits[0].runInputValidations,
 				{ isDuplicate: false }
-			)).to.be.true;
-			expect(stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices.calledOnce).to.be.true;
-			expect(stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices.getCall(0).calledWithExactly(
+			);
+			assert.calledOnce(stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices);
+			assert.calledWithExactly(
+				stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices.getCall(0),
 				instance.cast
-			)).to.be.true;
-			expect(instance.cast[0].runInputValidations.calledOnce).to.be.true;
-			expect(instance.cast[0].runInputValidations.calledWithExactly({ isDuplicate: false })).to.be.true;
-			expect(stubs.getDuplicateIndicesModule.getDuplicateNameIndices.getCall(1).calledWithExactly(
-				instance.creativeCredits
-			)).to.be.true;
-			expect(instance.creativeCredits[0].runInputValidations.calledOnce).to.be.true;
-			expect(instance.creativeCredits[0].runInputValidations.calledWithExactly(
+			);
+			assert.calledOnce(instance.cast[0].runInputValidations);
+			assert.calledWithExactly(
+				instance.cast[0].runInputValidations,
 				{ isDuplicate: false }
-			)).to.be.true;
-			expect(stubs.getDuplicateIndicesModule.getDuplicateNameIndices.getCall(2).calledWithExactly(
+			);
+			assert.calledWithExactly(
+				stubs.getDuplicateIndicesModule.getDuplicateNameIndices.getCall(1),
+				instance.creativeCredits
+			);
+			assert.calledOnce(instance.creativeCredits[0].runInputValidations);
+			assert.calledWithExactly(
+				instance.creativeCredits[0].runInputValidations,
+				{ isDuplicate: false }
+			);
+			assert.calledWithExactly(
+				stubs.getDuplicateIndicesModule.getDuplicateNameIndices.getCall(2),
 				instance.crewCredits
-			)).to.be.true;
-			expect(instance.crewCredits[0].runInputValidations.calledOnce).to.be.true;
-			expect(instance.crewCredits[0].runInputValidations.calledWithExactly({ isDuplicate: false })).to.be.true;
+			);
+			assert.calledOnce(instance.crewCredits[0].runInputValidations);
+			assert.calledWithExactly(
+				instance.crewCredits[0].runInputValidations,
+				{ isDuplicate: false }
+			);
 
 		});
 
@@ -559,7 +574,7 @@ describe('Production model', () => {
 					const instance = createInstance({ name: 'Hamlet', startDate: '' });
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
-					expect(instance.addPropertyError.notCalled).to.be.true;
+					assert.notCalled(instance.addPropertyError);
 
 				});
 
@@ -572,7 +587,7 @@ describe('Production model', () => {
 					const instance = createInstance({ name: 'Hamlet', startDate: '2010-09-30' });
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
-					expect(instance.addPropertyError.notCalled).to.be.true;
+					assert.notCalled(instance.addPropertyError);
 
 				});
 
@@ -585,7 +600,7 @@ describe('Production model', () => {
 					const instance = createInstance({ name: 'Hamlet', pressDate: '' });
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
-					expect(instance.addPropertyError.notCalled).to.be.true;
+					assert.notCalled(instance.addPropertyError);
 
 				});
 
@@ -598,7 +613,7 @@ describe('Production model', () => {
 					const instance = createInstance({ name: 'Hamlet', pressDate: '2010-10-07' });
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
-					expect(instance.addPropertyError.notCalled).to.be.true;
+					assert.notCalled(instance.addPropertyError);
 
 				});
 
@@ -611,7 +626,7 @@ describe('Production model', () => {
 					const instance = createInstance({ name: 'Hamlet', endDate: '' });
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
-					expect(instance.addPropertyError.notCalled).to.be.true;
+					assert.notCalled(instance.addPropertyError);
 
 				});
 
@@ -624,7 +639,7 @@ describe('Production model', () => {
 					const instance = createInstance({ name: 'Hamlet', endDate: '2011-01-26' });
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
-					expect(instance.addPropertyError.notCalled).to.be.true;
+					assert.notCalled(instance.addPropertyError);
 
 				});
 
@@ -637,7 +652,7 @@ describe('Production model', () => {
 					const instance = createInstance({ name: 'Hamlet', startDate: '2010-09-30', endDate: '2011-01-26' });
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
-					expect(instance.addPropertyError.notCalled).to.be.true;
+					assert.notCalled(instance.addPropertyError);
 
 				});
 
@@ -650,7 +665,7 @@ describe('Production model', () => {
 					const instance = createInstance({ name: 'Hamlet', startDate: '2010-09-30', endDate: '2010-09-30' });
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
-					expect(instance.addPropertyError.notCalled).to.be.true;
+					assert.notCalled(instance.addPropertyError);
 
 				});
 
@@ -667,7 +682,7 @@ describe('Production model', () => {
 					});
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
-					expect(instance.addPropertyError.notCalled).to.be.true;
+					assert.notCalled(instance.addPropertyError);
 
 				});
 
@@ -680,7 +695,7 @@ describe('Production model', () => {
 					const instance = createInstance({ name: 'Hamlet', startDate: '2010-09-30', pressDate: '2010-09-30' });
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
-					expect(instance.addPropertyError.notCalled).to.be.true;
+					assert.notCalled(instance.addPropertyError);
 
 				});
 
@@ -693,7 +708,7 @@ describe('Production model', () => {
 					const instance = createInstance({ name: 'Hamlet', pressDate: '2010-10-07', endDate: '2011-01-26' });
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
-					expect(instance.addPropertyError.notCalled).to.be.true;
+					assert.notCalled(instance.addPropertyError);
 
 				});
 
@@ -706,7 +721,7 @@ describe('Production model', () => {
 					const instance = createInstance({ name: 'Hamlet', pressDate: '2010-09-30', endDate: '2010-09-30' });
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
-					expect(instance.addPropertyError.notCalled).to.be.true;
+					assert.notCalled(instance.addPropertyError);
 
 				});
 
@@ -719,7 +734,7 @@ describe('Production model', () => {
 					const instance = createInstance({ name: 'Hamlet', startDate: '', pressDate: '', endDate: '' });
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
-					expect(instance.addPropertyError.notCalled).to.be.true;
+					assert.notCalled(instance.addPropertyError);
 
 				});
 
@@ -737,7 +752,7 @@ describe('Production model', () => {
 					});
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
-					expect(instance.addPropertyError.notCalled).to.be.true;
+					assert.notCalled(instance.addPropertyError);
 
 				});
 
@@ -755,7 +770,7 @@ describe('Production model', () => {
 					});
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
-					expect(instance.addPropertyError.notCalled).to.be.true;
+					assert.notCalled(instance.addPropertyError);
 
 				});
 
@@ -772,11 +787,11 @@ describe('Production model', () => {
 					const instance = createInstance({ name: 'Hamlet', startDate: 'foobar' });
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
-					expect(instance.addPropertyError.calledOnce).to.be.true;
-					expect(instance.addPropertyError.calledWithExactly(
-						'startDate',
-						'Value must be in date format'
-					)).to.be.true;
+					assert.calledOnce(instance.addPropertyError);
+					assert.calledWithExactly(
+						instance.addPropertyError,
+						'startDate', 'Value must be in date format'
+					);
 
 				});
 
@@ -789,11 +804,11 @@ describe('Production model', () => {
 					const instance = createInstance({ name: 'Hamlet', pressDate: 'foobar' });
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
-					expect(instance.addPropertyError.calledOnce).to.be.true;
-					expect(instance.addPropertyError.calledWithExactly(
-						'pressDate',
-						'Value must be in date format'
-					)).to.be.true;
+					assert.calledOnce(instance.addPropertyError);
+					assert.calledWithExactly(
+						instance.addPropertyError,
+						'pressDate', 'Value must be in date format'
+					);
 
 				});
 
@@ -806,11 +821,11 @@ describe('Production model', () => {
 					const instance = createInstance({ name: 'Hamlet', endDate: 'foobar' });
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
-					expect(instance.addPropertyError.calledOnce).to.be.true;
-					expect(instance.addPropertyError.calledWithExactly(
-						'endDate',
-						'Value must be in date format'
-					)).to.be.true;
+					assert.calledOnce(instance.addPropertyError);
+					assert.calledWithExactly(
+						instance.addPropertyError,
+						'endDate', 'Value must be in date format'
+					);
 
 				});
 
@@ -823,15 +838,15 @@ describe('Production model', () => {
 					const instance = createInstance({ name: 'Hamlet', startDate: '2011-01-26', endDate: '2010-09-30' });
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
-					expect(instance.addPropertyError.calledTwice).to.be.true;
-					expect(instance.addPropertyError.getCall(0).calledWithExactly(
-						'startDate',
-						'Start date must not be after end date'
-					)).to.be.true;
-					expect(instance.addPropertyError.getCall(1).calledWithExactly(
-						'endDate',
-						'End date must not be before start date'
-					)).to.be.true;
+					assert.calledTwice(instance.addPropertyError);
+					assert.calledWithExactly(
+						instance.addPropertyError.getCall(0),
+						'startDate', 'Start date must not be after end date'
+					);
+					assert.calledWithExactly(
+						instance.addPropertyError.getCall(1),
+						'endDate', 'End date must not be before start date'
+					);
 
 				});
 
@@ -844,15 +859,15 @@ describe('Production model', () => {
 					const instance = createInstance({ name: 'Hamlet', startDate: '2010-10-07', pressDate: '2010-09-30' });
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
-					expect(instance.addPropertyError.calledTwice).to.be.true;
-					expect(instance.addPropertyError.getCall(0).calledWithExactly(
-						'startDate',
-						'Start date must not be after press date'
-					)).to.be.true;
-					expect(instance.addPropertyError.getCall(1).calledWithExactly(
-						'pressDate',
-						'Press date must not be before start date'
-					)).to.be.true;
+					assert.calledTwice(instance.addPropertyError);
+					assert.calledWithExactly(
+						instance.addPropertyError.getCall(0),
+						'startDate', 'Start date must not be after press date'
+					);
+					assert.calledWithExactly(
+						instance.addPropertyError.getCall(1),
+						'pressDate', 'Press date must not be before start date'
+					);
 
 				});
 
@@ -865,15 +880,15 @@ describe('Production model', () => {
 					const instance = createInstance({ name: 'Hamlet', pressDate: '2011-01-26', endDate: '2010-10-07' });
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
-					expect(instance.addPropertyError.calledTwice).to.be.true;
-					expect(instance.addPropertyError.getCall(0).calledWithExactly(
-						'pressDate',
-						'Press date must not be after end date'
-					)).to.be.true;
-					expect(instance.addPropertyError.getCall(1).calledWithExactly(
-						'endDate',
-						'End date must not be before press date'
-					)).to.be.true;
+					assert.calledTwice(instance.addPropertyError);
+					assert.calledWithExactly(
+						instance.addPropertyError.getCall(0),
+						'pressDate', 'Press date must not be after end date'
+					);
+					assert.calledWithExactly(
+						instance.addPropertyError.getCall(1),
+						'endDate', 'End date must not be before press date'
+					);
 
 				});
 
@@ -892,30 +907,30 @@ describe('Production model', () => {
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
 					expect(instance.addPropertyError.callCount).to.equal(6);
-					expect(instance.addPropertyError.getCall(0).calledWithExactly(
-						'startDate',
-						'Start date must not be after end date'
-					)).to.be.true;
-					expect(instance.addPropertyError.getCall(1).calledWithExactly(
-						'endDate',
-						'End date must not be before start date'
-					)).to.be.true;
-					expect(instance.addPropertyError.getCall(2).calledWithExactly(
-						'startDate',
-						'Start date must not be after press date'
-					)).to.be.true;
-					expect(instance.addPropertyError.getCall(3).calledWithExactly(
-						'pressDate',
-						'Press date must not be before start date'
-					)).to.be.true;
-					expect(instance.addPropertyError.getCall(4).calledWithExactly(
-						'pressDate',
-						'Press date must not be after end date'
-					)).to.be.true;
-					expect(instance.addPropertyError.getCall(5).calledWithExactly(
-						'endDate',
-						'End date must not be before press date'
-					)).to.be.true;
+					assert.calledWithExactly(
+						instance.addPropertyError.getCall(0),
+						'startDate', 'Start date must not be after end date'
+					);
+					assert.calledWithExactly(
+						instance.addPropertyError.getCall(1),
+						'endDate', 'End date must not be before start date'
+					);
+					assert.calledWithExactly(
+						instance.addPropertyError.getCall(2),
+						'startDate', 'Start date must not be after press date'
+					);
+					assert.calledWithExactly(
+						instance.addPropertyError.getCall(3),
+						'pressDate', 'Press date must not be before start date'
+					);
+					assert.calledWithExactly(
+						instance.addPropertyError.getCall(4),
+						'pressDate', 'Press date must not be after end date'
+					);
+					assert.calledWithExactly(
+						instance.addPropertyError.getCall(5),
+						'endDate', 'End date must not be before press date'
+					);
 
 				});
 
@@ -938,8 +953,8 @@ describe('Production model', () => {
 			};
 			const instance = createInstance(props);
 			await instance.runDatabaseValidations();
-			expect(instance.subProductions[0].runDatabaseValidations.calledOnce).to.be.true;
-			expect(instance.subProductions[0].runDatabaseValidations.calledWithExactly()).to.be.true;
+			assert.calledOnce(instance.subProductions[0].runDatabaseValidations);
+			assert.calledWithExactly(instance.subProductions[0].runDatabaseValidations);
 
 		});
 

--- a/test-unit/src/models/ProductionIdentifier.test.js
+++ b/test-unit/src/models/ProductionIdentifier.test.js
@@ -1,5 +1,4 @@
-import { expect } from 'chai';
-import { spy, stub } from 'sinon';
+import { assert, spy, stub } from 'sinon';
 
 import { ProductionIdentifier } from '../../../src/models';
 
@@ -12,8 +11,8 @@ describe('ProductionIdentifier model', () => {
 			const instance = new ProductionIdentifier({ uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' });
 			spy(instance, 'validateStringForProperty');
 			instance.validateUuid();
-			expect(instance.validateStringForProperty.calledOnce).to.be.true;
-			expect(instance.validateStringForProperty.calledWithExactly('uuid', { isRequired: false })).to.be.true;
+			assert.calledOnce(instance.validateStringForProperty);
+			assert.calledWithExactly(instance.validateStringForProperty, 'uuid', { isRequired: false });
 
 		});
 
@@ -29,9 +28,9 @@ describe('ProductionIdentifier model', () => {
 				stub(instance, 'confirmExistenceInDatabase').resolves();
 				spy(instance, 'addPropertyError');
 				await instance.runDatabaseValidations();
-				expect(instance.confirmExistenceInDatabase.calledOnce).to.be.true;
-				expect(instance.confirmExistenceInDatabase.calledWithExactly({ model: 'PRODUCTION' })).to.be.true;
-				expect(instance.addPropertyError.notCalled).to.be.true;
+				assert.calledOnce(instance.confirmExistenceInDatabase);
+				assert.calledWithExactly(instance.confirmExistenceInDatabase, { model: 'PRODUCTION' });
+				assert.notCalled(instance.addPropertyError);
 
 			});
 
@@ -45,13 +44,13 @@ describe('ProductionIdentifier model', () => {
 				stub(instance, 'confirmExistenceInDatabase').rejects(new Error('Not Found'));
 				spy(instance, 'addPropertyError');
 				await instance.runDatabaseValidations();
-				expect(instance.confirmExistenceInDatabase.calledOnce).to.be.true;
-				expect(instance.confirmExistenceInDatabase.calledWithExactly({ model: 'PRODUCTION' })).to.be.true;
-				expect(instance.addPropertyError.calledOnce).to.be.true;
-				expect(instance.addPropertyError.calledWithExactly(
-					'uuid',
-					'Production with this UUID does not exist'
-				)).to.be.true;
+				assert.calledOnce(instance.confirmExistenceInDatabase);
+				assert.calledWithExactly(instance.confirmExistenceInDatabase, { model: 'PRODUCTION' });
+				assert.calledOnce(instance.addPropertyError);
+				assert.calledWithExactly(
+					instance.addPropertyError,
+					'uuid', 'Production with this UUID does not exist'
+				);
 
 			});
 

--- a/test-unit/src/models/ProductionTeamCredit.test.js
+++ b/test-unit/src/models/ProductionTeamCredit.test.js
@@ -139,39 +139,43 @@ describe('ProductionTeamCredit model', () => {
 				instance.entities[1].validateUniquenessInGroup,
 				instance.entities[1].runInputValidations
 			);
-			expect(instance.validateName.calledOnce).to.be.true;
-			expect(instance.validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.validateUniquenessInGroup.calledOnce).to.be.true;
-			expect(instance.validateUniquenessInGroup.calledWithExactly({ isDuplicate: false })).to.be.true;
-			expect(instance.validateNamePresenceIfNamedChildren.calledOnce).to.be.true;
-			expect(instance.validateNamePresenceIfNamedChildren.calledWithExactly(instance.entities)).to.be.true;
-			expect(stubs.getDuplicateEntityInfoModule.getDuplicateEntities.calledOnce).to.be.true;
-			expect(stubs.getDuplicateEntityInfoModule.getDuplicateEntities.calledWithExactly(
+			assert.calledOnce(instance.validateName);
+			assert.calledWithExactly(instance.validateName, { isRequired: false });
+			assert.calledOnce(instance.validateUniquenessInGroup);
+			assert.calledWithExactly(instance.validateUniquenessInGroup, { isDuplicate: false });
+			assert.calledOnce(instance.validateNamePresenceIfNamedChildren);
+			assert.calledWithExactly(instance.validateNamePresenceIfNamedChildren, instance.entities);
+			assert.calledOnce(stubs.getDuplicateEntityInfoModule.getDuplicateEntities);
+			assert.calledWithExactly(
+				stubs.getDuplicateEntityInfoModule.getDuplicateEntities,
 				instance.entities
-			)).to.be.true;
-			expect(instance.entities[0].validateName.calledOnce).to.be.true;
-			expect(instance.entities[0].validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.entities[0].validateDifferentiator.calledOnce).to.be.true;
-			expect(instance.entities[0].validateDifferentiator.calledWithExactly()).to.be.true;
-			expect(stubs.getDuplicateEntityInfoModule.isEntityInArray.calledTwice).to.be.true;
-			expect(stubs.getDuplicateEntityInfoModule.isEntityInArray.getCall(0).calledWithExactly(
+			);
+			assert.calledOnce(instance.entities[0].validateName);
+			assert.calledWithExactly(instance.entities[0].validateName, { isRequired: false });
+			assert.calledOnce(instance.entities[0].validateDifferentiator);
+			assert.calledWithExactly(instance.entities[0].validateDifferentiator);
+			assert.calledTwice(stubs.getDuplicateEntityInfoModule.isEntityInArray);
+			assert.calledWithExactly(
+				stubs.getDuplicateEntityInfoModule.isEntityInArray.getCall(0),
 				instance.entities[0], 'getDuplicateEntities response'
-			)).to.be.true;
-			expect(instance.entities[0].validateUniquenessInGroup.calledOnce).to.be.true;
-			expect(instance.entities[0].validateUniquenessInGroup.calledWithExactly({ isDuplicate: false })).to.be.true;
-			expect(instance.entities[1].validateName.calledOnce).to.be.true;
-			expect(instance.entities[1].validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.entities[1].validateDifferentiator.calledOnce).to.be.true;
-			expect(instance.entities[1].validateDifferentiator.calledWithExactly()).to.be.true;
-			expect(stubs.getDuplicateEntityInfoModule.isEntityInArray.getCall(1).calledWithExactly(
+			);
+			assert.calledOnce(instance.entities[0].validateUniquenessInGroup);
+			assert.calledWithExactly(instance.entities[0].validateUniquenessInGroup, { isDuplicate: false });
+			assert.calledOnce(instance.entities[1].validateName);
+			assert.calledWithExactly(instance.entities[1].validateName, { isRequired: false });
+			assert.calledOnce(instance.entities[1].validateDifferentiator);
+			assert.calledWithExactly(instance.entities[1].validateDifferentiator);
+			assert.calledWithExactly(
+				stubs.getDuplicateEntityInfoModule.isEntityInArray.getCall(1),
 				instance.entities[1], 'getDuplicateEntities response'
-			)).to.be.true;
-			expect(instance.entities[1].validateUniquenessInGroup.calledOnce).to.be.true;
-			expect(instance.entities[1].validateUniquenessInGroup.calledWithExactly({ isDuplicate: false })).to.be.true;
-			expect(instance.entities[1].runInputValidations.calledOnce).to.be.true;
-			expect(instance.entities[1].runInputValidations.calledWithExactly(
+			);
+			assert.calledOnce(instance.entities[1].validateUniquenessInGroup);
+			assert.calledWithExactly(instance.entities[1].validateUniquenessInGroup, { isDuplicate: false });
+			assert.calledOnce(instance.entities[1].runInputValidations);
+			assert.calledWithExactly(
+				instance.entities[1].runInputValidations,
 				{ duplicateEntities: 'getDuplicateEntities response' }
-			)).to.be.true;
+			);
 
 		});
 

--- a/test-unit/src/models/Role.test.js
+++ b/test-unit/src/models/Role.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { spy } from 'sinon';
+import { assert, spy } from 'sinon';
 
 import Role from '../../../src/models/Role';
 
@@ -172,10 +172,11 @@ describe('Role model', () => {
 			const instance = new Role({ name: 'Hamlet, Prince of Denmark', characterName: 'Hamlet' });
 			spy(instance, 'validateStringForProperty');
 			instance.validateCharacterName();
-			expect(instance.validateStringForProperty.calledOnce).to.be.true;
-			expect(instance.validateStringForProperty.calledWithExactly(
-				'characterName', { isRequired: false })
-			).to.be.true;
+			assert.calledOnce(instance.validateStringForProperty);
+			assert.calledWithExactly(
+				instance.validateStringForProperty,
+				'characterName', { isRequired: false }
+			);
 
 		});
 
@@ -188,10 +189,11 @@ describe('Role model', () => {
 			const instance = new Role({ name: 'Cinna', characterDifferentiator: '1' });
 			spy(instance, 'validateStringForProperty');
 			instance.validateCharacterDifferentiator();
-			expect(instance.validateStringForProperty.calledOnce).to.be.true;
-			expect(instance.validateStringForProperty.calledWithExactly(
-				'characterDifferentiator', { isRequired: false })
-			).to.be.true;
+			assert.calledOnce(instance.validateStringForProperty);
+			assert.calledWithExactly(
+				instance.validateStringForProperty,
+				'characterDifferentiator', { isRequired: false }
+			);
 
 		});
 
@@ -208,7 +210,7 @@ describe('Role model', () => {
 					const instance = new Role({ name: 'Hamlet', characterName: '' });
 					spy(instance, 'addPropertyError');
 					instance.validateRoleNameCharacterNameDisparity();
-					expect(instance.addPropertyError.notCalled).to.be.true;
+					assert.notCalled(instance.addPropertyError);
 
 				});
 
@@ -221,7 +223,7 @@ describe('Role model', () => {
 					const instance = new Role({ name: 'Hamlet, Prince of Denmark', characterName: 'Hamlet' });
 					spy(instance, 'addPropertyError');
 					instance.validateRoleNameCharacterNameDisparity();
-					expect(instance.addPropertyError.notCalled).to.be.true;
+					assert.notCalled(instance.addPropertyError);
 
 				});
 
@@ -234,7 +236,7 @@ describe('Role model', () => {
 					const instance = new Role({ name: '', characterName: '' });
 					spy(instance, 'addPropertyError');
 					instance.validateRoleNameCharacterNameDisparity();
-					expect(instance.addPropertyError.notCalled).to.be.true;
+					assert.notCalled(instance.addPropertyError);
 
 				});
 
@@ -249,11 +251,11 @@ describe('Role model', () => {
 				const instance = new Role({ name: 'Hamlet', characterName: 'Hamlet' });
 				spy(instance, 'addPropertyError');
 				instance.validateRoleNameCharacterNameDisparity();
-				expect(instance.addPropertyError.calledOnce).to.be.true;
-				expect(instance.addPropertyError.calledWithExactly(
-					'characterName',
-					'Character name is only required if different from role name'
-				)).to.be.true;
+				assert.calledOnce(instance.addPropertyError);
+				assert.calledWithExactly(
+					instance.addPropertyError,
+					'characterName', 'Character name is only required if different from role name'
+				);
 
 			});
 

--- a/test-unit/src/models/Venue.test.js
+++ b/test-unit/src/models/Venue.test.js
@@ -95,24 +95,26 @@ describe('Venue model', () => {
 				instance.subVenues[0].validateNoAssociationWithSelf,
 				instance.subVenues[0].validateUniquenessInGroup
 			);
-			expect(instance.validateName.calledOnce).to.be.true;
-			expect(instance.validateName.calledWithExactly({ isRequired: true })).to.be.true;
-			expect(instance.validateDifferentiator.calledOnce).to.be.true;
-			expect(instance.validateDifferentiator.calledWithExactly()).to.be.true;
-			expect(stubs.getDuplicateBaseInstanceIndices.calledOnce).to.be.true;
-			expect(stubs.getDuplicateBaseInstanceIndices.calledWithExactly(instance.subVenues)).to.be.true;
-			expect(instance.subVenues[0].validateName.calledOnce).to.be.true;
-			expect(instance.subVenues[0].validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.subVenues[0].validateDifferentiator.calledOnce).to.be.true;
-			expect(instance.subVenues[0].validateDifferentiator.calledWithExactly()).to.be.true;
-			expect(instance.subVenues[0].validateNoAssociationWithSelf.calledOnce).to.be.true;
-			expect(instance.subVenues[0].validateNoAssociationWithSelf.calledWithExactly(
+			assert.calledOnce(instance.validateName);
+			assert.calledWithExactly(instance.validateName, { isRequired: true });
+			assert.calledOnce(instance.validateDifferentiator);
+			assert.calledWithExactly(instance.validateDifferentiator);
+			assert.calledOnce(stubs.getDuplicateBaseInstanceIndices);
+			assert.calledWithExactly(stubs.getDuplicateBaseInstanceIndices, instance.subVenues);
+			assert.calledOnce(instance.subVenues[0].validateName);
+			assert.calledWithExactly(instance.subVenues[0].validateName, { isRequired: false });
+			assert.calledOnce(instance.subVenues[0].validateDifferentiator);
+			assert.calledWithExactly(instance.subVenues[0].validateDifferentiator);
+			assert.calledOnce(instance.subVenues[0].validateNoAssociationWithSelf);
+			assert.calledWithExactly(
+				instance.subVenues[0].validateNoAssociationWithSelf,
 				{ name: 'National Theatre', differentiator: '' }
-			)).to.be.true;
-			expect(instance.subVenues[0].validateUniquenessInGroup.calledOnce).to.be.true;
-			expect(instance.subVenues[0].validateUniquenessInGroup.calledWithExactly(
+			);
+			assert.calledOnce(instance.subVenues[0].validateUniquenessInGroup);
+			assert.calledWithExactly(
+				instance.subVenues[0].validateUniquenessInGroup,
 				{ isDuplicate: false }
-			)).to.be.true;
+			);
 
 		});
 

--- a/test-unit/src/models/WritingCredit.test.js
+++ b/test-unit/src/models/WritingCredit.test.js
@@ -199,36 +199,38 @@ describe('WritingCredit model', () => {
 				instance.entities[2].validateUniquenessInGroup,
 				instance.entities[2].validateNoAssociationWithSelf
 			);
-			expect(instance.validateName.calledOnce).to.be.true;
-			expect(instance.validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(stubs.getDuplicateIndicesModule.getDuplicateEntityIndices.calledOnce).to.be.true;
-			expect(stubs.getDuplicateIndicesModule.getDuplicateEntityIndices.calledWithExactly(
+			assert.calledOnce(instance.validateName);
+			assert.calledWithExactly(instance.validateName, { isRequired: false });
+			assert.calledOnce(stubs.getDuplicateIndicesModule.getDuplicateEntityIndices);
+			assert.calledWithExactly(
+				stubs.getDuplicateIndicesModule.getDuplicateEntityIndices,
 				instance.entities
-			)).to.be.true;
-			expect(instance.entities[0].validateName.calledOnce).to.be.true;
-			expect(instance.entities[0].validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.entities[0].validateDifferentiator.calledOnce).to.be.true;
-			expect(instance.entities[0].validateDifferentiator.calledWithExactly()).to.be.true;
-			expect(instance.entities[0].validateUniquenessInGroup.calledOnce).to.be.true;
-			expect(instance.entities[0].validateUniquenessInGroup.calledWithExactly({ isDuplicate: false })).to.be.true;
-			expect(instance.entities[0].validateNoAssociationWithSelf.notCalled).to.be.true;
-			expect(instance.entities[1].validateName.calledOnce).to.be.true;
-			expect(instance.entities[1].validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.entities[1].validateDifferentiator.calledOnce).to.be.true;
-			expect(instance.entities[1].validateDifferentiator.calledWithExactly()).to.be.true;
-			expect(instance.entities[1].validateUniquenessInGroup.calledOnce).to.be.true;
-			expect(instance.entities[1].validateUniquenessInGroup.calledWithExactly({ isDuplicate: false })).to.be.true;
-			expect(instance.entities[1].validateNoAssociationWithSelf.notCalled).to.be.true;
-			expect(instance.entities[2].validateName.calledOnce).to.be.true;
-			expect(instance.entities[2].validateName.calledWithExactly({ isRequired: false })).to.be.true;
-			expect(instance.entities[2].validateDifferentiator.calledOnce).to.be.true;
-			expect(instance.entities[2].validateDifferentiator.calledWithExactly()).to.be.true;
-			expect(instance.entities[2].validateUniquenessInGroup.calledOnce).to.be.true;
-			expect(instance.entities[2].validateUniquenessInGroup.calledWithExactly({ isDuplicate: false })).to.be.true;
-			expect(instance.entities[2].validateNoAssociationWithSelf.calledOnce).to.be.true;
-			expect(instance.entities[2].validateNoAssociationWithSelf.calledWithExactly(
+			);
+			assert.calledOnce(instance.entities[0].validateName);
+			assert.calledWithExactly(instance.entities[0].validateName, { isRequired: false });
+			assert.calledOnce(instance.entities[0].validateDifferentiator);
+			assert.calledWithExactly(instance.entities[0].validateDifferentiator);
+			assert.calledOnce(instance.entities[0].validateUniquenessInGroup);
+			assert.calledWithExactly(instance.entities[0].validateUniquenessInGroup, { isDuplicate: false });
+			assert.notCalled(instance.entities[0].validateNoAssociationWithSelf);
+			assert.calledOnce(instance.entities[1].validateName);
+			assert.calledWithExactly(instance.entities[1].validateName, { isRequired: false });
+			assert.calledOnce(instance.entities[1].validateDifferentiator);
+			assert.calledWithExactly(instance.entities[1].validateDifferentiator);
+			assert.calledOnce(instance.entities[1].validateUniquenessInGroup);
+			assert.calledWithExactly(instance.entities[1].validateUniquenessInGroup, { isDuplicate: false });
+			assert.notCalled(instance.entities[1].validateNoAssociationWithSelf);
+			assert.calledOnce(instance.entities[2].validateName);
+			assert.calledWithExactly(instance.entities[2].validateName, { isRequired: false });
+			assert.calledOnce(instance.entities[2].validateDifferentiator);
+			assert.calledWithExactly(instance.entities[2].validateDifferentiator);
+			assert.calledOnce(instance.entities[2].validateUniquenessInGroup);
+			assert.calledWithExactly(instance.entities[2].validateUniquenessInGroup, { isDuplicate: false });
+			assert.calledOnce(instance.entities[2].validateNoAssociationWithSelf);
+			assert.calledWithExactly(
+				instance.entities[2].validateNoAssociationWithSelf,
 				{ name: 'The Indian Boy', differentiator: '1' }
-			)).to.be.true;
+			);
 
 		});
 


### PR DESCRIPTION
This PR takes the idea from this PR https://github.com/Financial-Times/dotcom-biz-ops-package-updater/pull/22:

> When I was trying to refactor some of the code in this file, it was becoming really difficult to understand which part of each test was failing. This is because we were using `expect` and `to.be.true` wrapped around a stubbed call.
>
> The only debug information you get if these tests fail is:
>
> ```js
> expect(stubs.bizOpsGetClient.calledOnce).to.be.true;
> ```
>
> ```
> AssertionError: expected false to be true
> + expected - actual
>
> -false
> +true
> ```
>
> This is difficult to debug when you've got a large number of assertions in a single test case.
>
> I've switched to use sinon's built-in assertions. Now we get more information if the tests fail for any reason:
>
> ```js
> sinon.assert.calledOnce(stubs.bizOpsGetClient);
> ```
>
> ```
> AssertError: expected getClient to be called once but was called 0 times
> ```
>
> This gives us an immediate indicator of which function failed as well as some information which can help debug (in this case that the function was actually called zero times). It gets better with checking arguments:
>
> ```js
> sinon.assert.calledWithExactly(
>    stubs.bizOpsGetClient,
>    'hello',
>    'world'
> );
> ```
>
> ```
> AssertError: expected getClient to be called with exact arguments
> '"mock-biz-ops-api-key"' '"hello"'
> '"mock-biz-ops-api-url"' '"world"'
> ```
>
> (on the command line the different values are coloured red and green to indicate actual/expected values)

---

N.B. Tests have been manipulated to ensure failure.

#### Before

```js
expect(stubs.sendJsonResponseModule.sendJsonResponse.calledTwice).to.be.true;
```

```
1) Award ceremonies controller
     newRoute function
       calls sendJsonResponse module:

    AssertionError: expected false to be true
    + expected - actual

    -false
    +true

    at Context.<anonymous> (test-unit/src/controllers/award-ceremonies.test.js:57:4)
    at processImmediate (node:internal/timers:471:21)
```

#### After

```js
assert.calledTwice(stubs.sendJsonResponseModule.sendJsonResponse);
```

```
1) Award ceremonies controller
     newRoute function
       calls sendJsonResponse module:
   expected stub to be called twice but was called once
  stub([Function: functionStub], AwardCeremony {}) => 'sendJsonResponse response' at Object.newRoute ({path}/theatrebase-api/src/controllers/award-ceremonies.js:10:2)
AssertError: expected stub to be called twice but was called once
    stub([Function: functionStub], AwardCeremony {}) => 'sendJsonResponse response' at Object.newRoute (src/controllers/award-ceremonies.js:10:2)
    at Object.fail (node_modules/sinon/lib/sinon/assert.js:120:25)
    at failAssertion (node_modules/sinon/lib/sinon/assert.js:66:20)
    at Object.calledTwice (node_modules/sinon/lib/sinon/assert.js:95:17)
    at Context.<anonymous> (test-unit/src/controllers/award-ceremonies.test.js:57:11)
    at processImmediate (node:internal/timers:471:21)
```

---

#### Before

```js
expect(stubs.sendJsonResponseModule.sendJsonResponse.calledWithExactly(
	'stubs.response', stubs.models.AwardCeremony() // eslint-disable-line new-cap
)).to.be.true;
```

```
1) Award ceremonies controller
     newRoute function
       calls sendJsonResponse module:

    AssertionError: expected false to be true
    + expected - actual

    -false
    +true

    at Context.<anonymous> (test-unit/src/controllers/award-ceremonies.test.js:58:4)
    at processImmediate (node:internal/timers:471:21)
```

#### After

```js
assert.calledWithExactly(
	stubs.sendJsonResponseModule.sendJsonResponse,
	'stubs.response', stubs.models.AwardCeremony() // eslint-disable-line new-cap
);
```

```
1) Award ceremonies controller
     newRoute function
       calls sendJsonResponse module:
   AssertError: expected stub to be called with exact arguments
[Function: functionStub] '"stubs.response"'
AwardCeremony {}
    at Object.fail (node_modules/sinon/lib/sinon/assert.js:120:25)
    at failAssertion (node_modules/sinon/lib/sinon/assert.js:66:20)
    at Object.calledWithExactly (node_modules/sinon/lib/sinon/assert.js:95:17)
    at Context.<anonymous> (test-unit/src/controllers/award-ceremonies.test.js:58:11)
    at processImmediate (node:internal/timers:471:21)
```

---

I have only switched to `assert` for stub-related tests (e.g. `notCalled`, `calledOnce`, `calledWithExactly`) because I feel that Chai expectations provides equivalent/better feedback for non-stub-related tests, e.g. `expect(response.body).to.deep.equal(expectedResponseBody);` will return the specific differences in the (oftentimes very large) objects whereas Sinon's `assert` will display much larger chunks of the object, making it harder to identify the exact source of the failure.

### References:
- [Sinon.JS: Assertions](https://sinonjs.org/releases/latest/assertions)
- [Stack Overflow: Regular expression search replace in Sublime Text 2](https://stackoverflow.com/questions/11819886/regular-expression-search-replace-in-sublime-text-2#answer-11819914) (used for applying changes via find and replace)
- [GitHub: Financial-Times/dotcom-biz-ops-package-updater: PR 22](https://github.com/Financial-Times/dotcom-biz-ops-package-updater/pull/22)