### PR TITLE
Amend controller unit tests

### DIFF
--- a/test-unit/src/controllers/award-ceremonies.test.js
+++ b/test-unit/src/controllers/award-ceremonies.test.js
@@ -53,12 +53,13 @@ describe('Award ceremonies controller', () => {
 
 		it('calls sendJsonResponse module', () => {
 
-			expect(callFunction('newRoute')).to.equal('sendJsonResponse response');
+			const result = callFunction('newRoute');
 			assert.calledOnce(stubs.sendJsonResponseModule.sendJsonResponse);
 			assert.calledWithExactly(
 				stubs.sendJsonResponseModule.sendJsonResponse,
 				stubs.response, stubs.models.AwardCeremony() // eslint-disable-line new-cap
 			);
+			expect(result).to.equal('sendJsonResponse response');
 
 		});
 

--- a/test-unit/src/controllers/awards.test.js
+++ b/test-unit/src/controllers/awards.test.js
@@ -53,12 +53,13 @@ describe('Awards controller', () => {
 
 		it('calls sendJsonResponse module', () => {
 
-			expect(callFunction('newRoute')).to.equal('sendJsonResponse response');
+			const result = callFunction('newRoute');
 			assert.calledOnce(stubs.sendJsonResponseModule.sendJsonResponse);
 			assert.calledWithExactly(
 				stubs.sendJsonResponseModule.sendJsonResponse,
 				stubs.response, stubs.models.Award() // eslint-disable-line new-cap
 			);
+			expect(result).to.equal('sendJsonResponse response');
 
 		});
 

--- a/test-unit/src/controllers/characters.test.js
+++ b/test-unit/src/controllers/characters.test.js
@@ -53,12 +53,13 @@ describe('Characters controller', () => {
 
 		it('calls sendJsonResponse module', () => {
 
-			expect(callFunction('newRoute')).to.equal('sendJsonResponse response');
+			const result = callFunction('newRoute');
 			assert.calledOnce(stubs.sendJsonResponseModule.sendJsonResponse);
 			assert.calledWithExactly(
 				stubs.sendJsonResponseModule.sendJsonResponse,
 				stubs.response, stubs.models.Character() // eslint-disable-line new-cap
 			);
+			expect(result).to.equal('sendJsonResponse response');
 
 		});
 

--- a/test-unit/src/controllers/companies.test.js
+++ b/test-unit/src/controllers/companies.test.js
@@ -53,12 +53,13 @@ describe('Companies controller', () => {
 
 		it('calls sendJsonResponse module', () => {
 
-			expect(callFunction('newRoute')).to.equal('sendJsonResponse response');
+			const result = callFunction('newRoute');
 			assert.calledOnce(stubs.sendJsonResponseModule.sendJsonResponse);
 			assert.calledWithExactly(
 				stubs.sendJsonResponseModule.sendJsonResponse,
 				stubs.response, stubs.models.Company() // eslint-disable-line new-cap
 			);
+			expect(result).to.equal('sendJsonResponse response');
 
 		});
 

--- a/test-unit/src/controllers/materials.test.js
+++ b/test-unit/src/controllers/materials.test.js
@@ -53,12 +53,13 @@ describe('Materials controller', () => {
 
 		it('calls sendJsonResponse module', () => {
 
-			expect(callFunction('newRoute')).to.equal('sendJsonResponse response');
+			const result = callFunction('newRoute');
 			assert.calledOnce(stubs.sendJsonResponseModule.sendJsonResponse);
 			assert.calledWithExactly(
 				stubs.sendJsonResponseModule.sendJsonResponse,
 				stubs.response, stubs.models.Material() // eslint-disable-line new-cap
 			);
+			expect(result).to.equal('sendJsonResponse response');
 
 		});
 

--- a/test-unit/src/controllers/people.test.js
+++ b/test-unit/src/controllers/people.test.js
@@ -53,12 +53,13 @@ describe('People controller', () => {
 
 		it('calls sendJsonResponse module', () => {
 
-			expect(callFunction('newRoute')).to.equal('sendJsonResponse response');
+			const result = callFunction('newRoute');
 			assert.calledOnce(stubs.sendJsonResponseModule.sendJsonResponse);
 			assert.calledWithExactly(
 				stubs.sendJsonResponseModule.sendJsonResponse,
 				stubs.response, stubs.models.Person() // eslint-disable-line new-cap
 			);
+			expect(result).to.equal('sendJsonResponse response');
 
 		});
 

--- a/test-unit/src/controllers/productions.test.js
+++ b/test-unit/src/controllers/productions.test.js
@@ -53,12 +53,13 @@ describe('Productions controller', () => {
 
 		it('calls sendJsonResponse module', () => {
 
-			expect(callFunction('newRoute')).to.equal('sendJsonResponse response');
+			const result = callFunction('newRoute');
 			assert.calledOnce(stubs.sendJsonResponseModule.sendJsonResponse);
 			assert.calledWithExactly(
 				stubs.sendJsonResponseModule.sendJsonResponse,
 				stubs.response, stubs.models.Production() // eslint-disable-line new-cap
 			);
+			expect(result).to.equal('sendJsonResponse response');
 
 		});
 

--- a/test-unit/src/controllers/venues.test.js
+++ b/test-unit/src/controllers/venues.test.js
@@ -53,12 +53,13 @@ describe('Venues controller', () => {
 
 		it('calls sendJsonResponse module', () => {
 
-			expect(callFunction('newRoute')).to.equal('sendJsonResponse response');
+			const result = callFunction('newRoute');
 			assert.calledOnce(stubs.sendJsonResponseModule.sendJsonResponse);
 			assert.calledWithExactly(
 				stubs.sendJsonResponseModule.sendJsonResponse,
 				stubs.response, stubs.models.Venue() // eslint-disable-line new-cap
 			);
+			expect(result).to.equal('sendJsonResponse response');
 
 		});
 


### PR DESCRIPTION
This PR makes the controller unit tests for new routes consistent with the other routes, i.e. assigning the result to a variable and testing it separately.