### PR TITLE
Revise award ceremony endpoints

### DIFF
--- a/db-seeding/seed-db.js
+++ b/db-seeding/seed-db.js
@@ -66,7 +66,7 @@ async function seedDatabase () {
 
 	console.log('Seeding Neo4j database: Production seeds sown'); // eslint-disable-line no-console
 
-	await seedInstances('award-ceremonies', 'awards/ceremonies');
+	await seedInstances('award-ceremonies', 'award-ceremonies');
 
 	console.log('Seeding Neo4j database: Award ceremony seeds sown'); // eslint-disable-line no-console
 

--- a/src/router.js
+++ b/src/router.js
@@ -15,14 +15,6 @@ import {
 
 const router = new Router();
 
-router.get('/awards/ceremonies/new', awardCeremoniesController.newRoute);
-router.post('/awards/ceremonies', awardCeremoniesController.createRoute);
-router.get('/awards/ceremonies/:uuid/edit', awardCeremoniesController.editRoute);
-router.put('/awards/ceremonies/:uuid', awardCeremoniesController.updateRoute);
-router.delete('/awards/ceremonies/:uuid', awardCeremoniesController.deleteRoute);
-router.get('/awards/ceremonies/:uuid', awardCeremoniesController.showRoute);
-router.get('/awards/ceremonies', awardCeremoniesController.listRoute);
-
 router.get('/awards/new', awardsController.newRoute);
 router.post('/awards', awardsController.createRoute);
 router.get('/awards/:uuid/edit', awardsController.editRoute);
@@ -30,6 +22,14 @@ router.put('/awards/:uuid', awardsController.updateRoute);
 router.delete('/awards/:uuid', awardsController.deleteRoute);
 router.get('/awards/:uuid', awardsController.showRoute);
 router.get('/awards', awardsController.listRoute);
+
+router.get('/award-ceremonies/new', awardCeremoniesController.newRoute);
+router.post('/award-ceremonies', awardCeremoniesController.createRoute);
+router.get('/award-ceremonies/:uuid/edit', awardCeremoniesController.editRoute);
+router.put('/award-ceremonies/:uuid', awardCeremoniesController.updateRoute);
+router.delete('/award-ceremonies/:uuid', awardCeremoniesController.deleteRoute);
+router.get('/award-ceremonies/:uuid', awardCeremoniesController.showRoute);
+router.get('/award-ceremonies', awardCeremoniesController.listRoute);
 
 router.get('/characters/new', charactersController.newRoute);
 router.post('/characters', charactersController.createRoute);

--- a/test-e2e/crud/award-ceremonies-api.test.js
+++ b/test-e2e/crud/award-ceremonies-api.test.js
@@ -19,7 +19,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 		it('responds with data required to prepare new award ceremony', async () => {
 
 			const response = await chai.request(app)
-				.get('/awards/ceremonies/new');
+				.get('/award-ceremonies/new');
 
 			const expectedResponseBody = {
 				model: 'AWARD_CEREMONY',
@@ -101,7 +101,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 			expect(await countNodesWithLabel('AwardCeremony')).to.equal(0);
 
 			const response = await chai.request(app)
-				.post('/awards/ceremonies')
+				.post('/award-ceremonies')
 				.send({
 					name: '2020'
 				});
@@ -166,7 +166,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 		it('gets data required to edit specific award ceremony', async () => {
 
 			const response = await chai.request(app)
-				.get(`/awards/ceremonies/${AWARD_CEREMONY_UUID}/edit`);
+				.get(`/award-ceremonies/${AWARD_CEREMONY_UUID}/edit`);
 
 			const expectedResponseBody = {
 				model: 'AWARD_CEREMONY',
@@ -229,7 +229,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 			expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
 
 			const response = await chai.request(app)
-				.put(`/awards/ceremonies/${AWARD_CEREMONY_UUID}`)
+				.put(`/award-ceremonies/${AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2019'
 				});
@@ -294,7 +294,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 		it('shows award ceremony', async () => {
 
 			const response = await chai.request(app)
-				.get(`/awards/ceremonies/${AWARD_CEREMONY_UUID}`);
+				.get(`/award-ceremonies/${AWARD_CEREMONY_UUID}`);
 
 			const expectedResponseBody = {
 				model: 'AWARD_CEREMONY',
@@ -314,7 +314,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 			expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
 
 			const response = await chai.request(app)
-				.delete(`/awards/ceremonies/${AWARD_CEREMONY_UUID}`);
+				.delete(`/award-ceremonies/${AWARD_CEREMONY_UUID}`);
 
 			const expectedResponseBody = {
 				model: 'AWARD_CEREMONY',
@@ -493,7 +493,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 				});
 
 			const response = await chai.request(app)
-				.post('/awards/ceremonies')
+				.post('/award-ceremonies')
 				.send({
 					name: '2008',
 					award: {
@@ -1594,7 +1594,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 		it('shows award ceremony (post-creation)', async () => {
 
 			const response = await chai.request(app)
-				.get(`/awards/ceremonies/${AWARD_CEREMONY_UUID}`);
+				.get(`/award-ceremonies/${AWARD_CEREMONY_UUID}`);
 
 			const expectedResponseBody = {
 				model: 'AWARD_CEREMONY',
@@ -2083,7 +2083,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 		it('gets data required to edit specific award ceremony', async () => {
 
 			const response = await chai.request(app)
-				.get(`/awards/ceremonies/${AWARD_CEREMONY_UUID}/edit`);
+				.get(`/award-ceremonies/${AWARD_CEREMONY_UUID}/edit`);
 
 			const expectedResponseBody = {
 				model: 'AWARD_CEREMONY',
@@ -3020,7 +3020,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 				});
 
 			const response = await chai.request(app)
-				.put(`/awards/ceremonies/${AWARD_CEREMONY_UUID}`)
+				.put(`/award-ceremonies/${AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2009',
 					award: {
@@ -4137,7 +4137,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 		it('shows award ceremony (post-update)', async () => {
 
 			const response = await chai.request(app)
-				.get(`/awards/ceremonies/${AWARD_CEREMONY_UUID}`);
+				.get(`/award-ceremonies/${AWARD_CEREMONY_UUID}`);
 
 			const expectedResponseBody = {
 				model: 'AWARD_CEREMONY',
@@ -4656,7 +4656,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 			expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
 
 			const response = await chai.request(app)
-				.put(`/awards/ceremonies/${AWARD_CEREMONY_UUID}`)
+				.put(`/award-ceremonies/${AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2009'
 				});
@@ -4723,7 +4723,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 			expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
 
 			const response = await chai.request(app)
-				.delete(`/awards/ceremonies/${AWARD_CEREMONY_UUID}`);
+				.delete(`/award-ceremonies/${AWARD_CEREMONY_UUID}`);
 
 			const expectedResponseBody = {
 				model: 'AWARD_CEREMONY',
@@ -4766,7 +4766,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 			await purgeDatabase();
 
 			await chai.request(app)
-				.post('/awards/ceremonies')
+				.post('/award-ceremonies')
 				.send({
 					name: '2019',
 					award: {
@@ -4775,7 +4775,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 				});
 
 			await chai.request(app)
-				.post('/awards/ceremonies')
+				.post('/award-ceremonies')
 				.send({
 					name: '2020',
 					award: {
@@ -4784,7 +4784,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 				});
 
 			await chai.request(app)
-				.post('/awards/ceremonies')
+				.post('/award-ceremonies')
 				.send({
 					name: '2018',
 					award: {
@@ -4793,7 +4793,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 				});
 
 			await chai.request(app)
-				.post('/awards/ceremonies')
+				.post('/award-ceremonies')
 				.send({
 					name: '2019',
 					award: {
@@ -4802,7 +4802,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 				});
 
 			await chai.request(app)
-				.post('/awards/ceremonies')
+				.post('/award-ceremonies')
 				.send({
 					name: '2020',
 					award: {
@@ -4811,7 +4811,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 				});
 
 			await chai.request(app)
-				.post('/awards/ceremonies')
+				.post('/award-ceremonies')
 				.send({
 					name: '2018',
 					award: {
@@ -4830,7 +4830,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 		it('lists all award ceremonies ordered by name then award name', async () => {
 
 			const response = await chai.request(app)
-				.get('/awards/ceremonies');
+				.get('/award-ceremonies');
 
 			const expectedResponseBody = [
 				{

--- a/test-e2e/database-validation-failures/award-ceremonies-api.test.js
+++ b/test-e2e/database-validation-failures/award-ceremonies-api.test.js
@@ -27,7 +27,7 @@ describe('Database validation failures: Award ceremonies API', () => {
 				expect(await countNodesWithLabel('AwardCeremony')).to.equal(0);
 
 				const response = await chai.request(app)
-					.post('/awards/ceremonies')
+					.post('/award-ceremonies')
 					.send({
 						name: '2020',
 						award: {
@@ -138,7 +138,7 @@ describe('Database validation failures: Award ceremonies API', () => {
 				expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
 
 				const response = await chai.request(app)
-					.put(`/awards/ceremonies/${TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID}`)
+					.put(`/award-ceremonies/${TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID}`)
 					.send({
 						name: '2020',
 						award: {

--- a/test-e2e/instance-validation-failures/award-ceremonies-api.test.js
+++ b/test-e2e/instance-validation-failures/award-ceremonies-api.test.js
@@ -53,7 +53,7 @@ describe('Instance validation failures: Award ceremonies API', () => {
 				expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
 
 				const response = await chai.request(app)
-					.post('/awards/ceremonies')
+					.post('/award-ceremonies')
 					.send({
 						name: ''
 					});
@@ -91,7 +91,7 @@ describe('Instance validation failures: Award ceremonies API', () => {
 				expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
 
 				const response = await chai.request(app)
-					.post('/awards/ceremonies')
+					.post('/award-ceremonies')
 					.send({
 						name: '2020',
 						award: {
@@ -139,7 +139,7 @@ describe('Instance validation failures: Award ceremonies API', () => {
 				expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
 
 				const response = await chai.request(app)
-					.post('/awards/ceremonies')
+					.post('/award-ceremonies')
 					.send({
 						name: '2020',
 						award: {
@@ -243,7 +243,7 @@ describe('Instance validation failures: Award ceremonies API', () => {
 				expect(await countNodesWithLabel('AwardCeremony')).to.equal(2);
 
 				const response = await chai.request(app)
-					.put(`/awards/ceremonies/${TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID}`)
+					.put(`/award-ceremonies/${TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID}`)
 					.send({
 						name: ''
 					});
@@ -287,7 +287,7 @@ describe('Instance validation failures: Award ceremonies API', () => {
 				expect(await countNodesWithLabel('AwardCeremony')).to.equal(2);
 
 				const response = await chai.request(app)
-					.put(`/awards/ceremonies/${TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID}`)
+					.put(`/award-ceremonies/${TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID}`)
 					.send({
 						name: '2020',
 						award: {
@@ -341,7 +341,7 @@ describe('Instance validation failures: Award ceremonies API', () => {
 				expect(await countNodesWithLabel('AwardCeremony')).to.equal(2);
 
 				const response = await chai.request(app)
-					.put(`/awards/ceremonies/${TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID}`)
+					.put(`/award-ceremonies/${TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID}`)
 					.send({
 						name: '2020',
 						award: {
@@ -444,7 +444,7 @@ describe('Instance validation failures: Award ceremonies API', () => {
 				expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
 
 				const response = await chai.request(app)
-					.delete(`/awards/ceremonies/${TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID}`);
+					.delete(`/award-ceremonies/${TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID}`);
 
 				const expectedResponseBody = {
 					model: 'AWARD_CEREMONY',

--- a/test-e2e/model-interaction/award-ceremonies-with-crediting-materials.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-crediting-materials.test.js
@@ -714,7 +714,7 @@ describe('Award ceremonies with crediting materials', () => {
 			});
 
 		await chai.request(app)
-			.post('/awards/ceremonies')
+			.post('/award-ceremonies')
 			.send({
 				name: '2009',
 				award: {
@@ -779,7 +779,7 @@ describe('Award ceremonies with crediting materials', () => {
 			});
 
 		await chai.request(app)
-			.post('/awards/ceremonies')
+			.post('/award-ceremonies')
 			.send({
 				name: '2010',
 				award: {
@@ -842,7 +842,7 @@ describe('Award ceremonies with crediting materials', () => {
 			});
 
 		await chai.request(app)
-			.post('/awards/ceremonies')
+			.post('/award-ceremonies')
 			.send({
 				name: '2008',
 				award: {
@@ -898,7 +898,7 @@ describe('Award ceremonies with crediting materials', () => {
 			});
 
 		await chai.request(app)
-			.post('/awards/ceremonies')
+			.post('/award-ceremonies')
 			.send({
 				name: '2008',
 				award: {
@@ -954,7 +954,7 @@ describe('Award ceremonies with crediting materials', () => {
 			});
 
 		await chai.request(app)
-			.post('/awards/ceremonies')
+			.post('/award-ceremonies')
 			.send({
 				name: '2009',
 				award: {
@@ -1014,7 +1014,7 @@ describe('Award ceremonies with crediting materials', () => {
 			});
 
 		await chai.request(app)
-			.post('/awards/ceremonies')
+			.post('/award-ceremonies')
 			.send({
 				name: '2007',
 				award: {
@@ -1067,10 +1067,10 @@ describe('Award ceremonies with crediting materials', () => {
 			});
 
 		wordsmithAward2009AwardCeremony = await chai.request(app)
-			.get(`/awards/ceremonies/${WORDSMITH_AWARD_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID}`);
+			.get(`/award-ceremonies/${WORDSMITH_AWARD_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID}`);
 
 		playwritingPrize2009AwardCeremony = await chai.request(app)
-			.get(`/awards/ceremonies/${PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID}`);
+			.get(`/award-ceremonies/${PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID}`);
 
 		johnDoePerson = await chai.request(app)
 			.get(`/people/${JOHN_DOE_PERSON_UUID}`);

--- a/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-materials.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-materials.test.js
@@ -699,7 +699,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 			});
 
 		await chai.request(app)
-			.post('/awards/ceremonies')
+			.post('/award-ceremonies')
 			.send({
 				name: '2010',
 				award: {
@@ -777,7 +777,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 			});
 
 		await chai.request(app)
-			.post('/awards/ceremonies')
+			.post('/award-ceremonies')
 			.send({
 				name: '2009',
 				award: {
@@ -855,10 +855,10 @@ describe('Award ceremonies with crediting sub-materials', () => {
 			});
 
 		wordsmithAward2010AwardCeremony = await chai.request(app)
-			.get(`/awards/ceremonies/${WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`);
+			.get(`/award-ceremonies/${WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`);
 
 		playwritingPrize2009AwardCeremony = await chai.request(app)
-			.get(`/awards/ceremonies/${PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID}`);
+			.get(`/award-ceremonies/${PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID}`);
 
 		johnDoePerson = await chai.request(app)
 			.get(`/people/${JOHN_DOE_PERSON_UUID}`);

--- a/test-e2e/model-interaction/award-ceremonies-with-sub-materials-sub-prods.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-sub-materials-sub-prods.test.js
@@ -160,7 +160,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 			});
 
 		await chai.request(app)
-			.post('/awards/ceremonies')
+			.post('/award-ceremonies')
 			.send({
 				name: '2020',
 				award: {
@@ -208,7 +208,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 			});
 
 		await chai.request(app)
-			.post('/awards/ceremonies')
+			.post('/award-ceremonies')
 			.send({
 				name: '2019',
 				award: {
@@ -257,10 +257,10 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 			});
 
 		laurenceOlivierAwards2020AwardCeremony = await chai.request(app)
-			.get(`/awards/ceremonies/${LAURENCE_OLIVIER_AWARDS_TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID}`);
+			.get(`/award-ceremonies/${LAURENCE_OLIVIER_AWARDS_TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID}`);
 
 		eveningStandardTheatreAwards2019AwardCeremony = await chai.request(app)
-			.get(`/awards/ceremonies/${EVENING_STANDARD_THEATRE_AWARDS_TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID}`);
+			.get(`/award-ceremonies/${EVENING_STANDARD_THEATRE_AWARDS_TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID}`);
 
 		conorCorgePerson = await chai.request(app)
 			.get(`/people/${CONOR_CORGE_PERSON_UUID}`);

--- a/test-e2e/model-interaction/award-ceremonies.test.js
+++ b/test-e2e/model-interaction/award-ceremonies.test.js
@@ -408,7 +408,7 @@ describe('Award ceremonies', () => {
 			});
 
 		await chai.request(app)
-			.post('/awards/ceremonies')
+			.post('/award-ceremonies')
 			.send({
 				name: '2020',
 				award: {
@@ -678,7 +678,7 @@ describe('Award ceremonies', () => {
 			});
 
 		await chai.request(app)
-			.post('/awards/ceremonies')
+			.post('/award-ceremonies')
 			.send({
 				name: '2018',
 				award: {
@@ -871,7 +871,7 @@ describe('Award ceremonies', () => {
 			});
 
 		await chai.request(app)
-			.post('/awards/ceremonies')
+			.post('/award-ceremonies')
 			.send({
 				name: '2018',
 				award: {
@@ -965,7 +965,7 @@ describe('Award ceremonies', () => {
 			});
 
 		await chai.request(app)
-			.post('/awards/ceremonies')
+			.post('/award-ceremonies')
 			.send({
 				name: '2019',
 				award: {
@@ -1096,7 +1096,7 @@ describe('Award ceremonies', () => {
 			});
 
 		await chai.request(app)
-			.post('/awards/ceremonies')
+			.post('/award-ceremonies')
 			.send({
 				name: '2017',
 				award: {
@@ -1372,7 +1372,7 @@ describe('Award ceremonies', () => {
 			});
 
 		await chai.request(app)
-			.post('/awards/ceremonies')
+			.post('/award-ceremonies')
 			.send({
 				name: '2019',
 				award: {
@@ -1568,10 +1568,10 @@ describe('Award ceremonies', () => {
 			});
 
 		laurenceOlivierAwards2020AwardCeremony = await chai.request(app)
-			.get(`/awards/ceremonies/${LAURENCE_OLIVIER_AWARDS_TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID}`);
+			.get(`/award-ceremonies/${LAURENCE_OLIVIER_AWARDS_TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID}`);
 
 		eveningStandardTheatreAwards2017AwardCeremony = await chai.request(app)
-			.get(`/awards/ceremonies/${EVENING_STANDARD_THEATRE_AWARDS_TWO_THOUSAND_AND_SEVENTEEN_AWARD_CEREMONY_UUID}`);
+			.get(`/award-ceremonies/${EVENING_STANDARD_THEATRE_AWARDS_TWO_THOUSAND_AND_SEVENTEEN_AWARD_CEREMONY_UUID}`);
 
 		laurenceOlivierAwardsAward = await chai.request(app)
 			.get(`/awards/${LAURENCE_OLIVIER_AWARDS_AWARD_UUID}`);

--- a/test-e2e/non-existent-instances/award-ceremonies-api.test.js
+++ b/test-e2e/non-existent-instances/award-ceremonies-api.test.js
@@ -23,7 +23,7 @@ describe('Non-existent instances: Award ceremonies API', () => {
 			it('responds with 404 Not Found error', async () => {
 
 				const response = await chai.request(app)
-					.get(`/awards/ceremonies/${NON_EXISTENT_AWARD_CEREMONY_UUID}/edit`);
+					.get(`/award-ceremonies/${NON_EXISTENT_AWARD_CEREMONY_UUID}/edit`);
 
 				expect(response).to.have.status(404);
 				expect(response.text).to.equal('Not Found');
@@ -37,7 +37,7 @@ describe('Non-existent instances: Award ceremonies API', () => {
 			it('responds with 404 Not Found error', async () => {
 
 				const response = await chai.request(app)
-					.put(`/awards/ceremonies/${NON_EXISTENT_AWARD_CEREMONY_UUID}`)
+					.put(`/award-ceremonies/${NON_EXISTENT_AWARD_CEREMONY_UUID}`)
 					.send({ name: '2020' });
 
 				expect(response).to.have.status(404);
@@ -52,7 +52,7 @@ describe('Non-existent instances: Award ceremonies API', () => {
 			it('responds with 404 Not Found error', async () => {
 
 				const response = await chai.request(app)
-					.get(`/awards/ceremonies/${NON_EXISTENT_AWARD_CEREMONY_UUID}`);
+					.get(`/award-ceremonies/${NON_EXISTENT_AWARD_CEREMONY_UUID}`);
 
 				expect(response).to.have.status(404);
 				expect(response.text).to.equal('Not Found');
@@ -66,7 +66,7 @@ describe('Non-existent instances: Award ceremonies API', () => {
 			it('responds with 404 Not Found error', async () => {
 
 				const response = await chai.request(app)
-					.delete(`/awards/ceremonies/${NON_EXISTENT_AWARD_CEREMONY_UUID}`);
+					.delete(`/award-ceremonies/${NON_EXISTENT_AWARD_CEREMONY_UUID}`);
 
 				expect(response).to.have.status(404);
 				expect(response.text).to.equal('Not Found');

--- a/test-e2e/uniqueness-in-db/award-ceremonies-api.test.js
+++ b/test-e2e/uniqueness-in-db/award-ceremonies-api.test.js
@@ -60,7 +60,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 			expect(await countNodesWithLabel('Award')).to.equal(0);
 
 			const response = await chai.request(app)
-				.put(`/awards/ceremonies/${TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID}`)
+				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2020',
 					award: {
@@ -79,7 +79,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 			expect(await countNodesWithLabel('Award')).to.equal(1);
 
 			const response = await chai.request(app)
-				.put(`/awards/ceremonies/${TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID}`)
+				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2020',
 					award: {
@@ -99,7 +99,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 			expect(await countNodesWithLabel('Award')).to.equal(2);
 
 			const response = await chai.request(app)
-				.put(`/awards/ceremonies/${TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID}`)
+				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2020',
 					award: {
@@ -118,7 +118,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 			expect(await countNodesWithLabel('Award')).to.equal(2);
 
 			const response = await chai.request(app)
-				.put(`/awards/ceremonies/${TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID}`)
+				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2020',
 					award: {
@@ -180,7 +180,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 			expect(await countNodesWithLabel('Person')).to.equal(0);
 
 			const response = await chai.request(app)
-				.put(`/awards/ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
+				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2010',
 					categories: [
@@ -210,7 +210,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 			expect(await countNodesWithLabel('Person')).to.equal(1);
 
 			const response = await chai.request(app)
-				.put(`/awards/ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
+				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2010',
 					categories: [
@@ -241,7 +241,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 			expect(await countNodesWithLabel('Person')).to.equal(2);
 
 			const response = await chai.request(app)
-				.put(`/awards/ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
+				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2010',
 					categories: [
@@ -271,7 +271,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 			expect(await countNodesWithLabel('Person')).to.equal(2);
 
 			const response = await chai.request(app)
-				.put(`/awards/ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
+				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2010',
 					categories: [
@@ -360,7 +360,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 			expect(await countNodesWithLabel('Company')).to.equal(0);
 
 			const response = await chai.request(app)
-				.put(`/awards/ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
+				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2010',
 					categories: [
@@ -391,7 +391,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 			expect(await countNodesWithLabel('Company')).to.equal(1);
 
 			const response = await chai.request(app)
-				.put(`/awards/ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
+				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2010',
 					categories: [
@@ -423,7 +423,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 			expect(await countNodesWithLabel('Company')).to.equal(2);
 
 			const response = await chai.request(app)
-				.put(`/awards/ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
+				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2010',
 					categories: [
@@ -454,7 +454,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 			expect(await countNodesWithLabel('Company')).to.equal(2);
 
 			const response = await chai.request(app)
-				.put(`/awards/ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
+				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2010',
 					categories: [
@@ -528,7 +528,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 			expect(await countNodesWithLabel('Person')).to.equal(0);
 
 			const response = await chai.request(app)
-				.put(`/awards/ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
+				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2010',
 					categories: [
@@ -564,7 +564,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 			expect(await countNodesWithLabel('Person')).to.equal(1);
 
 			const response = await chai.request(app)
-				.put(`/awards/ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
+				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2010',
 					categories: [
@@ -601,7 +601,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 			expect(await countNodesWithLabel('Person')).to.equal(2);
 
 			const response = await chai.request(app)
-				.put(`/awards/ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
+				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2010',
 					categories: [
@@ -637,7 +637,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 			expect(await countNodesWithLabel('Person')).to.equal(2);
 
 			const response = await chai.request(app)
-				.put(`/awards/ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
+				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2010',
 					categories: [


### PR DESCRIPTION
This PR changes award ceremony endpoints as to:

#### Before:
`/awards/ceremonies`

#### After:
`/award-ceremonies`

The current endpoint format expresses ceremonies as a nested resource of awards, but given that award ceremonies have their own distinct UUID and do not need to rely on the UUID of the associated award (e.g. `awards/{awardUuid}/ceremonies/{ceremonyUuid}`), it seems far more straightforward for ceremonies to have their own distinct path.

This path also reflects the naming currently used for this resource, which is "award (singular) ceremony" rather than "award**s** (plural) ceremony".

#### Future consideration

This PR is concerned solely with the format of the endpoints, though the resource may be renamed to "award**s** (plural) ceremony" in the future - see below reference which argues well that "awards ceremony" may well be the better name in the context of this app: theatre awards generally present different categories, and while there are some awards that only have a single category (e.g. George Devine Award for Most Promising Playwright), in keeping with the coding convention of naming arrays, even if the array only includes one item then a plural name is nevertheless used because it has the _capacity_ to include more than one item; similarly an award(s) ceremony has the capacity to include more than one category.

On the flip side, using the name "award (singular) ceremony" makes the associated class/variable/file names clearer as to when they are a singular or plural instance, e.g. AwardsCeremony has an element of plurality, while AwardCeremony is unequivocal that it is a single instance.

### References:
- [Quora: Which one is correct "the award ceremony" or "the awards ceremony"?](https://www.quora.com/Which-one-is-correct-the-award-ceremony-or-the-awards-ceremony)
  - > Both are correct. Precision depends on the occasion of use.
    >
    > The Award Ceremony is used when we are talking about one award or a singular category. For instance, graduation award ceremony, where a single type of award is given to every graduating student.
    >
    > The Awards Ceremony can be used when there are multiple awards to various people, and different categories are involved.
    >
    > Although this isn't the onl...