### PR TITLE
Add production sub-sub-productions

### DIFF
--- a/src/neo4j/cypher-queries/award-ceremony/show.js
+++ b/src/neo4j/cypher-queries/award-ceremony/show.js
@@ -18,6 +18,8 @@ export default () => [`
 
 	OPTIONAL MATCH (nominee:Production)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
+	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+
 	OPTIONAL MATCH (nominee:Material)<-[:HAS_SUB_MATERIAL]-(surMaterial:Material)
 
 	OPTIONAL MATCH (surMaterial)<-[:HAS_SUB_MATERIAL]-(surSurMaterial:Material)
@@ -42,6 +44,7 @@ export default () => [`
 		venue,
 		surVenue,
 		surProduction,
+		surSurProduction,
 		surMaterial,
 		surSurMaterial,
 		entityRel,
@@ -62,6 +65,7 @@ export default () => [`
 		venue,
 		surVenue,
 		surProduction,
+		surSurProduction,
 		surMaterial,
 		surSurMaterial,
 		entityRel,
@@ -86,6 +90,7 @@ export default () => [`
 		venue,
 		surVenue,
 		surProduction,
+		surSurProduction,
 		surMaterial,
 		surSurMaterial,
 		entityRel,
@@ -114,6 +119,7 @@ export default () => [`
 		venue,
 		surVenue,
 		surProduction,
+		surSurProduction,
 		surMaterial,
 		surSurMaterial,
 		entityRel.credit AS writingCreditName,
@@ -153,6 +159,7 @@ export default () => [`
 		venue,
 		surVenue,
 		surProduction,
+		surSurProduction,
 		surMaterial,
 		surSurMaterial,
 		writingCreditName,
@@ -171,6 +178,7 @@ export default () => [`
 		venue,
 		surVenue,
 		surProduction,
+		surSurProduction,
 		CASE surMaterial WHEN NULL
 			THEN null
 			ELSE surMaterial {
@@ -216,7 +224,15 @@ export default () => [`
 			END,
 			surProduction: CASE surProduction WHEN NULL
 				THEN null
-				ELSE surProduction { model: 'PRODUCTION', .uuid, .name }
+				ELSE surProduction {
+					model: 'PRODUCTION',
+					.uuid,
+					.name,
+					surProduction: CASE surSurProduction WHEN NULL
+						THEN null
+						ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+					END
+				}
 			END,
 			.format,
 			.year,

--- a/src/neo4j/cypher-queries/character/show/show-productions.js
+++ b/src/neo4j/cypher-queries/character/show/show-productions.js
@@ -53,12 +53,15 @@ export default () => `
 
 	OPTIONAL MATCH (production)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
+	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+
 	WITH
 		variantNamedPortrayals,
 		production,
 		venue,
 		surVenue,
 		surProduction,
+		surSurProduction,
 		person,
 		role,
 		otherRole,
@@ -71,6 +74,7 @@ export default () => `
 		venue,
 		surVenue,
 		surProduction,
+		surSurProduction,
 		person,
 		role,
 		COLLECT(DISTINCT(
@@ -93,6 +97,7 @@ export default () => `
 		venue,
 		surVenue,
 		surProduction,
+		surSurProduction,
 		COLLECT(person {
 			model: 'PERSON',
 			.uuid,
@@ -129,7 +134,15 @@ export default () => `
 					END,
 					surProduction: CASE surProduction WHEN NULL
 						THEN null
-						ELSE surProduction { model: 'PRODUCTION', .uuid, .name }
+						ELSE surProduction {
+							model: 'PRODUCTION',
+							.uuid,
+							.name,
+							surProduction: CASE surSurProduction WHEN NULL
+								THEN null
+								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+							END
+						}
 					END,
 					performers
 				}

--- a/src/neo4j/cypher-queries/company/show/show-awards-rights-grantor-material.js
+++ b/src/neo4j/cypher-queries/company/show/show-awards-rights-grantor-material.js
@@ -135,6 +135,8 @@ export default () => `
 
 	OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
+	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+
 	WITH
 		nominatedRightsGrantorMaterial,
 		nominatedRightsGrantorSurMaterial,
@@ -149,7 +151,8 @@ export default () => `
 		nominatedProduction,
 		venue,
 		surVenue,
-		surProduction
+		surProduction,
+		surSurProduction
 		ORDER BY nominatedProductionRel.productionPosition
 
 	WITH
@@ -185,7 +188,15 @@ export default () => `
 					END,
 					surProduction: CASE surProduction WHEN NULL
 						THEN null
-						ELSE surProduction { model: 'PRODUCTION', .uuid, .name }
+						ELSE surProduction {
+							model: 'PRODUCTION',
+							.uuid,
+							.name,
+							surProduction: CASE surSurProduction WHEN NULL
+								THEN null
+								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+							END
+						}
 					END
 				}
 			END

--- a/src/neo4j/cypher-queries/company/show/show-awards-sourcing-material.js
+++ b/src/neo4j/cypher-queries/company/show/show-awards-sourcing-material.js
@@ -137,6 +137,8 @@ export default () => `
 
 	OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
+	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+
 	WITH
 		nominatedSourcingMaterial,
 		nominatedSourcingSurMaterial,
@@ -151,7 +153,8 @@ export default () => `
 		nominatedProduction,
 		venue,
 		surVenue,
-		surProduction
+		surProduction,
+		surSurProduction
 		ORDER BY nominatedProductionRel.productionPosition
 
 	WITH
@@ -187,7 +190,15 @@ export default () => `
 					END,
 					surProduction: CASE surProduction WHEN NULL
 						THEN null
-						ELSE surProduction { model: 'PRODUCTION', .uuid, .name }
+						ELSE surProduction {
+							model: 'PRODUCTION',
+							.uuid,
+							.name,
+							surProduction: CASE surSurProduction WHEN NULL
+								THEN null
+								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+							END
+						}
 					END
 				}
 			END

--- a/src/neo4j/cypher-queries/company/show/show-awards-subsequent-version-material.js
+++ b/src/neo4j/cypher-queries/company/show/show-awards-subsequent-version-material.js
@@ -136,6 +136,8 @@ export default () => `
 
 	OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
+	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+
 	WITH
 		nominatedSubsequentVersionMaterial,
 		nominatedSubsequentVersionSurMaterial,
@@ -150,7 +152,8 @@ export default () => `
 		nominatedProduction,
 		venue,
 		surVenue,
-		surProduction
+		surProduction,
+		surSurProduction
 		ORDER BY nominatedProductionRel.productionPosition
 
 	WITH
@@ -186,7 +189,15 @@ export default () => `
 					END,
 					surProduction: CASE surProduction WHEN NULL
 						THEN null
-						ELSE surProduction { model: 'PRODUCTION', .uuid, .name }
+						ELSE surProduction {
+							model: 'PRODUCTION',
+							.uuid,
+							.name,
+							surProduction: CASE surSurProduction WHEN NULL
+								THEN null
+								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+							END
+						}
 					END
 				}
 			END

--- a/src/neo4j/cypher-queries/company/show/show-awards.js
+++ b/src/neo4j/cypher-queries/company/show/show-awards.js
@@ -131,6 +131,8 @@ export default () => `
 
 	OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
+	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+
 	WITH
 		nomineeRel,
 		category,
@@ -143,7 +145,8 @@ export default () => `
 		nominatedProduction,
 		venue,
 		surVenue,
-		surProduction
+		surProduction,
+		surSurProduction
 		ORDER BY nominatedProductionRel.productionPosition
 
 	WITH
@@ -177,7 +180,15 @@ export default () => `
 					END,
 					surProduction: CASE surProduction WHEN NULL
 						THEN null
-						ELSE surProduction { model: 'PRODUCTION', .uuid, .name }
+						ELSE surProduction {
+							model: 'PRODUCTION',
+							.uuid,
+							.name,
+							surProduction: CASE surSurProduction WHEN NULL
+								THEN null
+								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+							END
+						}
 					END
 				}
 			END

--- a/src/neo4j/cypher-queries/company/show/show-productions.js
+++ b/src/neo4j/cypher-queries/company/show/show-productions.js
@@ -62,7 +62,9 @@ export default () => `
 
 	OPTIONAL MATCH (production)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
-	WITH company, production, producerCredits, venue, surVenue, surProduction
+	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+
+	WITH company, production, producerCredits, venue, surVenue, surProduction, surSurProduction
 		ORDER BY production.startDate DESC, production.name, venue.name
 
 	WITH company,
@@ -89,7 +91,15 @@ export default () => `
 					END,
 					surProduction: CASE surProduction WHEN NULL
 						THEN null
-						ELSE surProduction { model: 'PRODUCTION', .uuid, .name }
+						ELSE surProduction {
+							model: 'PRODUCTION',
+							.uuid,
+							.name,
+							surProduction: CASE surSurProduction WHEN NULL
+								THEN null
+								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+							END
+						}
 					END,
 					producerCredits
 				}
@@ -183,7 +193,9 @@ export default () => `
 
 	OPTIONAL MATCH (production)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
-	WITH company, producerProductions, production, venue, surVenue, surProduction,
+	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+
+	WITH company, producerProductions, production, venue, surVenue, surProduction, surSurProduction,
 		COLLECT({
 			model: 'CREATIVE_CREDIT',
 			name: creativeRel.credit,
@@ -216,7 +228,15 @@ export default () => `
 					END,
 					surProduction: CASE surProduction WHEN NULL
 						THEN null
-						ELSE surProduction { model: 'PRODUCTION', .uuid, .name }
+						ELSE surProduction {
+							model: 'PRODUCTION',
+							.uuid,
+							.name,
+							surProduction: CASE surSurProduction WHEN NULL
+								THEN null
+								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+							END
+						}
 					END,
 					creativeCredits
 				}
@@ -310,7 +330,9 @@ export default () => `
 
 	OPTIONAL MATCH (production)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
-	WITH producerProductions, creativeProductions, production, venue, surVenue, surProduction,
+	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+
+	WITH producerProductions, creativeProductions, production, venue, surVenue, surProduction, surSurProduction,
 		COLLECT({
 			model: 'CREW_CREDIT',
 			name: crewRel.credit,
@@ -345,7 +367,15 @@ export default () => `
 					END,
 					surProduction: CASE surProduction WHEN NULL
 						THEN null
-						ELSE surProduction { model: 'PRODUCTION', .uuid, .name }
+						ELSE surProduction {
+							model: 'PRODUCTION',
+							.uuid,
+							.name,
+							surProduction: CASE surSurProduction WHEN NULL
+								THEN null
+								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+							END
+						}
 					END,
 					crewCredits
 				}

--- a/src/neo4j/cypher-queries/material/show/show-awards-sourcing-material.js
+++ b/src/neo4j/cypher-queries/material/show/show-awards-sourcing-material.js
@@ -140,6 +140,8 @@ export default () => `
 
 	OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
+	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+
 	WITH
 		material,
 		nominatedSourcingMaterial,
@@ -155,7 +157,8 @@ export default () => `
 		nominatedProduction,
 		venue,
 		surVenue,
-		surProduction
+		surProduction,
+		surSurProduction
 		ORDER BY nominatedProductionRel.productionPosition
 
 	WITH
@@ -192,7 +195,15 @@ export default () => `
 					END,
 					surProduction: CASE surProduction WHEN NULL
 						THEN null
-						ELSE surProduction { model: 'PRODUCTION', .uuid, .name }
+						ELSE surProduction {
+							model: 'PRODUCTION',
+							.uuid,
+							.name,
+							surProduction: CASE surSurProduction WHEN NULL
+								THEN null
+								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+							END
+						}
 					END
 				}
 			END

--- a/src/neo4j/cypher-queries/material/show/show-awards-subsequent-version-material.js
+++ b/src/neo4j/cypher-queries/material/show/show-awards-subsequent-version-material.js
@@ -142,6 +142,8 @@ export default () => `
 
 	OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
+	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+
 	WITH
 		material,
 		nominatedSubsequentVersionMaterial,
@@ -157,7 +159,8 @@ export default () => `
 		nominatedProduction,
 		venue,
 		surVenue,
-		surProduction
+		surProduction,
+		surSurProduction
 		ORDER BY nominatedProductionRel.productionPosition
 
 	WITH
@@ -194,7 +197,15 @@ export default () => `
 					END,
 					surProduction: CASE surProduction WHEN NULL
 						THEN null
-						ELSE surProduction { model: 'PRODUCTION', .uuid, .name }
+						ELSE surProduction {
+							model: 'PRODUCTION',
+							.uuid,
+							.name,
+							surProduction: CASE surSurProduction WHEN NULL
+								THEN null
+								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+							END
+						}
 					END
 				}
 			END

--- a/src/neo4j/cypher-queries/material/show/show-awards.js
+++ b/src/neo4j/cypher-queries/material/show/show-awards.js
@@ -126,6 +126,8 @@ export default () => `
 
 	OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
+	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+
 	WITH
 		material,
 		recipientMaterial,
@@ -139,7 +141,8 @@ export default () => `
 		nominatedProduction,
 		venue,
 		surVenue,
-		surProduction
+		surProduction,
+		surSurProduction
 		ORDER BY nominatedProductionRel.productionPosition
 
 	WITH
@@ -174,7 +177,15 @@ export default () => `
 					END,
 					surProduction: CASE surProduction WHEN NULL
 						THEN null
-						ELSE surProduction { model: 'PRODUCTION', .uuid, .name }
+						ELSE surProduction {
+							model: 'PRODUCTION',
+							.uuid,
+							.name,
+							surProduction: CASE surSurProduction WHEN NULL
+								THEN null
+								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+							END
+						}
 					END
 				}
 			END

--- a/src/neo4j/cypher-queries/material/show/show-productions.js
+++ b/src/neo4j/cypher-queries/material/show/show-productions.js
@@ -13,6 +13,8 @@ export default () => `
 
 		OPTIONAL MATCH (production)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
+		OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+
 		OPTIONAL MATCH (material)<-[:USES_SOURCE_MATERIAL]-(:Material)<-[sourcingMaterialRel:PRODUCTION_OF]-(production)
 
 		WITH
@@ -20,6 +22,7 @@ export default () => `
 			venue,
 			surVenue,
 			surProduction,
+			surSurProduction,
 			CASE sourcingMaterialRel WHEN NULL THEN false ELSE true END AS usesSourcingMaterial
 			ORDER BY production.startDate DESC, production.name, venue.name
 
@@ -48,7 +51,15 @@ export default () => `
 						END,
 						surProduction: CASE surProduction WHEN NULL
 							THEN null
-							ELSE surProduction { model: 'PRODUCTION', .uuid, .name }
+							ELSE surProduction {
+								model: 'PRODUCTION',
+								.uuid,
+								.name,
+								surProduction: CASE surSurProduction WHEN NULL
+									THEN null
+									ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+								END
+							}
 						END
 					}
 				END

--- a/src/neo4j/cypher-queries/person/show/show-awards-rights-grantor-material.js
+++ b/src/neo4j/cypher-queries/person/show/show-awards-rights-grantor-material.js
@@ -135,6 +135,8 @@ export default () => `
 
 	OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
+	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+
 	WITH
 		nominatedRightsGrantorMaterial,
 		nominatedRightsGrantorSurMaterial,
@@ -149,7 +151,8 @@ export default () => `
 		nominatedProduction,
 		venue,
 		surVenue,
-		surProduction
+		surProduction,
+		surSurProduction
 		ORDER BY nominatedProductionRel.productionPosition
 
 	WITH
@@ -185,7 +188,15 @@ export default () => `
 					END,
 					surProduction: CASE surProduction WHEN NULL
 						THEN null
-						ELSE surProduction { model: 'PRODUCTION', .uuid, .name }
+						ELSE surProduction {
+							model: 'PRODUCTION',
+							.uuid,
+							.name,
+							surProduction: CASE surSurProduction WHEN NULL
+								THEN null
+								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+							END
+						}
 					END
 				}
 			END

--- a/src/neo4j/cypher-queries/person/show/show-awards-sourcing-material.js
+++ b/src/neo4j/cypher-queries/person/show/show-awards-sourcing-material.js
@@ -137,6 +137,8 @@ export default () => `
 
 	OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
+	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+
 	WITH
 		nominatedSourcingMaterial,
 		nominatedSourcingSurMaterial,
@@ -151,7 +153,8 @@ export default () => `
 		nominatedProduction,
 		venue,
 		surVenue,
-		surProduction
+		surProduction,
+		surSurProduction
 		ORDER BY nominatedProductionRel.productionPosition
 
 	WITH
@@ -187,7 +190,15 @@ export default () => `
 					END,
 					surProduction: CASE surProduction WHEN NULL
 						THEN null
-						ELSE surProduction { model: 'PRODUCTION', .uuid, .name }
+						ELSE surProduction {
+							model: 'PRODUCTION',
+							.uuid,
+							.name,
+							surProduction: CASE surSurProduction WHEN NULL
+								THEN null
+								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+							END
+						}
 					END
 				}
 			END

--- a/src/neo4j/cypher-queries/person/show/show-awards-subsequent-version-material.js
+++ b/src/neo4j/cypher-queries/person/show/show-awards-subsequent-version-material.js
@@ -136,6 +136,8 @@ export default () => `
 
 	OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
+	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+
 	WITH
 		nominatedSubsequentVersionMaterial,
 		nominatedSubsequentVersionSurMaterial,
@@ -150,7 +152,8 @@ export default () => `
 		nominatedProduction,
 		venue,
 		surVenue,
-		surProduction
+		surProduction,
+		surSurProduction
 		ORDER BY nominatedProductionRel.productionPosition
 
 	WITH
@@ -186,7 +189,15 @@ export default () => `
 					END,
 					surProduction: CASE surProduction WHEN NULL
 						THEN null
-						ELSE surProduction { model: 'PRODUCTION', .uuid, .name }
+						ELSE surProduction {
+							model: 'PRODUCTION',
+							.uuid,
+							.name,
+							surProduction: CASE surSurProduction WHEN NULL
+								THEN null
+								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+							END
+						}
 					END
 				}
 			END

--- a/src/neo4j/cypher-queries/person/show/show-awards.js
+++ b/src/neo4j/cypher-queries/person/show/show-awards.js
@@ -163,6 +163,8 @@ export default () => `
 
 	OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
+	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+
 	WITH
 		entityRel,
 		nominatedEmployerCompany,
@@ -175,7 +177,8 @@ export default () => `
 		nominatedProduction,
 		venue,
 		surVenue,
-		surProduction
+		surProduction,
+		surSurProduction
 		ORDER BY nominatedProductionRel.productionPosition
 
 	WITH
@@ -209,7 +212,15 @@ export default () => `
 					END,
 					surProduction: CASE surProduction WHEN NULL
 						THEN null
-						ELSE surProduction { model: 'PRODUCTION', .uuid, .name }
+						ELSE surProduction {
+							model: 'PRODUCTION',
+							.uuid,
+							.name,
+							surProduction: CASE surSurProduction WHEN NULL
+								THEN null
+								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+							END
+						}
 					END
 				}
 			END

--- a/src/neo4j/cypher-queries/person/show/show-productions.js
+++ b/src/neo4j/cypher-queries/person/show/show-productions.js
@@ -58,7 +58,9 @@ export default () => `
 
 	OPTIONAL MATCH (production)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
-	WITH person, production, producerCredits, venue, surVenue, surProduction
+	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+
+	WITH person, production, producerCredits, venue, surVenue, surProduction, surSurProduction
 		ORDER BY production.startDate DESC, production.name, venue.name
 
 	WITH person,
@@ -85,7 +87,15 @@ export default () => `
 					END,
 					surProduction: CASE surProduction WHEN NULL
 						THEN null
-						ELSE surProduction { model: 'PRODUCTION', .uuid, .name }
+						ELSE surProduction {
+							model: 'PRODUCTION',
+							.uuid,
+							.name,
+							surProduction: CASE surSurProduction WHEN NULL
+								THEN null
+								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+							END
+						}
 					END,
 					producerCredits
 				}
@@ -100,6 +110,8 @@ export default () => `
 
 	OPTIONAL MATCH (production)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
+	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+
 	OPTIONAL MATCH (production)-[:PRODUCTION_OF]->(:Material)-[characterRel:DEPICTS]->(character:Character)
 		WHERE
 			(
@@ -108,10 +120,19 @@ export default () => `
 			) AND
 			(role.characterDifferentiator IS NULL OR role.characterDifferentiator = character.differentiator)
 
-	WITH DISTINCT person, producerProductions, production, venue, surVenue, surProduction, role, character
+	WITH DISTINCT
+		person,
+		producerProductions,
+		production,
+		venue,
+		surVenue,
+		surProduction,
+		surSurProduction,
+		role,
+		character
 		ORDER BY role.rolePosition
 
-	WITH person, producerProductions, production, venue, surVenue, surProduction,
+	WITH person, producerProductions, production, venue, surVenue, surProduction, surSurProduction,
 		COLLECT(
 			CASE role.roleName WHEN NULL
 				THEN { name: 'Performer' }
@@ -150,7 +171,15 @@ export default () => `
 					END,
 					surProduction: CASE surProduction WHEN NULL
 						THEN null
-						ELSE surProduction { model: 'PRODUCTION', .uuid, .name }
+						ELSE surProduction {
+							model: 'PRODUCTION',
+							.uuid,
+							.name,
+							surProduction: CASE surSurProduction WHEN NULL
+								THEN null
+								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+							END
+						}
 					END,
 					roles
 				}
@@ -299,7 +328,17 @@ export default () => `
 
 	OPTIONAL MATCH (production)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
-	WITH person, producerProductions, castMemberProductions, production, venue, surVenue, surProduction,
+	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+
+	WITH
+		person,
+		producerProductions,
+		castMemberProductions,
+		production,
+		venue,
+		surVenue,
+		surProduction,
+		surSurProduction,
 		COLLECT({
 			model: 'CREATIVE_CREDIT',
 			name: entityRel.credit,
@@ -332,7 +371,15 @@ export default () => `
 					END,
 					surProduction: CASE surProduction WHEN NULL
 						THEN null
-						ELSE surProduction { model: 'PRODUCTION', .uuid, .name }
+						ELSE surProduction {
+							model: 'PRODUCTION',
+							.uuid,
+							.name,
+							surProduction: CASE surSurProduction WHEN NULL
+								THEN null
+								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+							END
+						}
 					END,
 					creativeCredits
 				}
@@ -484,6 +531,8 @@ export default () => `
 
 	OPTIONAL MATCH (production)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
+	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+
 	WITH
 		producerProductions,
 		castMemberProductions,
@@ -492,6 +541,7 @@ export default () => `
 		venue,
 		surVenue,
 		surProduction,
+		surSurProduction,
 		COLLECT({
 			model: 'CREW_CREDIT',
 			name: entityRel.credit,
@@ -527,7 +577,15 @@ export default () => `
 					END,
 					surProduction: CASE surProduction WHEN NULL
 						THEN null
-						ELSE surProduction { model: 'PRODUCTION', .uuid, .name }
+						ELSE surProduction {
+							model: 'PRODUCTION',
+							.uuid,
+							.name,
+							surProduction: CASE surSurProduction WHEN NULL
+								THEN null
+								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+							END
+						}
 					END,
 					crewCredits
 				}

--- a/src/neo4j/cypher-queries/production/list.js
+++ b/src/neo4j/cypher-queries/production/list.js
@@ -8,6 +8,8 @@ export default () => `
 
 	OPTIONAL MATCH (production)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
+	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+
 	RETURN
 		'PRODUCTION' AS model,
 		production.uuid AS uuid,
@@ -28,7 +30,15 @@ export default () => `
 		END AS venue,
 		CASE surProduction WHEN NULL
 			THEN null
-			ELSE surProduction { model: 'PRODUCTION', .uuid, .name }
+			ELSE surProduction {
+				model: 'PRODUCTION',
+				.uuid,
+				.name,
+				surProduction: CASE surSurProduction WHEN NULL
+					THEN null
+					ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+				END
+			}
 		END AS surProduction
 
 	ORDER BY production.startDate DESC, production.name, venue.name

--- a/src/neo4j/cypher-queries/venue/show.js
+++ b/src/neo4j/cypher-queries/venue/show.js
@@ -30,13 +30,16 @@ export default () => [`
 
 	OPTIONAL MATCH (production)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
+	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+
 	WITH
 		venue,
 		surVenue,
 		subVenues,
 		venueLinkedToProduction,
 		production,
-		surProduction
+		surProduction,
+		surSurProduction
 		ORDER BY production.startDate DESC, production.name
 
 	RETURN
@@ -61,7 +64,15 @@ export default () => [`
 					END,
 					surProduction: CASE surProduction WHEN NULL
 						THEN null
-						ELSE surProduction { model: 'PRODUCTION', .uuid, .name }
+						ELSE surProduction {
+							model: 'PRODUCTION',
+							.uuid,
+							.name,
+							surProduction: CASE surSurProduction WHEN NULL
+								THEN null
+								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+							END
+						}
 					END
 				}
 			END

--- a/test-e2e/crud/productions-api.test.js
+++ b/test-e2e/crud/productions-api.test.js
@@ -1635,7 +1635,8 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 						name: 'Hamlet sub-material #1',
 						startDate: null,
 						endDate: null,
-						venue: null
+						venue: null,
+						subProductions: []
 					},
 					{
 						model: 'PRODUCTION',
@@ -1643,7 +1644,8 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 						name: 'Hamlet sub-material #2',
 						startDate: null,
 						endDate: null,
-						venue: null
+						venue: null,
+						subProductions: []
 					},
 					{
 						model: 'PRODUCTION',
@@ -1651,7 +1653,8 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 						name: 'Hamlet sub-material #3',
 						startDate: null,
 						endDate: null,
-						venue: null
+						venue: null,
+						subProductions: []
 					}
 				],
 				producerCredits: [
@@ -3624,7 +3627,8 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 						name: 'Richard III sub-material #1',
 						startDate: null,
 						endDate: null,
-						venue: null
+						venue: null,
+						subProductions: []
 					},
 					{
 						model: 'PRODUCTION',
@@ -3632,7 +3636,8 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 						name: 'Richard III sub-material #2',
 						startDate: null,
 						endDate: null,
-						venue: null
+						venue: null,
+						subProductions: []
 					},
 					{
 						model: 'PRODUCTION',
@@ -3640,7 +3645,8 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 						name: 'Richard III sub-material #3',
 						startDate: null,
 						endDate: null,
-						venue: null
+						venue: null,
+						subProductions: []
 					}
 				],
 				producerCredits: [

--- a/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-materials.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-materials.test.js
@@ -938,7 +938,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 									surProduction: {
 										model: 'PRODUCTION',
 										uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
-										name: 'Sur-Fred'
+										name: 'Sur-Fred',
+										surProduction: null
 									}
 								},
 								{
@@ -956,7 +957,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 									surProduction: {
 										model: 'PRODUCTION',
 										uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
-										name: 'Sur-Fred'
+										name: 'Sur-Fred',
+										surProduction: null
 									}
 								}
 							],
@@ -1019,7 +1021,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 									surProduction: {
 										model: 'PRODUCTION',
 										uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
-										name: 'Sur-Plugh'
+										name: 'Sur-Plugh',
+										surProduction: null
 									}
 								},
 								{
@@ -1037,7 +1040,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 									surProduction: {
 										model: 'PRODUCTION',
 										uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
-										name: 'Sur-Plugh'
+										name: 'Sur-Plugh',
+										surProduction: null
 									}
 								}
 							],
@@ -1116,7 +1120,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 									surProduction: {
 										model: 'PRODUCTION',
 										uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-										name: 'Sur-Wibble'
+										name: 'Sur-Wibble',
+										surProduction: null
 									}
 								},
 								{
@@ -1134,7 +1139,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 									surProduction: {
 										model: 'PRODUCTION',
 										uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-										name: 'Sur-Wibble'
+										name: 'Sur-Wibble',
+										surProduction: null
 									}
 								}
 							],
@@ -1234,7 +1240,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 									surProduction: {
 										model: 'PRODUCTION',
 										uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
-										name: 'Sur-Hoge'
+										name: 'Sur-Hoge',
+										surProduction: null
 									}
 								},
 								{
@@ -1252,7 +1259,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 									surProduction: {
 										model: 'PRODUCTION',
 										uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-										name: 'Sur-Hoge'
+										name: 'Sur-Hoge',
+										surProduction: null
 									}
 								}
 							],
@@ -1791,7 +1799,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
-														name: 'Sur-Fred'
+														name: 'Sur-Fred',
+														surProduction: null
 													}
 												},
 												{
@@ -1809,7 +1818,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Sur-Fred'
+														name: 'Sur-Fred',
+														surProduction: null
 													}
 												}
 											],
@@ -1961,7 +1971,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
-														name: 'Sur-Fred'
+														name: 'Sur-Fred',
+														surProduction: null
 													}
 												},
 												{
@@ -1979,7 +1990,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Sur-Fred'
+														name: 'Sur-Fred',
+														surProduction: null
 													}
 												}
 											],
@@ -2130,7 +2142,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
-														name: 'Sur-Plugh'
+														name: 'Sur-Plugh',
+														surProduction: null
 													}
 												},
 												{
@@ -2148,7 +2161,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
-														name: 'Sur-Plugh'
+														name: 'Sur-Plugh',
+														surProduction: null
 													}
 												}
 											],
@@ -2300,7 +2314,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
-														name: 'Sur-Plugh'
+														name: 'Sur-Plugh',
+														surProduction: null
 													}
 												},
 												{
@@ -2318,7 +2333,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
-														name: 'Sur-Plugh'
+														name: 'Sur-Plugh',
+														surProduction: null
 													}
 												}
 											],
@@ -2472,7 +2488,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
-														name: 'Sur-Plugh'
+														name: 'Sur-Plugh',
+														surProduction: null
 													}
 												},
 												{
@@ -2490,7 +2507,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
-														name: 'Sur-Plugh'
+														name: 'Sur-Plugh',
+														surProduction: null
 													}
 												}
 											],
@@ -2645,7 +2663,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
-														name: 'Sur-Plugh'
+														name: 'Sur-Plugh',
+														surProduction: null
 													}
 												},
 												{
@@ -2663,7 +2682,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
-														name: 'Sur-Plugh'
+														name: 'Sur-Plugh',
+														surProduction: null
 													}
 												}
 											],
@@ -2816,7 +2836,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												},
 												{
@@ -2834,7 +2855,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												}
 											],
@@ -2986,7 +3008,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												},
 												{
@@ -3004,7 +3027,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												}
 											],
@@ -3156,7 +3180,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												},
 												{
@@ -3174,7 +3199,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												}
 											],
@@ -3326,7 +3352,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												},
 												{
@@ -3344,7 +3371,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												}
 											],
@@ -3498,7 +3526,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
-														name: 'Sur-Hoge'
+														name: 'Sur-Hoge',
+														surProduction: null
 													}
 												},
 												{
@@ -3516,7 +3545,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Sur-Hoge'
+														name: 'Sur-Hoge',
+														surProduction: null
 													}
 												}
 											],
@@ -3671,7 +3701,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
-														name: 'Sur-Hoge'
+														name: 'Sur-Hoge',
+														surProduction: null
 													}
 												},
 												{
@@ -3689,7 +3720,8 @@ describe('Award ceremonies with crediting sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Sur-Hoge'
+														name: 'Sur-Hoge',
+														surProduction: null
 													}
 												}
 											],

--- a/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-sub-materials.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-sub-materials.test.js
@@ -1370,7 +1370,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 									surProduction: {
 										model: 'PRODUCTION',
 										uuid: MID_FRED_LYTTELTON_PRODUCTION_UUID,
-										name: 'Mid-Fred'
+										name: 'Mid-Fred',
+										surProduction: {
+											model: 'PRODUCTION',
+											uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
+											name: 'Sur-Fred'
+										}
 									}
 								},
 								{
@@ -1388,7 +1393,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 									surProduction: {
 										model: 'PRODUCTION',
 										uuid: MID_FRED_NOËL_COWARD_PRODUCTION_UUID,
-										name: 'Mid-Fred'
+										name: 'Mid-Fred',
+										surProduction: {
+											model: 'PRODUCTION',
+											uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
+											name: 'Sur-Fred'
+										}
 									}
 								}
 							],
@@ -1455,7 +1465,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 									surProduction: {
 										model: 'PRODUCTION',
 										uuid: MID_PLUGH_OLIVIER_PRODUCTION_UUID,
-										name: 'Mid-Plugh'
+										name: 'Mid-Plugh',
+										surProduction: {
+											model: 'PRODUCTION',
+											uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+											name: 'Sur-Plugh'
+										}
 									}
 								},
 								{
@@ -1473,7 +1488,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 									surProduction: {
 										model: 'PRODUCTION',
 										uuid: MID_PLUGH_WYNDHAMS_PRODUCTION_UUID,
-										name: 'Mid-Plugh'
+										name: 'Mid-Plugh',
+										surProduction: {
+											model: 'PRODUCTION',
+											uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+											name: 'Sur-Plugh'
+										}
 									}
 								}
 							],
@@ -1556,7 +1576,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 									surProduction: {
 										model: 'PRODUCTION',
 										uuid: MID_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-										name: 'Mid-Wibble'
+										name: 'Mid-Wibble',
+										surProduction: {
+											model: 'PRODUCTION',
+											uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+											name: 'Sur-Wibble'
+										}
 									}
 								},
 								{
@@ -1574,7 +1599,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 									surProduction: {
 										model: 'PRODUCTION',
 										uuid: MID_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-										name: 'Mid-Wibble'
+										name: 'Mid-Wibble',
+										surProduction: {
+											model: 'PRODUCTION',
+											uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+											name: 'Sur-Wibble'
+										}
 									}
 								}
 							],
@@ -1682,7 +1712,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 									surProduction: {
 										model: 'PRODUCTION',
 										uuid: MID_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
-										name: 'Mid-Hoge'
+										name: 'Mid-Hoge',
+										surProduction: {
+											model: 'PRODUCTION',
+											uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+											name: 'Sur-Hoge'
+										}
 									}
 								},
 								{
@@ -1700,7 +1735,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 									surProduction: {
 										model: 'PRODUCTION',
 										uuid: MID_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-										name: 'Mid-Hoge'
+										name: 'Mid-Hoge',
+										surProduction: {
+											model: 'PRODUCTION',
+											uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+											name: 'Sur-Hoge'
+										}
 									}
 								}
 							],
@@ -2161,7 +2201,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 									surProduction: {
 										model: 'PRODUCTION',
 										uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
-										name: 'Sur-Fred'
+										name: 'Sur-Fred',
+										surProduction: null
 									}
 								},
 								{
@@ -2179,7 +2220,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 									surProduction: {
 										model: 'PRODUCTION',
 										uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
-										name: 'Sur-Fred'
+										name: 'Sur-Fred',
+										surProduction: null
 									}
 								}
 							],
@@ -2242,7 +2284,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 									surProduction: {
 										model: 'PRODUCTION',
 										uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
-										name: 'Sur-Plugh'
+										name: 'Sur-Plugh',
+										surProduction: null
 									}
 								},
 								{
@@ -2260,7 +2303,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 									surProduction: {
 										model: 'PRODUCTION',
 										uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
-										name: 'Sur-Plugh'
+										name: 'Sur-Plugh',
+										surProduction: null
 									}
 								}
 							],
@@ -2339,7 +2383,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 									surProduction: {
 										model: 'PRODUCTION',
 										uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-										name: 'Sur-Wibble'
+										name: 'Sur-Wibble',
+										surProduction: null
 									}
 								},
 								{
@@ -2357,7 +2402,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 									surProduction: {
 										model: 'PRODUCTION',
 										uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-										name: 'Sur-Wibble'
+										name: 'Sur-Wibble',
+										surProduction: null
 									}
 								}
 							],
@@ -2457,7 +2503,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 									surProduction: {
 										model: 'PRODUCTION',
 										uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
-										name: 'Sur-Hoge'
+										name: 'Sur-Hoge',
+										surProduction: null
 									}
 								},
 								{
@@ -2475,7 +2522,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 									surProduction: {
 										model: 'PRODUCTION',
 										uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-										name: 'Sur-Hoge'
+										name: 'Sur-Hoge',
+										surProduction: null
 									}
 								}
 							],
@@ -2586,7 +2634,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
-														name: 'Sur-Fred'
+														name: 'Sur-Fred',
+														surProduction: null
 													}
 												},
 												{
@@ -2604,7 +2653,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Sur-Fred'
+														name: 'Sur-Fred',
+														surProduction: null
 													}
 												}
 											],
@@ -2741,7 +2791,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_FRED_LYTTELTON_PRODUCTION_UUID,
-														name: 'Mid-Fred'
+														name: 'Mid-Fred',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
+															name: 'Sur-Fred'
+														}
 													}
 												},
 												{
@@ -2759,7 +2814,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_FRED_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Mid-Fred'
+														name: 'Mid-Fred',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
+															name: 'Sur-Fred'
+														}
 													}
 												}
 											],
@@ -2844,7 +2904,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
-														name: 'Sur-Fred'
+														name: 'Sur-Fred',
+														surProduction: null
 													}
 												},
 												{
@@ -2862,7 +2923,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Sur-Fred'
+														name: 'Sur-Fred',
+														surProduction: null
 													}
 												}
 											],
@@ -2999,7 +3061,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_FRED_LYTTELTON_PRODUCTION_UUID,
-														name: 'Mid-Fred'
+														name: 'Mid-Fred',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
+															name: 'Sur-Fred'
+														}
 													}
 												},
 												{
@@ -3017,7 +3084,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_FRED_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Mid-Fred'
+														name: 'Mid-Fred',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
+															name: 'Sur-Fred'
+														}
 													}
 												}
 											],
@@ -3101,7 +3173,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
-														name: 'Sur-Plugh'
+														name: 'Sur-Plugh',
+														surProduction: null
 													}
 												},
 												{
@@ -3119,7 +3192,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
-														name: 'Sur-Plugh'
+														name: 'Sur-Plugh',
+														surProduction: null
 													}
 												}
 											],
@@ -3256,7 +3330,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_PLUGH_OLIVIER_PRODUCTION_UUID,
-														name: 'Mid-Plugh'
+														name: 'Mid-Plugh',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+															name: 'Sur-Plugh'
+														}
 													}
 												},
 												{
@@ -3274,7 +3353,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_PLUGH_WYNDHAMS_PRODUCTION_UUID,
-														name: 'Mid-Plugh'
+														name: 'Mid-Plugh',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+															name: 'Sur-Plugh'
+														}
 													}
 												}
 											],
@@ -3359,7 +3443,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
-														name: 'Sur-Plugh'
+														name: 'Sur-Plugh',
+														surProduction: null
 													}
 												},
 												{
@@ -3377,7 +3462,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
-														name: 'Sur-Plugh'
+														name: 'Sur-Plugh',
+														surProduction: null
 													}
 												}
 											],
@@ -3514,7 +3600,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_PLUGH_OLIVIER_PRODUCTION_UUID,
-														name: 'Mid-Plugh'
+														name: 'Mid-Plugh',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+															name: 'Sur-Plugh'
+														}
 													}
 												},
 												{
@@ -3532,7 +3623,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_PLUGH_WYNDHAMS_PRODUCTION_UUID,
-														name: 'Mid-Plugh'
+														name: 'Mid-Plugh',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+															name: 'Sur-Plugh'
+														}
 													}
 												}
 											],
@@ -3617,7 +3713,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
-														name: 'Sur-Plugh'
+														name: 'Sur-Plugh',
+														surProduction: null
 													}
 												},
 												{
@@ -3635,7 +3732,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
-														name: 'Sur-Plugh'
+														name: 'Sur-Plugh',
+														surProduction: null
 													}
 												}
 											],
@@ -3772,7 +3870,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_PLUGH_OLIVIER_PRODUCTION_UUID,
-														name: 'Mid-Plugh'
+														name: 'Mid-Plugh',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+															name: 'Sur-Plugh'
+														}
 													}
 												},
 												{
@@ -3790,7 +3893,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_PLUGH_WYNDHAMS_PRODUCTION_UUID,
-														name: 'Mid-Plugh'
+														name: 'Mid-Plugh',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+															name: 'Sur-Plugh'
+														}
 													}
 												}
 											],
@@ -3877,7 +3985,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
-														name: 'Sur-Plugh'
+														name: 'Sur-Plugh',
+														surProduction: null
 													}
 												},
 												{
@@ -3895,7 +4004,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
-														name: 'Sur-Plugh'
+														name: 'Sur-Plugh',
+														surProduction: null
 													}
 												}
 											],
@@ -4032,7 +4142,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_PLUGH_OLIVIER_PRODUCTION_UUID,
-														name: 'Mid-Plugh'
+														name: 'Mid-Plugh',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+															name: 'Sur-Plugh'
+														}
 													}
 												},
 												{
@@ -4050,7 +4165,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_PLUGH_WYNDHAMS_PRODUCTION_UUID,
-														name: 'Mid-Plugh'
+														name: 'Mid-Plugh',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+															name: 'Sur-Plugh'
+														}
 													}
 												}
 											],
@@ -4138,7 +4258,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
-														name: 'Sur-Plugh'
+														name: 'Sur-Plugh',
+														surProduction: null
 													}
 												},
 												{
@@ -4156,7 +4277,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
-														name: 'Sur-Plugh'
+														name: 'Sur-Plugh',
+														surProduction: null
 													}
 												}
 											],
@@ -4293,7 +4415,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_PLUGH_OLIVIER_PRODUCTION_UUID,
-														name: 'Mid-Plugh'
+														name: 'Mid-Plugh',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+															name: 'Sur-Plugh'
+														}
 													}
 												},
 												{
@@ -4311,7 +4438,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_PLUGH_WYNDHAMS_PRODUCTION_UUID,
-														name: 'Mid-Plugh'
+														name: 'Mid-Plugh',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+															name: 'Sur-Plugh'
+														}
 													}
 												}
 											],
@@ -4397,7 +4529,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												},
 												{
@@ -4415,7 +4548,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												}
 											],
@@ -4552,7 +4686,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Mid-Wibble'
+														name: 'Mid-Wibble',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+															name: 'Sur-Wibble'
+														}
 													}
 												},
 												{
@@ -4570,7 +4709,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-														name: 'Mid-Wibble'
+														name: 'Mid-Wibble',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+															name: 'Sur-Wibble'
+														}
 													}
 												}
 											],
@@ -4655,7 +4799,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												},
 												{
@@ -4673,7 +4818,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												}
 											],
@@ -4810,7 +4956,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Mid-Wibble'
+														name: 'Mid-Wibble',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+															name: 'Sur-Wibble'
+														}
 													}
 												},
 												{
@@ -4828,7 +4979,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-														name: 'Mid-Wibble'
+														name: 'Mid-Wibble',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+															name: 'Sur-Wibble'
+														}
 													}
 												}
 											],
@@ -4913,7 +5069,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												},
 												{
@@ -4931,7 +5088,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												}
 											],
@@ -5068,7 +5226,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Mid-Wibble'
+														name: 'Mid-Wibble',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+															name: 'Sur-Wibble'
+														}
 													}
 												},
 												{
@@ -5086,7 +5249,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-														name: 'Mid-Wibble'
+														name: 'Mid-Wibble',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+															name: 'Sur-Wibble'
+														}
 													}
 												}
 											],
@@ -5171,7 +5339,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												},
 												{
@@ -5189,7 +5358,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												}
 											],
@@ -5326,7 +5496,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Mid-Wibble'
+														name: 'Mid-Wibble',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+															name: 'Sur-Wibble'
+														}
 													}
 												},
 												{
@@ -5344,7 +5519,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-														name: 'Mid-Wibble'
+														name: 'Mid-Wibble',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+															name: 'Sur-Wibble'
+														}
 													}
 												}
 											],
@@ -5429,7 +5609,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												},
 												{
@@ -5447,7 +5628,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												}
 											],
@@ -5584,7 +5766,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Mid-Wibble'
+														name: 'Mid-Wibble',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+															name: 'Sur-Wibble'
+														}
 													}
 												},
 												{
@@ -5602,7 +5789,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
-														name: 'Mid-Wibble'
+														name: 'Mid-Wibble',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+															name: 'Sur-Wibble'
+														}
 													}
 												}
 											],
@@ -5689,7 +5881,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
-														name: 'Sur-Hoge'
+														name: 'Sur-Hoge',
+														surProduction: null
 													}
 												},
 												{
@@ -5707,7 +5900,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Sur-Hoge'
+														name: 'Sur-Hoge',
+														surProduction: null
 													}
 												}
 											],
@@ -5844,7 +6038,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
-														name: 'Mid-Hoge'
+														name: 'Mid-Hoge',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+															name: 'Sur-Hoge'
+														}
 													}
 												},
 												{
@@ -5862,7 +6061,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Mid-Hoge'
+														name: 'Mid-Hoge',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+															name: 'Sur-Hoge'
+														}
 													}
 												}
 											],
@@ -5950,7 +6154,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
-														name: 'Sur-Hoge'
+														name: 'Sur-Hoge',
+														surProduction: null
 													}
 												},
 												{
@@ -5968,7 +6173,8 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Sur-Hoge'
+														name: 'Sur-Hoge',
+														surProduction: null
 													}
 												}
 											],
@@ -6105,7 +6311,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
-														name: 'Mid-Hoge'
+														name: 'Mid-Hoge',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+															name: 'Sur-Hoge'
+														}
 													}
 												},
 												{
@@ -6123,7 +6334,12 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Mid-Hoge'
+														name: 'Mid-Hoge',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+															name: 'Sur-Hoge'
+														}
 													}
 												}
 											],

--- a/test-e2e/model-interaction/award-ceremonies-with-sub-materials-sub-prods.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-sub-materials-sub-prods.test.js
@@ -345,7 +345,8 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 									surProduction: {
 										model: 'PRODUCTION',
 										uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-										name: 'Sur-Hoge'
+										name: 'Sur-Hoge',
+										surProduction: null
 									}
 								},
 								{
@@ -367,7 +368,8 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 									surProduction: {
 										model: 'PRODUCTION',
 										uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-										name: 'Sur-Wibble'
+										name: 'Sur-Wibble',
+										surProduction: null
 									}
 								}
 							],
@@ -659,7 +661,8 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Sur-Hoge'
+														name: 'Sur-Hoge',
+														surProduction: null
 													}
 												},
 												{
@@ -681,7 +684,8 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												}
 											],
@@ -874,7 +878,8 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Sur-Hoge'
+														name: 'Sur-Hoge',
+														surProduction: null
 													}
 												},
 												{
@@ -896,7 +901,8 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												}
 											],
@@ -1087,7 +1093,8 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Sur-Hoge'
+														name: 'Sur-Hoge',
+														surProduction: null
 													}
 												},
 												{
@@ -1109,7 +1116,8 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												}
 											],
@@ -1316,7 +1324,8 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												}
 											],
@@ -1523,7 +1532,8 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												}
 											],
@@ -1726,7 +1736,8 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Sur-Hoge'
+														name: 'Sur-Hoge',
+														surProduction: null
 													}
 												}
 											],
@@ -1929,7 +1940,8 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Sur-Hoge'
+														name: 'Sur-Hoge',
+														surProduction: null
 													}
 												}
 											],
@@ -2132,7 +2144,8 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Sur-Hoge'
+														name: 'Sur-Hoge',
+														surProduction: null
 													}
 												},
 												{
@@ -2154,7 +2167,8 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												}
 											],
@@ -2344,7 +2358,8 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Sur-Hoge'
+														name: 'Sur-Hoge',
+														surProduction: null
 													}
 												},
 												{
@@ -2366,7 +2381,8 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												}
 											],

--- a/test-e2e/model-interaction/award-ceremonies-with-sub-sub-materials-sub-sub-prods.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-sub-sub-materials-sub-sub-prods.test.js
@@ -474,7 +474,12 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 									surProduction: {
 										model: 'PRODUCTION',
 										uuid: MID_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-										name: 'Mid-Hoge'
+										name: 'Mid-Hoge',
+										surProduction: {
+											model: 'PRODUCTION',
+											uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+											name: 'Sur-Hoge'
+										}
 									}
 								},
 								{
@@ -496,7 +501,12 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 									surProduction: {
 										model: 'PRODUCTION',
 										uuid: MID_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-										name: 'Mid-Wibble'
+										name: 'Mid-Wibble',
+										surProduction: {
+											model: 'PRODUCTION',
+											uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+											name: 'Sur-Wibble'
+										}
 									}
 								}
 							],
@@ -698,7 +708,8 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 									surProduction: {
 										model: 'PRODUCTION',
 										uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-										name: 'Sur-Hoge'
+										name: 'Sur-Hoge',
+										surProduction: null
 									}
 								},
 								{
@@ -720,7 +731,8 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 									surProduction: {
 										model: 'PRODUCTION',
 										uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-										name: 'Sur-Wibble'
+										name: 'Sur-Wibble',
+										surProduction: null
 									}
 								}
 							],
@@ -821,7 +833,8 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Sur-Hoge'
+														name: 'Sur-Hoge',
+														surProduction: null
 													}
 												},
 												{
@@ -843,7 +856,8 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												}
 											],
@@ -1023,7 +1037,12 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Mid-Hoge'
+														name: 'Mid-Hoge',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+															name: 'Sur-Hoge'
+														}
 													}
 												},
 												{
@@ -1045,7 +1064,12 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Mid-Wibble'
+														name: 'Mid-Wibble',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+															name: 'Sur-Wibble'
+														}
 													}
 												}
 											],
@@ -1155,7 +1179,8 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Sur-Hoge'
+														name: 'Sur-Hoge',
+														surProduction: null
 													}
 												},
 												{
@@ -1177,7 +1202,8 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												}
 											],
@@ -1355,7 +1381,12 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Mid-Hoge'
+														name: 'Mid-Hoge',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+															name: 'Sur-Hoge'
+														}
 													}
 												},
 												{
@@ -1377,7 +1408,12 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Mid-Wibble'
+														name: 'Mid-Wibble',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+															name: 'Sur-Wibble'
+														}
 													}
 												}
 											],
@@ -1486,7 +1522,8 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Sur-Hoge'
+														name: 'Sur-Hoge',
+														surProduction: null
 													}
 												},
 												{
@@ -1508,7 +1545,8 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												}
 											],
@@ -1684,7 +1722,12 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Mid-Hoge'
+														name: 'Mid-Hoge',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+															name: 'Sur-Hoge'
+														}
 													}
 												},
 												{
@@ -1706,7 +1749,12 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Mid-Wibble'
+														name: 'Mid-Wibble',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+															name: 'Sur-Wibble'
+														}
 													}
 												}
 											],
@@ -1838,7 +1886,8 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												}
 											],
@@ -1868,6 +1917,101 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 														name: 'Sur-Wibble',
 														surMaterial: null
 													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: EVENING_STANDARD_THEATRE_AWARDS_AWARD_UUID,
+					name: 'Evening Standard Theatre Awards',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: EVENING_STANDARD_THEATRE_AWARDS_TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID,
+							name: '2019',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Role',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: true,
+											type: 'Winner',
+											recipientProduction: {
+												model: 'PRODUCTION',
+												uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+												name: 'Sur-Hoge',
+												startDate: '2019-05-01',
+												endDate: '2019-05-31',
+												venue: {
+													model: 'VENUE',
+													uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+													name: 'Noël Coward Theatre',
+													surVenue: null
+												}
+											},
+											entities: [
+												{
+													model: 'PERSON',
+													uuid: CONOR_CORGE_PERSON_UUID,
+													name: 'Conor Corge'
+												},
+												{
+													model: 'COMPANY',
+													uuid: STAGECRAFT_LTD_COMPANY_UUID,
+													name: 'Stagecraft Ltd',
+													members: [
+														{
+															model: 'PERSON',
+															uuid: FERDINAND_FOO_PERSON_UUID,
+															name: 'Ferdinand Foo'
+														}
+													]
+												}
+											],
+											coProductions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sur-Wibble',
+													startDate: '2019-06-01',
+													endDate: '2019-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: null
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_HOGE_MATERIAL_UUID,
+													name: 'Sur-Hoge',
+													format: 'collection of plays',
+													year: 2019,
+													surMaterial: null
+												},
+												{
+													model: 'MATERIAL',
+													uuid: SUR_WIBBLE_MATERIAL_UUID,
+													name: 'Sur-Wibble',
+													format: 'trilogy of trilogies of plays',
+													year: 2019,
+													surMaterial: null
 												}
 											]
 										}
@@ -1935,7 +2079,12 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Mid-Wibble'
+														name: 'Mid-Wibble',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+															name: 'Sur-Wibble'
+														}
 													}
 												}
 											],
@@ -2055,7 +2204,8 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												}
 											],
@@ -2259,7 +2409,12 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Mid-Wibble'
+														name: 'Mid-Wibble',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+															name: 'Sur-Wibble'
+														}
 													}
 												}
 											],
@@ -2391,7 +2546,8 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												}
 											],
@@ -2512,6 +2668,128 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 							]
 						}
 					]
+				},
+				{
+					model: 'AWARD',
+					uuid: LAURENCE_OLIVIER_AWARDS_AWARD_UUID,
+					name: 'Laurence Olivier Awards',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: LAURENCE_OLIVIER_AWARDS_TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID,
+							name: '2020',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Role',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											recipientProduction: {
+												model: 'PRODUCTION',
+												uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+												name: 'Sub-Hoge',
+												startDate: '2019-05-01',
+												endDate: '2019-05-31',
+												venue: {
+													model: 'VENUE',
+													uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+													name: 'Noël Coward Theatre',
+													surVenue: null
+												}
+											},
+											entities: [
+												{
+													model: 'PERSON',
+													uuid: CONOR_CORGE_PERSON_UUID,
+													name: 'Conor Corge'
+												},
+												{
+													model: 'COMPANY',
+													uuid: STAGECRAFT_LTD_COMPANY_UUID,
+													name: 'Stagecraft Ltd',
+													members: [
+														{
+															model: 'PERSON',
+															uuid: FERDINAND_FOO_PERSON_UUID,
+															name: 'Ferdinand Foo'
+														}
+													]
+												}
+											],
+											coProductions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sub-Wibble',
+													startDate: '2019-06-01',
+													endDate: '2019-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+														name: 'Mid-Wibble',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+															name: 'Sur-Wibble'
+														}
+													}
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_HOGE_MATERIAL_UUID,
+													name: 'Sub-Hoge',
+													format: 'play',
+													year: 2019,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: MID_HOGE_MATERIAL_UUID,
+														name: 'Mid-Hoge',
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_HOGE_MATERIAL_UUID,
+															name: 'Sur-Hoge'
+														}
+													}
+												},
+												{
+													model: 'MATERIAL',
+													uuid: SUB_WIBBLE_MATERIAL_UUID,
+													name: 'Sub-Wibble',
+													format: 'play',
+													year: 2019,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_MATERIAL_UUID,
+														name: 'Mid-Wibble',
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble'
+														}
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
 				}
 			];
 
@@ -2598,7 +2876,8 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Sur-Hoge'
+														name: 'Sur-Hoge',
+														surProduction: null
 													}
 												}
 											],
@@ -2628,6 +2907,101 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 														name: 'Sur-Wibble',
 														surMaterial: null
 													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: EVENING_STANDARD_THEATRE_AWARDS_AWARD_UUID,
+					name: 'Evening Standard Theatre Awards',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: EVENING_STANDARD_THEATRE_AWARDS_TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID,
+							name: '2019',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Role',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: true,
+											type: 'Winner',
+											recipientProduction: {
+												model: 'PRODUCTION',
+												uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+												name: 'Sur-Wibble',
+												startDate: '2019-06-01',
+												endDate: '2019-06-30',
+												venue: {
+													model: 'VENUE',
+													uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+													name: 'Jerwood Theatre Upstairs',
+													surVenue: {
+														model: 'VENUE',
+														uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+														name: 'Royal Court Theatre'
+													}
+												}
+											},
+											entities: [
+												{
+													model: 'PERSON',
+													uuid: CONOR_CORGE_PERSON_UUID,
+													name: 'Conor Corge'
+												},
+												{
+													model: 'COMPANY',
+													uuid: STAGECRAFT_LTD_COMPANY_UUID,
+													name: 'Stagecraft Ltd',
+													members: [
+														{
+															model: 'PERSON',
+															uuid: FERDINAND_FOO_PERSON_UUID,
+															name: 'Ferdinand Foo'
+														}
+													]
+												}
+											],
+											coProductions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sur-Hoge',
+													startDate: '2019-05-01',
+													endDate: '2019-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_HOGE_MATERIAL_UUID,
+													name: 'Sur-Hoge',
+													format: 'collection of plays',
+													year: 2019,
+													surMaterial: null
+												},
+												{
+													model: 'MATERIAL',
+													uuid: SUR_WIBBLE_MATERIAL_UUID,
+													name: 'Sur-Wibble',
+													format: 'trilogy of trilogies of plays',
+													year: 2019,
+													surMaterial: null
 												}
 											]
 										}
@@ -2691,7 +3065,12 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Mid-Hoge'
+														name: 'Mid-Hoge',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+															name: 'Sur-Hoge'
+														}
 													}
 												}
 											],
@@ -2807,7 +3186,8 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Sur-Hoge'
+														name: 'Sur-Hoge',
+														surProduction: null
 													}
 												}
 											],
@@ -3011,7 +3391,12 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Mid-Hoge'
+														name: 'Mid-Hoge',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+															name: 'Sur-Hoge'
+														}
 													}
 												}
 											],
@@ -3143,7 +3528,8 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Sur-Hoge'
+														name: 'Sur-Hoge',
+														surProduction: null
 													}
 												}
 											],
@@ -3260,6 +3646,128 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 							]
 						}
 					]
+				},
+				{
+					model: 'AWARD',
+					uuid: LAURENCE_OLIVIER_AWARDS_AWARD_UUID,
+					name: 'Laurence Olivier Awards',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: LAURENCE_OLIVIER_AWARDS_TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID,
+							name: '2020',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Role',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											recipientProduction: {
+												model: 'PRODUCTION',
+												uuid: SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+												name: 'Sub-Wibble',
+												startDate: '2019-06-01',
+												endDate: '2019-06-30',
+												venue: {
+													model: 'VENUE',
+													uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+													name: 'Jerwood Theatre Upstairs',
+													surVenue: {
+														model: 'VENUE',
+														uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+														name: 'Royal Court Theatre'
+													}
+												}
+											},
+											entities: [
+												{
+													model: 'PERSON',
+													uuid: CONOR_CORGE_PERSON_UUID,
+													name: 'Conor Corge'
+												},
+												{
+													model: 'COMPANY',
+													uuid: STAGECRAFT_LTD_COMPANY_UUID,
+													name: 'Stagecraft Ltd',
+													members: [
+														{
+															model: 'PERSON',
+															uuid: FERDINAND_FOO_PERSON_UUID,
+															name: 'Ferdinand Foo'
+														}
+													]
+												}
+											],
+											coProductions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sub-Hoge',
+													startDate: '2019-05-01',
+													endDate: '2019-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Mid-Hoge',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+															name: 'Sur-Hoge'
+														}
+													}
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_HOGE_MATERIAL_UUID,
+													name: 'Sub-Hoge',
+													format: 'play',
+													year: 2019,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: MID_HOGE_MATERIAL_UUID,
+														name: 'Mid-Hoge',
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_HOGE_MATERIAL_UUID,
+															name: 'Sur-Hoge'
+														}
+													}
+												},
+												{
+													model: 'MATERIAL',
+													uuid: SUB_WIBBLE_MATERIAL_UUID,
+													name: 'Sub-Wibble',
+													format: 'play',
+													year: 2019,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_MATERIAL_UUID,
+														name: 'Mid-Wibble',
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble'
+														}
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
 				}
 			];
 
@@ -3336,7 +3844,8 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Sur-Hoge'
+														name: 'Sur-Hoge',
+														surProduction: null
 													}
 												},
 												{
@@ -3358,7 +3867,8 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												}
 											],
@@ -3533,7 +4043,12 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Mid-Hoge'
+														name: 'Mid-Hoge',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+															name: 'Sur-Hoge'
+														}
 													}
 												},
 												{
@@ -3555,7 +4070,12 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Mid-Wibble'
+														name: 'Mid-Wibble',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+															name: 'Sur-Wibble'
+														}
 													}
 												}
 											],
@@ -3654,7 +4174,8 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Sur-Hoge'
+														name: 'Sur-Hoge',
+														surProduction: null
 													}
 												},
 												{
@@ -3676,7 +4197,8 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												}
 											],
@@ -3857,7 +4379,12 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Mid-Hoge'
+														name: 'Mid-Hoge',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+															name: 'Sur-Hoge'
+														}
 													}
 												},
 												{
@@ -3879,7 +4406,12 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Mid-Wibble'
+														name: 'Mid-Wibble',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+															name: 'Sur-Wibble'
+														}
 													}
 												}
 											],
@@ -3984,7 +4516,8 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Sur-Hoge'
+														name: 'Sur-Hoge',
+														surProduction: null
 													}
 												},
 												{
@@ -4006,7 +4539,8 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Sur-Wibble'
+														name: 'Sur-Wibble',
+														surProduction: null
 													}
 												}
 											],
@@ -4181,7 +4715,12 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-														name: 'Mid-Hoge'
+														name: 'Mid-Hoge',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+															name: 'Sur-Hoge'
+														}
 													}
 												},
 												{
@@ -4203,7 +4742,12 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													surProduction: {
 														model: 'PRODUCTION',
 														uuid: MID_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-														name: 'Mid-Wibble'
+														name: 'Mid-Wibble',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+															name: 'Sur-Wibble'
+														}
 													}
 												}
 											],

--- a/test-e2e/model-interaction/material-with-sub-materials-source-materials.test.js
+++ b/test-e2e/model-interaction/material-with-sub-materials-source-materials.test.js
@@ -340,7 +340,8 @@ describe('Material with sub-materials and source materials thereof', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_WOLF_HALL_TRILOGY_SWAN_THEATRE_PRODUCTION_UUID,
-						name: 'The Wolf Hall Trilogy'
+						name: 'The Wolf Hall Trilogy',
+						surProduction: null
 					}
 				}
 			];

--- a/test-e2e/model-interaction/material-with-sub-sub-materials-source-materials.test.js
+++ b/test-e2e/model-interaction/material-with-sub-sub-materials-source-materials.test.js
@@ -23,6 +23,9 @@ describe('Material with sub-sub-materials and source materials thereof', () => {
 	const THE_BOOKS_OF_THE_OLD_TESTAMENT_PLAYS_MATERIAL_UUID = '44';
 	const SIXTY_SIX_BOOKS_PLAYS_MATERIAL_UUID = '52';
 	const GODBLOG_BUSH_THEATRE_PRODUCTION_UUID = '56';
+	const BUSH_THEATRE_VENUE_UUID = '58';
+	const THE_BOOKS_OF_THE_OLD_TESTAMENT_BUSH_THEATRE_PRODUCTION_UUID = '59';
+	const SIXTY_SIX_BOOKS_BUSH_THEATRE_PRODUCTION_UUID = '62';
 
 	let genesisReligiousTextMaterial;
 	let godblogPlayMaterial;
@@ -230,7 +233,12 @@ describe('Material with sub-sub-materials and source materials thereof', () => {
 				},
 				venue: {
 					name: 'Bush Theatre'
-				}
+				},
+				subProductions: [
+					{
+						uuid: GODBLOG_BUSH_THEATRE_PRODUCTION_UUID
+					}
+				]
 			});
 
 		await chai.request(app)
@@ -245,7 +253,12 @@ describe('Material with sub-sub-materials and source materials thereof', () => {
 				},
 				venue: {
 					name: 'Bush Theatre'
-				}
+				},
+				subProductions: [
+					{
+						uuid: THE_BOOKS_OF_THE_OLD_TESTAMENT_BUSH_THEATRE_PRODUCTION_UUID
+					}
+				]
 			});
 
 		genesisReligiousTextMaterial = await chai.request(app)
@@ -366,6 +379,40 @@ describe('Material with sub-sub-materials and source materials thereof', () => {
 			const { sourcingMaterials } = genesisReligiousTextMaterial.body;
 
 			expect(sourcingMaterials).to.deep.equal(expectedSourcingMaterials);
+
+		});
+
+		it('includes productions of material that used it as source material, including the sur-production and sur-sur-production', () => {
+
+			const expectedSourcingMaterialProductions = [
+				{
+					model: 'PRODUCTION',
+					uuid: GODBLOG_BUSH_THEATRE_PRODUCTION_UUID,
+					name: 'Godblog',
+					startDate: '2011-10-10',
+					endDate: '2011-10-28',
+					venue: {
+						model: 'VENUE',
+						uuid: BUSH_THEATRE_VENUE_UUID,
+						name: 'Bush Theatre',
+						surVenue: null
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: THE_BOOKS_OF_THE_OLD_TESTAMENT_BUSH_THEATRE_PRODUCTION_UUID,
+						name: 'The Books of the Old Testament',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: SIXTY_SIX_BOOKS_BUSH_THEATRE_PRODUCTION_UUID,
+							name: 'Sixty-Six Books'
+						}
+					}
+				}
+			];
+
+			const { sourcingMaterialProductions } = genesisReligiousTextMaterial.body;
+
+			expect(sourcingMaterialProductions).to.deep.equal(expectedSourcingMaterialProductions);
 
 		});
 

--- a/test-e2e/model-interaction/material-with-sub-sub-materials.test.js
+++ b/test-e2e/model-interaction/material-with-sub-sub-materials.test.js
@@ -35,6 +35,10 @@ describe('Material with sub-sub-materials', () => {
 	const THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID = '101';
 	const BUGLES_AT_THE_GATES_OF_JALALABAD_TRICYCLE_PRODUCTION_UUID = '106';
 	const PART_ONE_INVASIONS_AND_INDEPENDENCE_TRICYCLE_PRODUCTION_UUID = '109';
+	const MINISKIRTS_OF_KABUL_TRICYCLE_PRODUCTION_UUID = '112';
+	const PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_TRICYCLE_PRODUCTION_UUID = '115';
+	const THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_TRICYCLE_PRODUCTION_UUID = '118';
+	const PART_THREE_ENDURING_FREEDOM_TRICYCLE_PRODUCTION_UUID = '121';
 	const THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID = '124';
 
 	let theGreatGameAfghanistanMaterial;
@@ -352,7 +356,12 @@ describe('Material with sub-sub-materials', () => {
 				},
 				venue: {
 					name: 'Tricycle Theatre'
-				}
+				},
+				subProductions: [
+					{
+						uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_TRICYCLE_PRODUCTION_UUID
+					}
+				]
 			});
 
 		await chai.request(app)
@@ -382,7 +391,12 @@ describe('Material with sub-sub-materials', () => {
 				},
 				venue: {
 					name: 'Tricycle Theatre'
-				}
+				},
+				subProductions: [
+					{
+						uuid: MINISKIRTS_OF_KABUL_TRICYCLE_PRODUCTION_UUID
+					}
+				]
 			});
 
 		await chai.request(app)
@@ -412,7 +426,12 @@ describe('Material with sub-sub-materials', () => {
 				},
 				venue: {
 					name: 'Tricycle Theatre'
-				}
+				},
+				subProductions: [
+					{
+						uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_TRICYCLE_PRODUCTION_UUID
+					}
+				]
 			});
 
 		await chai.request(app)
@@ -427,7 +446,18 @@ describe('Material with sub-sub-materials', () => {
 				},
 				venue: {
 					name: 'Tricycle Theatre'
-				}
+				},
+				subProductions: [
+					{
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_TRICYCLE_PRODUCTION_UUID
+					},
+					{
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_TRICYCLE_PRODUCTION_UUID
+					},
+					{
+						uuid: PART_THREE_ENDURING_FREEDOM_TRICYCLE_PRODUCTION_UUID
+					}
+				]
 			});
 
 		theGreatGameAfghanistanMaterial = await chai.request(app)

--- a/test-e2e/model-interaction/prod-with-sub-prods.test.js
+++ b/test-e2e/model-interaction/prod-with-sub-prods.test.js
@@ -571,7 +571,8 @@ describe('Production with sub-productions', () => {
 							uuid: NATIONAL_THEATRE_VENUE_UUID,
 							name: 'National Theatre'
 						}
-					}
+					},
+					subProductions: []
 				},
 				{
 					model: 'PRODUCTION',
@@ -588,7 +589,8 @@ describe('Production with sub-productions', () => {
 							uuid: NATIONAL_THEATRE_VENUE_UUID,
 							name: 'National Theatre'
 						}
-					}
+					},
+					subProductions: []
 				},
 				{
 					model: 'PRODUCTION',
@@ -605,7 +607,8 @@ describe('Production with sub-productions', () => {
 							uuid: NATIONAL_THEATRE_VENUE_UUID,
 							name: 'National Theatre'
 						}
-					}
+					},
+					subProductions: []
 				}
 			];
 
@@ -636,7 +639,8 @@ describe('Production with sub-productions', () => {
 						uuid: NATIONAL_THEATRE_VENUE_UUID,
 						name: 'National Theatre'
 					}
-				}
+				},
+				surProduction: null
 			};
 
 			const { surProduction } = voyageOlivierProduction.body;
@@ -663,7 +667,8 @@ describe('Production with sub-productions', () => {
 						uuid: VIVIAN_BEAUMONT_THEATRE_VENUE_UUID,
 						name: 'Vivian Beaumont Theatre',
 						surVenue: null
-					}
+					},
+					subProductions: []
 				},
 				{
 					model: 'PRODUCTION',
@@ -676,7 +681,8 @@ describe('Production with sub-productions', () => {
 						uuid: VIVIAN_BEAUMONT_THEATRE_VENUE_UUID,
 						name: 'Vivian Beaumont Theatre',
 						surVenue: null
-					}
+					},
+					subProductions: []
 				},
 				{
 					model: 'PRODUCTION',
@@ -689,7 +695,8 @@ describe('Production with sub-productions', () => {
 						uuid: VIVIAN_BEAUMONT_THEATRE_VENUE_UUID,
 						name: 'Vivian Beaumont Theatre',
 						surVenue: null
-					}
+					},
+					subProductions: []
 				}
 			];
 
@@ -716,7 +723,8 @@ describe('Production with sub-productions', () => {
 					uuid: VIVIAN_BEAUMONT_THEATRE_VENUE_UUID,
 					name: 'Vivian Beaumont Theatre',
 					surVenue: null
-				}
+				},
+				surProduction: null
 			};
 
 			const { surProduction } = voyageVivianBeaumontProduction.body;
@@ -794,7 +802,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_VIVIAN_BEAUMONT_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					}
 				},
 				{
@@ -816,7 +825,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					}
 				}
 			];
@@ -848,7 +858,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					}
 				},
 				{
@@ -865,7 +876,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					}
 				},
 				{
@@ -882,7 +894,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					}
 				}
 			];
@@ -910,7 +923,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					}
 				},
 				{
@@ -923,7 +937,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					}
 				},
 				{
@@ -936,7 +951,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					}
 				}
 			];
@@ -973,7 +989,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					producerCredits: [
 						{
@@ -1020,7 +1037,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					producerCredits: [
 						{
@@ -1067,7 +1085,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					producerCredits: [
 						{
@@ -1129,7 +1148,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					producerCredits: [
 						{
@@ -1176,7 +1196,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					producerCredits: [
 						{
@@ -1223,7 +1244,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					producerCredits: [
 						{
@@ -1285,7 +1307,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					producerCredits: [
 						{
@@ -1332,7 +1355,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					producerCredits: [
 						{
@@ -1379,7 +1403,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					producerCredits: [
 						{
@@ -1441,7 +1466,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					roles: [
 						{
@@ -1472,7 +1498,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					roles: [
 						{
@@ -1503,7 +1530,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					roles: [
 						{
@@ -1549,7 +1577,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					creativeCredits: [
 						{
@@ -1592,7 +1621,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					creativeCredits: [
 						{
@@ -1635,7 +1665,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					creativeCredits: [
 						{
@@ -1693,7 +1724,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					creativeCredits: [
 						{
@@ -1735,7 +1767,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					creativeCredits: [
 						{
@@ -1777,7 +1810,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					creativeCredits: [
 						{
@@ -1834,7 +1868,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					creativeCredits: [
 						{
@@ -1875,7 +1910,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					creativeCredits: [
 						{
@@ -1916,7 +1952,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					creativeCredits: [
 						{
@@ -1972,7 +2009,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					crewCredits: [
 						{
@@ -2015,7 +2053,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					crewCredits: [
 						{
@@ -2058,7 +2097,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					crewCredits: [
 						{
@@ -2116,7 +2156,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					crewCredits: [
 						{
@@ -2158,7 +2199,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					crewCredits: [
 						{
@@ -2200,7 +2242,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					crewCredits: [
 						{
@@ -2257,7 +2300,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					crewCredits: [
 						{
@@ -2298,7 +2342,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					crewCredits: [
 						{
@@ -2339,7 +2384,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					crewCredits: [
 						{
@@ -2395,7 +2441,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					performers: [
 						{
@@ -2428,7 +2475,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					performers: [
 						{
@@ -2461,7 +2509,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					},
 					performers: [
 						{
@@ -2508,7 +2557,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_VIVIAN_BEAUMONT_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					}
 				},
 				{
@@ -2526,7 +2576,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_VIVIAN_BEAUMONT_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					}
 				},
 				{
@@ -2544,7 +2595,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_VIVIAN_BEAUMONT_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					}
 				},
 				{
@@ -2566,7 +2618,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					}
 				},
 				{
@@ -2588,7 +2641,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					}
 				},
 				{
@@ -2610,7 +2664,8 @@ describe('Production with sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID,
-						name: 'The Coast of Utopia'
+						name: 'The Coast of Utopia',
+						surProduction: null
 					}
 				}
 			];

--- a/test-e2e/model-interaction/prod-with-sub-sub-prods.test.js
+++ b/test-e2e/model-interaction/prod-with-sub-sub-prods.test.js
@@ -1,0 +1,7920 @@
+import crypto from 'crypto';
+
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import { createSandbox } from 'sinon';
+
+import app from '../../src/app';
+import purgeDatabase from '../test-helpers/neo4j/purge-database';
+
+describe('Production with sub-sub-productions', () => {
+
+	chai.use(chaiHttp);
+
+	const BERKELEY_REPERTORY_THEATRE_VENUE_UUID = '2';
+	const RODA_THEATRE_VENUE_UUID = '3';
+	const BUGLES_AT_THE_GATES_OF_JALALABAD_MATERIAL_UUID = '7';
+	const BAR_CHARACTER_UUID = '9';
+	const PART_ONE_INVASIONS_AND_INDEPENDENCE_MATERIAL_UUID = '27';
+	const THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID = '93';
+	const BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID = '98';
+	const NICOLAS_KENT_PERSON_UUID = '101';
+	const TRICYCLE_THEATRE_COMPANY_UUID = '102';
+	const ZOË_INGENHAAG_PERSON_UUID = '103';
+	const RICK_WARDEN_PERSON_UUID = '104';
+	const HOWARD_HARRISON_PERSON_UUID = '105';
+	const LIGHTING_DESIGN_LTD_COMPANY_UUID = '106';
+	const JACK_KNOWLES_PERSON_UUID = '107';
+	const LIZZIE_CHAPMAN_PERSON_UUID = '108';
+	const STAGE_MANAGEMENT_LTD_COMPANY_UUID = '109';
+	const CHARLOTTE_PADGHAM_PERSON_UUID = '110';
+	const DURANDS_LINE_RODA_PRODUCTION_UUID = '111';
+	const CAMPAIGN_RODA_PRODUCTION_UUID = '124';
+	const PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID = '137';
+	const BLACK_TULIPS_RODA_PRODUCTION_UUID = '140';
+	const BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID = '153';
+	const MINISKIRTS_OF_KABUL_RODA_PRODUCTION_UUID = '166';
+	const PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID = '179';
+	const HONEY_RODA_PRODUCTION_UUID = '182';
+	const THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID = '195';
+	const ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID = '208';
+	const PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID = '221';
+	const THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID = '224';
+	const BUGLES_AT_THE_GATES_OF_JALALABAD_TRICYCLE_PRODUCTION_UUID = '227';
+	const TRICYCLE_THEATRE_VENUE_UUID = '229';
+	const DURANDS_LINE_TRICYCLE_PRODUCTION_UUID = '230';
+	const CAMPAIGN_TRICYCLE_PRODUCTION_UUID = '233';
+	const PART_ONE_INVASIONS_AND_INDEPENDENCE_TRICYCLE_PRODUCTION_UUID = '236';
+	const BLACK_TULIPS_TRICYCLE_PRODUCTION_UUID = '239';
+	const BLOOD_AND_GIFTS_TRICYCLE_PRODUCTION_UUID = '242';
+	const MINISKIRTS_OF_KABUL_TRICYCLE_PRODUCTION_UUID = '245';
+	const PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_TRICYCLE_PRODUCTION_UUID = '248';
+	const HONEY_TRICYCLE_PRODUCTION_UUID = '251';
+	const THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_TRICYCLE_PRODUCTION_UUID = '254';
+	const ON_THE_SIDE_OF_THE_ANGELS_TRICYCLE_PRODUCTION_UUID = '257';
+	const PART_THREE_ENDURING_FREEDOM_TRICYCLE_PRODUCTION_UUID = '260';
+	const THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID = '263';
+
+	let theGreatGameAfghanistanRodaProduction;
+	let partOneInvasionsAndIndependenceRodaProduction;
+	let buglesAtTheGatesOfJalalabadRodaProduction;
+	let theGreatGameAfghanistanTricycleProduction;
+	let partOneInvasionsAndIndependenceTricycleProduction;
+	let buglesAtTheGatesOfJalalabadTricycleProduction;
+	let theGreatGameAfghanistanMaterial;
+	let partOneInvasionsAndIndependenceMaterial;
+	let buglesAtTheGatesOfJalalabadMaterial;
+	let berkeleyRepertoryTheatreVenue;
+	let rodaTheatreVenue;
+	let nicolasKentPerson;
+	let tricycleTheatreCompany;
+	let zoëIngenhaagPerson;
+	let rickWardenPerson;
+	let howardHarrisonPerson;
+	let lightingDesignLtdCompany;
+	let jackKnowlesPerson;
+	let lizzieChapmanPerson;
+	let stageManagementLtdCompany;
+	let charlottePadghamPerson;
+	let barCharacter;
+
+	const sandbox = createSandbox();
+
+	before(async () => {
+
+		let uuidCallCount = 0;
+
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
+
+		await purgeDatabase();
+
+		await chai.request(app)
+			.post('/venues')
+			.send({
+				name: 'Berkeley Repertory Theatre',
+				subVenues: [
+					{
+						name: 'Roda Theatre'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Bugles at the Gates of Jalalabad',
+				format: 'play',
+				year: '2009',
+				characterGroups: [
+					{
+						characters: [
+							{
+								name: 'Bar'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Durand\'s Line',
+				format: 'play',
+				year: '2009',
+				characterGroups: [
+					{
+						characters: [
+							{
+								name: 'Bar'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Campaign',
+				format: 'play',
+				year: '2009',
+				characterGroups: [
+					{
+						characters: [
+							{
+								name: 'Bar'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Part One - Invasions and Independence 1842-1930',
+				format: 'sub-collection of plays',
+				year: '2009',
+				subMaterials: [
+					{
+						name: 'Bugles at the Gates of Jalalabad'
+					},
+					{
+						name: 'Durand\'s Line'
+					},
+					{
+						name: 'Campaign'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Black Tulips',
+				format: 'play',
+				year: '2009',
+				characterGroups: [
+					{
+						characters: [
+							{
+								name: 'Bar'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Blood and Gifts',
+				format: 'play',
+				year: '2009',
+				characterGroups: [
+					{
+						characters: [
+							{
+								name: 'Bar'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Miniskirts of Kabul',
+				format: 'play',
+				year: '2009',
+				characterGroups: [
+					{
+						characters: [
+							{
+								name: 'Bar'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+				format: 'sub-collection of plays',
+				year: '2009',
+				subMaterials: [
+					{
+						name: 'Black Tulips'
+					},
+					{
+						name: 'Blood and Gifts'
+					},
+					{
+						name: 'Miniskirts of Kabul'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Honey',
+				format: 'play',
+				year: '2009',
+				characterGroups: [
+					{
+						characters: [
+							{
+								name: 'Bar'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'The Night Is Darkest Before the Dawn',
+				format: 'play',
+				year: '2009',
+				characterGroups: [
+					{
+						characters: [
+							{
+								name: 'Bar'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'On the Side of the Angels',
+				format: 'play',
+				year: '2009',
+				characterGroups: [
+					{
+						characters: [
+							{
+								name: 'Bar'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Part Three - Enduring Freedom 1996-2009',
+				format: 'sub-collection of plays',
+				year: '2009',
+				subMaterials: [
+					{
+						name: 'Honey'
+					},
+					{
+						name: 'The Night Is Darkest Before the Dawn'
+					},
+					{
+						name: 'On the Side of the Angels'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'The Great Game: Afghanistan',
+				format: 'collection of plays',
+				year: '2009',
+				subMaterials: [
+					{
+						name: 'Part One - Invasions and Independence 1842-1930'
+					},
+					{
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996'
+					},
+					{
+						name: 'Part Three - Enduring Freedom 1996-2009'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Bugles at the Gates of Jalalabad',
+				startDate: '2010-10-22',
+				pressDate: '2010-10-25',
+				endDate: '2010-11-07',
+				material: {
+					name: 'Bugles at the Gates of Jalalabad'
+				},
+				venue: {
+					name: 'Roda Theatre'
+				},
+				producerCredits: [
+					{
+						entities: [
+							{
+								name: 'Nicolas Kent'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Tricycle Theatre Company',
+								members: [
+									{
+										name: 'Zoë Ingenhaag'
+									}
+								]
+							}
+						]
+					}
+				],
+				cast: [
+					{
+						name: 'Rick Warden',
+						roles: [
+							{
+								name: 'Bar'
+							}
+						]
+					}
+				],
+				creativeCredits: [
+					{
+						name: 'Lighting Designers',
+						entities: [
+							{
+								name: 'Howard Harrison'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Lighting Design Ltd',
+								members: [
+									{
+										name: 'Jack Knowles'
+									}
+								]
+							}
+						]
+					}
+				],
+				crewCredits: [
+					{
+						name: 'Stage Managers',
+						entities: [
+							{
+								name: 'Lizzie Chapman'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Stage Management Ltd',
+								members: [
+									{
+										name: 'Charlotte Padgham'
+									}
+								]
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Durand\'s Line',
+				startDate: '2010-10-22',
+				pressDate: '2010-10-25',
+				endDate: '2010-11-07',
+				material: {
+					name: 'Durand\'s Line'
+				},
+				venue: {
+					name: 'Roda Theatre'
+				},
+				producerCredits: [
+					{
+						entities: [
+							{
+								name: 'Nicolas Kent'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Tricycle Theatre Company',
+								members: [
+									{
+										name: 'Zoë Ingenhaag'
+									}
+								]
+							}
+						]
+					}
+				],
+				cast: [
+					{
+						name: 'Rick Warden',
+						roles: [
+							{
+								name: 'Bar'
+							}
+						]
+					}
+				],
+				creativeCredits: [
+					{
+						name: 'Lighting Designers',
+						entities: [
+							{
+								name: 'Howard Harrison'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Lighting Design Ltd',
+								members: [
+									{
+										name: 'Jack Knowles'
+									}
+								]
+							}
+						]
+					}
+				],
+				crewCredits: [
+					{
+						name: 'Stage Managers',
+						entities: [
+							{
+								name: 'Lizzie Chapman'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Stage Management Ltd',
+								members: [
+									{
+										name: 'Charlotte Padgham'
+									}
+								]
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Campaign',
+				startDate: '2010-10-22',
+				pressDate: '2010-10-25',
+				endDate: '2010-11-07',
+				material: {
+					name: 'Campaign'
+				},
+				venue: {
+					name: 'Roda Theatre'
+				},
+				producerCredits: [
+					{
+						entities: [
+							{
+								name: 'Nicolas Kent'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Tricycle Theatre Company',
+								members: [
+									{
+										name: 'Zoë Ingenhaag'
+									}
+								]
+							}
+						]
+					}
+				],
+				cast: [
+					{
+						name: 'Rick Warden',
+						roles: [
+							{
+								name: 'Bar'
+							}
+						]
+					}
+				],
+				creativeCredits: [
+					{
+						name: 'Lighting Designers',
+						entities: [
+							{
+								name: 'Howard Harrison'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Lighting Design Ltd',
+								members: [
+									{
+										name: 'Jack Knowles'
+									}
+								]
+							}
+						]
+					}
+				],
+				crewCredits: [
+					{
+						name: 'Stage Managers',
+						entities: [
+							{
+								name: 'Lizzie Chapman'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Stage Management Ltd',
+								members: [
+									{
+										name: 'Charlotte Padgham'
+									}
+								]
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Part One - Invasions and Independence 1842-1930',
+				startDate: '2010-10-22',
+				pressDate: '2010-10-25',
+				endDate: '2010-11-07',
+				material: {
+					name: 'Part One - Invasions and Independence 1842-1930'
+				},
+				venue: {
+					name: 'Roda Theatre'
+				},
+				subProductions: [
+					{
+						uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID
+					},
+					{
+						uuid: DURANDS_LINE_RODA_PRODUCTION_UUID
+					},
+					{
+						uuid: CAMPAIGN_RODA_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Black Tulips',
+				startDate: '2010-10-22',
+				pressDate: '2010-10-25',
+				endDate: '2010-11-07',
+				material: {
+					name: 'Black Tulips'
+				},
+				venue: {
+					name: 'Roda Theatre'
+				},
+				producerCredits: [
+					{
+						entities: [
+							{
+								name: 'Nicolas Kent'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Tricycle Theatre Company',
+								members: [
+									{
+										name: 'Zoë Ingenhaag'
+									}
+								]
+							}
+						]
+					}
+				],
+				cast: [
+					{
+						name: 'Rick Warden',
+						roles: [
+							{
+								name: 'Bar'
+							}
+						]
+					}
+				],
+				creativeCredits: [
+					{
+						name: 'Lighting Designers',
+						entities: [
+							{
+								name: 'Howard Harrison'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Lighting Design Ltd',
+								members: [
+									{
+										name: 'Jack Knowles'
+									}
+								]
+							}
+						]
+					}
+				],
+				crewCredits: [
+					{
+						name: 'Stage Managers',
+						entities: [
+							{
+								name: 'Lizzie Chapman'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Stage Management Ltd',
+								members: [
+									{
+										name: 'Charlotte Padgham'
+									}
+								]
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Blood and Gifts',
+				startDate: '2010-10-22',
+				pressDate: '2010-10-25',
+				endDate: '2010-11-07',
+				material: {
+					name: 'Blood and Gifts'
+				},
+				venue: {
+					name: 'Roda Theatre'
+				},
+				producerCredits: [
+					{
+						entities: [
+							{
+								name: 'Nicolas Kent'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Tricycle Theatre Company',
+								members: [
+									{
+										name: 'Zoë Ingenhaag'
+									}
+								]
+							}
+						]
+					}
+				],
+				cast: [
+					{
+						name: 'Rick Warden',
+						roles: [
+							{
+								name: 'Bar'
+							}
+						]
+					}
+				],
+				creativeCredits: [
+					{
+						name: 'Lighting Designers',
+						entities: [
+							{
+								name: 'Howard Harrison'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Lighting Design Ltd',
+								members: [
+									{
+										name: 'Jack Knowles'
+									}
+								]
+							}
+						]
+					}
+				],
+				crewCredits: [
+					{
+						name: 'Stage Managers',
+						entities: [
+							{
+								name: 'Lizzie Chapman'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Stage Management Ltd',
+								members: [
+									{
+										name: 'Charlotte Padgham'
+									}
+								]
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Miniskirts of Kabul',
+				startDate: '2010-10-22',
+				pressDate: '2010-10-25',
+				endDate: '2010-11-07',
+				material: {
+					name: 'Miniskirts of Kabul'
+				},
+				venue: {
+					name: 'Roda Theatre'
+				},
+				producerCredits: [
+					{
+						entities: [
+							{
+								name: 'Nicolas Kent'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Tricycle Theatre Company',
+								members: [
+									{
+										name: 'Zoë Ingenhaag'
+									}
+								]
+							}
+						]
+					}
+				],
+				cast: [
+					{
+						name: 'Rick Warden',
+						roles: [
+							{
+								name: 'Bar'
+							}
+						]
+					}
+				],
+				creativeCredits: [
+					{
+						name: 'Lighting Designers',
+						entities: [
+							{
+								name: 'Howard Harrison'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Lighting Design Ltd',
+								members: [
+									{
+										name: 'Jack Knowles'
+									}
+								]
+							}
+						]
+					}
+				],
+				crewCredits: [
+					{
+						name: 'Stage Managers',
+						entities: [
+							{
+								name: 'Lizzie Chapman'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Stage Management Ltd',
+								members: [
+									{
+										name: 'Charlotte Padgham'
+									}
+								]
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+				startDate: '2010-10-22',
+				pressDate: '2010-10-25',
+				endDate: '2010-11-07',
+				material: {
+					name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996'
+				},
+				venue: {
+					name: 'Roda Theatre'
+				},
+				subProductions: [
+					{
+						uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID
+					},
+					{
+						uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID
+					},
+					{
+						uuid: MINISKIRTS_OF_KABUL_RODA_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Honey',
+				startDate: '2010-10-22',
+				pressDate: '2010-10-25',
+				endDate: '2010-11-07',
+				material: {
+					name: 'Honey'
+				},
+				venue: {
+					name: 'Roda Theatre'
+				},
+				producerCredits: [
+					{
+						entities: [
+							{
+								name: 'Nicolas Kent'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Tricycle Theatre Company',
+								members: [
+									{
+										name: 'Zoë Ingenhaag'
+									}
+								]
+							}
+						]
+					}
+				],
+				cast: [
+					{
+						name: 'Rick Warden',
+						roles: [
+							{
+								name: 'Bar'
+							}
+						]
+					}
+				],
+				creativeCredits: [
+					{
+						name: 'Lighting Designers',
+						entities: [
+							{
+								name: 'Howard Harrison'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Lighting Design Ltd',
+								members: [
+									{
+										name: 'Jack Knowles'
+									}
+								]
+							}
+						]
+					}
+				],
+				crewCredits: [
+					{
+						name: 'Stage Managers',
+						entities: [
+							{
+								name: 'Lizzie Chapman'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Stage Management Ltd',
+								members: [
+									{
+										name: 'Charlotte Padgham'
+									}
+								]
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'The Night Is Darkest Before the Dawn',
+				startDate: '2010-10-22',
+				pressDate: '2010-10-25',
+				endDate: '2010-11-07',
+				material: {
+					name: 'The Night Is Darkest Before the Dawn'
+				},
+				venue: {
+					name: 'Roda Theatre'
+				},
+				producerCredits: [
+					{
+						entities: [
+							{
+								name: 'Nicolas Kent'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Tricycle Theatre Company',
+								members: [
+									{
+										name: 'Zoë Ingenhaag'
+									}
+								]
+							}
+						]
+					}
+				],
+				cast: [
+					{
+						name: 'Rick Warden',
+						roles: [
+							{
+								name: 'Bar'
+							}
+						]
+					}
+				],
+				creativeCredits: [
+					{
+						name: 'Lighting Designers',
+						entities: [
+							{
+								name: 'Howard Harrison'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Lighting Design Ltd',
+								members: [
+									{
+										name: 'Jack Knowles'
+									}
+								]
+							}
+						]
+					}
+				],
+				crewCredits: [
+					{
+						name: 'Stage Managers',
+						entities: [
+							{
+								name: 'Lizzie Chapman'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Stage Management Ltd',
+								members: [
+									{
+										name: 'Charlotte Padgham'
+									}
+								]
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'On the Side of the Angels',
+				startDate: '2010-10-22',
+				pressDate: '2010-10-25',
+				endDate: '2010-11-07',
+				material: {
+					name: 'On the Side of the Angels'
+				},
+				venue: {
+					name: 'Roda Theatre'
+				},
+				producerCredits: [
+					{
+						entities: [
+							{
+								name: 'Nicolas Kent'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Tricycle Theatre Company',
+								members: [
+									{
+										name: 'Zoë Ingenhaag'
+									}
+								]
+							}
+						]
+					}
+				],
+				cast: [
+					{
+						name: 'Rick Warden',
+						roles: [
+							{
+								name: 'Bar'
+							}
+						]
+					}
+				],
+				creativeCredits: [
+					{
+						name: 'Lighting Designers',
+						entities: [
+							{
+								name: 'Howard Harrison'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Lighting Design Ltd',
+								members: [
+									{
+										name: 'Jack Knowles'
+									}
+								]
+							}
+						]
+					}
+				],
+				crewCredits: [
+					{
+						name: 'Stage Managers',
+						entities: [
+							{
+								name: 'Lizzie Chapman'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Stage Management Ltd',
+								members: [
+									{
+										name: 'Charlotte Padgham'
+									}
+								]
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Part Three - Enduring Freedom 1996-2009',
+				startDate: '2010-10-22',
+				pressDate: '2010-10-25',
+				endDate: '2010-11-07',
+				material: {
+					name: 'Part Three - Enduring Freedom 1996-2009'
+				},
+				venue: {
+					name: 'Roda Theatre'
+				},
+				subProductions: [
+					{
+						uuid: HONEY_RODA_PRODUCTION_UUID
+					},
+					{
+						uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID
+					},
+					{
+						uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'The Great Game: Afghanistan',
+				startDate: '2010-10-22',
+				pressDate: '2010-10-25',
+				endDate: '2010-11-07',
+				material: {
+					name: 'The Great Game: Afghanistan'
+				},
+				venue: {
+					name: 'Roda Theatre'
+				},
+				subProductions: [
+					{
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID
+					},
+					{
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID
+					},
+					{
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Bugles at the Gates of Jalalabad',
+				startDate: '2009-04-17',
+				pressDate: '2009-04-24',
+				endDate: '2009-06-14',
+				material: {
+					name: 'Bugles at the Gates of Jalalabad'
+				},
+				venue: {
+					name: 'Tricycle Theatre'
+				}
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Durand\'s Line',
+				startDate: '2009-04-17',
+				pressDate: '2009-04-24',
+				endDate: '2009-06-14',
+				material: {
+					name: 'Durand\'s Line'
+				},
+				venue: {
+					name: 'Tricycle Theatre'
+				}
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Campaign',
+				startDate: '2009-04-17',
+				pressDate: '2009-04-24',
+				endDate: '2009-06-14',
+				material: {
+					name: 'Campaign'
+				},
+				venue: {
+					name: 'Tricycle Theatre'
+				}
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Part One - Invasions and Independence 1842-1930',
+				startDate: '2009-04-17',
+				pressDate: '2009-04-24',
+				endDate: '2009-06-14',
+				material: {
+					name: 'Part One - Invasions and Independence 1842-1930'
+				},
+				venue: {
+					name: 'Tricycle Theatre'
+				},
+				subProductions: [
+					{
+						uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_TRICYCLE_PRODUCTION_UUID
+					},
+					{
+						uuid: DURANDS_LINE_TRICYCLE_PRODUCTION_UUID
+					},
+					{
+						uuid: CAMPAIGN_TRICYCLE_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Black Tulips',
+				startDate: '2009-04-17',
+				pressDate: '2009-04-24',
+				endDate: '2009-06-14',
+				material: {
+					name: 'Black Tulips'
+				},
+				venue: {
+					name: 'Tricycle Theatre'
+				}
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Blood and Gifts',
+				startDate: '2009-04-17',
+				pressDate: '2009-04-24',
+				endDate: '2009-06-14',
+				material: {
+					name: 'Blood and Gifts'
+				},
+				venue: {
+					name: 'Tricycle Theatre'
+				}
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Miniskirts of Kabul',
+				startDate: '2009-04-17',
+				pressDate: '2009-04-24',
+				endDate: '2009-06-14',
+				material: {
+					name: 'Miniskirts of Kabul'
+				},
+				venue: {
+					name: 'Tricycle Theatre'
+				}
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+				startDate: '2009-04-17',
+				pressDate: '2009-04-24',
+				endDate: '2009-06-14',
+				material: {
+					name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996'
+				},
+				venue: {
+					name: 'Tricycle Theatre'
+				},
+				subProductions: [
+					{
+						uuid: BLACK_TULIPS_TRICYCLE_PRODUCTION_UUID
+					},
+					{
+						uuid: BLOOD_AND_GIFTS_TRICYCLE_PRODUCTION_UUID
+					},
+					{
+						uuid: MINISKIRTS_OF_KABUL_TRICYCLE_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Honey',
+				startDate: '2009-04-17',
+				pressDate: '2009-04-24',
+				endDate: '2009-06-14',
+				material: {
+					name: 'Honey'
+				},
+				venue: {
+					name: 'Tricycle Theatre'
+				}
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'The Night Is Darkest Before the Dawn',
+				startDate: '2009-04-17',
+				pressDate: '2009-04-24',
+				endDate: '2009-06-14',
+				material: {
+					name: 'The Night Is Darkest Before the Dawn'
+				},
+				venue: {
+					name: 'Tricycle Theatre'
+				}
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'On the Side of the Angels',
+				startDate: '2009-04-17',
+				pressDate: '2009-04-24',
+				endDate: '2009-06-14',
+				material: {
+					name: 'On the Side of the Angels'
+				},
+				venue: {
+					name: 'Tricycle Theatre'
+				}
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Part Three - Enduring Freedom 1996-2009',
+				startDate: '2009-04-17',
+				pressDate: '2009-04-24',
+				endDate: '2009-06-14',
+				material: {
+					name: 'Part Three - Enduring Freedom 1996-2009'
+				},
+				venue: {
+					name: 'Tricycle Theatre'
+				},
+				subProductions: [
+					{
+						uuid: HONEY_TRICYCLE_PRODUCTION_UUID
+					},
+					{
+						uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_TRICYCLE_PRODUCTION_UUID
+					},
+					{
+						uuid: ON_THE_SIDE_OF_THE_ANGELS_TRICYCLE_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'The Great Game: Afghanistan',
+				startDate: '2009-04-17',
+				pressDate: '2009-04-24',
+				endDate: '2009-06-14',
+				material: {
+					name: 'The Great Game: Afghanistan'
+				},
+				venue: {
+					name: 'Tricycle Theatre'
+				},
+				subProductions: [
+					{
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_TRICYCLE_PRODUCTION_UUID
+					},
+					{
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_TRICYCLE_PRODUCTION_UUID
+					},
+					{
+						uuid: PART_THREE_ENDURING_FREEDOM_TRICYCLE_PRODUCTION_UUID
+					}
+				]
+			});
+
+		theGreatGameAfghanistanRodaProduction = await chai.request(app)
+			.get(`/productions/${THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID}`);
+
+		partOneInvasionsAndIndependenceRodaProduction = await chai.request(app)
+			.get(`/productions/${PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID}`);
+
+		buglesAtTheGatesOfJalalabadRodaProduction = await chai.request(app)
+			.get(`/productions/${BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID}`);
+
+		theGreatGameAfghanistanTricycleProduction = await chai.request(app)
+			.get(`/productions/${THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID}`);
+
+		partOneInvasionsAndIndependenceTricycleProduction = await chai.request(app)
+			.get(`/productions/${PART_ONE_INVASIONS_AND_INDEPENDENCE_TRICYCLE_PRODUCTION_UUID}`);
+
+		buglesAtTheGatesOfJalalabadTricycleProduction = await chai.request(app)
+			.get(`/productions/${BUGLES_AT_THE_GATES_OF_JALALABAD_TRICYCLE_PRODUCTION_UUID}`);
+
+		theGreatGameAfghanistanMaterial = await chai.request(app)
+			.get(`/materials/${THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID}`);
+
+		partOneInvasionsAndIndependenceMaterial = await chai.request(app)
+			.get(`/materials/${PART_ONE_INVASIONS_AND_INDEPENDENCE_MATERIAL_UUID}`);
+
+		buglesAtTheGatesOfJalalabadMaterial = await chai.request(app)
+			.get(`/materials/${BUGLES_AT_THE_GATES_OF_JALALABAD_MATERIAL_UUID}`);
+
+		berkeleyRepertoryTheatreVenue = await chai.request(app)
+			.get(`/venues/${BERKELEY_REPERTORY_THEATRE_VENUE_UUID}`);
+
+		rodaTheatreVenue = await chai.request(app)
+			.get(`/venues/${RODA_THEATRE_VENUE_UUID}`);
+
+		nicolasKentPerson = await chai.request(app)
+			.get(`/people/${NICOLAS_KENT_PERSON_UUID}`);
+
+		tricycleTheatreCompany = await chai.request(app)
+			.get(`/companies/${TRICYCLE_THEATRE_COMPANY_UUID}`);
+
+		zoëIngenhaagPerson = await chai.request(app)
+			.get(`/people/${ZOË_INGENHAAG_PERSON_UUID}`);
+
+		rickWardenPerson = await chai.request(app)
+			.get(`/people/${RICK_WARDEN_PERSON_UUID}`);
+
+		howardHarrisonPerson = await chai.request(app)
+			.get(`/people/${HOWARD_HARRISON_PERSON_UUID}`);
+
+		lightingDesignLtdCompany = await chai.request(app)
+			.get(`/companies/${LIGHTING_DESIGN_LTD_COMPANY_UUID}`);
+
+		jackKnowlesPerson = await chai.request(app)
+			.get(`/people/${JACK_KNOWLES_PERSON_UUID}`);
+
+		lizzieChapmanPerson = await chai.request(app)
+			.get(`/people/${LIZZIE_CHAPMAN_PERSON_UUID}`);
+
+		stageManagementLtdCompany = await chai.request(app)
+			.get(`/companies/${STAGE_MANAGEMENT_LTD_COMPANY_UUID}`);
+
+		charlottePadghamPerson = await chai.request(app)
+			.get(`/people/${CHARLOTTE_PADGHAM_PERSON_UUID}`);
+
+		barCharacter = await chai.request(app)
+			.get(`/characters/${BAR_CHARACTER_UUID}`);
+
+	});
+
+	after(() => {
+
+		sandbox.restore();
+
+	});
+
+	describe('The Great Game: Afghanistan at Roda Theatre (production with sub-sub-productions that have a sur-venue)', () => {
+
+		it('includes its sub-productions and sub-sub-productions', () => {
+
+			const expectedSubProductions = [
+				{
+					model: 'PRODUCTION',
+					uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+					name: 'Part One - Invasions and Independence 1842-1930',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					subProductions: [
+						{
+							model: 'PRODUCTION',
+							uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
+							name: 'Bugles at the Gates of Jalalabad',
+							startDate: '2010-10-22',
+							endDate: '2010-11-07',
+							venue: {
+								model: 'VENUE',
+								uuid: RODA_THEATRE_VENUE_UUID,
+								name: 'Roda Theatre',
+								surVenue: {
+									model: 'VENUE',
+									uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+									name: 'Berkeley Repertory Theatre'
+								}
+							}
+						},
+						{
+							model: 'PRODUCTION',
+							uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
+							name: 'Durand\'s Line',
+							startDate: '2010-10-22',
+							endDate: '2010-11-07',
+							venue: {
+								model: 'VENUE',
+								uuid: RODA_THEATRE_VENUE_UUID,
+								name: 'Roda Theatre',
+								surVenue: {
+									model: 'VENUE',
+									uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+									name: 'Berkeley Repertory Theatre'
+								}
+							}
+						},
+						{
+							model: 'PRODUCTION',
+							uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
+							name: 'Campaign',
+							startDate: '2010-10-22',
+							endDate: '2010-11-07',
+							venue: {
+								model: 'VENUE',
+								uuid: RODA_THEATRE_VENUE_UUID,
+								name: 'Roda Theatre',
+								surVenue: {
+									model: 'VENUE',
+									uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+									name: 'Berkeley Repertory Theatre'
+								}
+							}
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+					name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					subProductions: [
+						{
+							model: 'PRODUCTION',
+							uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
+							name: 'Black Tulips',
+							startDate: '2010-10-22',
+							endDate: '2010-11-07',
+							venue: {
+								model: 'VENUE',
+								uuid: RODA_THEATRE_VENUE_UUID,
+								name: 'Roda Theatre',
+								surVenue: {
+									model: 'VENUE',
+									uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+									name: 'Berkeley Repertory Theatre'
+								}
+							}
+						},
+						{
+							model: 'PRODUCTION',
+							uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
+							name: 'Blood and Gifts',
+							startDate: '2010-10-22',
+							endDate: '2010-11-07',
+							venue: {
+								model: 'VENUE',
+								uuid: RODA_THEATRE_VENUE_UUID,
+								name: 'Roda Theatre',
+								surVenue: {
+									model: 'VENUE',
+									uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+									name: 'Berkeley Repertory Theatre'
+								}
+							}
+						},
+						{
+							model: 'PRODUCTION',
+							uuid: MINISKIRTS_OF_KABUL_RODA_PRODUCTION_UUID,
+							name: 'Miniskirts of Kabul',
+							startDate: '2010-10-22',
+							endDate: '2010-11-07',
+							venue: {
+								model: 'VENUE',
+								uuid: RODA_THEATRE_VENUE_UUID,
+								name: 'Roda Theatre',
+								surVenue: {
+									model: 'VENUE',
+									uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+									name: 'Berkeley Repertory Theatre'
+								}
+							}
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+					name: 'Part Three - Enduring Freedom 1996-2009',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					subProductions: [
+						{
+							model: 'PRODUCTION',
+							uuid: HONEY_RODA_PRODUCTION_UUID,
+							name: 'Honey',
+							startDate: '2010-10-22',
+							endDate: '2010-11-07',
+							venue: {
+								model: 'VENUE',
+								uuid: RODA_THEATRE_VENUE_UUID,
+								name: 'Roda Theatre',
+								surVenue: {
+									model: 'VENUE',
+									uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+									name: 'Berkeley Repertory Theatre'
+								}
+							}
+						},
+						{
+							model: 'PRODUCTION',
+							uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
+							name: 'The Night Is Darkest Before the Dawn',
+							startDate: '2010-10-22',
+							endDate: '2010-11-07',
+							venue: {
+								model: 'VENUE',
+								uuid: RODA_THEATRE_VENUE_UUID,
+								name: 'Roda Theatre',
+								surVenue: {
+									model: 'VENUE',
+									uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+									name: 'Berkeley Repertory Theatre'
+								}
+							}
+						},
+						{
+							model: 'PRODUCTION',
+							uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
+							name: 'On the Side of the Angels',
+							startDate: '2010-10-22',
+							endDate: '2010-11-07',
+							venue: {
+								model: 'VENUE',
+								uuid: RODA_THEATRE_VENUE_UUID,
+								name: 'Roda Theatre',
+								surVenue: {
+									model: 'VENUE',
+									uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+									name: 'Berkeley Repertory Theatre'
+								}
+							}
+						}
+					]
+				}
+			];
+
+			const { subProductions } = theGreatGameAfghanistanRodaProduction.body;
+
+			expect(subProductions).to.deep.equal(expectedSubProductions);
+
+		});
+
+	});
+
+	describe('Part One - Invasions and Independence 1842-1930 at Roda Theatre (production with sur-production and sub-productions that have a sur-venue)', () => {
+
+		it('includes The Great Game at Roda Theatre as its sur-production', () => {
+
+			const expectedSurProduction = {
+				model: 'PRODUCTION',
+				uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+				name: 'The Great Game: Afghanistan',
+				startDate: '2010-10-22',
+				endDate: '2010-11-07',
+				venue: {
+					model: 'VENUE',
+					uuid: RODA_THEATRE_VENUE_UUID,
+					name: 'Roda Theatre',
+					surVenue: {
+						model: 'VENUE',
+						uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+						name: 'Berkeley Repertory Theatre'
+					}
+				},
+				surProduction: null
+			};
+
+			const { surProduction } = partOneInvasionsAndIndependenceRodaProduction.body;
+
+			expect(surProduction).to.deep.equal(expectedSurProduction);
+
+		});
+
+		it('includes its sub-productions', () => {
+
+			const expectedSubProductions = [
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					subProductions: []
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					subProductions: []
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
+					name: 'Campaign',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					subProductions: []
+				}
+			];
+
+			const { subProductions } = partOneInvasionsAndIndependenceRodaProduction.body;
+
+			expect(subProductions).to.deep.equal(expectedSubProductions);
+
+		});
+
+	});
+
+	describe('Bugles at the Gates of Jalalabad at Roda Theatre', () => {
+
+		it('includes Part One - Invasions and Independence 1842-1930 at Roda Theatre as its sur-production and The Great Game: Afghanistan at Roda Theatre as its sur-sur-production', () => {
+
+			const expectedSurProduction = {
+				model: 'PRODUCTION',
+				uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+				name: 'Part One - Invasions and Independence 1842-1930',
+				startDate: '2010-10-22',
+				endDate: '2010-11-07',
+				venue: {
+					model: 'VENUE',
+					uuid: RODA_THEATRE_VENUE_UUID,
+					name: 'Roda Theatre',
+					surVenue: {
+						model: 'VENUE',
+						uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+						name: 'Berkeley Repertory Theatre'
+					}
+				},
+				surProduction: {
+					model: 'PRODUCTION',
+					uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+					name: 'The Great Game: Afghanistan'
+				}
+			};
+
+			const { surProduction } = buglesAtTheGatesOfJalalabadRodaProduction.body;
+
+			expect(surProduction).to.deep.equal(expectedSurProduction);
+
+		});
+
+	});
+
+	describe('The Great Game: Afghanistan at Tricycle Theatre (production with sub-sub-productions that do not have a sur-venue)', () => {
+
+		it('includes its sub-productions and sub-sub-productions', () => {
+
+			const expectedSubProductions = [
+				{
+					model: 'PRODUCTION',
+					uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_TRICYCLE_PRODUCTION_UUID,
+					name: 'Part One - Invasions and Independence 1842-1930',
+					startDate: '2009-04-17',
+					endDate: '2009-06-14',
+					venue: {
+						model: 'VENUE',
+						uuid: TRICYCLE_THEATRE_VENUE_UUID,
+						name: 'Tricycle Theatre',
+						surVenue: null
+					},
+					subProductions: [
+						{
+							model: 'PRODUCTION',
+							uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_TRICYCLE_PRODUCTION_UUID,
+							name: 'Bugles at the Gates of Jalalabad',
+							startDate: '2009-04-17',
+							endDate: '2009-06-14',
+							venue: {
+								model: 'VENUE',
+								uuid: TRICYCLE_THEATRE_VENUE_UUID,
+								name: 'Tricycle Theatre',
+								surVenue: null
+							}
+						},
+						{
+							model: 'PRODUCTION',
+							uuid: DURANDS_LINE_TRICYCLE_PRODUCTION_UUID,
+							name: 'Durand\'s Line',
+							startDate: '2009-04-17',
+							endDate: '2009-06-14',
+							venue: {
+								model: 'VENUE',
+								uuid: TRICYCLE_THEATRE_VENUE_UUID,
+								name: 'Tricycle Theatre',
+								surVenue: null
+							}
+						},
+						{
+							model: 'PRODUCTION',
+							uuid: CAMPAIGN_TRICYCLE_PRODUCTION_UUID,
+							name: 'Campaign',
+							startDate: '2009-04-17',
+							endDate: '2009-06-14',
+							venue: {
+								model: 'VENUE',
+								uuid: TRICYCLE_THEATRE_VENUE_UUID,
+								name: 'Tricycle Theatre',
+								surVenue: null
+							}
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_TRICYCLE_PRODUCTION_UUID,
+					name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+					startDate: '2009-04-17',
+					endDate: '2009-06-14',
+					venue: {
+						model: 'VENUE',
+						uuid: TRICYCLE_THEATRE_VENUE_UUID,
+						name: 'Tricycle Theatre',
+						surVenue: null
+					},
+					subProductions: [
+						{
+							model: 'PRODUCTION',
+							uuid: BLACK_TULIPS_TRICYCLE_PRODUCTION_UUID,
+							name: 'Black Tulips',
+							startDate: '2009-04-17',
+							endDate: '2009-06-14',
+							venue: {
+								model: 'VENUE',
+								uuid: TRICYCLE_THEATRE_VENUE_UUID,
+								name: 'Tricycle Theatre',
+								surVenue: null
+							}
+						},
+						{
+							model: 'PRODUCTION',
+							uuid: BLOOD_AND_GIFTS_TRICYCLE_PRODUCTION_UUID,
+							name: 'Blood and Gifts',
+							startDate: '2009-04-17',
+							endDate: '2009-06-14',
+							venue: {
+								model: 'VENUE',
+								uuid: TRICYCLE_THEATRE_VENUE_UUID,
+								name: 'Tricycle Theatre',
+								surVenue: null
+							}
+						},
+						{
+							model: 'PRODUCTION',
+							uuid: MINISKIRTS_OF_KABUL_TRICYCLE_PRODUCTION_UUID,
+							name: 'Miniskirts of Kabul',
+							startDate: '2009-04-17',
+							endDate: '2009-06-14',
+							venue: {
+								model: 'VENUE',
+								uuid: TRICYCLE_THEATRE_VENUE_UUID,
+								name: 'Tricycle Theatre',
+								surVenue: null
+							}
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: PART_THREE_ENDURING_FREEDOM_TRICYCLE_PRODUCTION_UUID,
+					name: 'Part Three - Enduring Freedom 1996-2009',
+					startDate: '2009-04-17',
+					endDate: '2009-06-14',
+					venue: {
+						model: 'VENUE',
+						uuid: TRICYCLE_THEATRE_VENUE_UUID,
+						name: 'Tricycle Theatre',
+						surVenue: null
+					},
+					subProductions: [
+						{
+							model: 'PRODUCTION',
+							uuid: HONEY_TRICYCLE_PRODUCTION_UUID,
+							name: 'Honey',
+							startDate: '2009-04-17',
+							endDate: '2009-06-14',
+							venue: {
+								model: 'VENUE',
+								uuid: TRICYCLE_THEATRE_VENUE_UUID,
+								name: 'Tricycle Theatre',
+								surVenue: null
+							}
+						},
+						{
+							model: 'PRODUCTION',
+							uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_TRICYCLE_PRODUCTION_UUID,
+							name: 'The Night Is Darkest Before the Dawn',
+							startDate: '2009-04-17',
+							endDate: '2009-06-14',
+							venue: {
+								model: 'VENUE',
+								uuid: TRICYCLE_THEATRE_VENUE_UUID,
+								name: 'Tricycle Theatre',
+								surVenue: null
+							}
+						},
+						{
+							model: 'PRODUCTION',
+							uuid: ON_THE_SIDE_OF_THE_ANGELS_TRICYCLE_PRODUCTION_UUID,
+							name: 'On the Side of the Angels',
+							startDate: '2009-04-17',
+							endDate: '2009-06-14',
+							venue: {
+								model: 'VENUE',
+								uuid: TRICYCLE_THEATRE_VENUE_UUID,
+								name: 'Tricycle Theatre',
+								surVenue: null
+							}
+						}
+					]
+				}
+			];
+
+			const { subProductions } = theGreatGameAfghanistanTricycleProduction.body;
+
+			expect(subProductions).to.deep.equal(expectedSubProductions);
+
+		});
+
+	});
+
+	describe('Part One - Invasions and Independence 1842-1930 at Tricycle Theatre (production with sur-production and sub-productions that do not have a sur-venue)', () => {
+
+		it('includes The Great Game at Tricycle Theatre as its sur-production', () => {
+
+			const expectedSurProduction = {
+				model: 'PRODUCTION',
+				uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
+				name: 'The Great Game: Afghanistan',
+				startDate: '2009-04-17',
+				endDate: '2009-06-14',
+				venue: {
+					model: 'VENUE',
+					uuid: TRICYCLE_THEATRE_VENUE_UUID,
+					name: 'Tricycle Theatre',
+					surVenue: null
+				},
+				surProduction: null
+			};
+
+			const { surProduction } = partOneInvasionsAndIndependenceTricycleProduction.body;
+
+			expect(surProduction).to.deep.equal(expectedSurProduction);
+
+		});
+
+		it('includes its sub-productions', () => {
+
+			const expectedSubProductions = [
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_TRICYCLE_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2009-04-17',
+					endDate: '2009-06-14',
+					venue: {
+						model: 'VENUE',
+						uuid: TRICYCLE_THEATRE_VENUE_UUID,
+						name: 'Tricycle Theatre',
+						surVenue: null
+					},
+					subProductions: []
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_TRICYCLE_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2009-04-17',
+					endDate: '2009-06-14',
+					venue: {
+						model: 'VENUE',
+						uuid: TRICYCLE_THEATRE_VENUE_UUID,
+						name: 'Tricycle Theatre',
+						surVenue: null
+					},
+					subProductions: []
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: CAMPAIGN_TRICYCLE_PRODUCTION_UUID,
+					name: 'Campaign',
+					startDate: '2009-04-17',
+					endDate: '2009-06-14',
+					venue: {
+						model: 'VENUE',
+						uuid: TRICYCLE_THEATRE_VENUE_UUID,
+						name: 'Tricycle Theatre',
+						surVenue: null
+					},
+					subProductions: []
+				}
+			];
+
+			const { subProductions } = partOneInvasionsAndIndependenceTricycleProduction.body;
+
+			expect(subProductions).to.deep.equal(expectedSubProductions);
+
+		});
+
+	});
+
+	describe('Bugles at the Gates of Jalalabad at Tricycle Theatre', () => {
+
+		it('includes Part One - Invasions and Independence 1842-1930 at Tricycle Theatre as its sur-production and The Great Game: Afghanistan at Tricycle Theatre as its sur-sur-production', () => {
+
+			const expectedSurProduction = {
+				model: 'PRODUCTION',
+				uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_TRICYCLE_PRODUCTION_UUID,
+				name: 'Part One - Invasions and Independence 1842-1930',
+				startDate: '2009-04-17',
+				endDate: '2009-06-14',
+				venue: {
+					model: 'VENUE',
+					uuid: TRICYCLE_THEATRE_VENUE_UUID,
+					name: 'Tricycle Theatre',
+					surVenue: null
+				},
+				surProduction: {
+					model: 'PRODUCTION',
+					uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
+					name: 'The Great Game: Afghanistan'
+				}
+			};
+
+			const { surProduction } = buglesAtTheGatesOfJalalabadTricycleProduction.body;
+
+			expect(surProduction).to.deep.equal(expectedSurProduction);
+
+		});
+
+	});
+
+	describe('The Great Game: Afghanistan (material)', () => {
+
+		it('includes its productions (but with no sur-productions as does not apply)', () => {
+
+			const expectedProductions = [
+				{
+					model: 'PRODUCTION',
+					uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+					name: 'The Great Game: Afghanistan',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: null
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
+					name: 'The Great Game: Afghanistan',
+					startDate: '2009-04-17',
+					endDate: '2009-06-14',
+					venue: {
+						model: 'VENUE',
+						uuid: TRICYCLE_THEATRE_VENUE_UUID,
+						name: 'Tricycle Theatre',
+						surVenue: null
+					},
+					surProduction: null
+				}
+			];
+
+			const { productions } = theGreatGameAfghanistanMaterial.body;
+
+			expect(productions).to.deep.equal(expectedProductions);
+
+		});
+
+	});
+
+	describe('Part One - Invasions and Independence 1842-1930 (material)', () => {
+
+		it('includes its productions and their sur-productions', () => {
+
+			const expectedProductions = [
+				{
+					model: 'PRODUCTION',
+					uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+					name: 'Part One - Invasions and Independence 1842-1930',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+						name: 'The Great Game: Afghanistan',
+						surProduction: null
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_TRICYCLE_PRODUCTION_UUID,
+					name: 'Part One - Invasions and Independence 1842-1930',
+					startDate: '2009-04-17',
+					endDate: '2009-06-14',
+					venue: {
+						model: 'VENUE',
+						uuid: TRICYCLE_THEATRE_VENUE_UUID,
+						name: 'Tricycle Theatre',
+						surVenue: null
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
+						name: 'The Great Game: Afghanistan',
+						surProduction: null
+					}
+				}
+			];
+
+			const { productions } = partOneInvasionsAndIndependenceMaterial.body;
+
+			expect(productions).to.deep.equal(expectedProductions);
+
+		});
+
+	});
+
+	describe('Bugles at the Gates of Jalalabad (material)', () => {
+
+		it('includes its productions and their sur-productions and sur-sur-productions', () => {
+
+			const expectedProductions = [
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_TRICYCLE_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2009-04-17',
+					endDate: '2009-06-14',
+					venue: {
+						model: 'VENUE',
+						uuid: TRICYCLE_THEATRE_VENUE_UUID,
+						name: 'Tricycle Theatre',
+						surVenue: null
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_TRICYCLE_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				}
+			];
+
+			const { productions } = buglesAtTheGatesOfJalalabadMaterial.body;
+
+			expect(productions).to.deep.equal(expectedProductions);
+
+		});
+
+	});
+
+	describe('Berkeley Repertory Theatre (venue)', () => {
+
+		it('includes productions at this venue, including the specific sub-venue and, where applicable, corresponding sur-productions and sur-sur-productions; will exclude sur-productions when included via sub-production association', () => {
+
+			const expectedProductions = [
+				{
+					model: 'PRODUCTION',
+					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
+					name: 'Black Tulips',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					subVenue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre'
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
+					name: 'Blood and Gifts',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					subVenue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre'
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					subVenue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre'
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
+					name: 'Campaign',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					subVenue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre'
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					subVenue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre'
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: HONEY_RODA_PRODUCTION_UUID,
+					name: 'Honey',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					subVenue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre'
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: MINISKIRTS_OF_KABUL_RODA_PRODUCTION_UUID,
+					name: 'Miniskirts of Kabul',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					subVenue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre'
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
+					name: 'On the Side of the Angels',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					subVenue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre'
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					subVenue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre'
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				}
+			];
+
+			const { productions } = berkeleyRepertoryTheatreVenue.body;
+
+			expect(productions).to.deep.equal(expectedProductions);
+
+		});
+
+	});
+
+	describe('Roda Theatre (venue)', () => {
+
+		it('includes productions at this venue and, where applicable, corresponding sur-productions and sur-sur-productions; will exclude sur-productions when included via sub-production association', () => {
+
+			const expectedProductions = [
+				{
+					model: 'PRODUCTION',
+					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
+					name: 'Black Tulips',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					subVenue: null,
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
+					name: 'Blood and Gifts',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					subVenue: null,
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					subVenue: null,
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
+					name: 'Campaign',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					subVenue: null,
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					subVenue: null,
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: HONEY_RODA_PRODUCTION_UUID,
+					name: 'Honey',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					subVenue: null,
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: MINISKIRTS_OF_KABUL_RODA_PRODUCTION_UUID,
+					name: 'Miniskirts of Kabul',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					subVenue: null,
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
+					name: 'On the Side of the Angels',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					subVenue: null,
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					subVenue: null,
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				}
+			];
+
+			const { productions } = rodaTheatreVenue.body;
+
+			expect(productions).to.deep.equal(expectedProductions);
+
+		});
+
+	});
+
+	describe('Nicolas Kent (person)', () => {
+
+		it('includes productions for which they have a producer credit, including the sur-production and sur-sur-production', () => {
+
+			const expectedProducerProductions = [
+				{
+					model: 'PRODUCTION',
+					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
+					name: 'Black Tulips',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
+					name: 'Blood and Gifts',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
+					name: 'Campaign',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: HONEY_RODA_PRODUCTION_UUID,
+					name: 'Honey',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: MINISKIRTS_OF_KABUL_RODA_PRODUCTION_UUID,
+					name: 'Miniskirts of Kabul',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
+					name: 'On the Side of the Angels',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { producerProductions } = nicolasKentPerson.body;
+
+			expect(producerProductions).to.deep.equal(expectedProducerProductions);
+
+		});
+
+	});
+
+	describe('Tricycle Theatre Company (company)', () => {
+
+		it('includes productions for which they have a producer credit, including the sur-production and sur-sur-production', () => {
+
+			const expectedProducerProductions = [
+				{
+					model: 'PRODUCTION',
+					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
+					name: 'Black Tulips',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
+					name: 'Blood and Gifts',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
+					name: 'Campaign',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: HONEY_RODA_PRODUCTION_UUID,
+					name: 'Honey',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: MINISKIRTS_OF_KABUL_RODA_PRODUCTION_UUID,
+					name: 'Miniskirts of Kabul',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
+					name: 'On the Side of the Angels',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { producerProductions } = tricycleTheatreCompany.body;
+
+			expect(producerProductions).to.deep.equal(expectedProducerProductions);
+
+		});
+
+	});
+
+	describe('Zoë Ingenhaag (person)', () => {
+
+		it('includes productions for which they have a producer credit, including the sur-production and sur-sur-production', () => {
+
+			const expectedProducerProductions = [
+				{
+					model: 'PRODUCTION',
+					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
+					name: 'Black Tulips',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
+					name: 'Blood and Gifts',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
+					name: 'Campaign',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: HONEY_RODA_PRODUCTION_UUID,
+					name: 'Honey',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: MINISKIRTS_OF_KABUL_RODA_PRODUCTION_UUID,
+					name: 'Miniskirts of Kabul',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
+					name: 'On the Side of the Angels',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { producerProductions } = zoëIngenhaagPerson.body;
+
+			expect(producerProductions).to.deep.equal(expectedProducerProductions);
+
+		});
+
+	});
+
+	describe('Rick Warden (person)', () => {
+
+		it('includes productions for which they have a cast credit, including the sur-production and sur-sur-production', () => {
+
+			const expectedCastMemberProductions = [
+				{
+					model: 'PRODUCTION',
+					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
+					name: 'Black Tulips',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					roles: [
+						{
+							model: 'CHARACTER',
+							uuid: BAR_CHARACTER_UUID,
+							name: 'Bar',
+							qualifier: null,
+							isAlternate: false
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
+					name: 'Blood and Gifts',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					roles: [
+						{
+							model: 'CHARACTER',
+							uuid: BAR_CHARACTER_UUID,
+							name: 'Bar',
+							qualifier: null,
+							isAlternate: false
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					roles: [
+						{
+							model: 'CHARACTER',
+							uuid: BAR_CHARACTER_UUID,
+							name: 'Bar',
+							qualifier: null,
+							isAlternate: false
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
+					name: 'Campaign',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					roles: [
+						{
+							model: 'CHARACTER',
+							uuid: BAR_CHARACTER_UUID,
+							name: 'Bar',
+							qualifier: null,
+							isAlternate: false
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					roles: [
+						{
+							model: 'CHARACTER',
+							uuid: BAR_CHARACTER_UUID,
+							name: 'Bar',
+							qualifier: null,
+							isAlternate: false
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: HONEY_RODA_PRODUCTION_UUID,
+					name: 'Honey',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					roles: [
+						{
+							model: 'CHARACTER',
+							uuid: BAR_CHARACTER_UUID,
+							name: 'Bar',
+							qualifier: null,
+							isAlternate: false
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: MINISKIRTS_OF_KABUL_RODA_PRODUCTION_UUID,
+					name: 'Miniskirts of Kabul',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					roles: [
+						{
+							model: 'CHARACTER',
+							uuid: BAR_CHARACTER_UUID,
+							name: 'Bar',
+							qualifier: null,
+							isAlternate: false
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
+					name: 'On the Side of the Angels',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					roles: [
+						{
+							model: 'CHARACTER',
+							uuid: BAR_CHARACTER_UUID,
+							name: 'Bar',
+							qualifier: null,
+							isAlternate: false
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					roles: [
+						{
+							model: 'CHARACTER',
+							uuid: BAR_CHARACTER_UUID,
+							name: 'Bar',
+							qualifier: null,
+							isAlternate: false
+						}
+					]
+				}
+			];
+
+			const { castMemberProductions } = rickWardenPerson.body;
+
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
+
+		});
+
+	});
+
+	describe('Howard Harrison (person)', () => {
+
+		it('includes productions for which they have a creative team credit, including the sur-production and sur-sur-production', () => {
+
+			const expectedCreativeProductions = [
+				{
+					model: 'PRODUCTION',
+					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
+					name: 'Black Tulips',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							employerCompany: null,
+							coEntities: [
+								{
+									model: 'COMPANY',
+									uuid: LIGHTING_DESIGN_LTD_COMPANY_UUID,
+									name: 'Lighting Design Ltd',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: JACK_KNOWLES_PERSON_UUID,
+											name: 'Jack Knowles'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
+					name: 'Blood and Gifts',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							employerCompany: null,
+							coEntities: [
+								{
+									model: 'COMPANY',
+									uuid: LIGHTING_DESIGN_LTD_COMPANY_UUID,
+									name: 'Lighting Design Ltd',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: JACK_KNOWLES_PERSON_UUID,
+											name: 'Jack Knowles'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							employerCompany: null,
+							coEntities: [
+								{
+									model: 'COMPANY',
+									uuid: LIGHTING_DESIGN_LTD_COMPANY_UUID,
+									name: 'Lighting Design Ltd',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: JACK_KNOWLES_PERSON_UUID,
+											name: 'Jack Knowles'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
+					name: 'Campaign',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							employerCompany: null,
+							coEntities: [
+								{
+									model: 'COMPANY',
+									uuid: LIGHTING_DESIGN_LTD_COMPANY_UUID,
+									name: 'Lighting Design Ltd',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: JACK_KNOWLES_PERSON_UUID,
+											name: 'Jack Knowles'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							employerCompany: null,
+							coEntities: [
+								{
+									model: 'COMPANY',
+									uuid: LIGHTING_DESIGN_LTD_COMPANY_UUID,
+									name: 'Lighting Design Ltd',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: JACK_KNOWLES_PERSON_UUID,
+											name: 'Jack Knowles'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: HONEY_RODA_PRODUCTION_UUID,
+					name: 'Honey',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							employerCompany: null,
+							coEntities: [
+								{
+									model: 'COMPANY',
+									uuid: LIGHTING_DESIGN_LTD_COMPANY_UUID,
+									name: 'Lighting Design Ltd',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: JACK_KNOWLES_PERSON_UUID,
+											name: 'Jack Knowles'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: MINISKIRTS_OF_KABUL_RODA_PRODUCTION_UUID,
+					name: 'Miniskirts of Kabul',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							employerCompany: null,
+							coEntities: [
+								{
+									model: 'COMPANY',
+									uuid: LIGHTING_DESIGN_LTD_COMPANY_UUID,
+									name: 'Lighting Design Ltd',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: JACK_KNOWLES_PERSON_UUID,
+											name: 'Jack Knowles'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
+					name: 'On the Side of the Angels',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							employerCompany: null,
+							coEntities: [
+								{
+									model: 'COMPANY',
+									uuid: LIGHTING_DESIGN_LTD_COMPANY_UUID,
+									name: 'Lighting Design Ltd',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: JACK_KNOWLES_PERSON_UUID,
+											name: 'Jack Knowles'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							employerCompany: null,
+							coEntities: [
+								{
+									model: 'COMPANY',
+									uuid: LIGHTING_DESIGN_LTD_COMPANY_UUID,
+									name: 'Lighting Design Ltd',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: JACK_KNOWLES_PERSON_UUID,
+											name: 'Jack Knowles'
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { creativeProductions } = howardHarrisonPerson.body;
+
+			expect(creativeProductions).to.deep.equal(expectedCreativeProductions);
+
+		});
+
+	});
+
+	describe('Lighting Design Ltd (company)', () => {
+
+		it('includes productions for which they have a creative team credit, including the sur-production and sur-sur-production', () => {
+
+			const expectedCreativeProductions = [
+				{
+					model: 'PRODUCTION',
+					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
+					name: 'Black Tulips',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							members: [
+								{
+									model: 'PERSON',
+									uuid: JACK_KNOWLES_PERSON_UUID,
+									name: 'Jack Knowles'
+								}
+							],
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: HOWARD_HARRISON_PERSON_UUID,
+									name: 'Howard Harrison'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
+					name: 'Blood and Gifts',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							members: [
+								{
+									model: 'PERSON',
+									uuid: JACK_KNOWLES_PERSON_UUID,
+									name: 'Jack Knowles'
+								}
+							],
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: HOWARD_HARRISON_PERSON_UUID,
+									name: 'Howard Harrison'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							members: [
+								{
+									model: 'PERSON',
+									uuid: JACK_KNOWLES_PERSON_UUID,
+									name: 'Jack Knowles'
+								}
+							],
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: HOWARD_HARRISON_PERSON_UUID,
+									name: 'Howard Harrison'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
+					name: 'Campaign',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							members: [
+								{
+									model: 'PERSON',
+									uuid: JACK_KNOWLES_PERSON_UUID,
+									name: 'Jack Knowles'
+								}
+							],
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: HOWARD_HARRISON_PERSON_UUID,
+									name: 'Howard Harrison'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							members: [
+								{
+									model: 'PERSON',
+									uuid: JACK_KNOWLES_PERSON_UUID,
+									name: 'Jack Knowles'
+								}
+							],
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: HOWARD_HARRISON_PERSON_UUID,
+									name: 'Howard Harrison'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: HONEY_RODA_PRODUCTION_UUID,
+					name: 'Honey',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							members: [
+								{
+									model: 'PERSON',
+									uuid: JACK_KNOWLES_PERSON_UUID,
+									name: 'Jack Knowles'
+								}
+							],
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: HOWARD_HARRISON_PERSON_UUID,
+									name: 'Howard Harrison'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: MINISKIRTS_OF_KABUL_RODA_PRODUCTION_UUID,
+					name: 'Miniskirts of Kabul',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							members: [
+								{
+									model: 'PERSON',
+									uuid: JACK_KNOWLES_PERSON_UUID,
+									name: 'Jack Knowles'
+								}
+							],
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: HOWARD_HARRISON_PERSON_UUID,
+									name: 'Howard Harrison'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
+					name: 'On the Side of the Angels',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							members: [
+								{
+									model: 'PERSON',
+									uuid: JACK_KNOWLES_PERSON_UUID,
+									name: 'Jack Knowles'
+								}
+							],
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: HOWARD_HARRISON_PERSON_UUID,
+									name: 'Howard Harrison'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							members: [
+								{
+									model: 'PERSON',
+									uuid: JACK_KNOWLES_PERSON_UUID,
+									name: 'Jack Knowles'
+								}
+							],
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: HOWARD_HARRISON_PERSON_UUID,
+									name: 'Howard Harrison'
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { creativeProductions } = lightingDesignLtdCompany.body;
+
+			expect(creativeProductions).to.deep.equal(expectedCreativeProductions);
+
+		});
+
+	});
+
+	describe('Jack Knowles (person)', () => {
+
+		it('includes productions for which they have a creative team credit, including the sur-production and sur-sur-production', () => {
+
+			const expectedCreativeProductions = [
+				{
+					model: 'PRODUCTION',
+					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
+					name: 'Black Tulips',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							employerCompany: {
+								model: 'COMPANY',
+								uuid: LIGHTING_DESIGN_LTD_COMPANY_UUID,
+								name: 'Lighting Design Ltd',
+								coMembers: []
+							},
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: HOWARD_HARRISON_PERSON_UUID,
+									name: 'Howard Harrison'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
+					name: 'Blood and Gifts',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							employerCompany: {
+								model: 'COMPANY',
+								uuid: LIGHTING_DESIGN_LTD_COMPANY_UUID,
+								name: 'Lighting Design Ltd',
+								coMembers: []
+							},
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: HOWARD_HARRISON_PERSON_UUID,
+									name: 'Howard Harrison'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							employerCompany: {
+								model: 'COMPANY',
+								uuid: LIGHTING_DESIGN_LTD_COMPANY_UUID,
+								name: 'Lighting Design Ltd',
+								coMembers: []
+							},
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: HOWARD_HARRISON_PERSON_UUID,
+									name: 'Howard Harrison'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
+					name: 'Campaign',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							employerCompany: {
+								model: 'COMPANY',
+								uuid: LIGHTING_DESIGN_LTD_COMPANY_UUID,
+								name: 'Lighting Design Ltd',
+								coMembers: []
+							},
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: HOWARD_HARRISON_PERSON_UUID,
+									name: 'Howard Harrison'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							employerCompany: {
+								model: 'COMPANY',
+								uuid: LIGHTING_DESIGN_LTD_COMPANY_UUID,
+								name: 'Lighting Design Ltd',
+								coMembers: []
+							},
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: HOWARD_HARRISON_PERSON_UUID,
+									name: 'Howard Harrison'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: HONEY_RODA_PRODUCTION_UUID,
+					name: 'Honey',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							employerCompany: {
+								model: 'COMPANY',
+								uuid: LIGHTING_DESIGN_LTD_COMPANY_UUID,
+								name: 'Lighting Design Ltd',
+								coMembers: []
+							},
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: HOWARD_HARRISON_PERSON_UUID,
+									name: 'Howard Harrison'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: MINISKIRTS_OF_KABUL_RODA_PRODUCTION_UUID,
+					name: 'Miniskirts of Kabul',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							employerCompany: {
+								model: 'COMPANY',
+								uuid: LIGHTING_DESIGN_LTD_COMPANY_UUID,
+								name: 'Lighting Design Ltd',
+								coMembers: []
+							},
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: HOWARD_HARRISON_PERSON_UUID,
+									name: 'Howard Harrison'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
+					name: 'On the Side of the Angels',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							employerCompany: {
+								model: 'COMPANY',
+								uuid: LIGHTING_DESIGN_LTD_COMPANY_UUID,
+								name: 'Lighting Design Ltd',
+								coMembers: []
+							},
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: HOWARD_HARRISON_PERSON_UUID,
+									name: 'Howard Harrison'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							employerCompany: {
+								model: 'COMPANY',
+								uuid: LIGHTING_DESIGN_LTD_COMPANY_UUID,
+								name: 'Lighting Design Ltd',
+								coMembers: []
+							},
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: HOWARD_HARRISON_PERSON_UUID,
+									name: 'Howard Harrison'
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { creativeProductions } = jackKnowlesPerson.body;
+
+			expect(creativeProductions).to.deep.equal(expectedCreativeProductions);
+
+		});
+
+	});
+
+	describe('Lizzie Chapman (person)', () => {
+
+		it('includes productions for which they have a crew credit, including the sur-production and sur-sur-production', () => {
+
+			const expectedCrewProductions = [
+				{
+					model: 'PRODUCTION',
+					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
+					name: 'Black Tulips',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							employerCompany: null,
+							coEntities: [
+								{
+									model: 'COMPANY',
+									uuid: STAGE_MANAGEMENT_LTD_COMPANY_UUID,
+									name: 'Stage Management Ltd',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: CHARLOTTE_PADGHAM_PERSON_UUID,
+											name: 'Charlotte Padgham'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
+					name: 'Blood and Gifts',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							employerCompany: null,
+							coEntities: [
+								{
+									model: 'COMPANY',
+									uuid: STAGE_MANAGEMENT_LTD_COMPANY_UUID,
+									name: 'Stage Management Ltd',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: CHARLOTTE_PADGHAM_PERSON_UUID,
+											name: 'Charlotte Padgham'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							employerCompany: null,
+							coEntities: [
+								{
+									model: 'COMPANY',
+									uuid: STAGE_MANAGEMENT_LTD_COMPANY_UUID,
+									name: 'Stage Management Ltd',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: CHARLOTTE_PADGHAM_PERSON_UUID,
+											name: 'Charlotte Padgham'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
+					name: 'Campaign',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							employerCompany: null,
+							coEntities: [
+								{
+									model: 'COMPANY',
+									uuid: STAGE_MANAGEMENT_LTD_COMPANY_UUID,
+									name: 'Stage Management Ltd',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: CHARLOTTE_PADGHAM_PERSON_UUID,
+											name: 'Charlotte Padgham'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							employerCompany: null,
+							coEntities: [
+								{
+									model: 'COMPANY',
+									uuid: STAGE_MANAGEMENT_LTD_COMPANY_UUID,
+									name: 'Stage Management Ltd',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: CHARLOTTE_PADGHAM_PERSON_UUID,
+											name: 'Charlotte Padgham'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: HONEY_RODA_PRODUCTION_UUID,
+					name: 'Honey',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							employerCompany: null,
+							coEntities: [
+								{
+									model: 'COMPANY',
+									uuid: STAGE_MANAGEMENT_LTD_COMPANY_UUID,
+									name: 'Stage Management Ltd',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: CHARLOTTE_PADGHAM_PERSON_UUID,
+											name: 'Charlotte Padgham'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: MINISKIRTS_OF_KABUL_RODA_PRODUCTION_UUID,
+					name: 'Miniskirts of Kabul',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							employerCompany: null,
+							coEntities: [
+								{
+									model: 'COMPANY',
+									uuid: STAGE_MANAGEMENT_LTD_COMPANY_UUID,
+									name: 'Stage Management Ltd',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: CHARLOTTE_PADGHAM_PERSON_UUID,
+											name: 'Charlotte Padgham'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
+					name: 'On the Side of the Angels',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							employerCompany: null,
+							coEntities: [
+								{
+									model: 'COMPANY',
+									uuid: STAGE_MANAGEMENT_LTD_COMPANY_UUID,
+									name: 'Stage Management Ltd',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: CHARLOTTE_PADGHAM_PERSON_UUID,
+											name: 'Charlotte Padgham'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							employerCompany: null,
+							coEntities: [
+								{
+									model: 'COMPANY',
+									uuid: STAGE_MANAGEMENT_LTD_COMPANY_UUID,
+									name: 'Stage Management Ltd',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: CHARLOTTE_PADGHAM_PERSON_UUID,
+											name: 'Charlotte Padgham'
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { crewProductions } = lizzieChapmanPerson.body;
+
+			expect(crewProductions).to.deep.equal(expectedCrewProductions);
+
+		});
+
+	});
+
+	describe('Stage Management Ltd (company)', () => {
+
+		it('includes productions for which they have a crew credit, including the sur-production and sur-sur-production', () => {
+
+			const expectedCrewProductions = [
+				{
+					model: 'PRODUCTION',
+					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
+					name: 'Black Tulips',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							members: [
+								{
+									model: 'PERSON',
+									uuid: CHARLOTTE_PADGHAM_PERSON_UUID,
+									name: 'Charlotte Padgham'
+								}
+							],
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: LIZZIE_CHAPMAN_PERSON_UUID,
+									name: 'Lizzie Chapman'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
+					name: 'Blood and Gifts',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							members: [
+								{
+									model: 'PERSON',
+									uuid: CHARLOTTE_PADGHAM_PERSON_UUID,
+									name: 'Charlotte Padgham'
+								}
+							],
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: LIZZIE_CHAPMAN_PERSON_UUID,
+									name: 'Lizzie Chapman'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							members: [
+								{
+									model: 'PERSON',
+									uuid: CHARLOTTE_PADGHAM_PERSON_UUID,
+									name: 'Charlotte Padgham'
+								}
+							],
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: LIZZIE_CHAPMAN_PERSON_UUID,
+									name: 'Lizzie Chapman'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
+					name: 'Campaign',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							members: [
+								{
+									model: 'PERSON',
+									uuid: CHARLOTTE_PADGHAM_PERSON_UUID,
+									name: 'Charlotte Padgham'
+								}
+							],
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: LIZZIE_CHAPMAN_PERSON_UUID,
+									name: 'Lizzie Chapman'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							members: [
+								{
+									model: 'PERSON',
+									uuid: CHARLOTTE_PADGHAM_PERSON_UUID,
+									name: 'Charlotte Padgham'
+								}
+							],
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: LIZZIE_CHAPMAN_PERSON_UUID,
+									name: 'Lizzie Chapman'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: HONEY_RODA_PRODUCTION_UUID,
+					name: 'Honey',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							members: [
+								{
+									model: 'PERSON',
+									uuid: CHARLOTTE_PADGHAM_PERSON_UUID,
+									name: 'Charlotte Padgham'
+								}
+							],
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: LIZZIE_CHAPMAN_PERSON_UUID,
+									name: 'Lizzie Chapman'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: MINISKIRTS_OF_KABUL_RODA_PRODUCTION_UUID,
+					name: 'Miniskirts of Kabul',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							members: [
+								{
+									model: 'PERSON',
+									uuid: CHARLOTTE_PADGHAM_PERSON_UUID,
+									name: 'Charlotte Padgham'
+								}
+							],
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: LIZZIE_CHAPMAN_PERSON_UUID,
+									name: 'Lizzie Chapman'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
+					name: 'On the Side of the Angels',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							members: [
+								{
+									model: 'PERSON',
+									uuid: CHARLOTTE_PADGHAM_PERSON_UUID,
+									name: 'Charlotte Padgham'
+								}
+							],
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: LIZZIE_CHAPMAN_PERSON_UUID,
+									name: 'Lizzie Chapman'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							members: [
+								{
+									model: 'PERSON',
+									uuid: CHARLOTTE_PADGHAM_PERSON_UUID,
+									name: 'Charlotte Padgham'
+								}
+							],
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: LIZZIE_CHAPMAN_PERSON_UUID,
+									name: 'Lizzie Chapman'
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { crewProductions } = stageManagementLtdCompany.body;
+
+			expect(crewProductions).to.deep.equal(expectedCrewProductions);
+
+		});
+
+	});
+
+	describe('Charlotte Padgham (person)', () => {
+
+		it('includes productions for which they have a crew credit, including the sur-production and sur-sur-production', () => {
+
+			const expectedCrewProductions = [
+				{
+					model: 'PRODUCTION',
+					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
+					name: 'Black Tulips',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							employerCompany: {
+								model: 'COMPANY',
+								uuid: STAGE_MANAGEMENT_LTD_COMPANY_UUID,
+								name: 'Stage Management Ltd',
+								coMembers: []
+							},
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: LIZZIE_CHAPMAN_PERSON_UUID,
+									name: 'Lizzie Chapman'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
+					name: 'Blood and Gifts',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							employerCompany: {
+								model: 'COMPANY',
+								uuid: STAGE_MANAGEMENT_LTD_COMPANY_UUID,
+								name: 'Stage Management Ltd',
+								coMembers: []
+							},
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: LIZZIE_CHAPMAN_PERSON_UUID,
+									name: 'Lizzie Chapman'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							employerCompany: {
+								model: 'COMPANY',
+								uuid: STAGE_MANAGEMENT_LTD_COMPANY_UUID,
+								name: 'Stage Management Ltd',
+								coMembers: []
+							},
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: LIZZIE_CHAPMAN_PERSON_UUID,
+									name: 'Lizzie Chapman'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
+					name: 'Campaign',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							employerCompany: {
+								model: 'COMPANY',
+								uuid: STAGE_MANAGEMENT_LTD_COMPANY_UUID,
+								name: 'Stage Management Ltd',
+								coMembers: []
+							},
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: LIZZIE_CHAPMAN_PERSON_UUID,
+									name: 'Lizzie Chapman'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							employerCompany: {
+								model: 'COMPANY',
+								uuid: STAGE_MANAGEMENT_LTD_COMPANY_UUID,
+								name: 'Stage Management Ltd',
+								coMembers: []
+							},
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: LIZZIE_CHAPMAN_PERSON_UUID,
+									name: 'Lizzie Chapman'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: HONEY_RODA_PRODUCTION_UUID,
+					name: 'Honey',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							employerCompany: {
+								model: 'COMPANY',
+								uuid: STAGE_MANAGEMENT_LTD_COMPANY_UUID,
+								name: 'Stage Management Ltd',
+								coMembers: []
+							},
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: LIZZIE_CHAPMAN_PERSON_UUID,
+									name: 'Lizzie Chapman'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: MINISKIRTS_OF_KABUL_RODA_PRODUCTION_UUID,
+					name: 'Miniskirts of Kabul',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							employerCompany: {
+								model: 'COMPANY',
+								uuid: STAGE_MANAGEMENT_LTD_COMPANY_UUID,
+								name: 'Stage Management Ltd',
+								coMembers: []
+							},
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: LIZZIE_CHAPMAN_PERSON_UUID,
+									name: 'Lizzie Chapman'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
+					name: 'On the Side of the Angels',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							employerCompany: {
+								model: 'COMPANY',
+								uuid: STAGE_MANAGEMENT_LTD_COMPANY_UUID,
+								name: 'Stage Management Ltd',
+								coMembers: []
+							},
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: LIZZIE_CHAPMAN_PERSON_UUID,
+									name: 'Lizzie Chapman'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							employerCompany: {
+								model: 'COMPANY',
+								uuid: STAGE_MANAGEMENT_LTD_COMPANY_UUID,
+								name: 'Stage Management Ltd',
+								coMembers: []
+							},
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: LIZZIE_CHAPMAN_PERSON_UUID,
+									name: 'Lizzie Chapman'
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { crewProductions } = charlottePadghamPerson.body;
+
+			expect(crewProductions).to.deep.equal(expectedCrewProductions);
+
+		});
+
+	});
+
+	describe('Bar (character)', () => {
+
+		it('includes productions in which character was portrayed, including the sur-production and sur-sur-production', () => {
+
+			const expectedProductions = [
+				{
+					model: 'PRODUCTION',
+					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
+					name: 'Black Tulips',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					performers: [
+						{
+							model: 'PERSON',
+							uuid: RICK_WARDEN_PERSON_UUID,
+							name: 'Rick Warden',
+							roleName: 'Bar',
+							qualifier: null,
+							isAlternate: false,
+							otherRoles: []
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
+					name: 'Blood and Gifts',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					performers: [
+						{
+							model: 'PERSON',
+							uuid: RICK_WARDEN_PERSON_UUID,
+							name: 'Rick Warden',
+							roleName: 'Bar',
+							qualifier: null,
+							isAlternate: false,
+							otherRoles: []
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					performers: [
+						{
+							model: 'PERSON',
+							uuid: RICK_WARDEN_PERSON_UUID,
+							name: 'Rick Warden',
+							roleName: 'Bar',
+							qualifier: null,
+							isAlternate: false,
+							otherRoles: []
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
+					name: 'Campaign',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					performers: [
+						{
+							model: 'PERSON',
+							uuid: RICK_WARDEN_PERSON_UUID,
+							name: 'Rick Warden',
+							roleName: 'Bar',
+							qualifier: null,
+							isAlternate: false,
+							otherRoles: []
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					performers: [
+						{
+							model: 'PERSON',
+							uuid: RICK_WARDEN_PERSON_UUID,
+							name: 'Rick Warden',
+							roleName: 'Bar',
+							qualifier: null,
+							isAlternate: false,
+							otherRoles: []
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: HONEY_RODA_PRODUCTION_UUID,
+					name: 'Honey',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					performers: [
+						{
+							model: 'PERSON',
+							uuid: RICK_WARDEN_PERSON_UUID,
+							name: 'Rick Warden',
+							roleName: 'Bar',
+							qualifier: null,
+							isAlternate: false,
+							otherRoles: []
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: MINISKIRTS_OF_KABUL_RODA_PRODUCTION_UUID,
+					name: 'Miniskirts of Kabul',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					performers: [
+						{
+							model: 'PERSON',
+							uuid: RICK_WARDEN_PERSON_UUID,
+							name: 'Rick Warden',
+							roleName: 'Bar',
+							qualifier: null,
+							isAlternate: false,
+							otherRoles: []
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
+					name: 'On the Side of the Angels',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					performers: [
+						{
+							model: 'PERSON',
+							uuid: RICK_WARDEN_PERSON_UUID,
+							name: 'Rick Warden',
+							roleName: 'Bar',
+							qualifier: null,
+							isAlternate: false,
+							otherRoles: []
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					performers: [
+						{
+							model: 'PERSON',
+							uuid: RICK_WARDEN_PERSON_UUID,
+							name: 'Rick Warden',
+							roleName: 'Bar',
+							qualifier: null,
+							isAlternate: false,
+							otherRoles: []
+						}
+					]
+				}
+			];
+
+			const { productions } = barCharacter.body;
+
+			expect(productions).to.deep.equal(expectedProductions);
+
+		});
+
+	});
+
+	describe('productions list', () => {
+
+		it('includes productions and, where applicable, corresponding sur-productions and sur-sur-productions; will exclude sur-productions as these will be included via their sub-productions', async () => {
+
+			const response = await chai.request(app)
+				.get('/productions');
+
+			const expectedResponseBody = [
+				{
+					model: 'PRODUCTION',
+					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
+					name: 'Black Tulips',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
+					name: 'Blood and Gifts',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
+					name: 'Campaign',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: HONEY_RODA_PRODUCTION_UUID,
+					name: 'Honey',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: MINISKIRTS_OF_KABUL_RODA_PRODUCTION_UUID,
+					name: 'Miniskirts of Kabul',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
+					name: 'On the Side of the Angels',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BLACK_TULIPS_TRICYCLE_PRODUCTION_UUID,
+					name: 'Black Tulips',
+					startDate: '2009-04-17',
+					endDate: '2009-06-14',
+					venue: {
+						model: 'VENUE',
+						uuid: TRICYCLE_THEATRE_VENUE_UUID,
+						name: 'Tricycle Theatre',
+						surVenue: null
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_TRICYCLE_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BLOOD_AND_GIFTS_TRICYCLE_PRODUCTION_UUID,
+					name: 'Blood and Gifts',
+					startDate: '2009-04-17',
+					endDate: '2009-06-14',
+					venue: {
+						model: 'VENUE',
+						uuid: TRICYCLE_THEATRE_VENUE_UUID,
+						name: 'Tricycle Theatre',
+						surVenue: null
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_TRICYCLE_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_TRICYCLE_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2009-04-17',
+					endDate: '2009-06-14',
+					venue: {
+						model: 'VENUE',
+						uuid: TRICYCLE_THEATRE_VENUE_UUID,
+						name: 'Tricycle Theatre',
+						surVenue: null
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_TRICYCLE_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: CAMPAIGN_TRICYCLE_PRODUCTION_UUID,
+					name: 'Campaign',
+					startDate: '2009-04-17',
+					endDate: '2009-06-14',
+					venue: {
+						model: 'VENUE',
+						uuid: TRICYCLE_THEATRE_VENUE_UUID,
+						name: 'Tricycle Theatre',
+						surVenue: null
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_TRICYCLE_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_TRICYCLE_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2009-04-17',
+					endDate: '2009-06-14',
+					venue: {
+						model: 'VENUE',
+						uuid: TRICYCLE_THEATRE_VENUE_UUID,
+						name: 'Tricycle Theatre',
+						surVenue: null
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_TRICYCLE_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: HONEY_TRICYCLE_PRODUCTION_UUID,
+					name: 'Honey',
+					startDate: '2009-04-17',
+					endDate: '2009-06-14',
+					venue: {
+						model: 'VENUE',
+						uuid: TRICYCLE_THEATRE_VENUE_UUID,
+						name: 'Tricycle Theatre',
+						surVenue: null
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_TRICYCLE_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: MINISKIRTS_OF_KABUL_TRICYCLE_PRODUCTION_UUID,
+					name: 'Miniskirts of Kabul',
+					startDate: '2009-04-17',
+					endDate: '2009-06-14',
+					venue: {
+						model: 'VENUE',
+						uuid: TRICYCLE_THEATRE_VENUE_UUID,
+						name: 'Tricycle Theatre',
+						surVenue: null
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_TRICYCLE_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: ON_THE_SIDE_OF_THE_ANGELS_TRICYCLE_PRODUCTION_UUID,
+					name: 'On the Side of the Angels',
+					startDate: '2009-04-17',
+					endDate: '2009-06-14',
+					venue: {
+						model: 'VENUE',
+						uuid: TRICYCLE_THEATRE_VENUE_UUID,
+						name: 'Tricycle Theatre',
+						surVenue: null
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_TRICYCLE_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_TRICYCLE_PRODUCTION_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
+					startDate: '2009-04-17',
+					endDate: '2009-06-14',
+					venue: {
+						model: 'VENUE',
+						uuid: TRICYCLE_THEATRE_VENUE_UUID,
+						name: 'Tricycle Theatre',
+						surVenue: null
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_THREE_ENDURING_FREEDOM_TRICYCLE_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				}
+			];
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+
+		});
+
+	});
+
+});


### PR DESCRIPTION
This PR enables three-tiered production collections, i.e. a collection of productions, which in turn are also each a collection of productions.

---

## Real-life examples

#### The Bomb: A Partial History at Tricycle Theatre (production)
<img width="614" alt="the-bomb-a-partial-history-at-tricycle-theatre-production" src="https://user-images.githubusercontent.com/10484515/222929502-8c18ae68-1653-4686-a809-7d98e0357827.png">

---

#### First Blast: Proliferation (1940-1992) at Tricycle Theatre (production)
<img width="597" alt="first-blast-proliferation-at-tricycle-theatre-production" src="https://user-images.githubusercontent.com/10484515/222929505-a1f0c5db-8143-4cd9-afbb-5f06cf536108.png">

---

#### From Elsewhere: The Message… at Tricycle Theatre (production)
<img width="802" alt="from-elsewhere-the-message-at-tricycle-theatre-production" src="https://user-images.githubusercontent.com/10484515/222929506-ff1d38cb-8ed3-4e99-acd5-64967900f06c.png">

---

#### From Elsewhere: The Message… (play) (material)
<img width="928" alt="from-elsewhere-the-message-material" src="https://user-images.githubusercontent.com/10484515/222929511-353e7656-a675-4468-9517-a844704f8379.png">

---

#### Tricycle Theatre (venue)
<img width="895" alt="tricycle-theatre-venue" src="https://user-images.githubusercontent.com/10484515/222929458-f2d01425-d5c0-4394-b068-3f778800741a.png">

---

#### Tricycle Theatre Company (company)
<img width="949" alt="tricycle-theatre-company" src="https://user-images.githubusercontent.com/10484515/222929453-746b9e15-ebd6-4353-ac29-bd88cfd4f5d5.png">

---

#### Rudolf (character)
<img width="942" alt="rudolf-character" src="https://user-images.githubusercontent.com/10484515/222929446-34dce012-e443-4be5-8e53-3ec17011e6cd.png">

---

#### Rick Warden (person)
<img width="941" alt="rick-warden-person" src="https://user-images.githubusercontent.com/10484515/222929444-24c8ea75-e90e-4714-9d64-93f231768954.png">

---

#### Nicolas Kent (person)
<img width="949" alt="nicolas-kent-person" src="https://user-images.githubusercontent.com/10484515/222929441-b7c7ac7e-0134-4e2d-8f42-f87fa5b3bc6e.png">

---

#### Productions list
<img width="947" alt="productions-list" src="https://user-images.githubusercontent.com/10484515/222929432-64b1f511-3ac3-4de0-9766-04122288d170.png">

---

## Test examples

### `award-ceremonies-with-crediting-sub-sub-materials.test.js`

#### Wordsmith Award 2010 (award ceremony)
<img width="933" alt="wordsmith-award-2010-award-ceremony" src="https://user-images.githubusercontent.com/10484515/222930490-56fd27e3-f3fb-49f6-85b9-45a1c4ae1ca1.png">

---

#### John Doe (person): credit for directly nominated material
<img width="938" alt="john-doe-person" src="https://user-images.githubusercontent.com/10484515/222930494-6271bcb1-df5b-4038-821f-14fe49c803d7.png">

---

#### Playwrights Ltd (company): credit for directly nominated material
<img width="942" alt="playwrights-ltd-company" src="https://user-images.githubusercontent.com/10484515/222930495-868e714c-77ad-4b54-94ca-4ae2ba05d7a8.png">

---

#### Sub-Plugh (play, 1899) (material): subsequent versions have nominations
<img width="934" alt="sub-plugh-original-material" src="https://user-images.githubusercontent.com/10484515/222930497-08014a3f-f1b5-4ddc-b3db-a674bf858b68.png">

---

#### Mid-Plugh (sub-collection of plays, 1899) (material): subsequent versions have nominations
<img width="932" alt="mid-plugh-original-material" src="https://user-images.githubusercontent.com/10484515/222930513-60f1f653-6615-4a42-9f5a-4479772c0398.png">

---

#### Sur-Plugh (collection of plays, 1899) (material): subsequent versions have nominations
<img width="925" alt="sur-plugh-original-material" src="https://user-images.githubusercontent.com/10484515/222930515-655e12f4-5225-4281-a37b-c37914f5866b.png">

---

#### Francis Flob (person): subsequent versions of their work have nominations
<img width="925" alt="francis-flob-person" src="https://user-images.githubusercontent.com/10484515/222930518-a0d8f7cb-130a-4f92-9a4a-7bca89bd4f09.png">

---

#### Curtain Up Ltd (company): subsequent versions of their work have nominations
<img width="922" alt="curtain-up-ltd-company" src="https://user-images.githubusercontent.com/10484515/222930520-ac0fb51e-f86b-4fc3-997a-4c8f4eaf6a9e.png">

---

#### Sub-Waldo (novel, 1974) (material): materials that used it as source material have nominations
<img width="940" alt="sub-waldo-material" src="https://user-images.githubusercontent.com/10484515/222930526-63c35045-98ce-417d-80e9-effced771b4e.png">

---

#### Mid-Waldo (sub-trilogy of novels, 1974) (material): materials that used it as source material have nominations
<img width="921" alt="mid-waldo-material" src="https://user-images.githubusercontent.com/10484515/222930528-2149b0d4-b339-40ee-bd96-370810c3f655.png">

---

#### Sur-Waldo (trilogy of trilogies of novels, 1974) (material): materials that used it as source material have nominations
<img width="946" alt="sur-waldo-material" src="https://user-images.githubusercontent.com/10484515/222933638-e5cc9489-b1f3-451e-9e11-33377b0bed6c.png">

---

#### Jane Roe (person): materials that used their (specific) work as source material have nominations
<img width="935" alt="jane-roe-person" src="https://user-images.githubusercontent.com/10484515/222930558-3d523b46-e4c1-4891-9d23-42e38c4071e8.png">

---

#### Fictioneers Ltd (company): materials that used their (specific) work as source material have nominations
<img width="928" alt="fictioneers-ltd-company" src="https://user-images.githubusercontent.com/10484515/222930562-3687cb2e-7370-4064-9452-7fa79a124c76.png">

---

#### Talyse Tata (person): materials to which they have granted rights have nominations
<img width="938" alt="talyse-tata-person" src="https://user-images.githubusercontent.com/10484515/222930566-86ca98b3-41c3-4d23-973f-07dac2497a7f.png">

---

#### Cinerights Ltd (company): materials to which they granted rights have nominations
<img width="937" alt="cinerights-ltd-company" src="https://user-images.githubusercontent.com/10484515/222930567-445f6e7e-5866-4fe8-a4b3-bb986f210c0e.png">

---

### `award-ceremonies-with-sub-sub-materials-sub-sub-prods.test.js`

#### Laurence Olivier Awards 2020 (award ceremony)
<img width="939" alt="laurence-olivier-awards-2020-award-ceremony" src="https://user-images.githubusercontent.com/10484515/222931247-684f0616-a497-4ab1-8644-18574abc16e0.png">

---

#### Conor Corge (person)
<img width="942" alt="conor-corge-person" src="https://user-images.githubusercontent.com/10484515/222931252-6eca0049-8e79-4ea1-8dbc-a20905a49bc2.png">

---

#### Stagecraft Ltd (company)
<img width="941" alt="stagecraft-ltd-company" src="https://user-images.githubusercontent.com/10484515/222931255-d307d47b-e094-4e24-91ec-1f4891f2976f.png">

---

#### Ferdinand Foo (person)
<img width="941" alt="ferdinand-foo-person" src="https://user-images.githubusercontent.com/10484515/222931261-df9dc4fb-6271-40f9-a6b9-4aa87e2d13e4.png">

---

#### Sub-Wibble at Jerwood Theatre Upstairs (production)
<img width="932" alt="sub-wibble-at-jerwood-theatre-upstairs-production" src="https://user-images.githubusercontent.com/10484515/222931264-84c34f6e-1ca8-434b-b1bf-c2809cb79339.png">

---

#### Mid-Wibble at Jerwood Theatre Upstairs (production)
<img width="936" alt="mid-wibble-at-jerwood-theatre-upstairs-production" src="https://user-images.githubusercontent.com/10484515/222931265-d6acef18-80c7-46ca-8cc1-051b96ca300a.png">

---

#### Sur-Wibble at Jerwood Theatre Upstairs (production)
<img width="935" alt="sur-wibble-at-jerwood-theatre-upstairs-production" src="https://user-images.githubusercontent.com/10484515/222931271-a87cfb83-2faf-4b7a-99aa-d827781abc06.png">

---

#### Sub-Hoge at Noël Coward Theatre (production)
<img width="943" alt="sub-hoge-at-noël-coward-theatre-production" src="https://user-images.githubusercontent.com/10484515/222931292-aea4c050-48cb-4e67-902a-2f25f66395ef.png">

---

#### Mid-Hoge at Noël Coward Theatre (production)
<img width="945" alt="mid-hoge-at-noël-coward-theatre-production" src="https://user-images.githubusercontent.com/10484515/222931293-d9f04465-de76-4107-9995-286782fedfd7.png">

---

#### Sur-Hoge at Noël Coward Theatre (production)
<img width="943" alt="sur-hoge-at-noël-coward-theatre-production" src="https://user-images.githubusercontent.com/10484515/222931296-eef9f206-2c7f-4586-b156-b00a95f3d80e.png">

---

#### Sub-Wibble (play) (material)
<img width="955" alt="sub-wibble-material" src="https://user-images.githubusercontent.com/10484515/222931298-0522b045-1b1c-49e5-9e6d-410099d1c2a0.png">

---

#### Sub-Wibble (sub-trilogy of plays) (material)
<img width="941" alt="mid-wibble-material" src="https://user-images.githubusercontent.com/10484515/222931302-4566072f-3dd2-41f0-b538-d0cebc827b11.png">

---

#### Sur-Wibble (trilogy of trilogies of plays) (material)
<img width="941" alt="sur-wibble-material" src="https://user-images.githubusercontent.com/10484515/222931307-1f2aacfa-214d-450c-a5c1-514387f0bee7.png">

---

### `material-with-sub-sub-materials-source-materials.test.js`

#### Genesis (religious text) (material)
<img width="933" alt="genesis-material" src="https://user-images.githubusercontent.com/10484515/222931446-c94e326f-7150-4814-8fd8-7f29355f5b62.png">

---

### `prod-with-sub-sub-prods.test.js`

#### The Great Game at Roda Theatre (production with sub-sub-productions that have a sur-venue)
<img width="890" alt="the-great-game-afghanistan-at-roda-theatre-production" src="https://user-images.githubusercontent.com/10484515/222933275-0d46faae-2ec1-41fd-b639-fd37b731e033.png">

---

#### Part One - Invasions and Independence 1842-1930 at Roda Theatre (production with sur-production and sub-productions that have a sur-venue)
<img width="812" alt="part-one-invastions-and-independence-1842-1930-at-roda-theatre-production" src="https://user-images.githubusercontent.com/10484515/222933288-f69ccdf5-1c88-4e20-b1a7-2f10ba23aedc.png">

---

#### Bugles at the Gates of Jalalabad at Roda Theatre (production with sur-production that has a sur-venue)
<img width="923" alt="bugles-at-the-gate-of-jalalabad-at-roda-theatre-production" src="https://user-images.githubusercontent.com/10484515/222933292-dfe2de0d-c405-4700-95b1-1d5e7ddeb72e.png">

---

#### The Great Game at Tricycle Theatre (production with sub-sub-productions that do not have a sur-venue)
<img width="745" alt="the-great-game-afghanistan-at-tricycle-theatre-production" src="https://user-images.githubusercontent.com/10484515/222933299-d37e0709-3c46-4907-ac71-1693e14eb5ff.png">

---

#### Part One - Invasions and Independence 1842-1930 at Tricycle Theatre (production with sur-production and sub-productions that do not have a sur-venue)
<img width="810" alt="part-one-invastions-and-independence-1842-1930-at-tricycle-theatre-production" src="https://user-images.githubusercontent.com/10484515/222933302-b2bfc2b8-b0e2-4e8b-a565-014e7e44b10c.png">

---

#### Bugles at the Gates of Jalalabad at Tricycle Theatre (production with sur-production that has a sur-venue)
<img width="809" alt="bugles-at-the-gate-of-jalalabad-at-tricycle-theatre-production" src="https://user-images.githubusercontent.com/10484515/222933305-f133e32c-f4a5-4aad-ab54-cfa73beae2e7.png">

---

#### The Great Game: Afghanistan (material)
<img width="676" alt="the-great-game-afghanistan-material" src="https://user-images.githubusercontent.com/10484515/222933308-3681038b-4a2f-4ece-89c7-41e29e7bd491.png">

---

#### Part One - Invasions and Independence 1842-1930 (material)
<img width="944" alt="part-one-invastions-and-independence-1842-1930-material" src="https://user-images.githubusercontent.com/10484515/222933310-33d08fa3-b2d5-4f08-ae60-644273a1e954.png">

---

#### Bugles at the Gates of Jalalabad (material)
<img width="945" alt="bugles-at-the-gate-of-jalalabad-material" src="https://user-images.githubusercontent.com/10484515/222933313-c470d086-299a-451d-91aa-85109204227e.png">

---

#### Berkeley Repertory Theatre (venue)
<img width="946" alt="berkeley-repertory-theatre-venue" src="https://user-images.githubusercontent.com/10484515/222933316-4436a481-d631-44c4-a043-45d221d61011.png">

---

#### Roda Theatre (venue)
<img width="934" alt="roda-theatre-venue" src="https://user-images.githubusercontent.com/10484515/222933319-7d5df390-d680-46b9-825b-3c77f22f3aba.png">

---

#### Nicolas Kent (person)
<img width="940" alt="nicolas-kent-person" src="https://user-images.githubusercontent.com/10484515/222933320-3746ab8a-aab5-4d65-9d1e-5a5040c6f30c.png">

---

#### Tricycle Theatre Company (company)
<img width="940" alt="tricycle-theatre-company" src="https://user-images.githubusercontent.com/10484515/222933325-46de5c2d-a187-47f7-8fdf-dcd859504257.png">

---

#### Zoë Ingenhaag (person)
<img width="940" alt="zoë-ingenhaag-person" src="https://user-images.githubusercontent.com/10484515/222933327-b7bafa88-2b43-449a-b0d6-903a83b1e775.png">

---

#### Rick Warden (person)
<img width="946" alt="rick-warden-person" src="https://user-images.githubusercontent.com/10484515/222933328-c4cf98f6-e1ce-43c8-90cd-46249d432d44.png">

---

#### Howard Harrison (person)
<img width="946" alt="howard-harrison-person" src="https://user-images.githubusercontent.com/10484515/222933330-470407e0-1783-492f-9ad9-f5b49a82d761.png">

---

#### Lighting Design Ltd (company)
<img width="935" alt="lighting-design-ltd-company" src="https://user-images.githubusercontent.com/10484515/222933334-6754ea5f-3374-466c-82b4-4f962ef1db9a.png">

---

#### Jack Knowles (person)
<img width="940" alt="jack-knowles-person" src="https://user-images.githubusercontent.com/10484515/222933344-263c8da4-0bc4-4bd7-b444-a21ac34f5b3d.png">

---

#### Lizzie Chapman (person)
<img width="939" alt="lizzie-chapman-person" src="https://user-images.githubusercontent.com/10484515/222933347-cffe2769-38cb-40f9-a34e-129e848e4bf6.png">

---

#### Stage Management Ltd (company)
<img width="941" alt="stage-management-ltd-company" src="https://user-images.githubusercontent.com/10484515/222933349-eabab77b-20e7-4d31-bb64-96c33bbf6021.png">

---

#### Charlotte Padgham (person)
<img width="945" alt="charlotte-padgham-person" src="https://user-images.githubusercontent.com/10484515/222933351-eb85dac2-153a-4945-bfe2-dcaa4a93c859.png">

---

#### Bar (character)
<img width="941" alt="bar-character" src="https://user-images.githubusercontent.com/10484515/222933354-81ca0be3-7e5b-4adb-ad53-4b857188defa.png">

---

#### Productions list
<img width="955" alt="productions" src="https://user-images.githubusercontent.com/10484515/222933357-c3a2db90-ca18-4616-a602-34fb03711131.png">