### PR TITLE
Revise Cypher queries

### DIFF
--- a/src/neo4j/cypher-queries/company/show/show-awards-rights-grantor-material.js
+++ b/src/neo4j/cypher-queries/company/show/show-awards-rights-grantor-material.js
@@ -6,13 +6,6 @@ export default () => `
 		<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
 		<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
 
-	OPTIONAL MATCH (nominatedRightsGrantorMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedRightsGrantorSurMaterial:Material)
-
-	OPTIONAL MATCH (nominatedRightsGrantorSurMaterial)
-		<-[:HAS_SUB_MATERIAL]-(nominatedRightsGrantorSurSurMaterial:Material)
-
-	OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(rightsGrantorMaterialAward:Award)
-
 	OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)
 		WHERE
 			(
@@ -24,16 +17,7 @@ export default () => `
 				nomineeRel.nominationPosition = nominatedEntityRel.nominationPosition
 			)
 
-	WITH
-		nominatedRightsGrantorMaterial,
-		nominatedRightsGrantorSurMaterial,
-		nominatedRightsGrantorSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		rightsGrantorMaterialAward,
-		nominatedEntityRel,
+	WITH nominatedRightsGrantorMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntityRel,
 		COLLECT(nominatedEntity {
 			model: TOUPPER(HEAD(LABELS(nominatedEntity))),
 			.uuid,
@@ -53,13 +37,10 @@ export default () => `
 
 			WITH
 				nominatedRightsGrantorMaterial,
-				nominatedRightsGrantorSurMaterial,
-				nominatedRightsGrantorSurSurMaterial,
 				nomineeRel,
 				category,
 				categoryRel,
 				ceremony,
-				rightsGrantorMaterialAward,
 				nominatedEntityRel,
 				nominatedEntity,
 				nominatedMember
@@ -67,40 +48,26 @@ export default () => `
 
 			WITH
 				nominatedRightsGrantorMaterial,
-				nominatedRightsGrantorSurMaterial,
-				nominatedRightsGrantorSurSurMaterial,
 				nomineeRel,
 				category,
 				categoryRel,
 				ceremony,
-				rightsGrantorMaterialAward,
 				nominatedEntityRel,
 				nominatedEntity,
 				COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
 
 	WITH
 		nominatedRightsGrantorMaterial,
-		nominatedRightsGrantorSurMaterial,
-		nominatedRightsGrantorSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		rightsGrantorMaterialAward,
 		nominatedEntityRel,
 		nominatedEntity,
 		nominatedMembers
 		ORDER BY nominatedEntityRel.nominationPosition, nominatedEntityRel.entityPosition
 
-	WITH
-		nominatedRightsGrantorMaterial,
-		nominatedRightsGrantorSurMaterial,
-		nominatedRightsGrantorSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		rightsGrantorMaterialAward,
+	WITH nominatedRightsGrantorMaterial, nomineeRel, category, categoryRel, ceremony,
 		COLLECT(
 			CASE nominatedEntity WHEN NULL
 				THEN null
@@ -108,15 +75,7 @@ export default () => `
 			END
 		) AS nominatedEntities
 
-	WITH
-		nominatedRightsGrantorMaterial,
-		nominatedRightsGrantorSurMaterial,
-		nominatedRightsGrantorSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		rightsGrantorMaterialAward,
+	WITH nominatedRightsGrantorMaterial, nomineeRel, category, categoryRel, ceremony,
 		[nominatedEntity IN nominatedEntities | CASE nominatedEntity.model WHEN 'COMPANY'
 			THEN nominatedEntity
 			ELSE nominatedEntity { .model, .uuid, .name }
@@ -139,13 +98,10 @@ export default () => `
 
 	WITH
 		nominatedRightsGrantorMaterial,
-		nominatedRightsGrantorSurMaterial,
-		nominatedRightsGrantorSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		rightsGrantorMaterialAward,
 		nominatedEntities,
 		nominatedProductionRel,
 		nominatedProduction,
@@ -155,16 +111,7 @@ export default () => `
 		surSurProduction
 		ORDER BY nominatedProductionRel.productionPosition
 
-	WITH
-		nominatedRightsGrantorMaterial,
-		nominatedRightsGrantorSurMaterial,
-		nominatedRightsGrantorSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		rightsGrantorMaterialAward,
-		nominatedEntities,
+	WITH nominatedRightsGrantorMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
 		COLLECT(
 			CASE nominatedProduction WHEN NULL
 				THEN null
@@ -214,13 +161,10 @@ export default () => `
 
 	WITH
 		nominatedRightsGrantorMaterial,
-		nominatedRightsGrantorSurMaterial,
-		nominatedRightsGrantorSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		rightsGrantorMaterialAward,
 		nominatedEntities,
 		nominatedProductions,
 		nominatedMaterialRel,
@@ -230,13 +174,10 @@ export default () => `
 
 	WITH
 		nominatedRightsGrantorMaterial,
-		nominatedRightsGrantorSurMaterial,
-		nominatedRightsGrantorSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		rightsGrantorMaterialAward,
 		nominatedEntities,
 		nominatedProductions,
 		COLLECT(
@@ -257,13 +198,17 @@ export default () => `
 		) AS nominatedMaterials
 		ORDER BY nomineeRel.nominationPosition, nomineeRel.materialPosition
 
+	OPTIONAL MATCH (nominatedRightsGrantorMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedRightsGrantorSurMaterial:Material)
+
+	OPTIONAL MATCH (nominatedRightsGrantorSurMaterial)
+		<-[:HAS_SUB_MATERIAL]-(nominatedRightsGrantorSurSurMaterial:Material)
+
 	WITH
 		nomineeRel.isWinner AS isWinner,
 		nomineeRel.customType AS customType,
 		category,
 		categoryRel,
 		ceremony,
-		rightsGrantorMaterialAward,
 		nominatedEntities,
 		nominatedProductions,
 		nominatedMaterials,
@@ -292,11 +237,7 @@ export default () => `
 			END
 		) AS nominatedRightsGrantorMaterials
 
-	WITH
-		category,
-		categoryRel,
-		ceremony,
-		rightsGrantorMaterialAward,
+	WITH category, categoryRel, ceremony,
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(isWinner, false),
@@ -308,17 +249,14 @@ export default () => `
 		}) AS nominations
 		ORDER BY categoryRel.position
 
-	WITH
-		ceremony,
-		rightsGrantorMaterialAward,
-		COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
+	WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
 		ORDER BY ceremony.name DESC
 
-	WITH
-		rightsGrantorMaterialAward,
-		COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
-		ORDER BY rightsGrantorMaterialAward.name
+	OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
+
+	WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
+		ORDER BY award.name
 
 	RETURN
-		COLLECT(rightsGrantorMaterialAward { model: 'AWARD', .uuid, .name, ceremonies }) AS rightsGrantorMaterialAwards
+		COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS rightsGrantorMaterialAwards
 `;

--- a/src/neo4j/cypher-queries/company/show/show-awards-sourcing-material.js
+++ b/src/neo4j/cypher-queries/company/show/show-awards-sourcing-material.js
@@ -9,12 +9,6 @@ export default () => `
 		writingRel.creditType = 'NON_SPECIFIC_SOURCE_MATERIAL' OR
 		ANY(rel IN RELATIONSHIPS(path) WHERE TYPE(rel) = 'USES_SOURCE_MATERIAL')
 
-	OPTIONAL MATCH (nominatedSourcingMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSourcingSurMaterial:Material)
-
-	OPTIONAL MATCH (nominatedSourcingSurMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSourcingSurSurMaterial:Material)
-
-	OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(sourcingMaterialAward:Award)
-
 	OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)
 		WHERE
 			(
@@ -26,16 +20,7 @@ export default () => `
 				nomineeRel.nominationPosition = nominatedEntityRel.nominationPosition
 			)
 
-	WITH
-		nominatedSourcingMaterial,
-		nominatedSourcingSurMaterial,
-		nominatedSourcingSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		sourcingMaterialAward,
-		nominatedEntityRel,
+	WITH nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntityRel,
 		COLLECT(nominatedEntity {
 			model: TOUPPER(HEAD(LABELS(nominatedEntity))),
 			.uuid,
@@ -55,13 +40,10 @@ export default () => `
 
 			WITH
 				nominatedSourcingMaterial,
-				nominatedSourcingSurMaterial,
-				nominatedSourcingSurSurMaterial,
 				nomineeRel,
 				category,
 				categoryRel,
 				ceremony,
-				sourcingMaterialAward,
 				nominatedEntityRel,
 				nominatedEntity,
 				nominatedMember
@@ -69,40 +51,26 @@ export default () => `
 
 			WITH
 				nominatedSourcingMaterial,
-				nominatedSourcingSurMaterial,
-				nominatedSourcingSurSurMaterial,
 				nomineeRel,
 				category,
 				categoryRel,
 				ceremony,
-				sourcingMaterialAward,
 				nominatedEntityRel,
 				nominatedEntity,
 				COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
 
 	WITH
 		nominatedSourcingMaterial,
-		nominatedSourcingSurMaterial,
-		nominatedSourcingSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		sourcingMaterialAward,
 		nominatedEntityRel,
 		nominatedEntity,
 		nominatedMembers
 		ORDER BY nominatedEntityRel.nominationPosition, nominatedEntityRel.entityPosition
 
-	WITH
-		nominatedSourcingMaterial,
-		nominatedSourcingSurMaterial,
-		nominatedSourcingSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		sourcingMaterialAward,
+	WITH nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony,
 		COLLECT(
 			CASE nominatedEntity WHEN NULL
 				THEN null
@@ -110,15 +78,7 @@ export default () => `
 			END
 		) AS nominatedEntities
 
-	WITH
-		nominatedSourcingMaterial,
-		nominatedSourcingSurMaterial,
-		nominatedSourcingSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		sourcingMaterialAward,
+	WITH nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony,
 		[nominatedEntity IN nominatedEntities | CASE nominatedEntity.model WHEN 'COMPANY'
 			THEN nominatedEntity
 			ELSE nominatedEntity { .model, .uuid, .name }
@@ -141,13 +101,10 @@ export default () => `
 
 	WITH
 		nominatedSourcingMaterial,
-		nominatedSourcingSurMaterial,
-		nominatedSourcingSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		sourcingMaterialAward,
 		nominatedEntities,
 		nominatedProductionRel,
 		nominatedProduction,
@@ -157,16 +114,7 @@ export default () => `
 		surSurProduction
 		ORDER BY nominatedProductionRel.productionPosition
 
-	WITH
-		nominatedSourcingMaterial,
-		nominatedSourcingSurMaterial,
-		nominatedSourcingSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		sourcingMaterialAward,
-		nominatedEntities,
+	WITH nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
 		COLLECT(
 			CASE nominatedProduction WHEN NULL
 				THEN null
@@ -216,13 +164,10 @@ export default () => `
 
 	WITH
 		nominatedSourcingMaterial,
-		nominatedSourcingSurMaterial,
-		nominatedSourcingSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		sourcingMaterialAward,
 		nominatedEntities,
 		nominatedProductions,
 		nominatedMaterialRel,
@@ -232,13 +177,10 @@ export default () => `
 
 	WITH
 		nominatedSourcingMaterial,
-		nominatedSourcingSurMaterial,
-		nominatedSourcingSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		sourcingMaterialAward,
 		nominatedEntities,
 		nominatedProductions,
 		COLLECT(
@@ -259,13 +201,16 @@ export default () => `
 		) AS nominatedMaterials
 		ORDER BY nomineeRel.nominationPosition, nomineeRel.materialPosition
 
+	OPTIONAL MATCH (nominatedSourcingMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSourcingSurMaterial:Material)
+
+	OPTIONAL MATCH (nominatedSourcingSurMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSourcingSurSurMaterial:Material)
+
 	WITH
 		nomineeRel.isWinner AS isWinner,
 		nomineeRel.customType AS customType,
 		category,
 		categoryRel,
 		ceremony,
-		sourcingMaterialAward,
 		nominatedEntities,
 		nominatedProductions,
 		nominatedMaterials,
@@ -294,11 +239,7 @@ export default () => `
 			END
 		) AS nominatedSourcingMaterials
 
-	WITH
-		category,
-		categoryRel,
-		ceremony,
-		sourcingMaterialAward,
+	WITH category, categoryRel, ceremony,
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(isWinner, false),
@@ -310,17 +251,14 @@ export default () => `
 		}) AS nominations
 		ORDER BY categoryRel.position
 
-	WITH
-		ceremony,
-		sourcingMaterialAward,
-		COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
+	WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
 		ORDER BY ceremony.name DESC
 
-	WITH
-		sourcingMaterialAward,
-		COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
-		ORDER BY sourcingMaterialAward.name
+	OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
+
+	WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
+		ORDER BY award.name
 
 	RETURN
-		COLLECT(sourcingMaterialAward { model: 'AWARD', .uuid, .name, ceremonies }) AS sourcingMaterialAwards
+		COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS sourcingMaterialAwards
 `;

--- a/src/neo4j/cypher-queries/company/show/show-awards-subsequent-version-material.js
+++ b/src/neo4j/cypher-queries/company/show/show-awards-subsequent-version-material.js
@@ -6,14 +6,6 @@ export default () => `
 		<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
 		<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
 
-	OPTIONAL MATCH (nominatedSubsequentVersionMaterial)
-		<-[:HAS_SUB_MATERIAL]-(nominatedSubsequentVersionSurMaterial:Material)
-
-	OPTIONAL MATCH (nominatedSubsequentVersionSurMaterial)
-		<-[:HAS_SUB_MATERIAL]-(nominatedSubsequentVersionSurSurMaterial:Material)
-
-	OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(subsequentVersionMaterialAward:Award)
-
 	OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)
 		WHERE
 			(
@@ -25,16 +17,7 @@ export default () => `
 				nomineeRel.nominationPosition = nominatedEntityRel.nominationPosition
 			)
 
-	WITH
-		nominatedSubsequentVersionMaterial,
-		nominatedSubsequentVersionSurMaterial,
-		nominatedSubsequentVersionSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		subsequentVersionMaterialAward,
-		nominatedEntityRel,
+	WITH nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntityRel,
 		COLLECT(nominatedEntity {
 			model: TOUPPER(HEAD(LABELS(nominatedEntity))),
 			.uuid,
@@ -54,13 +37,10 @@ export default () => `
 
 			WITH
 				nominatedSubsequentVersionMaterial,
-				nominatedSubsequentVersionSurMaterial,
-				nominatedSubsequentVersionSurSurMaterial,
 				nomineeRel,
 				category,
 				categoryRel,
 				ceremony,
-				subsequentVersionMaterialAward,
 				nominatedEntityRel,
 				nominatedEntity,
 				nominatedMember
@@ -68,40 +48,26 @@ export default () => `
 
 			WITH
 				nominatedSubsequentVersionMaterial,
-				nominatedSubsequentVersionSurMaterial,
-				nominatedSubsequentVersionSurSurMaterial,
 				nomineeRel,
 				category,
 				categoryRel,
 				ceremony,
-				subsequentVersionMaterialAward,
 				nominatedEntityRel,
 				nominatedEntity,
 				COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
 
 	WITH
 		nominatedSubsequentVersionMaterial,
-		nominatedSubsequentVersionSurMaterial,
-		nominatedSubsequentVersionSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		subsequentVersionMaterialAward,
 		nominatedEntityRel,
 		nominatedEntity,
 		nominatedMembers
 		ORDER BY nominatedEntityRel.nominationPosition, nominatedEntityRel.entityPosition
 
-	WITH
-		nominatedSubsequentVersionMaterial,
-		nominatedSubsequentVersionSurMaterial,
-		nominatedSubsequentVersionSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		subsequentVersionMaterialAward,
+	WITH nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony,
 		COLLECT(
 			CASE nominatedEntity WHEN NULL
 				THEN null
@@ -109,15 +75,7 @@ export default () => `
 			END
 		) AS nominatedEntities
 
-	WITH
-		nominatedSubsequentVersionMaterial,
-		nominatedSubsequentVersionSurMaterial,
-		nominatedSubsequentVersionSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		subsequentVersionMaterialAward,
+	WITH nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony,
 		[nominatedEntity IN nominatedEntities | CASE nominatedEntity.model WHEN 'COMPANY'
 			THEN nominatedEntity
 			ELSE nominatedEntity { .model, .uuid, .name }
@@ -140,13 +98,10 @@ export default () => `
 
 	WITH
 		nominatedSubsequentVersionMaterial,
-		nominatedSubsequentVersionSurMaterial,
-		nominatedSubsequentVersionSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		subsequentVersionMaterialAward,
 		nominatedEntities,
 		nominatedProductionRel,
 		nominatedProduction,
@@ -156,16 +111,7 @@ export default () => `
 		surSurProduction
 		ORDER BY nominatedProductionRel.productionPosition
 
-	WITH
-		nominatedSubsequentVersionMaterial,
-		nominatedSubsequentVersionSurMaterial,
-		nominatedSubsequentVersionSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		subsequentVersionMaterialAward,
-		nominatedEntities,
+	WITH nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
 		COLLECT(
 			CASE nominatedProduction WHEN NULL
 				THEN null
@@ -215,13 +161,10 @@ export default () => `
 
 	WITH
 		nominatedSubsequentVersionMaterial,
-		nominatedSubsequentVersionSurMaterial,
-		nominatedSubsequentVersionSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		subsequentVersionMaterialAward,
 		nominatedEntities,
 		nominatedProductions,
 		nominatedMaterialRel,
@@ -231,13 +174,10 @@ export default () => `
 
 	WITH
 		nominatedSubsequentVersionMaterial,
-		nominatedSubsequentVersionSurMaterial,
-		nominatedSubsequentVersionSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		subsequentVersionMaterialAward,
 		nominatedEntities,
 		nominatedProductions,
 		COLLECT(
@@ -258,6 +198,12 @@ export default () => `
 		) AS nominatedMaterials
 		ORDER BY nomineeRel.nominationPosition, nomineeRel.materialPosition
 
+	OPTIONAL MATCH (nominatedSubsequentVersionMaterial)
+		<-[:HAS_SUB_MATERIAL]-(nominatedSubsequentVersionSurMaterial:Material)
+
+	OPTIONAL MATCH (nominatedSubsequentVersionSurMaterial)
+		<-[:HAS_SUB_MATERIAL]-(nominatedSubsequentVersionSurSurMaterial:Material)
+
 	WITH
 		nomineeRel.isWinner AS isWinner,
 		nomineeRel.customType AS customType,
@@ -265,7 +211,6 @@ export default () => `
 		category,
 		categoryRel,
 		ceremony,
-		subsequentVersionMaterialAward,
 		nominatedEntities,
 		nominatedProductions,
 		nominatedMaterials,
@@ -294,11 +239,7 @@ export default () => `
 			END
 		) AS nominatedSubsequentVersionMaterials
 
-	WITH
-		category,
-		categoryRel,
-		ceremony,
-		subsequentVersionMaterialAward,
+	WITH category, categoryRel, ceremony,
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(isWinner, false),
@@ -310,22 +251,14 @@ export default () => `
 		}) AS nominations
 		ORDER BY categoryRel.position
 
-	WITH
-		ceremony,
-		subsequentVersionMaterialAward,
-		COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
+	WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
 		ORDER BY ceremony.name DESC
 
-	WITH
-		subsequentVersionMaterialAward,
-		COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
-		ORDER BY subsequentVersionMaterialAward.name
+	OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
+
+	WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
+		ORDER BY award.name
 
 	RETURN
-		COLLECT(subsequentVersionMaterialAward {
-			model: 'AWARD',
-			.uuid,
-			.name,
-			ceremonies
-		}) AS subsequentVersionMaterialAwards
+		COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS subsequentVersionMaterialAwards
 `;

--- a/src/neo4j/cypher-queries/material/show/show-awards-sourcing-material.js
+++ b/src/neo4j/cypher-queries/material/show/show-awards-sourcing-material.js
@@ -6,12 +6,6 @@ export default () => `
 		<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
 		<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
 
-	OPTIONAL MATCH (nominatedSourcingMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSourcingSurMaterial:Material)
-
-	OPTIONAL MATCH (nominatedSourcingSurMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSourcingSurSurMaterial:Material)
-
-	OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(sourcingMaterialAward:Award)
-
 	OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)
 		WHERE
 			(
@@ -23,17 +17,7 @@ export default () => `
 				nomineeRel.nominationPosition = nominatedEntityRel.nominationPosition
 			)
 
-	WITH
-		material,
-		nominatedSourcingMaterial,
-		nominatedSourcingSurMaterial,
-		nominatedSourcingSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		sourcingMaterialAward,
-		nominatedEntityRel,
+	WITH material, nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntityRel,
 		COLLECT(nominatedEntity {
 			model: TOUPPER(HEAD(LABELS(nominatedEntity))),
 			.uuid,
@@ -54,13 +38,10 @@ export default () => `
 			WITH
 				material,
 				nominatedSourcingMaterial,
-				nominatedSourcingSurMaterial,
-				nominatedSourcingSurSurMaterial,
 				nomineeRel,
 				category,
 				categoryRel,
 				ceremony,
-				sourcingMaterialAward,
 				nominatedEntityRel,
 				nominatedEntity,
 				nominatedMember
@@ -69,13 +50,10 @@ export default () => `
 			WITH
 				material,
 				nominatedSourcingMaterial,
-				nominatedSourcingSurMaterial,
-				nominatedSourcingSurSurMaterial,
 				nomineeRel,
 				category,
 				categoryRel,
 				ceremony,
-				sourcingMaterialAward,
 				nominatedEntityRel,
 				nominatedEntity,
 				COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
@@ -83,28 +61,16 @@ export default () => `
 	WITH
 		material,
 		nominatedSourcingMaterial,
-		nominatedSourcingSurMaterial,
-		nominatedSourcingSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		sourcingMaterialAward,
 		nominatedEntityRel,
 		nominatedEntity,
 		nominatedMembers
 		ORDER BY nominatedEntityRel.nominationPosition, nominatedEntityRel.entityPosition
 
-	WITH
-		material,
-		nominatedSourcingMaterial,
-		nominatedSourcingSurMaterial,
-		nominatedSourcingSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		sourcingMaterialAward,
+	WITH material, nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony,
 		COLLECT(
 			CASE nominatedEntity WHEN NULL
 				THEN null
@@ -112,16 +78,7 @@ export default () => `
 			END
 		) AS nominatedEntities
 
-	WITH
-		material,
-		nominatedSourcingMaterial,
-		nominatedSourcingSurMaterial,
-		nominatedSourcingSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		sourcingMaterialAward,
+	WITH material, nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony,
 		[nominatedEntity IN nominatedEntities | CASE nominatedEntity.model WHEN 'COMPANY'
 			THEN nominatedEntity
 			ELSE nominatedEntity { .model, .uuid, .name }
@@ -145,13 +102,10 @@ export default () => `
 	WITH
 		material,
 		nominatedSourcingMaterial,
-		nominatedSourcingSurMaterial,
-		nominatedSourcingSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		sourcingMaterialAward,
 		nominatedEntities,
 		nominatedProductionRel,
 		nominatedProduction,
@@ -161,17 +115,7 @@ export default () => `
 		surSurProduction
 		ORDER BY nominatedProductionRel.productionPosition
 
-	WITH
-		material,
-		nominatedSourcingMaterial,
-		nominatedSourcingSurMaterial,
-		nominatedSourcingSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		sourcingMaterialAward,
-		nominatedEntities,
+	WITH material, nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
 		COLLECT(
 			CASE nominatedProduction WHEN NULL
 				THEN null
@@ -220,13 +164,10 @@ export default () => `
 
 	WITH
 		nominatedSourcingMaterial,
-		nominatedSourcingSurMaterial,
-		nominatedSourcingSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		sourcingMaterialAward,
 		nominatedEntities,
 		nominatedProductions,
 		nominatedMaterialRel,
@@ -235,13 +176,10 @@ export default () => `
 
 	WITH
 		nominatedSourcingMaterial,
-		nominatedSourcingSurMaterial,
-		nominatedSourcingSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		sourcingMaterialAward,
 		nominatedEntities,
 		nominatedProductions,
 		COLLECT(
@@ -252,13 +190,16 @@ export default () => `
 		) AS nominatedMaterials
 		ORDER BY nomineeRel.nominationPosition, nomineeRel.materialPosition
 
+	OPTIONAL MATCH (nominatedSourcingMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSourcingSurMaterial:Material)
+
+	OPTIONAL MATCH (nominatedSourcingSurMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSourcingSurSurMaterial:Material)
+
 	WITH
 		nomineeRel.isWinner AS isWinner,
 		nomineeRel.customType AS customType,
 		category,
 		categoryRel,
 		ceremony,
-		sourcingMaterialAward,
 		nominatedEntities,
 		nominatedProductions,
 		nominatedMaterials,
@@ -287,11 +228,7 @@ export default () => `
 			END
 		) AS nominatedSourcingMaterials
 
-	WITH
-		category,
-		categoryRel,
-		ceremony,
-		sourcingMaterialAward,
+	WITH category, categoryRel, ceremony,
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(isWinner, false),
@@ -303,17 +240,14 @@ export default () => `
 		}) AS nominations
 		ORDER BY categoryRel.position
 
-	WITH
-		ceremony,
-		sourcingMaterialAward,
-		COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
+	WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
 		ORDER BY ceremony.name DESC
 
-	WITH
-		sourcingMaterialAward,
-		COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
-		ORDER BY sourcingMaterialAward.name
+	OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
+
+	WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
+		ORDER BY award.name
 
 	RETURN
-		COLLECT(sourcingMaterialAward { model: 'AWARD', .uuid, .name, ceremonies }) AS sourcingMaterialAwards
+		COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS sourcingMaterialAwards
 `;

--- a/src/neo4j/cypher-queries/material/show/show-awards-subsequent-version-material.js
+++ b/src/neo4j/cypher-queries/material/show/show-awards-subsequent-version-material.js
@@ -6,14 +6,6 @@ export default () => `
 		<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
 		<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
 
-	OPTIONAL MATCH (nominatedSubsequentVersionMaterial)
-		<-[:HAS_SUB_MATERIAL]-(nominatedSubsequentVersionSurMaterial:Material)
-
-	OPTIONAL MATCH (nominatedSubsequentVersionSurMaterial)
-		<-[:HAS_SUB_MATERIAL]-(nominatedSubsequentVersionSurSurMaterial:Material)
-
-	OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(subsequentVersionMaterialAward:Award)
-
 	OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)
 		WHERE
 			(
@@ -25,17 +17,7 @@ export default () => `
 				nomineeRel.nominationPosition = nominatedEntityRel.nominationPosition
 			)
 
-	WITH
-		material,
-		nominatedSubsequentVersionMaterial,
-		nominatedSubsequentVersionSurMaterial,
-		nominatedSubsequentVersionSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		subsequentVersionMaterialAward,
-		nominatedEntityRel,
+	WITH material, nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntityRel,
 		COLLECT(nominatedEntity {
 			model: TOUPPER(HEAD(LABELS(nominatedEntity))),
 			.uuid,
@@ -56,13 +38,10 @@ export default () => `
 			WITH
 				material,
 				nominatedSubsequentVersionMaterial,
-				nominatedSubsequentVersionSurMaterial,
-				nominatedSubsequentVersionSurSurMaterial,
 				nomineeRel,
 				category,
 				categoryRel,
 				ceremony,
-				subsequentVersionMaterialAward,
 				nominatedEntityRel,
 				nominatedEntity,
 				nominatedMember
@@ -71,13 +50,10 @@ export default () => `
 			WITH
 				material,
 				nominatedSubsequentVersionMaterial,
-				nominatedSubsequentVersionSurMaterial,
-				nominatedSubsequentVersionSurSurMaterial,
 				nomineeRel,
 				category,
 				categoryRel,
 				ceremony,
-				subsequentVersionMaterialAward,
 				nominatedEntityRel,
 				nominatedEntity,
 				COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
@@ -85,28 +61,16 @@ export default () => `
 	WITH
 		material,
 		nominatedSubsequentVersionMaterial,
-		nominatedSubsequentVersionSurMaterial,
-		nominatedSubsequentVersionSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		subsequentVersionMaterialAward,
 		nominatedEntityRel,
 		nominatedEntity,
 		nominatedMembers
 		ORDER BY nominatedEntityRel.nominationPosition, nominatedEntityRel.entityPosition
 
-	WITH
-		material,
-		nominatedSubsequentVersionMaterial,
-		nominatedSubsequentVersionSurMaterial,
-		nominatedSubsequentVersionSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		subsequentVersionMaterialAward,
+	WITH material, nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony,
 		COLLECT(
 			CASE nominatedEntity WHEN NULL
 				THEN null
@@ -114,16 +78,7 @@ export default () => `
 			END
 		) AS nominatedEntities
 
-	WITH
-		material,
-		nominatedSubsequentVersionMaterial,
-		nominatedSubsequentVersionSurMaterial,
-		nominatedSubsequentVersionSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		subsequentVersionMaterialAward,
+	WITH material, nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony,
 		[nominatedEntity IN nominatedEntities | CASE nominatedEntity.model WHEN 'COMPANY'
 			THEN nominatedEntity
 			ELSE nominatedEntity { .model, .uuid, .name }
@@ -147,13 +102,10 @@ export default () => `
 	WITH
 		material,
 		nominatedSubsequentVersionMaterial,
-		nominatedSubsequentVersionSurMaterial,
-		nominatedSubsequentVersionSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		subsequentVersionMaterialAward,
 		nominatedEntities,
 		nominatedProductionRel,
 		nominatedProduction,
@@ -163,17 +115,7 @@ export default () => `
 		surSurProduction
 		ORDER BY nominatedProductionRel.productionPosition
 
-	WITH
-		material,
-		nominatedSubsequentVersionMaterial,
-		nominatedSubsequentVersionSurMaterial,
-		nominatedSubsequentVersionSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		subsequentVersionMaterialAward,
-		nominatedEntities,
+	WITH material, nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
 		COLLECT(
 			CASE nominatedProduction WHEN NULL
 				THEN null
@@ -222,13 +164,10 @@ export default () => `
 
 	WITH
 		nominatedSubsequentVersionMaterial,
-		nominatedSubsequentVersionSurMaterial,
-		nominatedSubsequentVersionSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		subsequentVersionMaterialAward,
 		nominatedEntities,
 		nominatedProductions,
 		nominatedMaterialRel,
@@ -237,13 +176,10 @@ export default () => `
 
 	WITH
 		nominatedSubsequentVersionMaterial,
-		nominatedSubsequentVersionSurMaterial,
-		nominatedSubsequentVersionSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		subsequentVersionMaterialAward,
 		nominatedEntities,
 		nominatedProductions,
 		COLLECT(
@@ -254,13 +190,18 @@ export default () => `
 		) AS nominatedMaterials
 		ORDER BY nomineeRel.nominationPosition, nomineeRel.materialPosition
 
+	OPTIONAL MATCH (nominatedSubsequentVersionMaterial)
+		<-[:HAS_SUB_MATERIAL]-(nominatedSubsequentVersionSurMaterial:Material)
+
+	OPTIONAL MATCH (nominatedSubsequentVersionSurMaterial)
+		<-[:HAS_SUB_MATERIAL]-(nominatedSubsequentVersionSurSurMaterial:Material)
+
 	WITH
 		nomineeRel.isWinner AS isWinner,
 		nomineeRel.customType AS customType,
 		category,
 		categoryRel,
 		ceremony,
-		subsequentVersionMaterialAward,
 		nominatedEntities,
 		nominatedProductions,
 		nominatedMaterials,
@@ -289,11 +230,7 @@ export default () => `
 			END
 		) AS nominatedSubsequentVersionMaterials
 
-	WITH
-		category,
-		categoryRel,
-		ceremony,
-		subsequentVersionMaterialAward,
+	WITH category, categoryRel, ceremony,
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(isWinner, false),
@@ -305,22 +242,14 @@ export default () => `
 		}) AS nominations
 		ORDER BY categoryRel.position
 
-	WITH
-		ceremony,
-		subsequentVersionMaterialAward,
-		COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
+	WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
 		ORDER BY ceremony.name DESC
 
-	WITH
-		subsequentVersionMaterialAward,
-		COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
-		ORDER BY subsequentVersionMaterialAward.name
+	OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
+
+	WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
+		ORDER BY award.name
 
 	RETURN
-		COLLECT(subsequentVersionMaterialAward {
-			model: 'AWARD',
-			.uuid,
-			.name,
-			ceremonies
-		}) AS subsequentVersionMaterialAwards
+		COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS subsequentVersionMaterialAwards
 `;

--- a/src/neo4j/cypher-queries/person/show/show-awards-rights-grantor-material.js
+++ b/src/neo4j/cypher-queries/person/show/show-awards-rights-grantor-material.js
@@ -6,13 +6,6 @@ export default () => `
 		<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
 		<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
 
-	OPTIONAL MATCH (nominatedRightsGrantorMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedRightsGrantorSurMaterial:Material)
-
-	OPTIONAL MATCH (nominatedRightsGrantorSurMaterial)
-		<-[:HAS_SUB_MATERIAL]-(nominatedRightsGrantorSurSurMaterial:Material)
-
-	OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(rightsGrantorMaterialAward:Award)
-
 	OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)
 		WHERE
 			(
@@ -24,16 +17,7 @@ export default () => `
 				nomineeRel.nominationPosition = nominatedEntityRel.nominationPosition
 			)
 
-	WITH
-		nominatedRightsGrantorMaterial,
-		nominatedRightsGrantorSurMaterial,
-		nominatedRightsGrantorSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		rightsGrantorMaterialAward,
-		nominatedEntityRel,
+	WITH nominatedRightsGrantorMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntityRel,
 		COLLECT(nominatedEntity {
 			model: TOUPPER(HEAD(LABELS(nominatedEntity))),
 			.uuid,
@@ -53,13 +37,10 @@ export default () => `
 
 			WITH
 				nominatedRightsGrantorMaterial,
-				nominatedRightsGrantorSurMaterial,
-				nominatedRightsGrantorSurSurMaterial,
 				nomineeRel,
 				category,
 				categoryRel,
 				ceremony,
-				rightsGrantorMaterialAward,
 				nominatedEntityRel,
 				nominatedEntity,
 				nominatedMember
@@ -67,40 +48,26 @@ export default () => `
 
 			WITH
 				nominatedRightsGrantorMaterial,
-				nominatedRightsGrantorSurMaterial,
-				nominatedRightsGrantorSurSurMaterial,
 				nomineeRel,
 				category,
 				categoryRel,
 				ceremony,
-				rightsGrantorMaterialAward,
 				nominatedEntityRel,
 				nominatedEntity,
 				COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
 
 	WITH
 		nominatedRightsGrantorMaterial,
-		nominatedRightsGrantorSurMaterial,
-		nominatedRightsGrantorSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		rightsGrantorMaterialAward,
 		nominatedEntityRel,
 		nominatedEntity,
 		nominatedMembers
 		ORDER BY nominatedEntityRel.nominationPosition, nominatedEntityRel.entityPosition
 
-	WITH
-		nominatedRightsGrantorMaterial,
-		nominatedRightsGrantorSurMaterial,
-		nominatedRightsGrantorSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		rightsGrantorMaterialAward,
+	WITH nominatedRightsGrantorMaterial, nomineeRel, category, categoryRel, ceremony,
 		COLLECT(
 			CASE nominatedEntity WHEN NULL
 				THEN null
@@ -108,15 +75,7 @@ export default () => `
 			END
 		) AS nominatedEntities
 
-	WITH
-		nominatedRightsGrantorMaterial,
-		nominatedRightsGrantorSurMaterial,
-		nominatedRightsGrantorSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		rightsGrantorMaterialAward,
+	WITH nominatedRightsGrantorMaterial, nomineeRel, category, categoryRel, ceremony,
 		[nominatedEntity IN nominatedEntities | CASE nominatedEntity.model WHEN 'COMPANY'
 			THEN nominatedEntity
 			ELSE nominatedEntity { .model, .uuid, .name }
@@ -139,13 +98,10 @@ export default () => `
 
 	WITH
 		nominatedRightsGrantorMaterial,
-		nominatedRightsGrantorSurMaterial,
-		nominatedRightsGrantorSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		rightsGrantorMaterialAward,
 		nominatedEntities,
 		nominatedProductionRel,
 		nominatedProduction,
@@ -155,16 +111,7 @@ export default () => `
 		surSurProduction
 		ORDER BY nominatedProductionRel.productionPosition
 
-	WITH
-		nominatedRightsGrantorMaterial,
-		nominatedRightsGrantorSurMaterial,
-		nominatedRightsGrantorSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		rightsGrantorMaterialAward,
-		nominatedEntities,
+	WITH nominatedRightsGrantorMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
 		COLLECT(
 			CASE nominatedProduction WHEN NULL
 				THEN null
@@ -214,13 +161,10 @@ export default () => `
 
 	WITH
 		nominatedRightsGrantorMaterial,
-		nominatedRightsGrantorSurMaterial,
-		nominatedRightsGrantorSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		rightsGrantorMaterialAward,
 		nominatedEntities,
 		nominatedProductions,
 		nominatedMaterialRel,
@@ -230,13 +174,10 @@ export default () => `
 
 	WITH
 		nominatedRightsGrantorMaterial,
-		nominatedRightsGrantorSurMaterial,
-		nominatedRightsGrantorSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		rightsGrantorMaterialAward,
 		nominatedEntities,
 		nominatedProductions,
 		COLLECT(
@@ -257,13 +198,17 @@ export default () => `
 		) AS nominatedMaterials
 		ORDER BY nomineeRel.nominationPosition, nomineeRel.materialPosition
 
+	OPTIONAL MATCH (nominatedRightsGrantorMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedRightsGrantorSurMaterial:Material)
+
+	OPTIONAL MATCH (nominatedRightsGrantorSurMaterial)
+		<-[:HAS_SUB_MATERIAL]-(nominatedRightsGrantorSurSurMaterial:Material)
+
 	WITH
 		nomineeRel.isWinner AS isWinner,
 		nomineeRel.customType AS customType,
 		category,
 		categoryRel,
 		ceremony,
-		rightsGrantorMaterialAward,
 		nominatedEntities,
 		nominatedProductions,
 		nominatedMaterials,
@@ -292,11 +237,7 @@ export default () => `
 			END
 		) AS nominatedRightsGrantorMaterials
 
-	WITH
-		category,
-		categoryRel,
-		ceremony,
-		rightsGrantorMaterialAward,
+	WITH category, categoryRel, ceremony,
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(isWinner, false),
@@ -308,17 +249,14 @@ export default () => `
 		}) AS nominations
 		ORDER BY categoryRel.position
 
-	WITH
-		ceremony,
-		rightsGrantorMaterialAward,
-		COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
+	WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
 		ORDER BY ceremony.name DESC
 
-	WITH
-		rightsGrantorMaterialAward,
-		COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
-		ORDER BY rightsGrantorMaterialAward.name
+	OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
+
+	WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
+		ORDER BY award.name
 
 	RETURN
-		COLLECT(rightsGrantorMaterialAward { model: 'AWARD', .uuid, .name, ceremonies }) AS rightsGrantorMaterialAwards
+		COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS rightsGrantorMaterialAwards
 `;

--- a/src/neo4j/cypher-queries/person/show/show-awards-sourcing-material.js
+++ b/src/neo4j/cypher-queries/person/show/show-awards-sourcing-material.js
@@ -9,12 +9,6 @@ export default () => `
 		writingRel.creditType = 'NON_SPECIFIC_SOURCE_MATERIAL' OR
 		ANY(rel IN RELATIONSHIPS(path) WHERE TYPE(rel) = 'USES_SOURCE_MATERIAL')
 
-	OPTIONAL MATCH (nominatedSourcingMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSourcingSurMaterial:Material)
-
-	OPTIONAL MATCH (nominatedSourcingSurMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSourcingSurSurMaterial:Material)
-
-	OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(sourcingMaterialAward:Award)
-
 	OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)
 		WHERE
 			(
@@ -26,16 +20,7 @@ export default () => `
 				nomineeRel.nominationPosition = nominatedEntityRel.nominationPosition
 			)
 
-	WITH
-		nominatedSourcingMaterial,
-		nominatedSourcingSurMaterial,
-		nominatedSourcingSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		sourcingMaterialAward,
-		nominatedEntityRel,
+	WITH nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntityRel,
 		COLLECT(nominatedEntity {
 			model: TOUPPER(HEAD(LABELS(nominatedEntity))),
 			.uuid,
@@ -55,13 +40,10 @@ export default () => `
 
 			WITH
 				nominatedSourcingMaterial,
-				nominatedSourcingSurMaterial,
-				nominatedSourcingSurSurMaterial,
 				nomineeRel,
 				category,
 				categoryRel,
 				ceremony,
-				sourcingMaterialAward,
 				nominatedEntityRel,
 				nominatedEntity,
 				nominatedMember
@@ -69,40 +51,26 @@ export default () => `
 
 			WITH
 				nominatedSourcingMaterial,
-				nominatedSourcingSurMaterial,
-				nominatedSourcingSurSurMaterial,
 				nomineeRel,
 				category,
 				categoryRel,
 				ceremony,
-				sourcingMaterialAward,
 				nominatedEntityRel,
 				nominatedEntity,
 				COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
 
 	WITH
 		nominatedSourcingMaterial,
-		nominatedSourcingSurMaterial,
-		nominatedSourcingSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		sourcingMaterialAward,
 		nominatedEntityRel,
 		nominatedEntity,
 		nominatedMembers
 		ORDER BY nominatedEntityRel.nominationPosition, nominatedEntityRel.entityPosition
 
-	WITH
-		nominatedSourcingMaterial,
-		nominatedSourcingSurMaterial,
-		nominatedSourcingSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		sourcingMaterialAward,
+	WITH nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony,
 		COLLECT(
 			CASE nominatedEntity WHEN NULL
 				THEN null
@@ -110,15 +78,7 @@ export default () => `
 			END
 		) AS nominatedEntities
 
-	WITH
-		nominatedSourcingMaterial,
-		nominatedSourcingSurMaterial,
-		nominatedSourcingSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		sourcingMaterialAward,
+	WITH nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony,
 		[nominatedEntity IN nominatedEntities | CASE nominatedEntity.model WHEN 'COMPANY'
 			THEN nominatedEntity
 			ELSE nominatedEntity { .model, .uuid, .name }
@@ -141,13 +101,10 @@ export default () => `
 
 	WITH
 		nominatedSourcingMaterial,
-		nominatedSourcingSurMaterial,
-		nominatedSourcingSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		sourcingMaterialAward,
 		nominatedEntities,
 		nominatedProductionRel,
 		nominatedProduction,
@@ -157,16 +114,7 @@ export default () => `
 		surSurProduction
 		ORDER BY nominatedProductionRel.productionPosition
 
-	WITH
-		nominatedSourcingMaterial,
-		nominatedSourcingSurMaterial,
-		nominatedSourcingSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		sourcingMaterialAward,
-		nominatedEntities,
+	WITH nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
 		COLLECT(
 			CASE nominatedProduction WHEN NULL
 				THEN null
@@ -216,13 +164,10 @@ export default () => `
 
 	WITH
 		nominatedSourcingMaterial,
-		nominatedSourcingSurMaterial,
-		nominatedSourcingSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		sourcingMaterialAward,
 		nominatedEntities,
 		nominatedProductions,
 		nominatedMaterialRel,
@@ -232,13 +177,10 @@ export default () => `
 
 	WITH
 		nominatedSourcingMaterial,
-		nominatedSourcingSurMaterial,
-		nominatedSourcingSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		sourcingMaterialAward,
 		nominatedEntities,
 		nominatedProductions,
 		COLLECT(
@@ -259,13 +201,16 @@ export default () => `
 		) AS nominatedMaterials
 		ORDER BY nomineeRel.nominationPosition, nomineeRel.materialPosition
 
+	OPTIONAL MATCH (nominatedSourcingMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSourcingSurMaterial:Material)
+
+	OPTIONAL MATCH (nominatedSourcingSurMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSourcingSurSurMaterial:Material)
+
 	WITH
 		nomineeRel.isWinner AS isWinner,
 		nomineeRel.customType AS customType,
 		category,
 		categoryRel,
 		ceremony,
-		sourcingMaterialAward,
 		nominatedEntities,
 		nominatedProductions,
 		nominatedMaterials,
@@ -294,11 +239,7 @@ export default () => `
 			END
 		) AS nominatedSourcingMaterials
 
-	WITH
-		category,
-		categoryRel,
-		ceremony,
-		sourcingMaterialAward,
+	WITH category, categoryRel, ceremony,
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(isWinner, false),
@@ -310,17 +251,14 @@ export default () => `
 		}) AS nominations
 		ORDER BY categoryRel.position
 
-	WITH
-		ceremony,
-		sourcingMaterialAward,
-		COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
+	WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
 		ORDER BY ceremony.name DESC
 
-	WITH
-		sourcingMaterialAward,
-		COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
-		ORDER BY sourcingMaterialAward.name
+	OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
+
+	WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
+		ORDER BY award.name
 
 	RETURN
-		COLLECT(sourcingMaterialAward { model: 'AWARD', .uuid, .name, ceremonies }) AS sourcingMaterialAwards
+		COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS sourcingMaterialAwards
 `;

--- a/src/neo4j/cypher-queries/person/show/show-awards-subsequent-version-material.js
+++ b/src/neo4j/cypher-queries/person/show/show-awards-subsequent-version-material.js
@@ -6,14 +6,6 @@ export default () => `
 		<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
 		<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
 
-	OPTIONAL MATCH (nominatedSubsequentVersionMaterial)
-		<-[:HAS_SUB_MATERIAL]-(nominatedSubsequentVersionSurMaterial:Material)
-
-	OPTIONAL MATCH (nominatedSubsequentVersionSurMaterial)
-		<-[:HAS_SUB_MATERIAL]-(nominatedSubsequentVersionSurSurMaterial:Material)
-
-	OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(subsequentVersionMaterialAward:Award)
-
 	OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)
 		WHERE
 			(
@@ -25,16 +17,7 @@ export default () => `
 				nomineeRel.nominationPosition = nominatedEntityRel.nominationPosition
 			)
 
-	WITH
-		nominatedSubsequentVersionMaterial,
-		nominatedSubsequentVersionSurMaterial,
-		nominatedSubsequentVersionSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		subsequentVersionMaterialAward,
-		nominatedEntityRel,
+	WITH nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntityRel,
 		COLLECT(nominatedEntity {
 			model: TOUPPER(HEAD(LABELS(nominatedEntity))),
 			.uuid,
@@ -54,13 +37,10 @@ export default () => `
 
 			WITH
 				nominatedSubsequentVersionMaterial,
-				nominatedSubsequentVersionSurMaterial,
-				nominatedSubsequentVersionSurSurMaterial,
 				nomineeRel,
 				category,
 				categoryRel,
 				ceremony,
-				subsequentVersionMaterialAward,
 				nominatedEntityRel,
 				nominatedEntity,
 				nominatedMember
@@ -68,40 +48,26 @@ export default () => `
 
 			WITH
 				nominatedSubsequentVersionMaterial,
-				nominatedSubsequentVersionSurMaterial,
-				nominatedSubsequentVersionSurSurMaterial,
 				nomineeRel,
 				category,
 				categoryRel,
 				ceremony,
-				subsequentVersionMaterialAward,
 				nominatedEntityRel,
 				nominatedEntity,
 				COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
 
 	WITH
 		nominatedSubsequentVersionMaterial,
-		nominatedSubsequentVersionSurMaterial,
-		nominatedSubsequentVersionSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		subsequentVersionMaterialAward,
 		nominatedEntityRel,
 		nominatedEntity,
 		nominatedMembers
 		ORDER BY nominatedEntityRel.nominationPosition, nominatedEntityRel.entityPosition
 
-	WITH
-		nominatedSubsequentVersionMaterial,
-		nominatedSubsequentVersionSurMaterial,
-		nominatedSubsequentVersionSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		subsequentVersionMaterialAward,
+	WITH nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony,
 		COLLECT(
 			CASE nominatedEntity WHEN NULL
 				THEN null
@@ -109,15 +75,7 @@ export default () => `
 			END
 		) AS nominatedEntities
 
-	WITH
-		nominatedSubsequentVersionMaterial,
-		nominatedSubsequentVersionSurMaterial,
-		nominatedSubsequentVersionSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		subsequentVersionMaterialAward,
+	WITH nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony,
 		[nominatedEntity IN nominatedEntities | CASE nominatedEntity.model WHEN 'COMPANY'
 			THEN nominatedEntity
 			ELSE nominatedEntity { .model, .uuid, .name }
@@ -140,13 +98,10 @@ export default () => `
 
 	WITH
 		nominatedSubsequentVersionMaterial,
-		nominatedSubsequentVersionSurMaterial,
-		nominatedSubsequentVersionSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		subsequentVersionMaterialAward,
 		nominatedEntities,
 		nominatedProductionRel,
 		nominatedProduction,
@@ -156,16 +111,7 @@ export default () => `
 		surSurProduction
 		ORDER BY nominatedProductionRel.productionPosition
 
-	WITH
-		nominatedSubsequentVersionMaterial,
-		nominatedSubsequentVersionSurMaterial,
-		nominatedSubsequentVersionSurSurMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		subsequentVersionMaterialAward,
-		nominatedEntities,
+	WITH nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
 		COLLECT(
 			CASE nominatedProduction WHEN NULL
 				THEN null
@@ -215,13 +161,10 @@ export default () => `
 
 	WITH
 		nominatedSubsequentVersionMaterial,
-		nominatedSubsequentVersionSurMaterial,
-		nominatedSubsequentVersionSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		subsequentVersionMaterialAward,
 		nominatedEntities,
 		nominatedProductions,
 		nominatedMaterialRel,
@@ -231,13 +174,10 @@ export default () => `
 
 	WITH
 		nominatedSubsequentVersionMaterial,
-		nominatedSubsequentVersionSurMaterial,
-		nominatedSubsequentVersionSurSurMaterial,
 		nomineeRel,
 		category,
 		categoryRel,
 		ceremony,
-		subsequentVersionMaterialAward,
 		nominatedEntities,
 		nominatedProductions,
 		COLLECT(
@@ -258,13 +198,18 @@ export default () => `
 		) AS nominatedMaterials
 		ORDER BY nomineeRel.nominationPosition, nomineeRel.materialPosition
 
+	OPTIONAL MATCH (nominatedSubsequentVersionMaterial)
+		<-[:HAS_SUB_MATERIAL]-(nominatedSubsequentVersionSurMaterial:Material)
+
+	OPTIONAL MATCH (nominatedSubsequentVersionSurMaterial)
+		<-[:HAS_SUB_MATERIAL]-(nominatedSubsequentVersionSurSurMaterial:Material)
+
 	WITH
 		nomineeRel.isWinner AS isWinner,
 		nomineeRel.customType AS customType,
 		category,
 		categoryRel,
 		ceremony,
-		subsequentVersionMaterialAward,
 		nominatedEntities,
 		nominatedProductions,
 		nominatedMaterials,
@@ -293,11 +238,7 @@ export default () => `
 			END
 		) AS nominatedSubsequentVersionMaterials
 
-	WITH
-		category,
-		categoryRel,
-		ceremony,
-		subsequentVersionMaterialAward,
+	WITH category, categoryRel, ceremony,
 		COLLECT({
 			model: 'NOMINATION',
 			isWinner: COALESCE(isWinner, false),
@@ -309,22 +250,14 @@ export default () => `
 		}) AS nominations
 		ORDER BY categoryRel.position
 
-	WITH
-		ceremony,
-		subsequentVersionMaterialAward,
-		COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
+	WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
 		ORDER BY ceremony.name DESC
 
-	WITH
-		subsequentVersionMaterialAward,
-		COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
-		ORDER BY subsequentVersionMaterialAward.name
+	OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
+
+	WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
+		ORDER BY award.name
 
 	RETURN
-		COLLECT(subsequentVersionMaterialAward {
-			model: 'AWARD',
-			.uuid,
-			.name,
-			ceremonies
-		}) AS subsequentVersionMaterialAwards
+		COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS subsequentVersionMaterialAwards
 `;


### PR DESCRIPTION
This PR revises some of the Cypher queries to only perform the `MATCH` statements directly before the identifiers they acquire are required.

This results in far fewer identifiers being passed down through the queries in the `WITH` statements and consequently makes them much easier to understand and manage.