### PR TITLE
Apply database seeding revisions

### DIFF
--- a/db-seeding/seed-db.js
+++ b/db-seeding/seed-db.js
@@ -25,7 +25,10 @@ async function performFetch (url, instance, filenamePathSlug) {
 
 };
 
-async function seedInstances (directoryName, modelUrlRoute) {
+async function seedInstances (pluralisedModel) {
+
+	const directoryName = pluralisedModel;
+	const modelUrlRoute = pluralisedModel;
 
 	const directoryPath = path.join(__dirname, `seeds/${directoryName}`);
 
@@ -65,19 +68,19 @@ async function seedDatabase () {
 
 	console.log('Seeding Neo4j database: 🟢 Commenced'); // eslint-disable-line no-console
 
-	await seedInstances('venues', 'venues');
+	await seedInstances('venues');
 
 	console.log('Seeding Neo4j database: ✅ Venue seeds sown'); // eslint-disable-line no-console
 
-	await seedInstances('materials', 'materials');
+	await seedInstances('materials');
 
 	console.log('Seeding Neo4j database: ✅ Material seeds sown'); // eslint-disable-line no-console
 
-	await seedInstances('productions', 'productions');
+	await seedInstances('productions');
 
 	console.log('Seeding Neo4j database: ✅ Production seeds sown'); // eslint-disable-line no-console
 
-	await seedInstances('award-ceremonies', 'award-ceremonies');
+	await seedInstances('award-ceremonies');
 
 	console.log('Seeding Neo4j database: ✅ Award ceremony seeds sown'); // eslint-disable-line no-console
 

--- a/db-seeding/seed-db.js
+++ b/db-seeding/seed-db.js
@@ -5,7 +5,7 @@ const directly = require('directly');
 
 const BASE_URL = 'http://localhost:3000';
 
-async function performFetch (url, instance) {
+async function performFetch (url, instance, filenamePathSlug) {
 
 	const settings = {
 		headers: {
@@ -18,6 +18,8 @@ async function performFetch (url, instance) {
 	const response = await fetch(url, settings);
 
 	if (response.status !== 200) throw new Error(response.statusText);
+
+	console.log(`Seeding Neo4j database: ${filenamePathSlug}`); // eslint-disable-line no-console
 
 	return;
 
@@ -33,6 +35,8 @@ async function seedInstances (directoryName, modelUrlRoute) {
 		seedFilenames
 			.map(filename => () => {
 
+				const filenamePathSlug = `${directoryName}/${filename}`;
+
 				try {
 
 					const rawData = fs.readFileSync(`${directoryPath}/${filename}`);
@@ -41,11 +45,11 @@ async function seedInstances (directoryName, modelUrlRoute) {
 
 					const url = `${BASE_URL}/${modelUrlRoute}`;
 
-					return performFetch(url, instance);
+					return performFetch(url, instance, filenamePathSlug);
 
 				} catch (error) {
 
-					throw new Error(`${directoryName}/${filename}: ${error.message}`);
+					throw new Error(`${filenamePathSlug}: ${error.message}`);
 
 				}
 

--- a/db-seeding/seed-db.js
+++ b/db-seeding/seed-db.js
@@ -5,7 +5,14 @@ const directly = require('directly');
 
 const BASE_URL = 'http://localhost:3000';
 
-async function performFetch (url, instance, filenamePathSlug) {
+const PLURALISED_MODEL_TO_EMOJI_MAP = {
+	'award-ceremonies': '🏆',
+	'materials': '📖',
+	'productions': '🎭',
+	'venues': '🏛️'
+}
+
+async function performFetch (url, instance, modelEmoji, filenamePathSlug) {
 
 	const settings = {
 		headers: {
@@ -19,7 +26,7 @@ async function performFetch (url, instance, filenamePathSlug) {
 
 	if (response.status !== 200) throw new Error(response.statusText);
 
-	console.log(`Seeding Neo4j database: ${filenamePathSlug}`); // eslint-disable-line no-console
+	console.log(`Seeding Neo4j database: ${modelEmoji} ${filenamePathSlug}`); // eslint-disable-line no-console
 
 	return;
 
@@ -48,7 +55,12 @@ async function seedInstances (pluralisedModel) {
 
 					const url = `${BASE_URL}/${modelUrlRoute}`;
 
-					return performFetch(url, instance, filenamePathSlug);
+					return performFetch(
+						url,
+						instance,
+						PLURALISED_MODEL_TO_EMOJI_MAP[pluralisedModel],
+						filenamePathSlug
+					);
 
 				} catch (error) {
 

--- a/db-seeding/seed-db.js
+++ b/db-seeding/seed-db.js
@@ -59,25 +59,25 @@ async function seedInstances (directoryName, modelUrlRoute) {
 
 async function seedDatabase () {
 
-	console.log('Seeding Neo4j database: Commenced'); // eslint-disable-line no-console
+	console.log('Seeding Neo4j database: 🟢 Commenced'); // eslint-disable-line no-console
 
 	await seedInstances('venues', 'venues');
 
-	console.log('Seeding Neo4j database: Venue seeds sown'); // eslint-disable-line no-console
+	console.log('Seeding Neo4j database: ✅ Venue seeds sown'); // eslint-disable-line no-console
 
 	await seedInstances('materials', 'materials');
 
-	console.log('Seeding Neo4j database: Material seeds sown'); // eslint-disable-line no-console
+	console.log('Seeding Neo4j database: ✅ Material seeds sown'); // eslint-disable-line no-console
 
 	await seedInstances('productions', 'productions');
 
-	console.log('Seeding Neo4j database: Production seeds sown'); // eslint-disable-line no-console
+	console.log('Seeding Neo4j database: ✅ Production seeds sown'); // eslint-disable-line no-console
 
 	await seedInstances('award-ceremonies', 'award-ceremonies');
 
-	console.log('Seeding Neo4j database: Award ceremony seeds sown'); // eslint-disable-line no-console
+	console.log('Seeding Neo4j database: ✅ Award ceremony seeds sown'); // eslint-disable-line no-console
 
-	console.log('Seeding Neo4j database: Complete'); // eslint-disable-line no-console
+	console.log('Seeding Neo4j database: ✅ Complete'); // eslint-disable-line no-console
 
 	return;
 

--- a/db-seeding/seed-db.js
+++ b/db-seeding/seed-db.js
@@ -25,9 +25,9 @@ async function performFetch (url, instance) {
 
 async function seedInstances (directoryName, modelUrlRoute) {
 
-	const seedsPath = path.join(__dirname, `seeds/${directoryName}`);
+	const directoryPath = path.join(__dirname, `seeds/${directoryName}`);
 
-	const seedFilenames = fs.readdirSync(seedsPath);
+	const seedFilenames = fs.readdirSync(directoryPath);
 
 	const createInstanceFunctions =
 		seedFilenames
@@ -35,7 +35,7 @@ async function seedInstances (directoryName, modelUrlRoute) {
 
 				try {
 
-					const rawData = fs.readFileSync(`${seedsPath}/${filename}`);
+					const rawData = fs.readFileSync(`${directoryPath}/${filename}`);
 
 					const instance = JSON.parse(rawData);
 

--- a/db-seeding/seed-db.js
+++ b/db-seeding/seed-db.js
@@ -32,13 +32,22 @@ async function seedInstances (directoryName, modelUrlRoute) {
 	const createInstanceFunctions =
 		seedFilenames
 			.map(filename => () => {
-				const rawData = fs.readFileSync(`${seedsPath}/${filename}`);
 
-				const instance = JSON.parse(rawData);
+				try {
 
-				const url = `${BASE_URL}/${modelUrlRoute}`;
+					const rawData = fs.readFileSync(`${seedsPath}/${filename}`);
 
-				return performFetch(url, instance);
+					const instance = JSON.parse(rawData);
+
+					const url = `${BASE_URL}/${modelUrlRoute}`;
+
+					return performFetch(url, instance);
+
+				} catch (error) {
+
+					throw new Error(`${directoryName}/${filename}: ${error.message}`);
+
+				}
 
 			});
 

--- a/db-seeding/seed-db.js
+++ b/db-seeding/seed-db.js
@@ -31,16 +31,14 @@ async function seedInstances (directoryName, modelUrlRoute) {
 
 	const createInstanceFunctions =
 		seedFilenames
-			.map(filename => async () => {
+			.map(filename => () => {
 				const rawData = fs.readFileSync(`${seedsPath}/${filename}`);
 
 				const instance = JSON.parse(rawData);
 
 				const url = `${BASE_URL}/${modelUrlRoute}`;
 
-				await performFetch(url, instance);
-
-				return;
+				return performFetch(url, instance);
 
 			});
 

--- a/db-seeding/seeds/materials/3-winters.json
+++ b/db-seeding/seeds/materials/3-winters.json
@@ -1,7 +1,7 @@
 {
 	"name": "3 Winters",
 	"format": "play",
-	"year": 2014,
+	"year": "2014",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/a-disappearing-number.json
+++ b/db-seeding/seeds/materials/a-disappearing-number.json
@@ -1,7 +1,7 @@
 {
 	"name": "A Disappearing Number",
 	"format": "play",
-	"year": 2007,
+	"year": "2007",
 	"writingCredits": [
 		{
 			"name": "conceived by",

--- a/db-seeding/seeds/materials/a-dolls-house-original-version.json
+++ b/db-seeding/seeds/materials/a-dolls-house-original-version.json
@@ -2,7 +2,7 @@
 	"name": "A Doll's House",
 	"differentiator": "1",
 	"format": "play",
-	"year": 1879,
+	"year": "1879",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/a-dolls-house-subsequent-version.json
+++ b/db-seeding/seeds/materials/a-dolls-house-subsequent-version.json
@@ -2,7 +2,7 @@
 	"name": "A Doll's House",
 	"differentiator": "2",
 	"format": "play",
-	"year": 2009,
+	"year": "2009",
 	"originalVersionMaterial": {
 		"name": "A Doll's House",
 		"differentiator": "1"

--- a/db-seeding/seeds/materials/a-midsummer-nights-dream.json
+++ b/db-seeding/seeds/materials/a-midsummer-nights-dream.json
@@ -1,7 +1,7 @@
 {
 	"name": "A Midsummer Night's Dream",
 	"format": "play",
-	"year": 1595,
+	"year": "1595",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/a-streetcar-named-desire.json
+++ b/db-seeding/seeds/materials/a-streetcar-named-desire.json
@@ -1,7 +1,7 @@
 {
 	"name": "A Streetcar Named Desire",
 	"format": "play",
-	"year": 1947,
+	"year": "1947",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/a-view-from-the-bridge.json
+++ b/db-seeding/seeds/materials/a-view-from-the-bridge.json
@@ -1,7 +1,7 @@
 {
 	"name": "A View from the Bridge",
 	"format": "play",
-	"year": 1955,
+	"year": "1955",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/all-in-good-time.json
+++ b/db-seeding/seeds/materials/all-in-good-time.json
@@ -1,7 +1,7 @@
 {
 	"name": "All in Good Time",
 	"format": "play",
-	"year": 1963,
+	"year": "1963",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/august-osage-county.json
+++ b/db-seeding/seeds/materials/august-osage-county.json
@@ -1,7 +1,7 @@
 {
 	"name": "August: Osage County",
 	"format": "play",
-	"year": 2007,
+	"year": "2007",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/black-crows.json
+++ b/db-seeding/seeds/materials/black-crows.json
@@ -1,7 +1,7 @@
 {
 	"name": "Black Crows",
 	"format": "play",
-	"year": 2007,
+	"year": "2007",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/black-watch.json
+++ b/db-seeding/seeds/materials/black-watch.json
@@ -1,7 +1,7 @@
 {
 	"name": "Black Watch",
 	"format": "play",
-	"year": 2006,
+	"year": "2006",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/boats-on-a-river.json
+++ b/db-seeding/seeds/materials/boats-on-a-river.json
@@ -1,7 +1,7 @@
 {
 	"name": "Boats on a River",
 	"format": "play",
-	"year": 2007,
+	"year": "2007",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/boeing-boeing.json
+++ b/db-seeding/seeds/materials/boeing-boeing.json
@@ -1,7 +1,7 @@
 {
 	"name": "Boeing-Boeing",
 	"format": "play",
-	"year": 1960,
+	"year": "1960",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/cat-on-a-hot-tin-roof.json
+++ b/db-seeding/seeds/materials/cat-on-a-hot-tin-roof.json
@@ -1,7 +1,7 @@
 {
 	"name": "Cat on a Hot Tin Roof",
 	"format": "play",
-	"year": 1955,
+	"year": "1955",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/coriolanus.json
+++ b/db-seeding/seeds/materials/coriolanus.json
@@ -1,7 +1,7 @@
 {
 	"name": "Coriolanus",
 	"format": "play",
-	"year": 1608,
+	"year": "1608",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/death-on-the-nile-novel.json
+++ b/db-seeding/seeds/materials/death-on-the-nile-novel.json
@@ -1,7 +1,7 @@
 {
 	"name": "Death on the Nile",
 	"format": "novel",
-	"year": 1937,
+	"year": "1937",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/duet-for-one.json
+++ b/db-seeding/seeds/materials/duet-for-one.json
@@ -1,7 +1,7 @@
 {
 	"name": "Duet for One",
 	"format": "play",
-	"year": 1980,
+	"year": "1980",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/east-of-berlin.json
+++ b/db-seeding/seeds/materials/east-of-berlin.json
@@ -1,7 +1,7 @@
 {
 	"name": "East of Berlin",
 	"format": "play",
-	"year": 2009,
+	"year": "2009",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/elling-1-novel.json
+++ b/db-seeding/seeds/materials/elling-1-novel.json
@@ -2,7 +2,7 @@
 	"name": "Elling",
 	"differentiator": "1",
 	"format": "novel",
-	"year": 1996,
+	"year": "1996",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/elling-2-screenplay.json
+++ b/db-seeding/seeds/materials/elling-2-screenplay.json
@@ -2,7 +2,7 @@
 	"name": "Elling",
 	"differentiator": "2",
 	"format": "screenplay",
-	"year": 2001,
+	"year": "2001",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/elling-3-play.json
+++ b/db-seeding/seeds/materials/elling-3-play.json
@@ -2,7 +2,7 @@
 	"name": "Elling",
 	"differentiator": "3",
 	"format": "play",
-	"year": 2007,
+	"year": "2007",
 	"writingCredits": [
 		{
 			"name": "adapted by",

--- a/db-seeding/seeds/materials/enron.json
+++ b/db-seeding/seeds/materials/enron.json
@@ -1,7 +1,7 @@
 {
 	"name": "Enron",
 	"format": "play",
-	"year": 2009,
+	"year": "2009",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/entertaining-mr-sloane.json
+++ b/db-seeding/seeds/materials/entertaining-mr-sloane.json
@@ -1,7 +1,7 @@
 {
 	"name": "Entertaining Mr Sloane",
 	"format": "play",
-	"year": 1963,
+	"year": "1963",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/free-outgoing.json
+++ b/db-seeding/seeds/materials/free-outgoing.json
@@ -1,7 +1,7 @@
 {
 	"name": "Free Outgoing",
 	"format": "play",
-	"year": 2008,
+	"year": "2008",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/girls-and-dolls.json
+++ b/db-seeding/seeds/materials/girls-and-dolls.json
@@ -1,7 +1,7 @@
 {
 	"name": "Girls and Dolls",
 	"format": "play",
-	"year": 2007,
+	"year": "2007",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/gods-ear.json
+++ b/db-seeding/seeds/materials/gods-ear.json
@@ -1,7 +1,7 @@
 {
 	"name": "God's Ear",
 	"format": "play",
-	"year": 2008,
+	"year": "2008",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/hamlet.json
+++ b/db-seeding/seeds/materials/hamlet.json
@@ -1,7 +1,7 @@
 {
 	"name": "Hamlet",
 	"format": "play",
-	"year": 1601,
+	"year": "1601",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/happy-days.json
+++ b/db-seeding/seeds/materials/happy-days.json
@@ -1,7 +1,7 @@
 {
 	"name": "Happy Days",
 	"format": "play",
-	"year": 1961,
+	"year": "1961",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/happy-now?.json
+++ b/db-seeding/seeds/materials/happy-now?.json
@@ -1,7 +1,7 @@
 {
 	"name": "Happy Now?",
 	"format": "play",
-	"year": 2008,
+	"year": "2008",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/hardball.json
+++ b/db-seeding/seeds/materials/hardball.json
@@ -1,7 +1,7 @@
 {
 	"name": "Hardball",
 	"format": "play",
-	"year": 2007,
+	"year": "2007",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/henry-iv-part-1.json
+++ b/db-seeding/seeds/materials/henry-iv-part-1.json
@@ -1,7 +1,7 @@
 {
 	"name": "Henry IV, Part 1",
 	"format": "play",
-	"year": 1597,
+	"year": "1597",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/henry-iv-part-2.json
+++ b/db-seeding/seeds/materials/henry-iv-part-2.json
@@ -1,7 +1,7 @@
 {
 	"name": "Henry IV, Part 2",
 	"format": "play",
-	"year": 1599,
+	"year": "1599",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/henry-v.json
+++ b/db-seeding/seeds/materials/henry-v.json
@@ -1,7 +1,7 @@
 {
 	"name": "Henry V",
 	"format": "play",
-	"year": 1599,
+	"year": "1599",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/inana.json
+++ b/db-seeding/seeds/materials/inana.json
@@ -1,7 +1,7 @@
 {
 	"name": "Inana",
 	"format": "play",
-	"year": 2009,
+	"year": "2009",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/it-felt-empty-when-the-heart-went-at-first-but-it-is-alright-now.json
+++ b/db-seeding/seeds/materials/it-felt-empty-when-the-heart-went-at-first-but-it-is-alright-now.json
@@ -1,7 +1,7 @@
 {
 	"name": "It Felt Empty When the Heart Went at First But It Is Alright Now",
 	"format": "play",
-	"year": 2009,
+	"year": "2009",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/jerusalem.json
+++ b/db-seeding/seeds/materials/jerusalem.json
@@ -1,7 +1,7 @@
 {
 	"name": "Jerusalem",
 	"format": "play",
-	"year": 2009,
+	"year": "2009",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/john-gabriel-borkman-original-version.json
+++ b/db-seeding/seeds/materials/john-gabriel-borkman-original-version.json
@@ -2,7 +2,7 @@
 	"name": "John Gabriel Borkman",
 	"differentiator": "1",
 	"format": "play",
-	"year": 1896,
+	"year": "1896",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/john-gabriel-borkman-subsequent-version-1.json
+++ b/db-seeding/seeds/materials/john-gabriel-borkman-subsequent-version-1.json
@@ -2,7 +2,7 @@
 	"name": "John Gabriel Borkman",
 	"differentiator": "2",
 	"format": "play",
-	"year": 2007,
+	"year": "2007",
 	"originalVersionMaterial": {
 		"name": "John Gabriel Borkman",
 		"differentiator": "1"

--- a/db-seeding/seeds/materials/julius-caesar.json
+++ b/db-seeding/seeds/materials/julius-caesar.json
@@ -1,7 +1,7 @@
 {
 	"name": "Julius Caesar",
 	"format": "play",
-	"year": 1599,
+	"year": "1599",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/king-lear.json
+++ b/db-seeding/seeds/materials/king-lear.json
@@ -1,7 +1,7 @@
 {
 	"name": "King Lear",
 	"format": "play",
-	"year": 1606,
+	"year": "1606",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/little-eyolf.json
+++ b/db-seeding/seeds/materials/little-eyolf.json
@@ -1,7 +1,7 @@
 {
 	"name": "Little Eyolf",
 	"format": "play",
-	"year": 1894,
+	"year": "1894",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/macbeth.json
+++ b/db-seeding/seeds/materials/macbeth.json
@@ -1,7 +1,7 @@
 {
 	"name": "Macbeth",
 	"format": "play",
-	"year": 1606,
+	"year": "1606",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/miss-julie-original-version.json
+++ b/db-seeding/seeds/materials/miss-julie-original-version.json
@@ -1,7 +1,7 @@
 {
 	"name": "Miss Julie",
 	"format": "play",
-	"year": 1888,
+	"year": "1888",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/miss-julie-subsequent-version-1.json
+++ b/db-seeding/seeds/materials/miss-julie-subsequent-version-1.json
@@ -1,7 +1,7 @@
 {
 	"name": "After Miss Julie",
 	"format": "play",
-	"year": 1996,
+	"year": "1996",
 	"originalVersionMaterial": {
 		"name": "Miss Julie"
 	},

--- a/db-seeding/seeds/materials/miss-julie-subsequent-version-2.json
+++ b/db-seeding/seeds/materials/miss-julie-subsequent-version-2.json
@@ -1,7 +1,7 @@
 {
 	"name": "Julie",
 	"format": "play",
-	"year": 2018,
+	"year": "2018",
 	"originalVersionMaterial": {
 		"name": "Miss Julie"
 	},

--- a/db-seeding/seeds/materials/mrs-affleck.json
+++ b/db-seeding/seeds/materials/mrs-affleck.json
@@ -1,7 +1,7 @@
 {
 	"name": "Mrs Affleck",
 	"format": "play",
-	"year": 2009,
+	"year": "2009",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/murder-on-the-nile-play.json
+++ b/db-seeding/seeds/materials/murder-on-the-nile-play.json
@@ -1,7 +1,7 @@
 {
 	"name": "Murder on the Nile",
 	"format": "play",
-	"year": 1944,
+	"year": "1944",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/no-mans-land.json
+++ b/db-seeding/seeds/materials/no-mans-land.json
@@ -1,7 +1,7 @@
 {
 	"name": "No Man's Land",
 	"format": "play",
-	"year": 1974,
+	"year": "1974",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/now-or-later.json
+++ b/db-seeding/seeds/materials/now-or-later.json
@@ -1,7 +1,7 @@
 {
 	"name": "Now or Later",
 	"format": "play",
-	"year": 2008,
+	"year": "2008",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/olivier-parker!.json
+++ b/db-seeding/seeds/materials/olivier-parker!.json
@@ -1,7 +1,7 @@
 {
 	"name": "Oliver Parker!",
 	"format": "play",
-	"year": 2009,
+	"year": "2009",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/on-the-rocks.json
+++ b/db-seeding/seeds/materials/on-the-rocks.json
@@ -1,7 +1,7 @@
 {
 	"name": "On the Rocks",
 	"format": "play",
-	"year": 2008,
+	"year": "2008",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/othello.json
+++ b/db-seeding/seeds/materials/othello.json
@@ -1,7 +1,7 @@
 {
 	"name": "Othello",
 	"format": "play",
-	"year": 1603,
+	"year": "1603",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/palace-of-the-end.json
+++ b/db-seeding/seeds/materials/palace-of-the-end.json
@@ -1,7 +1,7 @@
 {
 	"name": "Palace of the End",
 	"format": "play",
-	"year": 2007,
+	"year": "2007",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/peer-gynt-original-version.json
+++ b/db-seeding/seeds/materials/peer-gynt-original-version.json
@@ -2,7 +2,7 @@
 	"name": "Peer Gynt",
 	"differentiator": "1",
 	"format": "play",
-	"year": 1867,
+	"year": "1867",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/peer-gynt-subsequent-version-1.json
+++ b/db-seeding/seeds/materials/peer-gynt-subsequent-version-1.json
@@ -2,7 +2,7 @@
 	"name": "Peer Gynt",
 	"differentiator": "2",
 	"format": "play",
-	"year": 2000,
+	"year": "2000",
 	"originalVersionMaterial": {
 		"name": "Peer Gynt",
 		"differentiator": "1"

--- a/db-seeding/seeds/materials/peer-gynt-subsequent-version-2.json
+++ b/db-seeding/seeds/materials/peer-gynt-subsequent-version-2.json
@@ -2,7 +2,7 @@
 	"name": "Peer Gynt",
 	"differentiator": "3",
 	"format": "play",
-	"year": 2007,
+	"year": "2007",
 	"originalVersionMaterial": {
 		"name": "Peer Gynt",
 		"differentiator": "1"

--- a/db-seeding/seeds/materials/punk-rock.json
+++ b/db-seeding/seeds/materials/punk-rock.json
@@ -1,7 +1,7 @@
 {
 	"name": "Punk Rock",
 	"format": "play",
-	"year": 2009,
+	"year": "2009",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/rafta-rafta.json
+++ b/db-seeding/seeds/materials/rafta-rafta.json
@@ -1,7 +1,7 @@
 {
 	"name": "Rafta, Rafta…",
 	"format": "play",
-	"year": 2007,
+	"year": "2007",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/rain-main-1-screenplay.json
+++ b/db-seeding/seeds/materials/rain-main-1-screenplay.json
@@ -2,7 +2,7 @@
 	"name": "Rain Main",
 	"differentiator": "1",
 	"format": "screenplay",
-	"year": 1988,
+	"year": "1988",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/rain-main-2-play.json
+++ b/db-seeding/seeds/materials/rain-main-2-play.json
@@ -2,7 +2,7 @@
 	"name": "Rain Main",
 	"differentiator": "2",
 	"format": "play",
-	"year": 2008,
+	"year": "2008",
 	"writingCredits": [
 		{
 			"name": "adapted by",

--- a/db-seeding/seeds/materials/red.json
+++ b/db-seeding/seeds/materials/red.json
@@ -1,7 +1,7 @@
 {
 	"name": "Red",
 	"format": "play",
-	"year": 2009,
+	"year": "2009",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/rock-n-roll.json
+++ b/db-seeding/seeds/materials/rock-n-roll.json
@@ -1,7 +1,7 @@
 {
 	"name": "Rock 'n' Roll",
 	"format": "play",
-	"year": 2006,
+	"year": "2006",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/rope.json
+++ b/db-seeding/seeds/materials/rope.json
@@ -1,7 +1,7 @@
 {
 	"name": "Rope",
 	"format": "play",
-	"year": 1929,
+	"year": "1929",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/ruined.json
+++ b/db-seeding/seeds/materials/ruined.json
@@ -1,7 +1,7 @@
 {
 	"name": "Ruined",
 	"format": "play",
-	"year": 2008,
+	"year": "2008",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/saint-joan.json
+++ b/db-seeding/seeds/materials/saint-joan.json
@@ -1,7 +1,7 @@
 {
 	"name": "Saint Joan",
 	"format": "play",
-	"year": 1923,
+	"year": "1923",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/shakespeares-villains.json
+++ b/db-seeding/seeds/materials/shakespeares-villains.json
@@ -1,7 +1,7 @@
 {
 	"name": "Shakespeare's Villains",
 	"format": "play",
-	"year": 1998,
+	"year": "1998",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/stick-fly.json
+++ b/db-seeding/seeds/materials/stick-fly.json
@@ -1,7 +1,7 @@
 {
 	"name": "Stick Fly",
 	"format": "play",
-	"year": 2007,
+	"year": "2007",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/stockholm.json
+++ b/db-seeding/seeds/materials/stockholm.json
@@ -1,7 +1,7 @@
 {
 	"name": "Stockholm",
 	"format": "play",
-	"year": 2007,
+	"year": "2007",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/strandline.json
+++ b/db-seeding/seeds/materials/strandline.json
@@ -1,7 +1,7 @@
 {
 	"name": "Strandline",
 	"format": "play",
-	"year": 2009,
+	"year": "2009",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/strangers-babies.json
+++ b/db-seeding/seeds/materials/strangers-babies.json
@@ -1,7 +1,7 @@
 {
 	"name": "Strangers, Babies",
 	"format": "play",
-	"year": 2007,
+	"year": "2007",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/ten-tiny-toes.json
+++ b/db-seeding/seeds/materials/ten-tiny-toes.json
@@ -1,7 +1,7 @@
 {
 	"name": "Ten Tiny Toes",
 	"format": "play",
-	"year": 2008,
+	"year": "2008",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/that-face.json
+++ b/db-seeding/seeds/materials/that-face.json
@@ -1,7 +1,7 @@
 {
 	"name": "That Face",
 	"format": "play",
-	"year": 2007,
+	"year": "2007",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-aliens.json
+++ b/db-seeding/seeds/materials/the-aliens.json
@@ -1,7 +1,7 @@
 {
 	"name": "The Aliens",
 	"format": "play",
-	"year": 2010,
+	"year": "2010",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-almond-and-the-seahorse.json
+++ b/db-seeding/seeds/materials/the-almond-and-the-seahorse.json
@@ -1,7 +1,7 @@
 {
 	"name": "The Almond and the Seahorse",
 	"format": "play",
-	"year": 2008,
+	"year": "2008",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-b-file.json
+++ b/db-seeding/seeds/materials/the-b-file.json
@@ -1,7 +1,7 @@
 {
 	"name": "The B File",
 	"format": "play",
-	"year": 1992,
+	"year": "1992",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-bomb-01-from-elsewhere-the-message.json
+++ b/db-seeding/seeds/materials/the-bomb-01-from-elsewhere-the-message.json
@@ -1,7 +1,7 @@
 {
 	"name": "From Elsewhere: The Message…",
 	"format": "play",
-	"year": 2012,
+	"year": "2012",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-bomb-02-calculated-risk.json
+++ b/db-seeding/seeds/materials/the-bomb-02-calculated-risk.json
@@ -1,7 +1,7 @@
 {
 	"name": "Calculated Risk",
 	"format": "play",
-	"year": 2012,
+	"year": "2012",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-bomb-03-seven-joys.json
+++ b/db-seeding/seeds/materials/the-bomb-03-seven-joys.json
@@ -1,7 +1,7 @@
 {
 	"name": "Seven Joys",
 	"format": "play",
-	"year": 2012,
+	"year": "2012",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-bomb-04-option.json
+++ b/db-seeding/seeds/materials/the-bomb-04-option.json
@@ -1,7 +1,7 @@
 {
 	"name": "Option",
 	"format": "play",
-	"year": 2012,
+	"year": "2012",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-bomb-05-little-russians.json
+++ b/db-seeding/seeds/materials/the-bomb-05-little-russians.json
@@ -1,7 +1,7 @@
 {
 	"name": "Little Russians",
 	"format": "play",
-	"year": 2012,
+	"year": "2012",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-bomb-06-there-was-a-man-there-was-no-man.json
+++ b/db-seeding/seeds/materials/the-bomb-06-there-was-a-man-there-was-no-man.json
@@ -1,7 +1,7 @@
 {
 	"name": "There Was a Man, There Was No Man",
 	"format": "play",
-	"year": 2012,
+	"year": "2012",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-bomb-07-axis.json
+++ b/db-seeding/seeds/materials/the-bomb-07-axis.json
@@ -1,7 +1,7 @@
 {
 	"name": "Axis",
 	"format": "play",
-	"year": 2012,
+	"year": "2012",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-bomb-08-talk-talk-fight-fight.json
+++ b/db-seeding/seeds/materials/the-bomb-08-talk-talk-fight-fight.json
@@ -1,7 +1,7 @@
 {
 	"name": "Talk Talk Fight Fight",
 	"format": "play",
-	"year": 2012,
+	"year": "2012",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-bomb-09-the-letter-of-last-resort.json
+++ b/db-seeding/seeds/materials/the-bomb-09-the-letter-of-last-resort.json
@@ -1,7 +1,7 @@
 {
 	"name": "The Letter of Last Resort",
 	"format": "play",
-	"year": 2012,
+	"year": "2012",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-bomb-10-from-elsewhere-on-the-watch.json
+++ b/db-seeding/seeds/materials/the-bomb-10-from-elsewhere-on-the-watch.json
@@ -1,7 +1,7 @@
 {
 	"name": "From Elsewhere: On the Watch…",
 	"format": "play",
-	"year": 2012,
+	"year": "2012",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-bomb-11-anadyr.json
+++ b/db-seeding/seeds/materials/the-bomb-11-anadyr.json
@@ -1,7 +1,7 @@
 {
 	"name": "ANADYR'",
 	"format": "play",
-	"year": 2012,
+	"year": "2012",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-bomb-12-first-blast.json
+++ b/db-seeding/seeds/materials/the-bomb-12-first-blast.json
@@ -1,7 +1,7 @@
 {
 	"name": "First Blast: Proliferation (1940-1992)",
 	"format": "collection of plays",
-	"year": 2012,
+	"year": "2012",
 	"subMaterials": [
 		{
 			"name": "From Elsewhere: The Message…"

--- a/db-seeding/seeds/materials/the-bomb-13-second-blast.json
+++ b/db-seeding/seeds/materials/the-bomb-13-second-blast.json
@@ -1,7 +1,7 @@
 {
 	"name": "Second Blast: Present Dangers (1992-2012)",
 	"format": "collection of plays",
-	"year": 2012,
+	"year": "2012",
 	"subMaterials": [
 		{
 			"name": "There Was a Man, There Was No Man"

--- a/db-seeding/seeds/materials/the-bomb-14-collection.json
+++ b/db-seeding/seeds/materials/the-bomb-14-collection.json
@@ -1,7 +1,7 @@
 {
 	"name": "The Bomb: A Partial History",
 	"format": "collection of plays",
-	"year": 2012,
+	"year": "2012",
 	"subMaterials": [
 		{
 			"name": "First Blast: Proliferation (1940-1992)"

--- a/db-seeding/seeds/materials/the-chalk-garden.json
+++ b/db-seeding/seeds/materials/the-chalk-garden.json
@@ -1,7 +1,7 @@
 {
 	"name": "The Chalk Garden",
 	"format": "play",
-	"year": 1955,
+	"year": "1955",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-coast-of-utopia-1-voyage.json
+++ b/db-seeding/seeds/materials/the-coast-of-utopia-1-voyage.json
@@ -1,7 +1,7 @@
 {
 	"name": "Voyage",
 	"format": "play",
-	"year": 2002,
+	"year": "2002",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-coast-of-utopia-2-shipwreck.json
+++ b/db-seeding/seeds/materials/the-coast-of-utopia-2-shipwreck.json
@@ -1,7 +1,7 @@
 {
 	"name": "Shipwreck",
 	"format": "play",
-	"year": 2002,
+	"year": "2002",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-coast-of-utopia-3-salvage.json
+++ b/db-seeding/seeds/materials/the-coast-of-utopia-3-salvage.json
@@ -1,7 +1,7 @@
 {
 	"name": "Salvage",
 	"format": "play",
-	"year": 2002,
+	"year": "2002",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-coast-of-utopia-4-collection.json
+++ b/db-seeding/seeds/materials/the-coast-of-utopia-4-collection.json
@@ -1,7 +1,7 @@
 {
 	"name": "The Coast of Utopia",
 	"format": "trilogy of plays",
-	"year": 2002,
+	"year": "2002",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-dark-philosophers.json
+++ b/db-seeding/seeds/materials/the-dark-philosophers.json
@@ -1,7 +1,7 @@
 {
 	"name": "The Dark Philosophers",
 	"format": "play",
-	"year": 2011,
+	"year": "2011",
 	"writingCredits": [
 		{
 			"name": "adapted by",

--- a/db-seeding/seeds/materials/the-donkey-show.json
+++ b/db-seeding/seeds/materials/the-donkey-show.json
@@ -1,7 +1,7 @@
 {
 	"name": "The Donkey Show",
 	"format": "musical",
-	"year": 2000,
+	"year": "2000",
 	"writingCredits": [
 		{
 			"name": "book by",

--- a/db-seeding/seeds/materials/the-dumb-waiter.json
+++ b/db-seeding/seeds/materials/the-dumb-waiter.json
@@ -1,7 +1,7 @@
 {
 	"name": "The Dumb Waiter",
 	"format": "play",
-	"year": 1959,
+	"year": "1959",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-girl-on-the-train-film.json
+++ b/db-seeding/seeds/materials/the-girl-on-the-train-film.json
@@ -2,7 +2,7 @@
 	"name": "The Girl on the Train",
 	"differentiator": "2",
 	"format": "film",
-	"year": 2016,
+	"year": "2016",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-girl-on-the-train-novel.json
+++ b/db-seeding/seeds/materials/the-girl-on-the-train-novel.json
@@ -2,7 +2,7 @@
 	"name": "The Girl on the Train",
 	"differentiator": "1",
 	"format": "novel",
-	"year": 2015,
+	"year": "2015",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-girl-on-the-train-play.json
+++ b/db-seeding/seeds/materials/the-girl-on-the-train-play.json
@@ -2,7 +2,7 @@
 	"name": "The Girl on the Train",
 	"differentiator": "3",
 	"format": "play",
-	"year": 2018,
+	"year": "2018",
 	"writingCredits": [
 		{
 			"name": "based on",

--- a/db-seeding/seeds/materials/the-indian-boy.json
+++ b/db-seeding/seeds/materials/the-indian-boy.json
@@ -1,7 +1,7 @@
 {
 	"name": "The Indian Boy",
 	"format": "play",
-	"year": 2006,
+	"year": "2006",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-ladykillers-1-screenplay.json
+++ b/db-seeding/seeds/materials/the-ladykillers-1-screenplay.json
@@ -2,7 +2,7 @@
 	"name": "The Ladykillers",
 	"differentiator": "1",
 	"format": "motion picture screenplay",
-	"year": 1955,
+	"year": "1955",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-ladykillers-2-play.json
+++ b/db-seeding/seeds/materials/the-ladykillers-2-play.json
@@ -2,7 +2,7 @@
 	"name": "The Ladykillers",
 	"differentiator": "2",
 	"format": "play",
-	"year": 2011,
+	"year": "2011",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-language-archive.json
+++ b/db-seeding/seeds/materials/the-language-archive.json
@@ -1,7 +1,7 @@
 {
 	"name": "The Language Archive",
 	"format": "play",
-	"year": 2010,
+	"year": "2010",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-mountaintop.json
+++ b/db-seeding/seeds/materials/the-mountaintop.json
@@ -1,7 +1,7 @@
 {
 	"name": "The Mountaintop",
 	"format": "play",
-	"year": 2009,
+	"year": "2009",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-nature-of-love.json
+++ b/db-seeding/seeds/materials/the-nature-of-love.json
@@ -1,7 +1,7 @@
 {
 	"name": "The Nature of Love",
 	"format": "play",
-	"year": 2009,
+	"year": "2009",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-pitmen-painters-book.json
+++ b/db-seeding/seeds/materials/the-pitmen-painters-book.json
@@ -2,7 +2,7 @@
 	"name": "The Pitmen Painters",
 	"differentiator": "1",
 	"format": "book",
-	"year": 1988,
+	"year": "1988",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-pitmen-painters-play.json
+++ b/db-seeding/seeds/materials/the-pitmen-painters-play.json
@@ -2,7 +2,7 @@
 	"name": "The Pitmen Painters",
 	"differentiator": "2",
 	"format": "play",
-	"year": 2008,
+	"year": "2008",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-reporter.json
+++ b/db-seeding/seeds/materials/the-reporter.json
@@ -1,7 +1,7 @@
 {
 	"name": "The Reporter",
 	"format": "play",
-	"year": 2007,
+	"year": "2007",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-seagull-original-version.json
+++ b/db-seeding/seeds/materials/the-seagull-original-version.json
@@ -2,7 +2,7 @@
 	"name": "The Seagull",
 	"differentiator": "1",
 	"format": "play",
-	"year": 1896,
+	"year": "1896",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-seagull-subsequent-version-1.json
+++ b/db-seeding/seeds/materials/the-seagull-subsequent-version-1.json
@@ -2,7 +2,7 @@
 	"name": "The Seagull",
 	"differentiator": "2",
 	"format": "play",
-	"year": 2007,
+	"year": "2007",
 	"originalVersionMaterial": {
 		"name": "The Seagull",
 		"differentiator": "1"

--- a/db-seeding/seeds/materials/the-seagull-subsequent-version-2.json
+++ b/db-seeding/seeds/materials/the-seagull-subsequent-version-2.json
@@ -2,7 +2,7 @@
 	"name": "The Seagull",
 	"differentiator": "3",
 	"format": "play",
-	"year": 2013,
+	"year": "2013",
 	"originalVersionMaterial": {
 		"name": "The Seagull",
 		"differentiator": "1"

--- a/db-seeding/seeds/materials/the-shipment.json
+++ b/db-seeding/seeds/materials/the-shipment.json
@@ -1,7 +1,7 @@
 {
 	"name": "The Shipment",
 	"format": "play",
-	"year": 2009,
+	"year": "2009",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/the-swallowing-dark.json
+++ b/db-seeding/seeds/materials/the-swallowing-dark.json
@@ -1,7 +1,7 @@
 {
 	"name": "The Swallowing Dark",
 	"format": "play",
-	"year": 2010,
+	"year": "2010",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/this-wide-night.json
+++ b/db-seeding/seeds/materials/this-wide-night.json
@@ -1,7 +1,7 @@
 {
 	"name": "This Wide Night",
 	"format": "play",
-	"year": 2008,
+	"year": "2008",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/this.json
+++ b/db-seeding/seeds/materials/this.json
@@ -1,7 +1,7 @@
 {
 	"name": "This",
 	"format": "play",
-	"year": 2009,
+	"year": "2009",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/three-days-of-rain.json
+++ b/db-seeding/seeds/materials/three-days-of-rain.json
@@ -1,7 +1,7 @@
 {
 	"name": "Three Days of Rain",
 	"format": "play",
-	"year": 1997,
+	"year": "1997",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/three-sisters-original-version.json
+++ b/db-seeding/seeds/materials/three-sisters-original-version.json
@@ -2,7 +2,7 @@
 	"name": "Three Sisters",
 	"differentiator": "1",
 	"format": "play",
-	"year": 1901,
+	"year": "1901",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/three-sisters-subsequent-version-1.json
+++ b/db-seeding/seeds/materials/three-sisters-subsequent-version-1.json
@@ -2,7 +2,7 @@
 	"name": "Three Sisters",
 	"differentiator": "2",
 	"format": "play",
-	"year": 2012,
+	"year": "2012",
 	"originalVersionMaterial": {
 		"name": "Three Sisters",
 		"differentiator": "1"

--- a/db-seeding/seeds/materials/three-sisters-subsequent-version-2.json
+++ b/db-seeding/seeds/materials/three-sisters-subsequent-version-2.json
@@ -2,7 +2,7 @@
 	"name": "Three Sisters",
 	"differentiator": "3",
 	"format": "play",
-	"year": 2019,
+	"year": "2019",
 	"originalVersionMaterial": {
 		"name": "Three Sisters",
 		"differentiator": "1"

--- a/db-seeding/seeds/materials/titus-andronicus.json
+++ b/db-seeding/seeds/materials/titus-andronicus.json
@@ -1,7 +1,7 @@
 {
 	"name": "Titus Andronicus",
 	"format": "play",
-	"year": 1593,
+	"year": "1593",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/true-west.json
+++ b/db-seeding/seeds/materials/true-west.json
@@ -1,7 +1,7 @@
 {
 	"name": "True West",
 	"format": "play",
-	"year": 1980,
+	"year": "1980",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/twelfth-night.json
+++ b/db-seeding/seeds/materials/twelfth-night.json
@@ -1,7 +1,7 @@
 {
 	"name": "Twelfth Night",
 	"format": "play",
-	"year": 1601,
+	"year": "1601",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/vernon-god-little-novel.json
+++ b/db-seeding/seeds/materials/vernon-god-little-novel.json
@@ -2,7 +2,7 @@
 	"name": "Vernon God Little",
 	"differentiator": "1",
 	"format": "novel",
-	"year": 2003,
+	"year": "2003",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/vernon-god-little-play.json
+++ b/db-seeding/seeds/materials/vernon-god-little-play.json
@@ -2,7 +2,7 @@
 	"name": "Vernon God Little",
 	"differentiator": "2",
 	"format": "play",
-	"year": 2007,
+	"year": "2007",
 	"writingCredits": [
 		{
 			"name": "from",

--- a/db-seeding/seeds/materials/war-horse-novel.json
+++ b/db-seeding/seeds/materials/war-horse-novel.json
@@ -2,7 +2,7 @@
 	"name": "War Horse",
 	"differentiator": "1",
 	"format": "novel",
-	"year": 1982,
+	"year": "1982",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/war-horse-play.json
+++ b/db-seeding/seeds/materials/war-horse-play.json
@@ -2,7 +2,7 @@
 	"name": "War Horse",
 	"differentiator": "2",
 	"format": "play",
-	"year": 2007,
+	"year": "2007",
 	"writingCredits": [
 		{
 			"entities": [

--- a/db-seeding/seeds/materials/what-once-we-felt.json
+++ b/db-seeding/seeds/materials/what-once-we-felt.json
@@ -1,7 +1,7 @@
 {
 	"name": "What Once We Felt",
 	"format": "play",
-	"year": 2009,
+	"year": "2009",
 	"writingCredits": [
 		{
 			"entities": [


### PR DESCRIPTION
This PR applies some revisions to the database seeding process, logging the filenames of the seeds as they are added, and specifying which file has failed in the event of an error being thrown.

It also changes the material seed `year` values from an integer to a string to provide consistency with the types used in the end-to-end tests.