### PR TITLE
Apply multi-tiered materials/productions ordering

### DIFF
--- a/src/neo4j/cypher-queries/character/show/show-materials.js
+++ b/src/neo4j/cypher-queries/character/show/show-materials.js
@@ -107,11 +107,17 @@ export default () => `
 				ELSE materialRel { .displayName, .qualifier, .group }
 			END
 		) AS depictions
-		ORDER BY material.year DESC, material.name
 
-	OPTIONAL MATCH (material)<-[:HAS_SUB_MATERIAL]-(surMaterial:Material)
+	OPTIONAL MATCH (material)<-[surMaterialRel:HAS_SUB_MATERIAL]-(surMaterial:Material)
 
-	OPTIONAL MATCH (surMaterial)<-[:HAS_SUB_MATERIAL]-(surSurMaterial:Material)
+	OPTIONAL MATCH (surMaterial)<-[surSurMaterialRel:HAS_SUB_MATERIAL]-(surSurMaterial:Material)
+
+	WITH character, material, writingCredits, depictions, surMaterial, surSurMaterial
+		ORDER BY
+			material.year DESC,
+			COALESCE(surSurMaterial.name, surMaterial.name, material.name),
+			surSurMaterialRel.position DESC,
+			surMaterialRel.position DESC
 
 	WITH character,
 		COLLECT(

--- a/src/neo4j/cypher-queries/company/show/show-productions.js
+++ b/src/neo4j/cypher-queries/company/show/show-productions.js
@@ -60,12 +60,26 @@ export default () => `
 
 	OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
 
-	OPTIONAL MATCH (production)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
+	OPTIONAL MATCH (production)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
-	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+	OPTIONAL MATCH (surProduction)<-[surSurProductionRel:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
 
-	WITH company, production, producerCredits, venue, surVenue, surProduction, surSurProduction
-		ORDER BY production.startDate DESC, production.name, venue.name
+	WITH
+		company,
+		production,
+		producerCredits,
+		venue,
+		surVenue,
+		surProduction,
+		surProductionRel,
+		surSurProduction,
+		surSurProductionRel
+		ORDER BY
+			production.startDate DESC,
+			COALESCE(surSurProduction.name, surProduction.name, production.name),
+			surSurProductionRel.position DESC,
+			surProductionRel.position DESC,
+			venue.name
 
 	WITH company,
 		COLLECT(
@@ -191,18 +205,32 @@ export default () => `
 
 	OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
 
-	OPTIONAL MATCH (production)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
+	OPTIONAL MATCH (production)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
-	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+	OPTIONAL MATCH (surProduction)<-[surSurProductionRel:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
 
-	WITH company, producerProductions, production, venue, surVenue, surProduction, surSurProduction,
+	WITH
+		company,
+		producerProductions,
+		production,
+		venue,
+		surVenue,
+		surProduction,
+		surProductionRel,
+		surSurProduction,
+		surSurProductionRel,
 		COLLECT({
 			model: 'CREATIVE_CREDIT',
 			name: creativeRel.credit,
 			members: creditedMembers,
 			coEntities: coCreditedEntities
 		}) AS creativeCredits
-		ORDER BY production.startDate DESC, production.name, venue.name
+		ORDER BY
+			production.startDate DESC,
+			COALESCE(surSurProduction.name, surProduction.name, production.name),
+			surSurProductionRel.position DESC,
+			surProductionRel.position DESC,
+			venue.name
 
 	WITH company, producerProductions,
 		COLLECT(
@@ -328,18 +356,32 @@ export default () => `
 
 	OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
 
-	OPTIONAL MATCH (production)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
+	OPTIONAL MATCH (production)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
-	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+	OPTIONAL MATCH (surProduction)<-[surSurProductionRel:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
 
-	WITH producerProductions, creativeProductions, production, venue, surVenue, surProduction, surSurProduction,
+	WITH
+		producerProductions,
+		creativeProductions,
+		production,
+		venue,
+		surVenue,
+		surProduction,
+		surProductionRel,
+		surSurProduction,
+		surSurProductionRel,
 		COLLECT({
 			model: 'CREW_CREDIT',
 			name: crewRel.credit,
 			members: creditedMembers,
 			coEntities: coCreditedEntities
 		}) AS crewCredits
-		ORDER BY production.startDate DESC, production.name, venue.name
+		ORDER BY
+			production.startDate DESC,
+			COALESCE(surSurProduction.name, surProduction.name, production.name),
+			surSurProductionRel.position DESC,
+			surProductionRel.position DESC,
+			venue.name
 
 	RETURN
 		producerProductions,

--- a/src/neo4j/cypher-queries/material/list.js
+++ b/src/neo4j/cypher-queries/material/list.js
@@ -94,9 +94,9 @@ export default () => `
 			END
 		) AS writingCredits
 
-	OPTIONAL MATCH (material)<-[:HAS_SUB_MATERIAL]-(surMaterial:Material)
+	OPTIONAL MATCH (material)<-[surMaterialRel:HAS_SUB_MATERIAL]-(surMaterial:Material)
 
-	OPTIONAL MATCH (surMaterial)<-[:HAS_SUB_MATERIAL]-(surSurMaterial:Material)
+	OPTIONAL MATCH (surMaterial)<-[surSurMaterialRel:HAS_SUB_MATERIAL]-(surSurMaterial:Material)
 
 	RETURN
 		'MATERIAL' AS model,
@@ -117,7 +117,11 @@ export default () => `
 			}
 		END AS surMaterial,
 		writingCredits
-		ORDER BY material.year DESC, material.name
+		ORDER BY
+			material.year DESC,
+			COALESCE(surSurMaterial.name, surMaterial.name, material.name),
+			surSurMaterialRel.position DESC,
+			surMaterialRel.position DESC
 
 	LIMIT 100
 `;

--- a/src/neo4j/cypher-queries/material/show/show-productions.js
+++ b/src/neo4j/cypher-queries/material/show/show-productions.js
@@ -11,9 +11,9 @@ export default () => `
 
 		OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
 
-		OPTIONAL MATCH (production)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
+		OPTIONAL MATCH (production)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
-		OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+		OPTIONAL MATCH (surProduction)<-[surSurProductionRel:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
 
 		OPTIONAL MATCH (material)<-[:USES_SOURCE_MATERIAL]-(:Material)<-[sourcingMaterialRel:PRODUCTION_OF]-(production)
 
@@ -22,9 +22,16 @@ export default () => `
 			venue,
 			surVenue,
 			surProduction,
+			surProductionRel,
 			surSurProduction,
+			surSurProductionRel,
 			CASE sourcingMaterialRel WHEN NULL THEN false ELSE true END AS usesSourcingMaterial
-			ORDER BY production.startDate DESC, production.name, venue.name
+			ORDER BY
+				production.startDate DESC,
+				COALESCE(surSurProduction.name, surProduction.name, production.name),
+				surSurProductionRel.position DESC,
+				surProductionRel.position DESC,
+				venue.name
 
 		WITH
 			COLLECT(

--- a/src/neo4j/cypher-queries/person/show/show-materials.js
+++ b/src/neo4j/cypher-queries/person/show/show-materials.js
@@ -133,7 +133,21 @@ export default () => `
 				ELSE entity { .model, .uuid, .name }
 			END] AS entities
 
-		WITH person, material, creditType, hasDirectCredit, isSubsequentVersion, isSourcingMaterial,
+		OPTIONAL MATCH (material)<-[surMaterialRel:HAS_SUB_MATERIAL]-(surMaterial:Material)
+
+		OPTIONAL MATCH (surMaterial)<-[surSurMaterialRel:HAS_SUB_MATERIAL]-(surSurMaterial:Material)
+
+		WITH
+			person,
+			material,
+			creditType,
+			hasDirectCredit,
+			isSubsequentVersion,
+			isSourcingMaterial,
+			surMaterial,
+			surMaterialRel,
+			surSurMaterial,
+			surSurMaterialRel,
 			COLLECT(
 				CASE SIZE(entities) WHEN 0
 					THEN null
@@ -144,11 +158,11 @@ export default () => `
 					}
 				END
 			) AS writingCredits
-			ORDER BY material.year DESC, material.name
-
-		OPTIONAL MATCH (material)<-[:HAS_SUB_MATERIAL]-(surMaterial:Material)
-
-		OPTIONAL MATCH (surMaterial)<-[:HAS_SUB_MATERIAL]-(surSurMaterial:Material)
+			ORDER BY
+				material.year DESC,
+				COALESCE(surSurMaterial.name, surMaterial.name, material.name),
+				surSurMaterialRel.position DESC,
+				surMaterialRel.position DESC
 
 		WITH person,
 			COLLECT(

--- a/src/neo4j/cypher-queries/person/show/show-productions.js
+++ b/src/neo4j/cypher-queries/person/show/show-productions.js
@@ -56,12 +56,26 @@ export default () => `
 
 	OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
 
-	OPTIONAL MATCH (production)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
+	OPTIONAL MATCH (production)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
-	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+	OPTIONAL MATCH (surProduction)<-[surSurProductionRel:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
 
-	WITH person, production, producerCredits, venue, surVenue, surProduction, surSurProduction
-		ORDER BY production.startDate DESC, production.name, venue.name
+	WITH
+		person,
+		production,
+		producerCredits,
+		venue,
+		surVenue,
+		surProduction,
+		surProductionRel,
+		surSurProduction,
+		surSurProductionRel
+		ORDER BY
+			production.startDate DESC,
+			COALESCE(surSurProduction.name, surProduction.name, production.name),
+			surSurProductionRel.position DESC,
+			surProductionRel.position DESC,
+			venue.name
 
 	WITH person,
 		COLLECT(
@@ -108,10 +122,6 @@ export default () => `
 
 	OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
 
-	OPTIONAL MATCH (production)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
-
-	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
-
 	OPTIONAL MATCH (production)-[:PRODUCTION_OF]->(:Material)-[characterRel:DEPICTS]->(character:Character)
 		WHERE
 			(
@@ -120,19 +130,23 @@ export default () => `
 			) AND
 			(role.characterDifferentiator IS NULL OR role.characterDifferentiator = character.differentiator)
 
-	WITH DISTINCT
+	WITH DISTINCT person, producerProductions, production, venue, surVenue, role, character
+		ORDER BY role.rolePosition
+
+	OPTIONAL MATCH (production)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
+
+	OPTIONAL MATCH (surProduction)<-[surSurProductionRel:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+
+	WITH
 		person,
 		producerProductions,
 		production,
 		venue,
 		surVenue,
 		surProduction,
+		surProductionRel,
 		surSurProduction,
-		role,
-		character
-		ORDER BY role.rolePosition
-
-	WITH person, producerProductions, production, venue, surVenue, surProduction, surSurProduction,
+		surSurProductionRel,
 		COLLECT(
 			CASE role.roleName WHEN NULL
 				THEN { name: 'Performer' }
@@ -145,7 +159,12 @@ export default () => `
 				}
 			END
 		) AS roles
-		ORDER BY production.startDate DESC, production.name, venue.name
+		ORDER BY
+			production.startDate DESC,
+			COALESCE(surSurProduction.name, surProduction.name, production.name),
+			surSurProductionRel.position DESC,
+			surProductionRel.position DESC,
+			venue.name
 
 	WITH person, producerProductions,
 		COLLECT(
@@ -326,9 +345,9 @@ export default () => `
 
 	OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
 
-	OPTIONAL MATCH (production)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
+	OPTIONAL MATCH (production)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
-	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+	OPTIONAL MATCH (surProduction)<-[surSurProductionRel:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
 
 	WITH
 		person,
@@ -338,14 +357,21 @@ export default () => `
 		venue,
 		surVenue,
 		surProduction,
+		surProductionRel,
 		surSurProduction,
+		surSurProductionRel,
 		COLLECT({
 			model: 'CREATIVE_CREDIT',
 			name: entityRel.credit,
 			employerCompany: creditedEmployerCompany,
 			coEntities: coCreditedEntities
 		}) AS creativeCredits
-		ORDER BY production.startDate DESC, production.name, venue.name
+		ORDER BY
+			production.startDate DESC,
+			COALESCE(surSurProduction.name, surProduction.name, production.name),
+			surSurProductionRel.position DESC,
+			surProductionRel.position DESC,
+			venue.name
 
 	WITH person, producerProductions, castMemberProductions,
 		COLLECT(
@@ -529,9 +555,9 @@ export default () => `
 
 	OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
 
-	OPTIONAL MATCH (production)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
+	OPTIONAL MATCH (production)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
-	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+	OPTIONAL MATCH (surProduction)<-[surSurProductionRel:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
 
 	WITH
 		producerProductions,
@@ -541,14 +567,21 @@ export default () => `
 		venue,
 		surVenue,
 		surProduction,
+		surProductionRel,
 		surSurProduction,
+		surSurProductionRel,
 		COLLECT({
 			model: 'CREW_CREDIT',
 			name: entityRel.credit,
 			employerCompany: creditedEmployerCompany,
 			coEntities: coCreditedEntities
 		}) AS crewCredits
-		ORDER BY production.startDate DESC, production.name, venue.name
+		ORDER BY
+			production.startDate DESC,
+			COALESCE(surSurProduction.name, surProduction.name, production.name),
+			surSurProductionRel.position DESC,
+			surProductionRel.position DESC,
+			venue.name
 
 	RETURN
 		producerProductions,

--- a/src/neo4j/cypher-queries/production/list.js
+++ b/src/neo4j/cypher-queries/production/list.js
@@ -6,9 +6,9 @@ export default () => `
 
 	OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
 
-	OPTIONAL MATCH (production)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
+	OPTIONAL MATCH (production)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
-	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+	OPTIONAL MATCH (surProduction)<-[surSurProductionRel:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
 
 	RETURN
 		'PRODUCTION' AS model,
@@ -40,8 +40,12 @@ export default () => `
 				END
 			}
 		END AS surProduction
-
-	ORDER BY production.startDate DESC, production.name, venue.name
+		ORDER BY
+			production.startDate DESC,
+			COALESCE(surSurProduction.name, surProduction.name, production.name),
+			surSurProductionRel.position DESC,
+			surProductionRel.position DESC,
+			venue.name
 
 	LIMIT 100
 `;

--- a/src/neo4j/cypher-queries/production/show/show.js
+++ b/src/neo4j/cypher-queries/production/show/show.js
@@ -212,7 +212,7 @@ export default () => `
 		subSubProduction,
 		subSubProductionVenue,
 		subSubProductionSurVenue
-		ORDER BY subSubProduction.startDate DESC, subSubProductionRel.position
+		ORDER BY subSubProductionRel.position
 
 	WITH
 		production,
@@ -247,7 +247,7 @@ export default () => `
 				}
 			END
 		) AS subSubProductions
-		ORDER BY subProduction.startDate DESC, subProductionRel.position
+		ORDER BY subProductionRel.position
 
 	WITH production, material, venue, surProduction,
 		COLLECT(

--- a/src/neo4j/cypher-queries/venue/show.js
+++ b/src/neo4j/cypher-queries/venue/show.js
@@ -28,9 +28,9 @@ export default () => [`
 			<-[:PLAYS_AT]-(:Production)<-[:HAS_SUB_PRODUCTION]-(production)
 		)
 
-	OPTIONAL MATCH (production)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
+	OPTIONAL MATCH (production)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
-	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+	OPTIONAL MATCH (surProduction)<-[surSurProductionRel:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
 
 	WITH
 		venue,
@@ -39,8 +39,14 @@ export default () => [`
 		venueLinkedToProduction,
 		production,
 		surProduction,
-		surSurProduction
-		ORDER BY production.startDate DESC, production.name
+		surProductionRel,
+		surSurProduction,
+		surSurProductionRel
+		ORDER BY
+			production.startDate DESC,
+			COALESCE(surSurProduction.name, surProduction.name, production.name),
+			surSurProductionRel.position DESC,
+			surProductionRel.position DESC
 
 	RETURN
 		'VENUE' AS model,

--- a/test-e2e/model-interaction/material-with-sub-sub-materials.test.js
+++ b/test-e2e/model-interaction/material-with-sub-sub-materials.test.js
@@ -869,14 +869,14 @@ describe('Material with sub-sub-materials', () => {
 			const expectedMaterials = [
 				{
 					model: 'MATERIAL',
-					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_MATERIAL_UUID,
-					name: 'Bugles at the Gates of Jalalabad',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_MATERIAL_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
 					format: 'play',
 					year: 2009,
 					surMaterial: {
 						model: 'MATERIAL',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_MATERIAL_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
+						uuid: PART_THREE_ENDURING_FREEDOM_MATERIAL_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -941,14 +941,14 @@ describe('Material with sub-sub-materials', () => {
 				},
 				{
 					model: 'MATERIAL',
-					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_MATERIAL_UUID,
-					name: 'The Night Is Darkest Before the Dawn',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_MATERIAL_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
 					format: 'play',
 					year: 2009,
 					surMaterial: {
 						model: 'MATERIAL',
-						uuid: PART_THREE_ENDURING_FREEDOM_MATERIAL_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_MATERIAL_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -1089,14 +1089,14 @@ describe('Material with sub-sub-materials', () => {
 			const expectedMaterials = [
 				{
 					model: 'MATERIAL',
-					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_MATERIAL_UUID,
-					name: 'Bugles at the Gates of Jalalabad',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_MATERIAL_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
 					format: 'play',
 					year: 2009,
 					surMaterial: {
 						model: 'MATERIAL',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_MATERIAL_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
+						uuid: PART_THREE_ENDURING_FREEDOM_MATERIAL_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -1159,14 +1159,14 @@ describe('Material with sub-sub-materials', () => {
 				},
 				{
 					model: 'MATERIAL',
-					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_MATERIAL_UUID,
-					name: 'The Night Is Darkest Before the Dawn',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_MATERIAL_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
 					format: 'play',
 					year: 2009,
 					surMaterial: {
 						model: 'MATERIAL',
-						uuid: PART_THREE_ENDURING_FREEDOM_MATERIAL_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_MATERIAL_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -1209,14 +1209,14 @@ describe('Material with sub-sub-materials', () => {
 			const expectedMaterials = [
 				{
 					model: 'MATERIAL',
-					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_MATERIAL_UUID,
-					name: 'Bugles at the Gates of Jalalabad',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_MATERIAL_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
 					format: 'play',
 					year: 2009,
 					surMaterial: {
 						model: 'MATERIAL',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_MATERIAL_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
+						uuid: PART_THREE_ENDURING_FREEDOM_MATERIAL_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -1279,14 +1279,14 @@ describe('Material with sub-sub-materials', () => {
 				},
 				{
 					model: 'MATERIAL',
-					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_MATERIAL_UUID,
-					name: 'The Night Is Darkest Before the Dawn',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_MATERIAL_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
 					format: 'play',
 					year: 2009,
 					surMaterial: {
 						model: 'MATERIAL',
-						uuid: PART_THREE_ENDURING_FREEDOM_MATERIAL_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_MATERIAL_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -1332,14 +1332,14 @@ describe('Material with sub-sub-materials', () => {
 			const expectedResponseBody = [
 				{
 					model: 'MATERIAL',
-					uuid: BLACK_TULIPS_MATERIAL_UUID,
-					name: 'Black Tulips',
+					uuid: ON_THE_SIDE_OF_THE_ANGELS_MATERIAL_UUID,
+					name: 'On the Side of the Angels',
 					format: 'play',
 					year: 2009,
 					surMaterial: {
 						model: 'MATERIAL',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_MATERIAL_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						uuid: PART_THREE_ENDURING_FREEDOM_MATERIAL_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -1353,8 +1353,8 @@ describe('Material with sub-sub-materials', () => {
 							entities: [
 								{
 									model: 'PERSON',
-									uuid: DAVID_EDGAR_PERSON_UUID,
-									name: 'David Edgar'
+									uuid: RICHARD_BEAN_PERSON_UUID,
+									name: 'Richard Bean'
 								}
 							]
 						}
@@ -1362,44 +1362,14 @@ describe('Material with sub-sub-materials', () => {
 				},
 				{
 					model: 'MATERIAL',
-					uuid: BLOOD_AND_GIFTS_MATERIAL_UUID,
-					name: 'Blood and Gifts',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_MATERIAL_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
 					format: 'play',
 					year: 2009,
 					surMaterial: {
 						model: 'MATERIAL',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_MATERIAL_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
-						surMaterial: {
-							model: 'MATERIAL',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					writingCredits: [
-						{
-							model: 'WRITING_CREDIT',
-							name: 'by',
-							entities: [
-								{
-									model: 'PERSON',
-									uuid: J_T_ROGERS_PERSON_UUID,
-									name: 'J T Rogers'
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'MATERIAL',
-					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_MATERIAL_UUID,
-					name: 'Bugles at the Gates of Jalalabad',
-					format: 'play',
-					year: 2009,
-					surMaterial: {
-						model: 'MATERIAL',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_MATERIAL_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
+						uuid: PART_THREE_ENDURING_FREEDOM_MATERIAL_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -1420,66 +1390,6 @@ describe('Material with sub-sub-materials', () => {
 									model: 'COMPANY',
 									uuid: FICTIONEERS_LTD_COMPANY_UUID,
 									name: 'Fictioneers Ltd'
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'MATERIAL',
-					uuid: CAMPAIGN_MATERIAL_UUID,
-					name: 'Campaign',
-					format: 'play',
-					year: 2009,
-					surMaterial: {
-						model: 'MATERIAL',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_MATERIAL_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
-						surMaterial: {
-							model: 'MATERIAL',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					writingCredits: [
-						{
-							model: 'WRITING_CREDIT',
-							name: 'by',
-							entities: [
-								{
-									model: 'PERSON',
-									uuid: AMIT_GUPTA_PERSON_UUID,
-									name: 'Amit Gupta'
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'MATERIAL',
-					uuid: DURANDS_LINE_MATERIAL_UUID,
-					name: 'Durand\'s Line',
-					format: 'play',
-					year: 2009,
-					surMaterial: {
-						model: 'MATERIAL',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_MATERIAL_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
-						surMaterial: {
-							model: 'MATERIAL',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					writingCredits: [
-						{
-							model: 'WRITING_CREDIT',
-							name: 'by',
-							entities: [
-								{
-									model: 'PERSON',
-									uuid: RON_HUTCHINSON_PERSON_UUID,
-									name: 'Ron Hutchinson'
 								}
 							]
 						}
@@ -1552,14 +1462,14 @@ describe('Material with sub-sub-materials', () => {
 				},
 				{
 					model: 'MATERIAL',
-					uuid: ON_THE_SIDE_OF_THE_ANGELS_MATERIAL_UUID,
-					name: 'On the Side of the Angels',
+					uuid: BLOOD_AND_GIFTS_MATERIAL_UUID,
+					name: 'Blood and Gifts',
 					format: 'play',
 					year: 2009,
 					surMaterial: {
 						model: 'MATERIAL',
-						uuid: PART_THREE_ENDURING_FREEDOM_MATERIAL_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_MATERIAL_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -1573,8 +1483,8 @@ describe('Material with sub-sub-materials', () => {
 							entities: [
 								{
 									model: 'PERSON',
-									uuid: RICHARD_BEAN_PERSON_UUID,
-									name: 'Richard Bean'
+									uuid: J_T_ROGERS_PERSON_UUID,
+									name: 'J T Rogers'
 								}
 							]
 						}
@@ -1582,14 +1492,104 @@ describe('Material with sub-sub-materials', () => {
 				},
 				{
 					model: 'MATERIAL',
-					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_MATERIAL_UUID,
-					name: 'The Night Is Darkest Before the Dawn',
+					uuid: BLACK_TULIPS_MATERIAL_UUID,
+					name: 'Black Tulips',
 					format: 'play',
 					year: 2009,
 					surMaterial: {
 						model: 'MATERIAL',
-						uuid: PART_THREE_ENDURING_FREEDOM_MATERIAL_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_MATERIAL_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surMaterial: {
+							model: 'MATERIAL',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					writingCredits: [
+						{
+							model: 'WRITING_CREDIT',
+							name: 'by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: DAVID_EDGAR_PERSON_UUID,
+									name: 'David Edgar'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'MATERIAL',
+					uuid: CAMPAIGN_MATERIAL_UUID,
+					name: 'Campaign',
+					format: 'play',
+					year: 2009,
+					surMaterial: {
+						model: 'MATERIAL',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_MATERIAL_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surMaterial: {
+							model: 'MATERIAL',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					writingCredits: [
+						{
+							model: 'WRITING_CREDIT',
+							name: 'by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: AMIT_GUPTA_PERSON_UUID,
+									name: 'Amit Gupta'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'MATERIAL',
+					uuid: DURANDS_LINE_MATERIAL_UUID,
+					name: 'Durand\'s Line',
+					format: 'play',
+					year: 2009,
+					surMaterial: {
+						model: 'MATERIAL',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_MATERIAL_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surMaterial: {
+							model: 'MATERIAL',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					writingCredits: [
+						{
+							model: 'WRITING_CREDIT',
+							name: 'by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: RON_HUTCHINSON_PERSON_UUID,
+									name: 'Ron Hutchinson'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'MATERIAL',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_MATERIAL_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					format: 'play',
+					year: 2009,
+					surMaterial: {
+						model: 'MATERIAL',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_MATERIAL_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,

--- a/test-e2e/model-interaction/prod-with-sub-prods.test.js
+++ b/test-e2e/model-interaction/prod-with-sub-prods.test.js
@@ -558,9 +558,9 @@ describe('Production with sub-productions', () => {
 			const expectedSubProductions = [
 				{
 					model: 'PRODUCTION',
-					uuid: SALVAGE_OLIVIER_PRODUCTION_UUID,
-					name: 'Salvage',
-					startDate: '2002-07-19',
+					uuid: VOYAGE_OLIVIER_PRODUCTION_UUID,
+					name: 'Voyage',
+					startDate: '2002-06-27',
 					endDate: '2002-11-23',
 					venue: {
 						model: 'VENUE',
@@ -594,9 +594,9 @@ describe('Production with sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: VOYAGE_OLIVIER_PRODUCTION_UUID,
-					name: 'Voyage',
-					startDate: '2002-06-27',
+					uuid: SALVAGE_OLIVIER_PRODUCTION_UUID,
+					name: 'Salvage',
+					startDate: '2002-07-19',
 					endDate: '2002-11-23',
 					venue: {
 						model: 'VENUE',
@@ -658,10 +658,10 @@ describe('Production with sub-productions', () => {
 			const expectedSubProductions = [
 				{
 					model: 'PRODUCTION',
-					uuid: SALVAGE_VIVIAN_BEAUMONT_PRODUCTION_UUID,
-					name: 'Salvage',
-					startDate: '2007-01-31',
-					endDate: '2007-05-13',
+					uuid: VOYAGE_VIVIAN_BEAUMONT_PRODUCTION_UUID,
+					name: 'Voyage',
+					startDate: '2006-10-17',
+					endDate: '2007-05-12',
 					venue: {
 						model: 'VENUE',
 						uuid: VIVIAN_BEAUMONT_THEATRE_VENUE_UUID,
@@ -686,10 +686,10 @@ describe('Production with sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: VOYAGE_VIVIAN_BEAUMONT_PRODUCTION_UUID,
-					name: 'Voyage',
-					startDate: '2006-10-17',
-					endDate: '2007-05-12',
+					uuid: SALVAGE_VIVIAN_BEAUMONT_PRODUCTION_UUID,
+					name: 'Salvage',
+					startDate: '2007-01-31',
+					endDate: '2007-05-13',
 					venue: {
 						model: 'VENUE',
 						uuid: VIVIAN_BEAUMONT_THEATRE_VENUE_UUID,

--- a/test-e2e/model-interaction/prod-with-sub-sub-prods.test.js
+++ b/test-e2e/model-interaction/prod-with-sub-sub-prods.test.js
@@ -2294,8 +2294,8 @@ describe('Production with sub-sub-productions', () => {
 			const expectedProductions = [
 				{
 					model: 'PRODUCTION',
-					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
-					name: 'Black Tulips',
+					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
+					name: 'On the Side of the Angels',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					subVenue: {
@@ -2305,8 +2305,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -2316,8 +2316,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
-					name: 'Blood and Gifts',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					subVenue: {
@@ -2327,74 +2327,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					}
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
-					name: 'Bugles at the Gates of Jalalabad',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					subVenue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre'
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					}
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
-					name: 'Campaign',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					subVenue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre'
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					}
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
-					name: 'Durand\'s Line',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					subVenue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre'
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -2448,8 +2382,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
-					name: 'On the Side of the Angels',
+					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
+					name: 'Blood and Gifts',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					subVenue: {
@@ -2459,8 +2393,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -2470,8 +2404,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
-					name: 'The Night Is Darkest Before the Dawn',
+					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
+					name: 'Black Tulips',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					subVenue: {
@@ -2481,8 +2415,74 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
+					name: 'Campaign',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					subVenue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre'
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					subVenue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre'
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					subVenue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre'
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -2507,15 +2507,15 @@ describe('Production with sub-sub-productions', () => {
 			const expectedProductions = [
 				{
 					model: 'PRODUCTION',
-					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
-					name: 'Black Tulips',
+					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
+					name: 'On the Side of the Angels',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					subVenue: null,
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -2525,69 +2525,15 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
-					name: 'Blood and Gifts',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					subVenue: null,
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					}
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
-					name: 'Bugles at the Gates of Jalalabad',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					subVenue: null,
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					}
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
-					name: 'Campaign',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					subVenue: null,
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					}
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
-					name: 'Durand\'s Line',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					subVenue: null,
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -2633,15 +2579,15 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
-					name: 'On the Side of the Angels',
+					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
+					name: 'Blood and Gifts',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					subVenue: null,
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -2651,15 +2597,69 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
-					name: 'The Night Is Darkest Before the Dawn',
+					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
+					name: 'Black Tulips',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					subVenue: null,
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
+					name: 'Campaign',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					subVenue: null,
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					subVenue: null,
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					subVenue: null,
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -2684,8 +2684,8 @@ describe('Production with sub-sub-productions', () => {
 			const expectedProducerProductions = [
 				{
 					model: 'PRODUCTION',
-					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
-					name: 'Black Tulips',
+					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
+					name: 'On the Side of the Angels',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -2700,8 +2700,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -2736,8 +2736,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
-					name: 'Blood and Gifts',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -2752,164 +2752,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					producerCredits: [
-						{
-							model: 'PRODUCER_CREDIT',
-							name: 'produced by',
-							entities: [
-								{
-									model: 'PERSON',
-									uuid: NICOLAS_KENT_PERSON_UUID,
-									name: 'Nicolas Kent'
-								},
-								{
-									model: 'COMPANY',
-									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
-									name: 'Tricycle Theatre Company',
-									members: [
-										{
-											model: 'PERSON',
-											uuid: ZOË_INGENHAAG_PERSON_UUID,
-											name: 'Zoë Ingenhaag'
-										}
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
-					name: 'Bugles at the Gates of Jalalabad',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					producerCredits: [
-						{
-							model: 'PRODUCER_CREDIT',
-							name: 'produced by',
-							entities: [
-								{
-									model: 'PERSON',
-									uuid: NICOLAS_KENT_PERSON_UUID,
-									name: 'Nicolas Kent'
-								},
-								{
-									model: 'COMPANY',
-									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
-									name: 'Tricycle Theatre Company',
-									members: [
-										{
-											model: 'PERSON',
-											uuid: ZOË_INGENHAAG_PERSON_UUID,
-											name: 'Zoë Ingenhaag'
-										}
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
-					name: 'Campaign',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					producerCredits: [
-						{
-							model: 'PRODUCER_CREDIT',
-							name: 'produced by',
-							entities: [
-								{
-									model: 'PERSON',
-									uuid: NICOLAS_KENT_PERSON_UUID,
-									name: 'Nicolas Kent'
-								},
-								{
-									model: 'COMPANY',
-									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
-									name: 'Tricycle Theatre Company',
-									members: [
-										{
-											model: 'PERSON',
-											uuid: ZOË_INGENHAAG_PERSON_UUID,
-											name: 'Zoë Ingenhaag'
-										}
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
-					name: 'Durand\'s Line',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -3048,8 +2892,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
-					name: 'On the Side of the Angels',
+					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
+					name: 'Blood and Gifts',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -3064,8 +2908,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -3100,8 +2944,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
-					name: 'The Night Is Darkest Before the Dawn',
+					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
+					name: 'Black Tulips',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -3116,8 +2960,164 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
+					name: 'Campaign',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -3167,8 +3167,8 @@ describe('Production with sub-sub-productions', () => {
 			const expectedProducerProductions = [
 				{
 					model: 'PRODUCTION',
-					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
-					name: 'Black Tulips',
+					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
+					name: 'On the Side of the Angels',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -3183,8 +3183,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -3219,8 +3219,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
-					name: 'Blood and Gifts',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -3235,164 +3235,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					producerCredits: [
-						{
-							model: 'PRODUCER_CREDIT',
-							name: 'produced by',
-							entities: [
-								{
-									model: 'PERSON',
-									uuid: NICOLAS_KENT_PERSON_UUID,
-									name: 'Nicolas Kent'
-								},
-								{
-									model: 'COMPANY',
-									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
-									name: 'Tricycle Theatre Company',
-									members: [
-										{
-											model: 'PERSON',
-											uuid: ZOË_INGENHAAG_PERSON_UUID,
-											name: 'Zoë Ingenhaag'
-										}
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
-					name: 'Bugles at the Gates of Jalalabad',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					producerCredits: [
-						{
-							model: 'PRODUCER_CREDIT',
-							name: 'produced by',
-							entities: [
-								{
-									model: 'PERSON',
-									uuid: NICOLAS_KENT_PERSON_UUID,
-									name: 'Nicolas Kent'
-								},
-								{
-									model: 'COMPANY',
-									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
-									name: 'Tricycle Theatre Company',
-									members: [
-										{
-											model: 'PERSON',
-											uuid: ZOË_INGENHAAG_PERSON_UUID,
-											name: 'Zoë Ingenhaag'
-										}
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
-					name: 'Campaign',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					producerCredits: [
-						{
-							model: 'PRODUCER_CREDIT',
-							name: 'produced by',
-							entities: [
-								{
-									model: 'PERSON',
-									uuid: NICOLAS_KENT_PERSON_UUID,
-									name: 'Nicolas Kent'
-								},
-								{
-									model: 'COMPANY',
-									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
-									name: 'Tricycle Theatre Company',
-									members: [
-										{
-											model: 'PERSON',
-											uuid: ZOË_INGENHAAG_PERSON_UUID,
-											name: 'Zoë Ingenhaag'
-										}
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
-					name: 'Durand\'s Line',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -3531,8 +3375,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
-					name: 'On the Side of the Angels',
+					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
+					name: 'Blood and Gifts',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -3547,8 +3391,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -3583,8 +3427,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
-					name: 'The Night Is Darkest Before the Dawn',
+					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
+					name: 'Black Tulips',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -3599,8 +3443,164 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
+					name: 'Campaign',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -3650,8 +3650,8 @@ describe('Production with sub-sub-productions', () => {
 			const expectedProducerProductions = [
 				{
 					model: 'PRODUCTION',
-					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
-					name: 'Black Tulips',
+					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
+					name: 'On the Side of the Angels',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -3666,8 +3666,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -3702,8 +3702,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
-					name: 'Blood and Gifts',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -3718,164 +3718,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					producerCredits: [
-						{
-							model: 'PRODUCER_CREDIT',
-							name: 'produced by',
-							entities: [
-								{
-									model: 'PERSON',
-									uuid: NICOLAS_KENT_PERSON_UUID,
-									name: 'Nicolas Kent'
-								},
-								{
-									model: 'COMPANY',
-									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
-									name: 'Tricycle Theatre Company',
-									members: [
-										{
-											model: 'PERSON',
-											uuid: ZOË_INGENHAAG_PERSON_UUID,
-											name: 'Zoë Ingenhaag'
-										}
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
-					name: 'Bugles at the Gates of Jalalabad',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					producerCredits: [
-						{
-							model: 'PRODUCER_CREDIT',
-							name: 'produced by',
-							entities: [
-								{
-									model: 'PERSON',
-									uuid: NICOLAS_KENT_PERSON_UUID,
-									name: 'Nicolas Kent'
-								},
-								{
-									model: 'COMPANY',
-									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
-									name: 'Tricycle Theatre Company',
-									members: [
-										{
-											model: 'PERSON',
-											uuid: ZOË_INGENHAAG_PERSON_UUID,
-											name: 'Zoë Ingenhaag'
-										}
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
-					name: 'Campaign',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					producerCredits: [
-						{
-							model: 'PRODUCER_CREDIT',
-							name: 'produced by',
-							entities: [
-								{
-									model: 'PERSON',
-									uuid: NICOLAS_KENT_PERSON_UUID,
-									name: 'Nicolas Kent'
-								},
-								{
-									model: 'COMPANY',
-									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
-									name: 'Tricycle Theatre Company',
-									members: [
-										{
-											model: 'PERSON',
-											uuid: ZOË_INGENHAAG_PERSON_UUID,
-											name: 'Zoë Ingenhaag'
-										}
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
-					name: 'Durand\'s Line',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -4014,8 +3858,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
-					name: 'On the Side of the Angels',
+					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
+					name: 'Blood and Gifts',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -4030,8 +3874,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -4066,8 +3910,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
-					name: 'The Night Is Darkest Before the Dawn',
+					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
+					name: 'Black Tulips',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -4082,8 +3926,164 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
+					name: 'Campaign',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					producerCredits: [
+						{
+							model: 'PRODUCER_CREDIT',
+							name: 'produced by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: NICOLAS_KENT_PERSON_UUID,
+									name: 'Nicolas Kent'
+								},
+								{
+									model: 'COMPANY',
+									uuid: TRICYCLE_THEATRE_COMPANY_UUID,
+									name: 'Tricycle Theatre Company',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: ZOË_INGENHAAG_PERSON_UUID,
+											name: 'Zoë Ingenhaag'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -4133,8 +4133,8 @@ describe('Production with sub-sub-productions', () => {
 			const expectedCastMemberProductions = [
 				{
 					model: 'PRODUCTION',
-					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
-					name: 'Black Tulips',
+					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
+					name: 'On the Side of the Angels',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -4149,8 +4149,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -4169,8 +4169,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
-					name: 'Blood and Gifts',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -4185,116 +4185,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					roles: [
-						{
-							model: 'CHARACTER',
-							uuid: BAR_CHARACTER_UUID,
-							name: 'Bar',
-							qualifier: null,
-							isAlternate: false
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
-					name: 'Bugles at the Gates of Jalalabad',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					roles: [
-						{
-							model: 'CHARACTER',
-							uuid: BAR_CHARACTER_UUID,
-							name: 'Bar',
-							qualifier: null,
-							isAlternate: false
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
-					name: 'Campaign',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					roles: [
-						{
-							model: 'CHARACTER',
-							uuid: BAR_CHARACTER_UUID,
-							name: 'Bar',
-							qualifier: null,
-							isAlternate: false
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
-					name: 'Durand\'s Line',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -4385,8 +4277,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
-					name: 'On the Side of the Angels',
+					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
+					name: 'Blood and Gifts',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -4401,8 +4293,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -4421,8 +4313,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
-					name: 'The Night Is Darkest Before the Dawn',
+					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
+					name: 'Black Tulips',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -4437,8 +4329,116 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					roles: [
+						{
+							model: 'CHARACTER',
+							uuid: BAR_CHARACTER_UUID,
+							name: 'Bar',
+							qualifier: null,
+							isAlternate: false
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
+					name: 'Campaign',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					roles: [
+						{
+							model: 'CHARACTER',
+							uuid: BAR_CHARACTER_UUID,
+							name: 'Bar',
+							qualifier: null,
+							isAlternate: false
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					roles: [
+						{
+							model: 'CHARACTER',
+							uuid: BAR_CHARACTER_UUID,
+							name: 'Bar',
+							qualifier: null,
+							isAlternate: false
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -4472,8 +4472,8 @@ describe('Production with sub-sub-productions', () => {
 			const expectedCreativeProductions = [
 				{
 					model: 'PRODUCTION',
-					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
-					name: 'Black Tulips',
+					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
+					name: 'On the Side of the Angels',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -4488,8 +4488,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -4520,8 +4520,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
-					name: 'Blood and Gifts',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -4536,152 +4536,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					creativeCredits: [
-						{
-							model: 'CREATIVE_CREDIT',
-							name: 'Lighting Designers',
-							employerCompany: null,
-							coEntities: [
-								{
-									model: 'COMPANY',
-									uuid: LIGHTING_DESIGN_LTD_COMPANY_UUID,
-									name: 'Lighting Design Ltd',
-									members: [
-										{
-											model: 'PERSON',
-											uuid: JACK_KNOWLES_PERSON_UUID,
-											name: 'Jack Knowles'
-										}
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
-					name: 'Bugles at the Gates of Jalalabad',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					creativeCredits: [
-						{
-							model: 'CREATIVE_CREDIT',
-							name: 'Lighting Designers',
-							employerCompany: null,
-							coEntities: [
-								{
-									model: 'COMPANY',
-									uuid: LIGHTING_DESIGN_LTD_COMPANY_UUID,
-									name: 'Lighting Design Ltd',
-									members: [
-										{
-											model: 'PERSON',
-											uuid: JACK_KNOWLES_PERSON_UUID,
-											name: 'Jack Knowles'
-										}
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
-					name: 'Campaign',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					creativeCredits: [
-						{
-							model: 'CREATIVE_CREDIT',
-							name: 'Lighting Designers',
-							employerCompany: null,
-							coEntities: [
-								{
-									model: 'COMPANY',
-									uuid: LIGHTING_DESIGN_LTD_COMPANY_UUID,
-									name: 'Lighting Design Ltd',
-									members: [
-										{
-											model: 'PERSON',
-											uuid: JACK_KNOWLES_PERSON_UUID,
-											name: 'Jack Knowles'
-										}
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
-					name: 'Durand\'s Line',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -4808,8 +4664,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
-					name: 'On the Side of the Angels',
+					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
+					name: 'Blood and Gifts',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -4824,8 +4680,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -4856,8 +4712,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
-					name: 'The Night Is Darkest Before the Dawn',
+					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
+					name: 'Black Tulips',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -4872,8 +4728,152 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							employerCompany: null,
+							coEntities: [
+								{
+									model: 'COMPANY',
+									uuid: LIGHTING_DESIGN_LTD_COMPANY_UUID,
+									name: 'Lighting Design Ltd',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: JACK_KNOWLES_PERSON_UUID,
+											name: 'Jack Knowles'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
+					name: 'Campaign',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							employerCompany: null,
+							coEntities: [
+								{
+									model: 'COMPANY',
+									uuid: LIGHTING_DESIGN_LTD_COMPANY_UUID,
+									name: 'Lighting Design Ltd',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: JACK_KNOWLES_PERSON_UUID,
+											name: 'Jack Knowles'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							employerCompany: null,
+							coEntities: [
+								{
+									model: 'COMPANY',
+									uuid: LIGHTING_DESIGN_LTD_COMPANY_UUID,
+									name: 'Lighting Design Ltd',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: JACK_KNOWLES_PERSON_UUID,
+											name: 'Jack Knowles'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -4919,8 +4919,8 @@ describe('Production with sub-sub-productions', () => {
 			const expectedCreativeProductions = [
 				{
 					model: 'PRODUCTION',
-					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
-					name: 'Black Tulips',
+					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
+					name: 'On the Side of the Angels',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -4935,8 +4935,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -4966,8 +4966,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
-					name: 'Blood and Gifts',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -4982,149 +4982,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					creativeCredits: [
-						{
-							model: 'CREATIVE_CREDIT',
-							name: 'Lighting Designers',
-							members: [
-								{
-									model: 'PERSON',
-									uuid: JACK_KNOWLES_PERSON_UUID,
-									name: 'Jack Knowles'
-								}
-							],
-							coEntities: [
-								{
-									model: 'PERSON',
-									uuid: HOWARD_HARRISON_PERSON_UUID,
-									name: 'Howard Harrison'
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
-					name: 'Bugles at the Gates of Jalalabad',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					creativeCredits: [
-						{
-							model: 'CREATIVE_CREDIT',
-							name: 'Lighting Designers',
-							members: [
-								{
-									model: 'PERSON',
-									uuid: JACK_KNOWLES_PERSON_UUID,
-									name: 'Jack Knowles'
-								}
-							],
-							coEntities: [
-								{
-									model: 'PERSON',
-									uuid: HOWARD_HARRISON_PERSON_UUID,
-									name: 'Howard Harrison'
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
-					name: 'Campaign',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					creativeCredits: [
-						{
-							model: 'CREATIVE_CREDIT',
-							name: 'Lighting Designers',
-							members: [
-								{
-									model: 'PERSON',
-									uuid: JACK_KNOWLES_PERSON_UUID,
-									name: 'Jack Knowles'
-								}
-							],
-							coEntities: [
-								{
-									model: 'PERSON',
-									uuid: HOWARD_HARRISON_PERSON_UUID,
-									name: 'Howard Harrison'
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
-					name: 'Durand\'s Line',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -5248,8 +5107,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
-					name: 'On the Side of the Angels',
+					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
+					name: 'Blood and Gifts',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -5264,8 +5123,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -5295,8 +5154,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
-					name: 'The Night Is Darkest Before the Dawn',
+					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
+					name: 'Black Tulips',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -5311,8 +5170,149 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							members: [
+								{
+									model: 'PERSON',
+									uuid: JACK_KNOWLES_PERSON_UUID,
+									name: 'Jack Knowles'
+								}
+							],
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: HOWARD_HARRISON_PERSON_UUID,
+									name: 'Howard Harrison'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
+					name: 'Campaign',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							members: [
+								{
+									model: 'PERSON',
+									uuid: JACK_KNOWLES_PERSON_UUID,
+									name: 'Jack Knowles'
+								}
+							],
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: HOWARD_HARRISON_PERSON_UUID,
+									name: 'Howard Harrison'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							members: [
+								{
+									model: 'PERSON',
+									uuid: JACK_KNOWLES_PERSON_UUID,
+									name: 'Jack Knowles'
+								}
+							],
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: HOWARD_HARRISON_PERSON_UUID,
+									name: 'Howard Harrison'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -5357,8 +5357,8 @@ describe('Production with sub-sub-productions', () => {
 			const expectedCreativeProductions = [
 				{
 					model: 'PRODUCTION',
-					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
-					name: 'Black Tulips',
+					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
+					name: 'On the Side of the Angels',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -5373,8 +5373,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -5403,8 +5403,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
-					name: 'Blood and Gifts',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -5419,146 +5419,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					creativeCredits: [
-						{
-							model: 'CREATIVE_CREDIT',
-							name: 'Lighting Designers',
-							employerCompany: {
-								model: 'COMPANY',
-								uuid: LIGHTING_DESIGN_LTD_COMPANY_UUID,
-								name: 'Lighting Design Ltd',
-								coMembers: []
-							},
-							coEntities: [
-								{
-									model: 'PERSON',
-									uuid: HOWARD_HARRISON_PERSON_UUID,
-									name: 'Howard Harrison'
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
-					name: 'Bugles at the Gates of Jalalabad',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					creativeCredits: [
-						{
-							model: 'CREATIVE_CREDIT',
-							name: 'Lighting Designers',
-							employerCompany: {
-								model: 'COMPANY',
-								uuid: LIGHTING_DESIGN_LTD_COMPANY_UUID,
-								name: 'Lighting Design Ltd',
-								coMembers: []
-							},
-							coEntities: [
-								{
-									model: 'PERSON',
-									uuid: HOWARD_HARRISON_PERSON_UUID,
-									name: 'Howard Harrison'
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
-					name: 'Campaign',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					creativeCredits: [
-						{
-							model: 'CREATIVE_CREDIT',
-							name: 'Lighting Designers',
-							employerCompany: {
-								model: 'COMPANY',
-								uuid: LIGHTING_DESIGN_LTD_COMPANY_UUID,
-								name: 'Lighting Design Ltd',
-								coMembers: []
-							},
-							coEntities: [
-								{
-									model: 'PERSON',
-									uuid: HOWARD_HARRISON_PERSON_UUID,
-									name: 'Howard Harrison'
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
-					name: 'Durand\'s Line',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -5679,8 +5541,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
-					name: 'On the Side of the Angels',
+					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
+					name: 'Blood and Gifts',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -5695,8 +5557,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -5725,8 +5587,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
-					name: 'The Night Is Darkest Before the Dawn',
+					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
+					name: 'Black Tulips',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -5741,8 +5603,146 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							employerCompany: {
+								model: 'COMPANY',
+								uuid: LIGHTING_DESIGN_LTD_COMPANY_UUID,
+								name: 'Lighting Design Ltd',
+								coMembers: []
+							},
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: HOWARD_HARRISON_PERSON_UUID,
+									name: 'Howard Harrison'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
+					name: 'Campaign',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							employerCompany: {
+								model: 'COMPANY',
+								uuid: LIGHTING_DESIGN_LTD_COMPANY_UUID,
+								name: 'Lighting Design Ltd',
+								coMembers: []
+							},
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: HOWARD_HARRISON_PERSON_UUID,
+									name: 'Howard Harrison'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					creativeCredits: [
+						{
+							model: 'CREATIVE_CREDIT',
+							name: 'Lighting Designers',
+							employerCompany: {
+								model: 'COMPANY',
+								uuid: LIGHTING_DESIGN_LTD_COMPANY_UUID,
+								name: 'Lighting Design Ltd',
+								coMembers: []
+							},
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: HOWARD_HARRISON_PERSON_UUID,
+									name: 'Howard Harrison'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -5786,8 +5786,8 @@ describe('Production with sub-sub-productions', () => {
 			const expectedCrewProductions = [
 				{
 					model: 'PRODUCTION',
-					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
-					name: 'Black Tulips',
+					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
+					name: 'On the Side of the Angels',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -5802,8 +5802,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -5834,8 +5834,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
-					name: 'Blood and Gifts',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -5850,152 +5850,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					crewCredits: [
-						{
-							model: 'CREW_CREDIT',
-							name: 'Stage Managers',
-							employerCompany: null,
-							coEntities: [
-								{
-									model: 'COMPANY',
-									uuid: STAGE_MANAGEMENT_LTD_COMPANY_UUID,
-									name: 'Stage Management Ltd',
-									members: [
-										{
-											model: 'PERSON',
-											uuid: CHARLOTTE_PADGHAM_PERSON_UUID,
-											name: 'Charlotte Padgham'
-										}
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
-					name: 'Bugles at the Gates of Jalalabad',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					crewCredits: [
-						{
-							model: 'CREW_CREDIT',
-							name: 'Stage Managers',
-							employerCompany: null,
-							coEntities: [
-								{
-									model: 'COMPANY',
-									uuid: STAGE_MANAGEMENT_LTD_COMPANY_UUID,
-									name: 'Stage Management Ltd',
-									members: [
-										{
-											model: 'PERSON',
-											uuid: CHARLOTTE_PADGHAM_PERSON_UUID,
-											name: 'Charlotte Padgham'
-										}
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
-					name: 'Campaign',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					crewCredits: [
-						{
-							model: 'CREW_CREDIT',
-							name: 'Stage Managers',
-							employerCompany: null,
-							coEntities: [
-								{
-									model: 'COMPANY',
-									uuid: STAGE_MANAGEMENT_LTD_COMPANY_UUID,
-									name: 'Stage Management Ltd',
-									members: [
-										{
-											model: 'PERSON',
-											uuid: CHARLOTTE_PADGHAM_PERSON_UUID,
-											name: 'Charlotte Padgham'
-										}
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
-					name: 'Durand\'s Line',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6122,8 +5978,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
-					name: 'On the Side of the Angels',
+					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
+					name: 'Blood and Gifts',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -6138,8 +5994,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6170,8 +6026,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
-					name: 'The Night Is Darkest Before the Dawn',
+					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
+					name: 'Black Tulips',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -6186,8 +6042,152 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							employerCompany: null,
+							coEntities: [
+								{
+									model: 'COMPANY',
+									uuid: STAGE_MANAGEMENT_LTD_COMPANY_UUID,
+									name: 'Stage Management Ltd',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: CHARLOTTE_PADGHAM_PERSON_UUID,
+											name: 'Charlotte Padgham'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
+					name: 'Campaign',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							employerCompany: null,
+							coEntities: [
+								{
+									model: 'COMPANY',
+									uuid: STAGE_MANAGEMENT_LTD_COMPANY_UUID,
+									name: 'Stage Management Ltd',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: CHARLOTTE_PADGHAM_PERSON_UUID,
+											name: 'Charlotte Padgham'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							employerCompany: null,
+							coEntities: [
+								{
+									model: 'COMPANY',
+									uuid: STAGE_MANAGEMENT_LTD_COMPANY_UUID,
+									name: 'Stage Management Ltd',
+									members: [
+										{
+											model: 'PERSON',
+											uuid: CHARLOTTE_PADGHAM_PERSON_UUID,
+											name: 'Charlotte Padgham'
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6233,8 +6233,8 @@ describe('Production with sub-sub-productions', () => {
 			const expectedCrewProductions = [
 				{
 					model: 'PRODUCTION',
-					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
-					name: 'Black Tulips',
+					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
+					name: 'On the Side of the Angels',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -6249,8 +6249,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6280,8 +6280,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
-					name: 'Blood and Gifts',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -6296,149 +6296,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					crewCredits: [
-						{
-							model: 'CREW_CREDIT',
-							name: 'Stage Managers',
-							members: [
-								{
-									model: 'PERSON',
-									uuid: CHARLOTTE_PADGHAM_PERSON_UUID,
-									name: 'Charlotte Padgham'
-								}
-							],
-							coEntities: [
-								{
-									model: 'PERSON',
-									uuid: LIZZIE_CHAPMAN_PERSON_UUID,
-									name: 'Lizzie Chapman'
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
-					name: 'Bugles at the Gates of Jalalabad',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					crewCredits: [
-						{
-							model: 'CREW_CREDIT',
-							name: 'Stage Managers',
-							members: [
-								{
-									model: 'PERSON',
-									uuid: CHARLOTTE_PADGHAM_PERSON_UUID,
-									name: 'Charlotte Padgham'
-								}
-							],
-							coEntities: [
-								{
-									model: 'PERSON',
-									uuid: LIZZIE_CHAPMAN_PERSON_UUID,
-									name: 'Lizzie Chapman'
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
-					name: 'Campaign',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					crewCredits: [
-						{
-							model: 'CREW_CREDIT',
-							name: 'Stage Managers',
-							members: [
-								{
-									model: 'PERSON',
-									uuid: CHARLOTTE_PADGHAM_PERSON_UUID,
-									name: 'Charlotte Padgham'
-								}
-							],
-							coEntities: [
-								{
-									model: 'PERSON',
-									uuid: LIZZIE_CHAPMAN_PERSON_UUID,
-									name: 'Lizzie Chapman'
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
-					name: 'Durand\'s Line',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6562,8 +6421,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
-					name: 'On the Side of the Angels',
+					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
+					name: 'Blood and Gifts',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -6578,8 +6437,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6609,8 +6468,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
-					name: 'The Night Is Darkest Before the Dawn',
+					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
+					name: 'Black Tulips',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -6625,8 +6484,149 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							members: [
+								{
+									model: 'PERSON',
+									uuid: CHARLOTTE_PADGHAM_PERSON_UUID,
+									name: 'Charlotte Padgham'
+								}
+							],
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: LIZZIE_CHAPMAN_PERSON_UUID,
+									name: 'Lizzie Chapman'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
+					name: 'Campaign',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							members: [
+								{
+									model: 'PERSON',
+									uuid: CHARLOTTE_PADGHAM_PERSON_UUID,
+									name: 'Charlotte Padgham'
+								}
+							],
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: LIZZIE_CHAPMAN_PERSON_UUID,
+									name: 'Lizzie Chapman'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							members: [
+								{
+									model: 'PERSON',
+									uuid: CHARLOTTE_PADGHAM_PERSON_UUID,
+									name: 'Charlotte Padgham'
+								}
+							],
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: LIZZIE_CHAPMAN_PERSON_UUID,
+									name: 'Lizzie Chapman'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6671,8 +6671,8 @@ describe('Production with sub-sub-productions', () => {
 			const expectedCrewProductions = [
 				{
 					model: 'PRODUCTION',
-					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
-					name: 'Black Tulips',
+					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
+					name: 'On the Side of the Angels',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -6687,8 +6687,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6717,8 +6717,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
-					name: 'Blood and Gifts',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -6733,146 +6733,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					crewCredits: [
-						{
-							model: 'CREW_CREDIT',
-							name: 'Stage Managers',
-							employerCompany: {
-								model: 'COMPANY',
-								uuid: STAGE_MANAGEMENT_LTD_COMPANY_UUID,
-								name: 'Stage Management Ltd',
-								coMembers: []
-							},
-							coEntities: [
-								{
-									model: 'PERSON',
-									uuid: LIZZIE_CHAPMAN_PERSON_UUID,
-									name: 'Lizzie Chapman'
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
-					name: 'Bugles at the Gates of Jalalabad',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					crewCredits: [
-						{
-							model: 'CREW_CREDIT',
-							name: 'Stage Managers',
-							employerCompany: {
-								model: 'COMPANY',
-								uuid: STAGE_MANAGEMENT_LTD_COMPANY_UUID,
-								name: 'Stage Management Ltd',
-								coMembers: []
-							},
-							coEntities: [
-								{
-									model: 'PERSON',
-									uuid: LIZZIE_CHAPMAN_PERSON_UUID,
-									name: 'Lizzie Chapman'
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
-					name: 'Campaign',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					crewCredits: [
-						{
-							model: 'CREW_CREDIT',
-							name: 'Stage Managers',
-							employerCompany: {
-								model: 'COMPANY',
-								uuid: STAGE_MANAGEMENT_LTD_COMPANY_UUID,
-								name: 'Stage Management Ltd',
-								coMembers: []
-							},
-							coEntities: [
-								{
-									model: 'PERSON',
-									uuid: LIZZIE_CHAPMAN_PERSON_UUID,
-									name: 'Lizzie Chapman'
-								}
-							]
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
-					name: 'Durand\'s Line',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6993,8 +6855,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
-					name: 'On the Side of the Angels',
+					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
+					name: 'Blood and Gifts',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -7009,8 +6871,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -7039,8 +6901,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
-					name: 'The Night Is Darkest Before the Dawn',
+					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
+					name: 'Black Tulips',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -7055,8 +6917,146 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							employerCompany: {
+								model: 'COMPANY',
+								uuid: STAGE_MANAGEMENT_LTD_COMPANY_UUID,
+								name: 'Stage Management Ltd',
+								coMembers: []
+							},
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: LIZZIE_CHAPMAN_PERSON_UUID,
+									name: 'Lizzie Chapman'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
+					name: 'Campaign',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							employerCompany: {
+								model: 'COMPANY',
+								uuid: STAGE_MANAGEMENT_LTD_COMPANY_UUID,
+								name: 'Stage Management Ltd',
+								coMembers: []
+							},
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: LIZZIE_CHAPMAN_PERSON_UUID,
+									name: 'Lizzie Chapman'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					crewCredits: [
+						{
+							model: 'CREW_CREDIT',
+							name: 'Stage Managers',
+							employerCompany: {
+								model: 'COMPANY',
+								uuid: STAGE_MANAGEMENT_LTD_COMPANY_UUID,
+								name: 'Stage Management Ltd',
+								coMembers: []
+							},
+							coEntities: [
+								{
+									model: 'PERSON',
+									uuid: LIZZIE_CHAPMAN_PERSON_UUID,
+									name: 'Lizzie Chapman'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -7100,8 +7100,8 @@ describe('Production with sub-sub-productions', () => {
 			const expectedProductions = [
 				{
 					model: 'PRODUCTION',
-					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
-					name: 'Black Tulips',
+					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
+					name: 'On the Side of the Angels',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -7116,8 +7116,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -7138,8 +7138,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
-					name: 'Blood and Gifts',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -7154,122 +7154,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					performers: [
-						{
-							model: 'PERSON',
-							uuid: RICK_WARDEN_PERSON_UUID,
-							name: 'Rick Warden',
-							roleName: 'Bar',
-							qualifier: null,
-							isAlternate: false,
-							otherRoles: []
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
-					name: 'Bugles at the Gates of Jalalabad',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					performers: [
-						{
-							model: 'PERSON',
-							uuid: RICK_WARDEN_PERSON_UUID,
-							name: 'Rick Warden',
-							roleName: 'Bar',
-							qualifier: null,
-							isAlternate: false,
-							otherRoles: []
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
-					name: 'Campaign',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					},
-					performers: [
-						{
-							model: 'PERSON',
-							uuid: RICK_WARDEN_PERSON_UUID,
-							name: 'Rick Warden',
-							roleName: 'Bar',
-							qualifier: null,
-							isAlternate: false,
-							otherRoles: []
-						}
-					]
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
-					name: 'Durand\'s Line',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -7366,8 +7252,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
-					name: 'On the Side of the Angels',
+					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
+					name: 'Blood and Gifts',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -7382,8 +7268,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -7404,8 +7290,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
-					name: 'The Night Is Darkest Before the Dawn',
+					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
+					name: 'Black Tulips',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -7420,8 +7306,122 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					performers: [
+						{
+							model: 'PERSON',
+							uuid: RICK_WARDEN_PERSON_UUID,
+							name: 'Rick Warden',
+							roleName: 'Bar',
+							qualifier: null,
+							isAlternate: false,
+							otherRoles: []
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
+					name: 'Campaign',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					performers: [
+						{
+							model: 'PERSON',
+							uuid: RICK_WARDEN_PERSON_UUID,
+							name: 'Rick Warden',
+							roleName: 'Bar',
+							qualifier: null,
+							isAlternate: false,
+							otherRoles: []
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					},
+					performers: [
+						{
+							model: 'PERSON',
+							uuid: RICK_WARDEN_PERSON_UUID,
+							name: 'Rick Warden',
+							roleName: 'Bar',
+							qualifier: null,
+							isAlternate: false,
+							otherRoles: []
+						}
+					]
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -7460,8 +7460,8 @@ describe('Production with sub-sub-productions', () => {
 			const expectedResponseBody = [
 				{
 					model: 'PRODUCTION',
-					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
-					name: 'Black Tulips',
+					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
+					name: 'On the Side of the Angels',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -7476,8 +7476,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -7487,8 +7487,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
-					name: 'Blood and Gifts',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -7503,89 +7503,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					}
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
-					name: 'Bugles at the Gates of Jalalabad',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					}
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
-					name: 'Campaign',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					}
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
-					name: 'Durand\'s Line',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
+						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -7649,131 +7568,143 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: ON_THE_SIDE_OF_THE_ANGELS_RODA_PRODUCTION_UUID,
-					name: 'On the Side of the Angels',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					}
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_RODA_PRODUCTION_UUID,
-					name: 'The Night Is Darkest Before the Dawn',
-					startDate: '2010-10-22',
-					endDate: '2010-11-07',
-					venue: {
-						model: 'VENUE',
-						uuid: RODA_THEATRE_VENUE_UUID,
-						name: 'Roda Theatre',
-						surVenue: {
-							model: 'VENUE',
-							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
-							name: 'Berkeley Repertory Theatre'
-						}
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_THREE_ENDURING_FREEDOM_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					}
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: BLACK_TULIPS_TRICYCLE_PRODUCTION_UUID,
-					name: 'Black Tulips',
-					startDate: '2009-04-17',
-					endDate: '2009-06-14',
-					venue: {
-						model: 'VENUE',
-						uuid: TRICYCLE_THEATRE_VENUE_UUID,
-						name: 'Tricycle Theatre',
-						surVenue: null
-					},
-					surProduction: {
-						model: 'PRODUCTION',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
-						surProduction: {
-							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
-							name: 'The Great Game: Afghanistan'
-						}
-					}
-				},
-				{
-					model: 'PRODUCTION',
-					uuid: BLOOD_AND_GIFTS_TRICYCLE_PRODUCTION_UUID,
+					uuid: BLOOD_AND_GIFTS_RODA_PRODUCTION_UUID,
 					name: 'Blood and Gifts',
-					startDate: '2009-04-17',
-					endDate: '2009-06-14',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
 					venue: {
 						model: 'VENUE',
-						uuid: TRICYCLE_THEATRE_VENUE_UUID,
-						name: 'Tricycle Theatre',
-						surVenue: null
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_TRICYCLE_PRODUCTION_UUID,
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
 						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
 						surProduction: {
 							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
 							name: 'The Great Game: Afghanistan'
 						}
 					}
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_TRICYCLE_PRODUCTION_UUID,
-					name: 'Bugles at the Gates of Jalalabad',
-					startDate: '2009-04-17',
-					endDate: '2009-06-14',
+					uuid: BLACK_TULIPS_RODA_PRODUCTION_UUID,
+					name: 'Black Tulips',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
 					venue: {
 						model: 'VENUE',
-						uuid: TRICYCLE_THEATRE_VENUE_UUID,
-						name: 'Tricycle Theatre',
-						surVenue: null
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_RODA_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
 						surProduction: {
 							model: 'PRODUCTION',
-							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
 							name: 'The Great Game: Afghanistan'
 						}
 					}
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: CAMPAIGN_TRICYCLE_PRODUCTION_UUID,
+					uuid: CAMPAIGN_RODA_PRODUCTION_UUID,
 					name: 'Campaign',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_RODA_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2010-10-22',
+					endDate: '2010-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: RODA_THEATRE_VENUE_UUID,
+						name: 'Roda Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BERKELEY_REPERTORY_THEATRE_VENUE_UUID,
+							name: 'Berkeley Repertory Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_RODA_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: ON_THE_SIDE_OF_THE_ANGELS_TRICYCLE_PRODUCTION_UUID,
+					name: 'On the Side of the Angels',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -7784,8 +7715,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
+						uuid: PART_THREE_ENDURING_FREEDOM_TRICYCLE_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -7795,8 +7726,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: DURANDS_LINE_TRICYCLE_PRODUCTION_UUID,
-					name: 'Durand\'s Line',
+					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_TRICYCLE_PRODUCTION_UUID,
+					name: 'The Night Is Darkest Before the Dawn',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -7807,8 +7738,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence 1842-1930',
+						uuid: PART_THREE_ENDURING_FREEDOM_TRICYCLE_PRODUCTION_UUID,
+						name: 'Part Three - Enduring Freedom 1996-2009',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -7864,8 +7795,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: ON_THE_SIDE_OF_THE_ANGELS_TRICYCLE_PRODUCTION_UUID,
-					name: 'On the Side of the Angels',
+					uuid: BLOOD_AND_GIFTS_TRICYCLE_PRODUCTION_UUID,
+					name: 'Blood and Gifts',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -7876,8 +7807,8 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_THREE_ENDURING_FREEDOM_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_TRICYCLE_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -7887,8 +7818,8 @@ describe('Production with sub-sub-productions', () => {
 				},
 				{
 					model: 'PRODUCTION',
-					uuid: THE_NIGHT_IS_DARKEST_BEFORE_THE_DAWN_TRICYCLE_PRODUCTION_UUID,
-					name: 'The Night Is Darkest Before the Dawn',
+					uuid: BLACK_TULIPS_TRICYCLE_PRODUCTION_UUID,
+					name: 'Black Tulips',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -7899,8 +7830,77 @@ describe('Production with sub-sub-productions', () => {
 					},
 					surProduction: {
 						model: 'PRODUCTION',
-						uuid: PART_THREE_ENDURING_FREEDOM_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom 1996-2009',
+						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_TRICYCLE_PRODUCTION_UUID,
+						name: 'Part Two - Communism, the Mujahideen and the Taliban 1979-1996',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: CAMPAIGN_TRICYCLE_PRODUCTION_UUID,
+					name: 'Campaign',
+					startDate: '2009-04-17',
+					endDate: '2009-06-14',
+					venue: {
+						model: 'VENUE',
+						uuid: TRICYCLE_THEATRE_VENUE_UUID,
+						name: 'Tricycle Theatre',
+						surVenue: null
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_TRICYCLE_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: DURANDS_LINE_TRICYCLE_PRODUCTION_UUID,
+					name: 'Durand\'s Line',
+					startDate: '2009-04-17',
+					endDate: '2009-06-14',
+					venue: {
+						model: 'VENUE',
+						uuid: TRICYCLE_THEATRE_VENUE_UUID,
+						name: 'Tricycle Theatre',
+						surVenue: null
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_TRICYCLE_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
+							name: 'The Great Game: Afghanistan'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: BUGLES_AT_THE_GATES_OF_JALALABAD_TRICYCLE_PRODUCTION_UUID,
+					name: 'Bugles at the Gates of Jalalabad',
+					startDate: '2009-04-17',
+					endDate: '2009-06-14',
+					venue: {
+						model: 'VENUE',
+						uuid: TRICYCLE_THEATRE_VENUE_UUID,
+						name: 'Tricycle Theatre',
+						surVenue: null
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_TRICYCLE_PRODUCTION_UUID,
+						name: 'Part One - Invasions and Independence 1842-1930',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,


### PR DESCRIPTION
This PR applies some changes to the `ORDER BY` clauses of Cypher queries to ensure that multi-tiered materials and productions (i.e. materials with sub-materials and sub-sub-materials; productions with sub-productions and sub-sub-productions) are ordered in line with their defined position, rather than by name as is done currently and which does not group them under their respective parent.

---

#### Materials list (before)
![materials-list-before](https://user-images.githubusercontent.com/10484515/226448302-4963424a-3d20-4abf-b759-1b06c86843f0.png)

---

#### Materials list (after)
Ordered by sur-sur-material then sur-material (both descending) - this logic is also applied for all credits that are date-ordered (where most recent is at the start)
<img width="933" alt="materials-list-after" src="https://user-images.githubusercontent.com/10484515/226448256-254d6a00-528d-4127-9931-56a0c9240c47.png">

---

#### Productions list (before)
<img width="944" alt="productions-list-before" src="https://user-images.githubusercontent.com/10484515/226448316-a8c25386-258c-46b5-ab8f-9449bed4bda5.png">

---

#### Productions list (after)
Ordered by sur-sur-production then sur-production (both descending) - this logic is also applied for all credits that are date-ordered (where most recent is at the start)
<img width="942" alt="productions-list-after" src="https://user-images.githubusercontent.com/10484515/226448279-bcddffac-3d4c-4908-9f06-a7fdc057ef3c.png">

---

#### The Bomb: A Partial History (material) (before)
<img width="590" alt="the-bomb-a-partial-history-material-before" src="https://user-images.githubusercontent.com/10484515/226448627-63485569-b57f-4af3-ab13-31280a2345b3.png">

---

#### The Bomb: A Partial History (material) (after)
Ordered by the positional values created at time of create/update - this ordering is only applied for the 'Comprises' section of the material instance page

N.B. This query was already ordering correctly, so no changes have actually been made there
<img width="596" alt="the-bomb-a-partial-history-material-after" src="https://user-images.githubusercontent.com/10484515/226448599-1528732a-1e33-4b3a-979d-06408834a132.png">

---

 #### The Bomb: A Partial History at Tricycle Theatre (production) (before)
<img width="600" alt="the-bomb-a-partial-history-at-tricycle-theatre-production-before" src="https://user-images.githubusercontent.com/10484515/226448609-55eb879f-c1a2-4c57-bd0b-b17974cf3c8e.png">

---

 #### The Bomb: A Partial History at Tricycle Theatre (production) (after)
Ordered by the positional values created at time of create/update - this ordering is only applied for the 'Comprises' section of the production instance page
<img width="620" alt="the-bomb-a-partial-history-at-tricycle-theatre-production-after" src="https://user-images.githubusercontent.com/10484515/226448575-40a3ecc3-cb03-4935-9a6d-2bce26d22e12.png">
