### PR TITLE
Add database seeds for examples of nominated multi-tiered materials/productions

### DIFF
--- a/db-seeding/seeds/award-ceremonies/laurence-olivier-awards-2008.json
+++ b/db-seeding/seeds/award-ceremonies/laurence-olivier-awards-2008.json
@@ -191,6 +191,61 @@
 					]
 				}
 			]
+		},
+		{
+			"name": "Best New Comedy",
+			"nominations": [
+				{
+					"productions": [
+						{
+							"uuid": "aa0d868f-072f-4b91-b562-bc382f78b61f"
+						}
+					],
+					"materials": [
+						{
+							"name": "The Crimson Hotel"
+						}
+					]
+				},
+				{
+					"productions": [
+						{
+							"uuid": "5b6332a9-9d55-4223-8313-637e66f79809"
+						}
+					],
+					"materials": [
+						{
+							"name": "Elling",
+							"differentiator": "3"
+						}
+					]
+				},
+				{
+					"isWinner": true,
+					"productions": [
+						{
+							"uuid": "80fe797f-1408-4b0c-bcd4-7a288ed4d847"
+						}
+					],
+					"materials": [
+						{
+							"name": "Rafta, Rafta…"
+						}
+					]
+				},
+				{
+					"productions": [
+						{
+							"uuid": "763878c6-14ff-4f8e-9d51-20b426c77f8b"
+						}
+					],
+					"materials": [
+						{
+							"name": "Whipping It Up"
+						}
+					]
+				}
+			]
 		}
 	]
 }

--- a/db-seeding/seeds/award-ceremonies/laurence-olivier-awards-2009.json
+++ b/db-seeding/seeds/award-ceremonies/laurence-olivier-awards-2009.json
@@ -166,6 +166,48 @@
 					]
 				}
 			]
+		},
+		{
+			"name": "Best New Comedy",
+			"nominations": [
+				{
+					"productions": [
+						{
+							"uuid": "55166aff-587f-48c7-b1b7-bad1722853f7"
+						}
+					],
+					"materials": [
+						{
+							"name": "Fat Pig"
+						}
+					]
+				},
+				{
+					"productions": [
+						{
+							"uuid": "a84658d2-d58f-4add-bef0-530d899d84a3"
+						}
+					],
+					"materials": [
+						{
+							"name": "The Female of the Species"
+						}
+					]
+				},
+				{
+					"isWinner": true,
+					"productions": [
+						{
+							"uuid": "53bb5e95-7250-4889-ae5a-586f93f697ae"
+						}
+					],
+					"materials": [
+						{
+							"name": "God of Carnage"
+						}
+					]
+				}
+			]
 		}
 	]
 }

--- a/db-seeding/seeds/award-ceremonies/laurence-olivier-awards-2010.json
+++ b/db-seeding/seeds/award-ceremonies/laurence-olivier-awards-2010.json
@@ -216,6 +216,61 @@
 					]
 				}
 			]
+		},
+		{
+			"name": "Best New Comedy",
+			"nominations": [
+				{
+					"productions": [
+						{
+							"uuid": "b4946df7-063b-430e-bbf3-82fe056f2ea0"
+						}
+					],
+					"materials": [
+						{
+							"name": "Calendar Girls",
+							"differentiator": "2"
+						}
+					]
+				},
+				{
+					"productions": [
+						{
+							"uuid": "e59e0923-ec85-468d-8c51-a9abcb0afd70"
+						}
+					],
+					"materials": [
+						{
+							"name": "England People Very Nice"
+						}
+					]
+				},
+				{
+					"productions": [
+						{
+							"uuid": "87c383b4-6b2c-4772-a5a2-6320686739d3"
+						}
+					],
+					"materials": [
+						{
+							"name": "Parlour Song"
+						}
+					]
+				},
+				{
+					"isWinner": true,
+					"productions": [
+						{
+							"uuid": "36017da2-5a4e-4ed1-a4a2-4e04b4e24531"
+						}
+					],
+					"materials": [
+						{
+							"name": "The Priory"
+						}
+					]
+				}
+			]
 		}
 	]
 }

--- a/db-seeding/seeds/materials/a-resounding-tinkle.json
+++ b/db-seeding/seeds/materials/a-resounding-tinkle.json
@@ -1,0 +1,29 @@
+{
+	"name": "A Resounding Tinkle",
+	"format": "play",
+	"year": "1957",
+	"writingCredits": [
+		{
+			"entities": [
+				{
+					"name": "N F Simpson"
+				}
+			]
+		}
+	],
+	"characterGroups": [
+		{
+			"characters": [
+				{
+					"name": "Bro Paradock"
+				},
+				{
+					"name": "Middie Paradock"
+				},
+				{
+					"name": "Uncle Ted"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/materials/calendar-girls-1-screenplay.json
+++ b/db-seeding/seeds/materials/calendar-girls-1-screenplay.json
@@ -1,0 +1,18 @@
+{
+	"name": "Calendar Girls",
+	"differentiator": "1",
+	"format": "screenplay",
+	"year": "2003",
+	"writingCredits": [
+		{
+			"entities": [
+				{
+					"name": "Juliette Towhidi"
+				},
+				{
+					"name": "Tim Firth"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/materials/calendar-girls-2-play.json
+++ b/db-seeding/seeds/materials/calendar-girls-2-play.json
@@ -1,0 +1,76 @@
+{
+	"name": "Calendar Girls",
+	"differentiator": "2",
+	"format": "play",
+	"year": "2009",
+	"writingCredits": [
+		{
+			"name": "by",
+			"entities": [
+				{
+					"name": "Tim Firth"
+				}
+			]
+		},
+		{
+			"name": "based on",
+			"entities": [
+				{
+					"model": "MATERIAL",
+					"name": "Calendar Girls",
+					"differentiator": "1"
+				}
+			]
+		}
+	],
+	"characterGroups": [
+		{
+			"characters": [
+				{
+					"name": "Cora"
+				},
+				{
+					"name": "Chris"
+				},
+				{
+					"name": "Annie"
+				},
+				{
+					"name": "Jessie"
+				},
+				{
+					"name": "Celia"
+				},
+				{
+					"name": "Ruth",
+					"differentiator": "Calendar Girls"
+				},
+				{
+					"name": "Marie"
+				},
+				{
+					"name": "Brenda Hulse"
+				},
+				{
+					"name": "John",
+					"differentiator": "Calendar Girls"
+				},
+				{
+					"name": "Rod"
+				},
+				{
+					"name": "Lady Cravenshire"
+				},
+				{
+					"name": "Lawrence"
+				},
+				{
+					"name": "Liam"
+				},
+				{
+					"name": "Elaine"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/materials/england-people-very-nice.json
+++ b/db-seeding/seeds/materials/england-people-very-nice.json
@@ -1,0 +1,91 @@
+{
+	"name": "England People Very Nice",
+	"format": "play",
+	"year": "2009",
+	"writingCredits": [
+		{
+			"entities": [
+				{
+					"name": "Richard Bean"
+				}
+			]
+		}
+	],
+	"characterGroups": [
+		{
+			"characters": [
+				{
+					"name": "Norfolk Danny"
+				},
+				{
+					"name": "Carlo"
+				},
+				{
+					"name": "Aaron",
+					"differentiator": "England People Very Nice"
+				},
+				{
+					"name": "Mushi"
+				},
+				{
+					"name": "The boy lover"
+				},
+				{
+					"name": "Camille"
+				},
+				{
+					"name": "Mary"
+				},
+				{
+					"name": "Ruth",
+					"differentiator": "Calendar Girls"
+				},
+				{
+					"name": "Deborah"
+				},
+				{
+					"name": "The girl lover"
+				},
+				{
+					"name": "Ida"
+				},
+				{
+					"name": "Laurie"
+				},
+				{
+					"name": "Rennie"
+				},
+				{
+					"name": "Yayah"
+				},
+				{
+					"name": "Philippa"
+				},
+				{
+					"name": "Elmar"
+				},
+				{
+					"name": "Taher"
+				},
+				{
+					"name": "Sanya"
+				},
+				{
+					"name": "Iqbal"
+				},
+				{
+					"name": "Officer Kelly"
+				},
+				{
+					"name": "Officer Parker"
+				},
+				{
+					"name": "Tatyana"
+				},
+				{
+					"name": "Ginny"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/materials/fat-pig.json
+++ b/db-seeding/seeds/materials/fat-pig.json
@@ -1,0 +1,32 @@
+{
+	"name": "Fat Pig",
+	"format": "play",
+	"year": "2004",
+	"writingCredits": [
+		{
+			"entities": [
+				{
+					"name": "Neil LaBute"
+				}
+			]
+		}
+	],
+	"characterGroups": [
+		{
+			"characters": [
+				{
+					"name": "Helen"
+				},
+				{
+					"name": "Tom"
+				},
+				{
+					"name": "Carter"
+				},
+				{
+					"name": "Jeannie"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/materials/gladly-otherwise.json
+++ b/db-seeding/seeds/materials/gladly-otherwise.json
@@ -1,0 +1,29 @@
+{
+	"name": "Gladly Otherwise",
+	"format": "play",
+	"year": "2007",
+	"writingCredits": [
+		{
+			"entities": [
+				{
+					"name": "N F Simpson"
+				}
+			]
+		}
+	],
+	"characterGroups": [
+		{
+			"characters": [
+				{
+					"name": "Mrs Brandywine"
+				},
+				{
+					"name": "Mr Brandywine"
+				},
+				{
+					"name": "Man"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/materials/god-of-carnage.json
+++ b/db-seeding/seeds/materials/god-of-carnage.json
@@ -1,0 +1,40 @@
+{
+	"name": "God of Carnage",
+	"format": "play",
+	"year": "2008",
+	"writingCredits": [
+		{
+			"entities": [
+				{
+					"name": "Yasmina Reza"
+				}
+			]
+		},
+		{
+			"name": "translated by",
+			"entities": [
+				{
+					"name": "Christopher Hampton"
+				}
+			]
+		}
+	],
+	"characterGroups": [
+		{
+			"characters": [
+				{
+					"name": "Véronique Vallon"
+				},
+				{
+					"name": "Michel Vallon"
+				},
+				{
+					"name": "Annette Reille"
+				},
+				{
+					"name": "Alain Reille"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/materials/parlour-song.json
+++ b/db-seeding/seeds/materials/parlour-song.json
@@ -1,0 +1,30 @@
+{
+	"name": "Parlour Song",
+	"format": "play",
+	"year": "2009",
+	"writingCredits": [
+		{
+			"entities": [
+				{
+					"name": "Jez Butterworth"
+				}
+			]
+		}
+	],
+	"characterGroups": [
+		{
+			"characters": [
+				{
+					"name": "Dale"
+				},
+				{
+					"name": "Ned",
+					"differentiator": "Parlour Song"
+				},
+				{
+					"name": "Joy"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/materials/the-crimson-hotel.json
+++ b/db-seeding/seeds/materials/the-crimson-hotel.json
@@ -1,0 +1,32 @@
+{
+	"name": "The Crimson Hotel",
+	"format": "play",
+	"year": "2007",
+	"writingCredits": [
+		{
+			"entities": [
+				{
+					"name": "Michael Frayn"
+				}
+			]
+		}
+	],
+	"characterGroups": [
+		{
+			"characters": [
+				{
+					"name": "Lucienne"
+				},
+				{
+					"name": "Pilou"
+				},
+				{
+					"name": "Dodine"
+				},
+				{
+					"name": "Bibette"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/materials/the-female-of-the-species.json
+++ b/db-seeding/seeds/materials/the-female-of-the-species.json
@@ -1,0 +1,38 @@
+{
+	"name": "The Female of the Species",
+	"format": "play",
+	"year": "2008",
+	"writingCredits": [
+		{
+			"entities": [
+				{
+					"name": "Joanna Murray-Smith"
+				}
+			]
+		}
+	],
+	"characterGroups": [
+		{
+			"characters": [
+				{
+					"name": "Margot Mason"
+				},
+				{
+					"name": "Molly Rivers"
+				},
+				{
+					"name": "Tess Thornton"
+				},
+				{
+					"name": "Bryan Thornton"
+				},
+				{
+					"name": "Frank"
+				},
+				{
+					"name": "Theo Reynolds"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/materials/the-priory.json
+++ b/db-seeding/seeds/materials/the-priory.json
@@ -1,0 +1,43 @@
+{
+	"name": "The Priory",
+	"format": "play",
+	"year": "2009",
+	"writingCredits": [
+		{
+			"entities": [
+				{
+					"name": "Michael Wynne"
+				}
+			]
+		}
+	],
+	"characterGroups": [
+		{
+			"characters": [
+				{
+					"name": "Kate"
+				},
+				{
+					"name": "Daniel",
+					"differentiator": "The Priory"
+				},
+				{
+					"name": "Ben",
+					"differentiator": "The Priory"
+				},
+				{
+					"name": "Laura"
+				},
+				{
+					"name": "Carl"
+				},
+				{
+					"name": "Rebecca"
+				},
+				{
+					"name": "Adam"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/materials/the-reporter.json
+++ b/db-seeding/seeds/materials/the-reporter.json
@@ -37,7 +37,8 @@
 					"name": "Ray Ray"
 				},
 				{
-					"name": "Daniel"
+					"name": "Daniel",
+					"differentiator": "The Reporter"
 				},
 				{
 					"name": "Cameraman"

--- a/db-seeding/seeds/materials/three-days-of-rain.json
+++ b/db-seeding/seeds/materials/three-days-of-rain.json
@@ -18,7 +18,8 @@
 					"name": "Walker"
 				},
 				{
-					"name": "Ned"
+					"name": "Ned",
+					"differentiator": "Three Days of Rain"
 				},
 				{
 					"name": "Pip"

--- a/db-seeding/seeds/materials/titus-andronicus.json
+++ b/db-seeding/seeds/materials/titus-andronicus.json
@@ -108,7 +108,8 @@
 					"name": "Chiron"
 				},
 				{
-					"name": "Aaron"
+					"name": "Aaron",
+					"differentiator": "Titus Andronicus"
 				},
 				{
 					"name": "Goths"

--- a/db-seeding/seeds/materials/whipping-it-up.json
+++ b/db-seeding/seeds/materials/whipping-it-up.json
@@ -1,0 +1,38 @@
+{
+	"name": "Whipping It Up",
+	"format": "play",
+	"year": "2006",
+	"writingCredits": [
+		{
+			"entities": [
+				{
+					"name": "Steve Thompson"
+				}
+			]
+		}
+	],
+	"characterGroups": [
+		{
+			"characters": [
+				{
+					"name": "Alastair"
+				},
+				{
+					"name": "Guy"
+				},
+				{
+					"name": "Tim"
+				},
+				{
+					"name": "Maggie"
+				},
+				{
+					"name": "Fulton"
+				},
+				{
+					"name": "Delia"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/productions/absurdia-1-a-resounding-tinkle.json
+++ b/db-seeding/seeds/productions/absurdia-1-a-resounding-tinkle.json
@@ -1,0 +1,134 @@
+{
+	"uuid": "94e000e5-a170-4226-8558-b17ea8956c38",
+	"name": "A Resounding Tinkle",
+	"startDate": "2007-07-26",
+	"pressDate": "2007-07-31",
+	"endDate": "2007-09-08",
+	"material": {
+		"name": "A Resounding Tinkle"
+	},
+	"venue": {
+		"name": "Donmar Warehouse"
+	},
+	"producerCredits": [
+		{
+			"entities": [
+				{
+					"model": "COMPANY",
+					"name": "Donmar Warehouse"
+				}
+			]
+		}
+	],
+	"cast": [
+		{
+			"name": "Judith Scott",
+			"roles": [
+				{
+					"name": "Middie Paradock"
+				}
+			]
+		},
+		{
+			"name": "Peter Capaldi",
+			"roles": [
+				{
+					"name": "Bro Paradock"
+				}
+			]
+		},
+		{
+			"name": "Lyndsey Marshal",
+			"roles": [
+				{
+					"name": "Uncle Ted"
+				}
+			]
+		},
+		{
+			"name": "John Hodgkinson",
+			"roles": [
+				{
+					"name": "Voice of Vicar"
+				}
+			]
+		}
+	],
+	"creativeCredits": [
+		{
+			"name": "Director",
+			"entities": [
+				{
+					"name": "Douglas Hodge"
+				}
+			]
+		},
+		{
+			"name": "Designer",
+			"entities": [
+				{
+					"name": "Vicki Mortimer"
+				}
+			]
+		},
+		{
+			"name": "Lighting Designer",
+			"entities": [
+				{
+					"name": "Paule Constable"
+				}
+			]
+		},
+		{
+			"name": "Sound Designer",
+			"entities": [
+				{
+					"name": "Carolyn Downing"
+				}
+			]
+		},
+		{
+			"name": "Composers",
+			"entities": [
+				{
+					"name": "Stu Barker"
+				},
+				{
+					"name": "Douglas Hodge"
+				}
+			]
+		},
+		{
+			"name": "Movement",
+			"entities": [
+				{
+					"name": "Carolina Valdés"
+				}
+			]
+		},
+		{
+			"name": "Assistant Director",
+			"entities": [
+				{
+					"name": "Alex Sims"
+				}
+			]
+		},
+		{
+			"name": "Casting Director",
+			"entities": [
+				{
+					"name": "Anne McNulty"
+				}
+			]
+		},
+		{
+			"name": "Casting Assistant",
+			"entities": [
+				{
+					"name": "Gracie Harris"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/productions/absurdia-2-gladly-otherwise.json
+++ b/db-seeding/seeds/productions/absurdia-2-gladly-otherwise.json
@@ -1,0 +1,126 @@
+{
+	"uuid": "2439fa34-c973-43c8-b030-8dcbb2c88f22",
+	"name": "Gladly Otherwise",
+	"startDate": "2007-07-26",
+	"pressDate": "2007-07-31",
+	"endDate": "2007-09-08",
+	"material": {
+		"name": "Gladly Otherwise"
+	},
+	"venue": {
+		"name": "Donmar Warehouse"
+	},
+	"producerCredits": [
+		{
+			"entities": [
+				{
+					"model": "COMPANY",
+					"name": "Donmar Warehouse"
+				}
+			]
+		}
+	],
+	"cast": [
+		{
+			"name": "Judith Scott",
+			"roles": [
+				{
+					"name": "Mrs Brandywine"
+				}
+			]
+		},
+		{
+			"name": "Peter Capaldi",
+			"roles": [
+				{
+					"name": "Mr Brandywine"
+				}
+			]
+		},
+		{
+			"name": "John Hodgkinson",
+			"roles": [
+				{
+					"name": "Man"
+				}
+			]
+		}
+	],
+	"creativeCredits": [
+		{
+			"name": "Director",
+			"entities": [
+				{
+					"name": "Douglas Hodge"
+				}
+			]
+		},
+		{
+			"name": "Designer",
+			"entities": [
+				{
+					"name": "Vicki Mortimer"
+				}
+			]
+		},
+		{
+			"name": "Lighting Designer",
+			"entities": [
+				{
+					"name": "Paule Constable"
+				}
+			]
+		},
+		{
+			"name": "Sound Designer",
+			"entities": [
+				{
+					"name": "Carolyn Downing"
+				}
+			]
+		},
+		{
+			"name": "Composers",
+			"entities": [
+				{
+					"name": "Stu Barker"
+				},
+				{
+					"name": "Douglas Hodge"
+				}
+			]
+		},
+		{
+			"name": "Movement",
+			"entities": [
+				{
+					"name": "Carolina Valdés"
+				}
+			]
+		},
+		{
+			"name": "Assistant Director",
+			"entities": [
+				{
+					"name": "Alex Sims"
+				}
+			]
+		},
+		{
+			"name": "Casting Director",
+			"entities": [
+				{
+					"name": "Anne McNulty"
+				}
+			]
+		},
+		{
+			"name": "Casting Assistant",
+			"entities": [
+				{
+					"name": "Gracie Harris"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/productions/absurdia-3-the-crimson-hotel.json
+++ b/db-seeding/seeds/productions/absurdia-3-the-crimson-hotel.json
@@ -1,0 +1,134 @@
+{
+	"uuid": "aa0d868f-072f-4b91-b562-bc382f78b61f",
+	"name": "The Crimson Hotel",
+	"startDate": "2007-07-26",
+	"pressDate": "2007-07-31",
+	"endDate": "2007-09-08",
+	"material": {
+		"name": "The Crimson Hotel"
+	},
+	"venue": {
+		"name": "Donmar Warehouse"
+	},
+	"producerCredits": [
+		{
+			"entities": [
+				{
+					"model": "COMPANY",
+					"name": "Donmar Warehouse"
+				}
+			]
+		}
+	],
+	"cast": [
+		{
+			"name": "Lyndsey Marshal",
+			"roles": [
+				{
+					"name": "Lucienne"
+				}
+			]
+		},
+		{
+			"name": "Peter Capaldi",
+			"roles": [
+				{
+					"name": "Pilou"
+				}
+			]
+		},
+		{
+			"name": "John Hodgkinson",
+			"roles": [
+				{
+					"name": "Dodine"
+				}
+			]
+		},
+		{
+			"name": "Judith Scott",
+			"roles": [
+				{
+					"name": "Bibette"
+				}
+			]
+		}
+	],
+	"creativeCredits": [
+		{
+			"name": "Director",
+			"entities": [
+				{
+					"name": "Douglas Hodge"
+				}
+			]
+		},
+		{
+			"name": "Designer",
+			"entities": [
+				{
+					"name": "Vicki Mortimer"
+				}
+			]
+		},
+		{
+			"name": "Lighting Designer",
+			"entities": [
+				{
+					"name": "Paule Constable"
+				}
+			]
+		},
+		{
+			"name": "Sound Designer",
+			"entities": [
+				{
+					"name": "Carolyn Downing"
+				}
+			]
+		},
+		{
+			"name": "Composers",
+			"entities": [
+				{
+					"name": "Stu Barker"
+				},
+				{
+					"name": "Douglas Hodge"
+				}
+			]
+		},
+		{
+			"name": "Movement",
+			"entities": [
+				{
+					"name": "Carolina Valdés"
+				}
+			]
+		},
+		{
+			"name": "Assistant Director",
+			"entities": [
+				{
+					"name": "Alex Sims"
+				}
+			]
+		},
+		{
+			"name": "Casting Director",
+			"entities": [
+				{
+					"name": "Anne McNulty"
+				}
+			]
+		},
+		{
+			"name": "Casting Assistant",
+			"entities": [
+				{
+					"name": "Gracie Harris"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/productions/absurdia-4-collection.json
+++ b/db-seeding/seeds/productions/absurdia-4-collection.json
@@ -1,0 +1,20 @@
+{
+	"name": "Absurdia",
+	"startDate": "2007-07-26",
+	"pressDate": "2007-07-31",
+	"endDate": "2007-09-08",
+	"venue": {
+		"name": "Donmar Warehouse"
+	},
+	"subProductions": [
+		{
+			"uuid": "94e000e5-a170-4226-8558-b17ea8956c38"
+		},
+		{
+			"uuid": "2439fa34-c973-43c8-b030-8dcbb2c88f22"
+		},
+		{
+			"uuid": "aa0d868f-072f-4b91-b562-bc382f78b61f"
+		}
+	]
+}

--- a/db-seeding/seeds/productions/calendar-girls.json
+++ b/db-seeding/seeds/productions/calendar-girls.json
@@ -1,0 +1,205 @@
+{
+	"uuid": "b4946df7-063b-430e-bbf3-82fe056f2ea0",
+	"name": "Calendar Girls",
+	"startDate": "2009-04-04",
+	"pressDate": "2009-04-14",
+	"endDate": "2010-01-09",
+	"material": {
+		"name": "Calendar Girls",
+		"differentiator": "2"
+	},
+	"venue": {
+		"name": "Noël Coward Theatre"
+	},
+	"producerCredits": [
+		{
+			"entities": [
+				{
+					"model": "COMPANY",
+					"name": "Chichester Festival Theatre"
+				}
+			]
+		},
+		{
+			"name": "presented in association with",
+			"entities": [
+				{
+					"name": "David Pugh"
+				},
+				{
+					"name": "Dafydd Rogers"
+				}
+			]
+		}
+	],
+	"cast": [
+		{
+			"name": "Elaine C Smith",
+			"roles": [
+				{
+					"name": "Cora"
+				}
+			]
+		},
+		{
+			"name": "Lynda Bellingham",
+			"roles": [
+				{
+					"name": "Chris"
+				}
+			]
+		},
+		{
+			"name": "Patricia Hodge",
+			"roles": [
+				{
+					"name": "Annie"
+				}
+			]
+		},
+		{
+			"name": "Siân Phillips",
+			"roles": [
+				{
+					"name": "Jessie"
+				}
+			]
+		},
+		{
+			"name": "Gaynor Faye",
+			"roles": [
+				{
+					"name": "Celia"
+				}
+			]
+		},
+		{
+			"name": "Julia Hills",
+			"roles": [
+				{
+					"name": "Ruth"
+				}
+			]
+		},
+		{
+			"name": "Brigit Forsyth",
+			"roles": [
+				{
+					"name": "Marie"
+				}
+			]
+		},
+		{
+			"name": "Joan Blackburn",
+			"roles": [
+				{
+					"name": "Brenda Hulse"
+				},
+				{
+					"name": "Lady Cravenshire"
+				}
+			]
+		},
+		{
+			"name": "Gary Lilburn",
+			"roles": [
+				{
+					"name": "John"
+				}
+			]
+		},
+		{
+			"name": "Gerard McDermot",
+			"roles": [
+				{
+					"name": "Rod"
+				}
+			]
+		},
+		{
+			"name": "Carl Prekopp",
+			"roles": [
+				{
+					"name": "Lawrence"
+				},
+				{
+					"name": "Liam"
+				}
+			]
+		},
+		{
+			"name": "Abby Francis",
+			"roles": [
+				{
+					"name": "Elaine"
+				}
+			]
+		}
+	],
+	"creativeCredits": [
+		{
+			"name": "Director",
+			"entities": [
+				{
+					"name": "Hamish McColl"
+				}
+			]
+		},
+		{
+			"name": "Designer",
+			"entities": [
+				{
+					"name": "Robert Jones"
+				}
+			]
+		},
+		{
+			"name": "Costume Designer",
+			"entities": [
+				{
+					"name": "Emma Williams"
+				}
+			]
+		},
+		{
+			"name": "Lighting Designer",
+			"entities": [
+				{
+					"name": "Malcolm Rippeth"
+				}
+			]
+		},
+		{
+			"name": "Sound Designer",
+			"entities": [
+				{
+					"name": "John Leonard"
+				}
+			]
+		},
+		{
+			"name": "Music",
+			"entities": [
+				{
+					"name": "Steve Parry"
+				}
+			]
+		},
+		{
+			"name": "Assistant Director",
+			"entities": [
+				{
+					"name": "Jake Brunger"
+				}
+			]
+		},
+		{
+			"name": "Casting Director",
+			"entities": [
+				{
+					"name": "Sarah Bird"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/productions/england-people-very-nice.json
+++ b/db-seeding/seeds/productions/england-people-very-nice.json
@@ -1,0 +1,415 @@
+{
+	"uuid": "e59e0923-ec85-468d-8c51-a9abcb0afd70",
+	"name": "England People Very Nice",
+	"startDate": "2009-02-04",
+	"pressDate": "2009-02-11",
+	"endDate": "2009-08-09",
+	"material": {
+		"name": "England People Very Nice"
+	},
+	"venue": {
+		"name": "Olivier Theatre"
+	},
+	"producerCredits": [
+		{
+			"entities": [
+				{
+					"model": "COMPANY",
+					"name": "National Theatre Company"
+				}
+			]
+		}
+	],
+	"cast": [
+		{
+			"name": "Philip Arditti",
+			"roles": [
+				{
+					"name": "Elmar"
+				},
+				{
+					"name": "André"
+				},
+				{
+					"name": "Sweatshop Owner"
+				},
+				{
+					"name": "Tchisikov"
+				}
+			]
+		},
+		{
+			"name": "Jamie Beamish",
+			"roles": [
+				{
+					"name": "Officer Kelly"
+				},
+				{
+					"name": "Patrick Houlihan"
+				},
+				{
+					"name": "Rothschild"
+				},
+				{
+					"name": "Ashraful"
+				},
+				{
+					"name": "Barry"
+				}
+			]
+		},
+		{
+			"name": "Paul Chequer",
+			"roles": [
+				{
+					"name": "Hugo"
+				}
+			]
+		},
+		{
+			"name": "Olivia Colman",
+			"roles": [
+				{
+					"name": "Philippa"
+				},
+				{
+					"name": "Anne O'Neill"
+				},
+				{
+					"name": "Camilla"
+				}
+			]
+		},
+		{
+			"name": "Rudi Dharmalingam",
+			"roles": [
+				{
+					"name": "Benny"
+				},
+				{
+					"name": "Naz"
+				}
+			]
+		},
+		{
+			"name": "Sacha Dhawan",
+			"roles": [
+				{
+					"name": "Norfolk Danny"
+				},
+				{
+					"name": "Carlo"
+				},
+				{
+					"name": "Aaron"
+				},
+				{
+					"name": "Mushi"
+				}
+			]
+		},
+		{
+			"name": "Hasina Haque",
+			"roles": [
+				{
+					"name": "Ginny"
+				},
+				{
+					"name": "Eels"
+				},
+				{
+					"name": "Labiba"
+				}
+			]
+		},
+		{
+			"name": "Tony Jayawardena",
+			"roles": [
+				{
+					"name": "Morrie"
+				},
+				{
+					"name": "Shah Abdul"
+				}
+			]
+		},
+		{
+			"name": "Trevor Laird",
+			"roles": [
+				{
+					"name": "Yayah"
+				},
+				{
+					"name": "Rennie"
+				}
+			]
+		},
+		{
+			"name": "Elliot Levey",
+			"roles": [
+				{
+					"name": "Taher"
+				},
+				{
+					"name": "Denham"
+				},
+				{
+					"name": "Lord George Gordon"
+				},
+				{
+					"name": "Katz"
+				},
+				{
+					"name": "St John"
+				},
+				{
+					"name": "Milkman"
+				}
+			]
+		},
+		{
+			"name": "Siobhán McSweeney",
+			"roles": [
+				{
+					"name": "Tatyana"
+				},
+				{
+					"name": "Kathleen"
+				},
+				{
+					"name": "Janice"
+				}
+			]
+		},
+		{
+			"name": "Neet Mohan",
+			"roles": [
+				{
+					"name": "Dick"
+				},
+				{
+					"name": "Barrow Boy"
+				},
+				{
+					"name": "Thomas"
+				},
+				{
+					"name": "Egg-Nog"
+				}
+			]
+		},
+		{
+			"name": "Aaron Neil",
+			"roles": [
+				{
+					"name": "Iqbal"
+				},
+				{
+					"name": "De Gascoigne"
+				},
+				{
+					"name": "John O'Neill"
+				},
+				{
+					"name": "Chief Rabbi"
+				},
+				{
+					"name": "Attar"
+				},
+				{
+					"name": "Imam"
+				}
+			]
+		},
+		{
+			"name": "Sophia Nomvete",
+			"roles": [
+				{
+					"name": "Sausages"
+				},
+				{
+					"name": "Lilly"
+				},
+				{
+					"name": "Anika"
+				}
+			]
+		},
+		{
+			"name": "Daniel Poyser",
+			"roles": [
+				{
+					"name": "Turkish Coffee"
+				},
+				{
+					"name": "Major Evans-Gordon"
+				},
+				{
+					"name": "Stretcher-bearer"
+				}
+			]
+		},
+		{
+			"name": "Claire Prempeh",
+			"roles": [
+				{
+					"name": "Adriana"
+				},
+				{
+					"name": "Sea-Coals"
+				},
+				{
+					"name": "Rayhana"
+				}
+			]
+		},
+		{
+			"name": "Fred Ridgeway",
+			"roles": [
+				{
+					"name": "Laurie"
+				},
+				{
+					"name": "Brick Lane Rabbi"
+				}
+			]
+		},
+		{
+			"name": "Avin Shah",
+			"roles": [
+				{
+					"name": "Gaskin"
+				},
+				{
+					"name": "Harry Samuels MP"
+				},
+				{
+					"name": "Police Sergeant"
+				}
+			]
+		},
+		{
+			"name": "Sophie Stanton",
+			"roles": [
+				{
+					"name": "Sanya"
+				},
+				{
+					"name": "Ida"
+				}
+			]
+		},
+		{
+			"name": "Michelle Terry",
+			"roles": [
+				{
+					"name": "Camille"
+				},
+				{
+					"name": "Mary"
+				},
+				{
+					"name": "Black Ruth",
+					"characterName": "Ruth"
+				},
+				{
+					"name": "Deborah"
+				}
+			]
+		},
+		{
+			"name": "David Verrey",
+			"roles": [
+				{
+					"name": "Bishop of London"
+				},
+				{
+					"name": "Lord Ballast"
+				},
+				{
+					"name": "Harvey Kleinman"
+				},
+				{
+					"name": "National Front Speaker"
+				}
+			]
+		},
+		{
+			"name": "Harvey Virdi",
+			"roles": [
+				{
+					"name": "Beggar"
+				},
+				{
+					"name": "Anjum"
+				}
+			]
+		}
+	],
+	"creativeCredits": [
+		{
+			"name": "Director",
+			"entities": [
+				{
+					"name": "Nicholas Hytner"
+				}
+			]
+		},
+		{
+			"name": "Designer",
+			"entities": [
+				{
+					"name": "Mark Thompson"
+				}
+			]
+		},
+		{
+			"name": "Director of Animation",
+			"entities": [
+				{
+					"name": "Pete Bishop"
+				}
+			]
+		},
+		{
+			"name": "Lighting Designer",
+			"entities": [
+				{
+					"name": "Neil Austin"
+				}
+			]
+		},
+		{
+			"name": "Sound Designer",
+			"entities": [
+				{
+					"name": "John Leonard"
+				}
+			]
+		},
+		{
+			"name": "Choreographer",
+			"entities": [
+				{
+					"name": "Scarlett Mackmin"
+				}
+			]
+		},
+		{
+			"name": "Music",
+			"entities": [
+				{
+					"name": "Grant Olding"
+				}
+			]
+		},
+		{
+			"name": "Fight Director",
+			"entities": [
+				{
+					"name": "Terry King"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/productions/fat-pig.json
+++ b/db-seeding/seeds/productions/fat-pig.json
@@ -1,0 +1,132 @@
+{
+	"uuid": "55166aff-587f-48c7-b1b7-bad1722853f7",
+	"name": "Fat Pig",
+	"startDate": "2008-05-16",
+	"pressDate": "2008-05-27",
+	"endDate": "2008-09-06",
+	"material": {
+		"name": "Fat Pig"
+	},
+	"venue": {
+		"name": "Studio 1"
+	},
+	"producerCredits": [
+		{
+			"name": "presented by",
+			"entities": [
+				{
+					"model": "COMPANY",
+					"name": "Ambassador Theatre Group",
+					"members": [
+						{
+							"name": "Howard Panter"
+						}
+					]
+				},
+				{
+					"name": "Barry Weissler"
+				},
+				{
+					"name": "Fran Weissler"
+				},
+				{
+					"name": "Michael Watt"
+				},
+				{
+					"name": "Anna Waterhouse"
+				}
+			]
+		},
+		{
+			"name": "in association with",
+			"entities": [
+				{
+					"model": "COMPANY",
+					"name": "Bozeman Group LLC"
+				},
+				{
+					"name": "Jay Harris"
+				}
+			]
+		}
+	],
+	"cast": [
+		{
+			"name": "Robert Webb",
+			"roles": [
+				{
+					"name": "Tom"
+				}
+			]
+		},
+		{
+			"name": "Ella Smith",
+			"roles": [
+				{
+					"name": "Helen"
+				}
+			]
+		},
+		{
+			"name": "Kris Marshall",
+			"roles": [
+				{
+					"name": "Carter"
+				}
+			]
+		},
+		{
+			"name": "Joanna Page",
+			"roles": [
+				{
+					"name": "Jeannie"
+				}
+			]
+		}
+	],
+	"creativeCredits": [
+		{
+			"name": "Director",
+			"entities": [
+				{
+					"name": "Neil LaBute"
+				}
+			]
+		},
+		{
+			"name": "Designer",
+			"entities": [
+				{
+					"name": "Christopher Oram"
+				}
+			]
+		},
+		{
+			"name": "Lighting Designer",
+			"entities": [
+				{
+					"name": "Johanna Town"
+				}
+			]
+		},
+		{
+			"name": "Sound Designer",
+			"entities": [
+				{
+					"name": "Fergus O'Hare"
+				}
+			]
+		},
+		{
+			"name": "Casting Directors",
+			"entities": [
+				{
+					"name": "Neil Rutherford"
+				},
+				{
+					"name": "Stuart Burt"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/productions/god-of-carnage.json
+++ b/db-seeding/seeds/productions/god-of-carnage.json
@@ -1,0 +1,110 @@
+{
+	"uuid": "53bb5e95-7250-4889-ae5a-586f93f697ae",
+	"name": "God of Carnage",
+	"startDate": "2008-03-07",
+	"pressDate": "2008-03-25",
+	"endDate": "2008-06-14",
+	"material": {
+		"name": "God of Carnage"
+	},
+	"venue": {
+		"name": "Gielgud Theatre"
+	},
+	"producerCredits": [
+		{
+			"name": "presented by",
+			"entities": [
+				{
+					"name": "David Pugh"
+				},
+				{
+					"name": "Dafydd Rogers"
+				}
+			]
+		}
+	],
+	"cast": [
+		{
+			"name": "Ralph Fiennes",
+			"roles": [
+				{
+					"name": "Alain Reille"
+				}
+			]
+		},
+		{
+			"name": "Tamsin Greig",
+			"roles": [
+				{
+					"name": "Annette Reille"
+				}
+			]
+		},
+		{
+			"name": "Janet McTeer",
+			"roles": [
+				{
+					"name": "Véronique Vallon"
+				}
+			]
+		},
+		{
+			"name": "Ken Stott",
+			"roles": [
+				{
+					"name": "Michel Vallon"
+				}
+			]
+		}
+	],
+	"creativeCredits": [
+		{
+			"name": "Director",
+			"entities": [
+				{
+					"name": "Matthew Warchus"
+				}
+			]
+		},
+		{
+			"name": "Designer",
+			"entities": [
+				{
+					"name": "Mark Thompson"
+				}
+			]
+		},
+		{
+			"name": "Lighting Designer",
+			"entities": [
+				{
+					"name": "Hugh Vanstone"
+				}
+			]
+		},
+		{
+			"name": "Music",
+			"entities": [
+				{
+					"name": "Gary Yershon"
+				}
+			]
+		},
+		{
+			"name": "Sound Designer",
+			"entities": [
+				{
+					"name": "Simon Baker"
+				}
+			]
+		},
+		{
+			"name": "Assistant Director",
+			"entities": [
+				{
+					"name": "Rachel Russell"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/productions/parlour-song.json
+++ b/db-seeding/seeds/productions/parlour-song.json
@@ -1,0 +1,126 @@
+{
+	"uuid": "87c383b4-6b2c-4772-a5a2-6320686739d3",
+	"name": "Parlour Song",
+	"startDate": "2009-03-19",
+	"pressDate": "2009-03-26",
+	"endDate": "2009-05-09",
+	"material": {
+		"name": "Parlour Song"
+	},
+	"venue": {
+		"name": "Almeida Theatre"
+	},
+	"producerCredits": [
+		{
+			"entities": [
+				{
+					"model": "COMPANY",
+					"name": "Almeida Theatre Company"
+				}
+			]
+		}
+	],
+	"cast": [
+		{
+			"name": "Andrew Lincoln",
+			"roles": [
+				{
+					"name": "Dale"
+				}
+			]
+		},
+		{
+			"name": "Toby Jones",
+			"roles": [
+				{
+					"name": "Ned"
+				}
+			]
+		},
+		{
+			"name": "Amanda Drew",
+			"roles": [
+				{
+					"name": "Joy"
+				}
+			]
+		}
+	],
+	"creativeCredits": [
+		{
+			"name": "Director",
+			"entities": [
+				{
+					"name": "Ian Rickson"
+				}
+			]
+		},
+		{
+			"name": "Designer",
+			"entities": [
+				{
+					"name": "Jeremy Herbert"
+				}
+			]
+		},
+		{
+			"name": "Lighting Designer",
+			"entities": [
+				{
+					"name": "Peter Mumford"
+				}
+			]
+		},
+		{
+			"name": "Sound Designer",
+			"entities": [
+				{
+					"name": "Paul Groothuis"
+				}
+			]
+		},
+		{
+			"name": "Composer",
+			"entities": [
+				{
+					"name": "Stephen Warbeck"
+				}
+			]
+		},
+		{
+			"name": "Video Designer",
+			"entities": [
+				{
+					"name": "Jeremy Herbert"
+				},
+				{
+					"name": "Steven Williams"
+				}
+			]
+		},
+		{
+			"name": "Casting Director",
+			"entities": [
+				{
+					"name": "Fiona Weir"
+				}
+			]
+		},
+		{
+			"name": "Dialect Coach",
+			"entities": [
+				{
+					"name": "Penny Dyer"
+				}
+			]
+		},
+		{
+			"name": "Assistant Director",
+			"entities": [
+				{
+					"name": "Lootie Johansen-Bibby"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/productions/the-female-of-the-species.json
+++ b/db-seeding/seeds/productions/the-female-of-the-species.json
@@ -1,0 +1,140 @@
+{
+	"uuid": "a84658d2-d58f-4add-bef0-530d899d84a3",
+	"name": "The Female of the Species",
+	"startDate": "2008-07-10",
+	"pressDate": "2008-07-16",
+	"endDate": "2008-10-04",
+	"material": {
+		"name": "The Female of the Species"
+	},
+	"venue": {
+		"name": "Vaudeville Theatre"
+	},
+	"producerCredits": [
+		{
+			"name": "presented by",
+			"entities": [
+				{
+					"name": "David Richenthal"
+				},
+				{
+					"name": "Mary Beth O'Connor"
+				}
+			]
+		},
+		{
+			"name": "in association with",
+			"entities": [
+				{
+					"model": "COMPANY",
+					"name": "Nimax Theatres",
+					"members": [
+						{
+							"name": "Nica Burns"
+						},
+						{
+							"name": "Max Weitzenhoffer"
+						}
+					]
+				}
+			]
+		}
+	],
+	"cast": [
+		{
+			"name": "Eileen Atkins",
+			"roles": [
+				{
+					"name": "Margot",
+					"characterName": "Margot Mason"
+				}
+			]
+		},
+		{
+			"name": "Anna Maxwell Martin",
+			"roles": [
+				{
+					"name": "Molly",
+					"characterName": "Molly Rivers"
+				}
+			]
+		},
+		{
+			"name": "Sophie Thompson",
+			"roles": [
+				{
+					"name": "Tess",
+					"characterName": "Tess Thornton"
+				}
+			]
+		},
+		{
+			"name": "Paul Chahidi",
+			"roles": [
+				{
+					"name": "Bryan",
+					"characterName": "Bryan Thornton"
+				}
+			]
+		},
+		{
+			"name": "Con O'Neill",
+			"roles": [
+				{
+					"name": "Frank"
+				}
+			]
+		},
+		{
+			"name": "Sam Kelly",
+			"roles": [
+				{
+					"name": "Theo",
+					"characterName": "Theo Reynolds"
+				}
+			]
+		}
+	],
+	"creativeCredits": [
+		{
+			"name": "Director",
+			"entities": [
+				{
+					"name": "Roger Michell"
+				}
+			]
+		},
+		{
+			"name": "Designer",
+			"entities": [
+				{
+					"name": "Mark Thompson"
+				}
+			]
+		},
+		{
+			"name": "Lighting Designer",
+			"entities": [
+				{
+					"name": "James Whiteside"
+				}
+			]
+		},
+		{
+			"name": "Sound Designer",
+			"entities": [
+				{
+					"name": "Matt McKenzie"
+				}
+			]
+		},
+		{
+			"name": "Fight Director",
+			"entities": [
+				{
+					"name": "Terry King"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/productions/the-priory.json
+++ b/db-seeding/seeds/productions/the-priory.json
@@ -1,0 +1,147 @@
+{
+	"uuid": "36017da2-5a4e-4ed1-a4a2-4e04b4e24531",
+	"name": "The Priory",
+	"startDate": "2009-11-19",
+	"pressDate": "2009-11-26",
+	"endDate": "2010-01-16",
+	"material": {
+		"name": "The Priory"
+	},
+	"venue": {
+		"name": "Jerwood Theatre Downstairs"
+	},
+	"producerCredits": [
+		{
+			"entities": [
+				{
+					"model": "COMPANY",
+					"name": "Royal Court Theatre"
+				}
+			]
+		}
+	],
+	"cast": [
+		{
+			"name": "Jessica Hynes",
+			"roles": [
+				{
+					"name": "Kate"
+				}
+			]
+		},
+		{
+			"name": "Joseph Millson",
+			"roles": [
+				{
+					"name": "Daniel"
+				}
+			]
+		},
+		{
+			"name": "Alastair Mackenzie",
+			"roles": [
+				{
+					"name": "Ben"
+				}
+			]
+		},
+		{
+			"name": "Charlotte Riley",
+			"roles": [
+				{
+					"name": "Laura"
+				}
+			]
+		},
+		{
+			"name": "Rupert Penry-Jones",
+			"roles": [
+				{
+					"name": "Carl"
+				}
+			]
+		},
+		{
+			"name": "Rachael Stirling",
+			"roles": [
+				{
+					"name": "Rebecca"
+				}
+			]
+		},
+		{
+			"name": "Nick Blood",
+			"roles": [
+				{
+					"name": "Adam"
+				}
+			]
+		}
+	],
+	"creativeCredits": [
+		{
+			"name": "Director",
+			"entities": [
+				{
+					"name": "Jeremy Herrin"
+				}
+			]
+		},
+		{
+			"name": "Designer",
+			"entities": [
+				{
+					"name": "Robert Innes Hopkins"
+				}
+			]
+		},
+		{
+			"name": "Costume Designer",
+			"entities": [
+				{
+					"name": "Iona Kenrick"
+				}
+			]
+		},
+		{
+			"name": "Lighting Designer",
+			"entities": [
+				{
+					"name": "Neil Austin"
+				}
+			]
+		},
+		{
+			"name": "Music and Sound Designer",
+			"entities": [
+				{
+					"name": "Nick Powell"
+				}
+			]
+		},
+		{
+			"name": "Assistant Director",
+			"entities": [
+				{
+					"name": "Joe Murphy"
+				}
+			]
+		},
+		{
+			"name": "Casting Director",
+			"entities": [
+				{
+					"name": "Amy Ball"
+				}
+			]
+		},
+		{
+			"name": "Casting Assistant",
+			"entities": [
+				{
+					"name": "Lotte Hines"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/productions/whipping-it-up.json
+++ b/db-seeding/seeds/productions/whipping-it-up.json
@@ -1,0 +1,152 @@
+{
+	"uuid": "763878c6-14ff-4f8e-9d51-20b426c77f8b",
+	"name": "Whipping It Up",
+	"startDate": "2007-02-22",
+	"pressDate": "2007-03-01",
+	"endDate": "2007-04-28",
+	"material": {
+		"name": "Whipping It Up"
+	},
+	"venue": {
+		"name": "New Amabassadors Theatre"
+	},
+	"producerCredits": [
+		{
+			"entities": [
+				{
+					"model": "COMPANY",
+					"name": "Act Productions"
+				},
+				{
+					"model": "COMPANY",
+					"name": "Ambassador Theatre Group"
+				},
+				{
+					"model": "COMPANY",
+					"name": "Bush Theatre Productions"
+				},
+				{
+					"name": "Matthew Byam Shaw"
+				},
+				{
+					"name": "Mark Goucher"
+				},
+				{
+					"name": "Lee Menzies"
+				},
+				{
+					"model": "COMPANY",
+					"name": "Wimpole Theatre"
+				}
+			]
+		}
+	],
+	"cast": [
+		{
+			"name": "Robert Bathurst",
+			"roles": [
+				{
+					"name": "Alastair"
+				}
+			]
+		},
+		{
+			"name": "Nicholas Rowe",
+			"roles": [
+				{
+					"name": "Guy"
+				}
+			]
+		},
+		{
+			"name": "Lee Ross",
+			"roles": [
+				{
+					"name": "Tim"
+				}
+			]
+		},
+		{
+			"name": "Kellie Bright",
+			"roles": [
+				{
+					"name": "Maggie"
+				}
+			]
+		},
+		{
+			"name": "Richard Wilson",
+			"roles": [
+				{
+					"name": "Fulton"
+				}
+			]
+		},
+		{
+			"name": "Helen Schlesinger",
+			"roles": [
+				{
+					"name": "Delia"
+				}
+			]
+		}
+	],
+	"creativeCredits": [
+		{
+			"name": "Director",
+			"entities": [
+				{
+					"name": "Tamara Harvey"
+				}
+			]
+		},
+		{
+			"name": "Original Director",
+			"entities": [
+				{
+					"name": "Terry Johnson"
+				}
+			]
+		},
+		{
+			"name": "Designer",
+			"entities": [
+				{
+					"name": "Tim Shortall"
+				}
+			]
+		},
+		{
+			"name": "Lighting Designer",
+			"entities": [
+				{
+					"name": "Simon Corder"
+				}
+			]
+		},
+		{
+			"name": "Sound Designer",
+			"entities": [
+				{
+					"name": "Fergus O'Hare"
+				}
+			]
+		},
+		{
+			"name": "Assistant Director",
+			"entities": [
+				{
+					"name": "Seb Billings"
+				}
+			]
+		},
+		{
+			"name": "Casting Director",
+			"entities": [
+				{
+					"name": "Imogen Kinchin"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
This PR adds database seeds that demonstrate a segment of a collection (The Crimson Hotel) being nominated for an award (Best New Comedy at the Laurence Olivier Awards 2008).

The other seeds are added to provide consistent data for this award ceremony category for all three ceremonies (2008, 2009, 2010) for which there is currently seed data.