### PR TITLE
Grant credited writers award nominations via sub/sur-material association

### DIFF
--- a/src/neo4j/cypher-queries/company/show/show-awards-rights-grantor-material.js
+++ b/src/neo4j/cypher-queries/company/show/show-awards-rights-grantor-material.js
@@ -2,7 +2,8 @@ export default () => `
 	MATCH (company:Company { uuid: $uuid })
 
 	OPTIONAL MATCH (company)
-		<-[:HAS_WRITING_ENTITY { creditType: 'RIGHTS_GRANTOR' }]-(nominatedRightsGrantorMaterial:Material)
+		<-[:HAS_WRITING_ENTITY { creditType: 'RIGHTS_GRANTOR' }]
+		-(:Material)-[:HAS_SUB_MATERIAL*0..2]-(nominatedRightsGrantorMaterial:Material)
 		<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
 		<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
 

--- a/src/neo4j/cypher-queries/company/show/show-awards-sourcing-material.js
+++ b/src/neo4j/cypher-queries/company/show/show-awards-sourcing-material.js
@@ -2,7 +2,8 @@ export default () => `
 	MATCH (company:Company { uuid: $uuid })
 
 	OPTIONAL MATCH path=(company)
-		<-[writingRel:HAS_WRITING_ENTITY]-(:Material)<-[:USES_SOURCE_MATERIAL*0..1]-(nominatedSourcingMaterial:Material)
+		<-[writingRel:HAS_WRITING_ENTITY]-(:Material)-[:HAS_SUB_MATERIAL*0..1]-(:Material)
+		<-[:USES_SOURCE_MATERIAL*0..1]-(:Material)-[:HAS_SUB_MATERIAL*0..1]-(nominatedSourcingMaterial:Material)
 		<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
 		<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
 	WHERE

--- a/src/neo4j/cypher-queries/company/show/show-awards-subsequent-version-material.js
+++ b/src/neo4j/cypher-queries/company/show/show-awards-subsequent-version-material.js
@@ -2,7 +2,7 @@ export default () => `
 	MATCH (company:Company { uuid: $uuid })
 
 	OPTIONAL MATCH (company)<-[:HAS_WRITING_ENTITY]-(:Material)
-		<-[:SUBSEQUENT_VERSION_OF]-(nominatedSubsequentVersionMaterial:Material)
+		<-[:SUBSEQUENT_VERSION_OF]-(:Material)-[:HAS_SUB_MATERIAL*0..2]-(nominatedSubsequentVersionMaterial:Material)
 		<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
 		<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
 

--- a/src/neo4j/cypher-queries/company/show/show-awards.js
+++ b/src/neo4j/cypher-queries/company/show/show-awards.js
@@ -2,15 +2,18 @@ export default () => `
 	MATCH (company:Company { uuid: $uuid })
 
 	OPTIONAL MATCH path=(company)
-		<-[:HAS_WRITING_ENTITY*0..1]-()<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
+		<-[:HAS_WRITING_ENTITY*0..1]-()-[:HAS_SUB_MATERIAL*0..2]-()
+		<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
 		<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
 	WHERE
 		(NONE(rel IN RELATIONSHIPS(path)
 			WHERE COALESCE(rel.creditType IN ['NON_SPECIFIC_SOURCE_MATERIAL', 'RIGHTS_GRANTOR'], false)
 		)) AND
 		NOT EXISTS(
-			(company)<-[:HAS_WRITING_ENTITY]-(:Material)
-			<-[:SUBSEQUENT_VERSION_OF]-(:Material)<-[:HAS_NOMINEE]-(category)
+			(company)
+			<-[:HAS_WRITING_ENTITY]-(:Material)
+			<-[:SUBSEQUENT_VERSION_OF]-(:Material)-[:HAS_SUB_MATERIAL*0..2]-(:Material)
+			<-[:HAS_NOMINEE]-(category)
 		)
 
 	WITH company, nomineeRel, category, categoryRel, ceremony

--- a/src/neo4j/cypher-queries/person/show/show-awards-rights-grantor-material.js
+++ b/src/neo4j/cypher-queries/person/show/show-awards-rights-grantor-material.js
@@ -2,7 +2,8 @@ export default () => `
 	MATCH (person:Person { uuid: $uuid })
 
 	OPTIONAL MATCH (person)
-		<-[:HAS_WRITING_ENTITY { creditType: 'RIGHTS_GRANTOR' }]-(nominatedRightsGrantorMaterial:Material)
+		<-[:HAS_WRITING_ENTITY { creditType: 'RIGHTS_GRANTOR' }]
+		-(:Material)-[:HAS_SUB_MATERIAL*0..2]-(nominatedRightsGrantorMaterial:Material)
 		<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
 		<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
 

--- a/src/neo4j/cypher-queries/person/show/show-awards-sourcing-material.js
+++ b/src/neo4j/cypher-queries/person/show/show-awards-sourcing-material.js
@@ -2,7 +2,8 @@ export default () => `
 	MATCH (person:Person { uuid: $uuid })
 
 	OPTIONAL MATCH path=(person)
-		<-[writingRel:HAS_WRITING_ENTITY]-(:Material)<-[:USES_SOURCE_MATERIAL*0..1]-(nominatedSourcingMaterial:Material)
+		<-[writingRel:HAS_WRITING_ENTITY]-(:Material)-[:HAS_SUB_MATERIAL*0..1]-(:Material)
+		<-[:USES_SOURCE_MATERIAL*0..1]-(:Material)-[:HAS_SUB_MATERIAL*0..1]-(nominatedSourcingMaterial:Material)
 		<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
 		<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
 	WHERE

--- a/src/neo4j/cypher-queries/person/show/show-awards-subsequent-version-material.js
+++ b/src/neo4j/cypher-queries/person/show/show-awards-subsequent-version-material.js
@@ -2,7 +2,7 @@ export default () => `
 	MATCH (person:Person { uuid: $uuid })
 
 	OPTIONAL MATCH (person)<-[:HAS_WRITING_ENTITY]-(:Material)
-		<-[:SUBSEQUENT_VERSION_OF]-(nominatedSubsequentVersionMaterial:Material)
+		<-[:SUBSEQUENT_VERSION_OF]-(:Material)-[:HAS_SUB_MATERIAL*0..2]-(nominatedSubsequentVersionMaterial:Material)
 		<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
 		<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
 

--- a/src/neo4j/cypher-queries/person/show/show-awards.js
+++ b/src/neo4j/cypher-queries/person/show/show-awards.js
@@ -2,14 +2,18 @@ export default () => `
 	MATCH (person:Person { uuid: $uuid })
 
 	OPTIONAL MATCH path=(person)
-		<-[:HAS_WRITING_ENTITY*0..1]-()<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
+		<-[:HAS_WRITING_ENTITY*0..1]-()-[:HAS_SUB_MATERIAL*0..2]-()
+		<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
 		<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
 	WHERE
 		(NONE(rel IN RELATIONSHIPS(path)
 			WHERE COALESCE(rel.creditType IN ['NON_SPECIFIC_SOURCE_MATERIAL', 'RIGHTS_GRANTOR'], false)
 		)) AND
 		NOT EXISTS(
-			(person)<-[:HAS_WRITING_ENTITY]-(:Material)<-[:SUBSEQUENT_VERSION_OF]-(:Material)<-[:HAS_NOMINEE]-(category)
+			(person)
+			<-[:HAS_WRITING_ENTITY]-(:Material)
+			<-[:SUBSEQUENT_VERSION_OF]-(:Material)-[:HAS_SUB_MATERIAL*0..2]-(:Material)
+			<-[:HAS_NOMINEE]-(category)
 		)
 
 	WITH person, nomineeRel, category, categoryRel, ceremony

--- a/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-materials-assocs.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-materials-assocs.test.js
@@ -1,0 +1,3691 @@
+import crypto from 'crypto';
+
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import { createSandbox } from 'sinon';
+
+import app from '../../src/app';
+import purgeDatabase from '../test-helpers/neo4j/purge-database';
+
+describe('Award ceremonies with crediting sub-materials (with person/company nominations gained through associations to sur and sub-materials)', () => {
+
+	chai.use(chaiHttp);
+
+	const SUB_FRED_MATERIAL_UUID = '4';
+	const JOHN_DOE_JR_PERSON_UUID = '6';
+	const SUB_PLAYWRIGHTS_LTD_COMPANY_UUID = '7';
+	const SUR_FRED_MATERIAL_UUID = '13';
+	const JOHN_DOE_SR_PERSON_UUID = '15';
+	const SUR_PLAYWRIGHTS_LTD_COMPANY_UUID = '16';
+	const FRANCIS_FLOB_JR_PERSON_UUID = '24';
+	const SUB_CURTAIN_UP_LTD_COMPANY_UUID = '25';
+	const FRANCIS_FLOB_SR_PERSON_UUID = '33';
+	const SUR_CURTAIN_UP_LTD_COMPANY_UUID = '34';
+	const SUB_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID = '42';
+	const SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID = '55';
+	const JANE_ROE_JR_PERSON_UUID = '68';
+	const SUB_FICTIONEERS_LTD_COMPANY_UUID = '69';
+	const JANE_ROE_SR_PERSON_UUID = '77';
+	const SUR_FICTIONEERS_LTD_COMPANY_UUID = '78';
+	const SUB_WIBBLE_MATERIAL_UUID = '85';
+	const SUR_WIBBLE_MATERIAL_UUID = '96';
+	const SUB_HOGE_MATERIAL_UUID = '108';
+	const SUB_CINERIGHTS_LTD_COMPANY_UUID = '112';
+	const TALYSE_TATA_JR_PERSON_UUID = '113';
+	const SUR_HOGE_MATERIAL_UUID = '121';
+	const SUR_CINERIGHTS_LTD_COMPANY_UUID = '125';
+	const TALYSE_TATA_SR_PERSON_UUID = '126';
+	const NATIONAL_THEATRE_VENUE_UUID = '131';
+	const OLIVIER_THEATRE_VENUE_UUID = '132';
+	const LYTTELTON_THEATRE_VENUE_UUID = '133';
+	const ROYAL_COURT_THEATRE_VENUE_UUID = '137';
+	const JERWOOD_THEATRE_DOWNSTAIRS_VENUE_UUID = '138';
+	const JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID = '139';
+	const SUB_FRED_LYTTELTON_PRODUCTION_UUID = '140';
+	const SUR_FRED_LYTTELTON_PRODUCTION_UUID = '143';
+	const SUB_FRED_NOËL_COWARD_PRODUCTION_UUID = '146';
+	const NOËL_COWARD_THEATRE_VENUE_UUID = '148';
+	const SUR_FRED_NOËL_COWARD_PRODUCTION_UUID = '149';
+	const SUB_PLUGH_OLIVIER_PRODUCTION_UUID = '152';
+	const SUR_PLUGH_OLIVIER_PRODUCTION_UUID = '155';
+	const SUB_PLUGH_WYNDHAMS_PRODUCTION_UUID = '158';
+	const WYNDHAMS_THEATRE_VENUE_UUID = '160';
+	const SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID = '161';
+	const SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID = '164';
+	const SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID = '167';
+	const SUB_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID = '170';
+	const DUKE_OF_YORKS_THEATRE_VENUE_UUID = '172';
+	const SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID = '173';
+	const SUB_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID = '176';
+	const SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID = '179';
+	const SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID = '182';
+	const SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID = '185';
+	const WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID = '194';
+	const WORDSMITH_AWARD_UUID = '195';
+	const PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID = '206';
+	const PLAYWRITING_PRIZE_AWARD_UUID = '207';
+
+	let johnDoeJrPerson;
+	let johnDoeSrPerson;
+	let subPlaywrightsLtdCompany;
+	let surPlaywrightsLtdCompany;
+	let francisFlobJrPerson;
+	let francisFlobSrPerson;
+	let subCurtainUpLtdCompany;
+	let surCurtainUpLtdCompany;
+	let janeRoeJrPerson;
+	let janeRoeSrPerson;
+	let subFictioneersLtdCompany;
+	let surFictioneersLtdCompany;
+	let talyseTataJrPerson;
+	let talyseTataSrPerson;
+	let subCinerightsLtdCompany;
+	let surCinerightsLtdCompany;
+
+	const sandbox = createSandbox();
+
+	before(async () => {
+
+		let uuidCallCount = 0;
+
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
+
+		await purgeDatabase();
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sub-Fred',
+				format: 'play',
+				year: '2010',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'John Doe Jr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sub-Playwrights Ltd'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sur-Fred',
+				format: 'collection of plays',
+				year: '2010',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'John Doe Sr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sur-Playwrights Ltd'
+							}
+						]
+					}
+				],
+				subMaterials: [
+					{
+						name: 'Sub-Fred'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sub-Plugh',
+				differentiator: '1',
+				format: 'play',
+				year: '1899',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Francis Flob Jr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sub-Curtain Up Ltd'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sur-Plugh',
+				differentiator: '1',
+				format: 'collection of plays',
+				year: '1899',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Francis Flob Sr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sur-Curtain Up Ltd'
+							}
+						]
+					}
+				],
+				subMaterials: [
+					{
+						name: 'Sub-Plugh',
+						differentiator: '1'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sub-Plugh',
+				differentiator: '2',
+				format: 'play',
+				year: '2009',
+				originalVersionMaterial: {
+					name: 'Sub-Plugh',
+					differentiator: '1'
+				},
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Francis Flob Jr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sub-Curtain Up Ltd'
+							}
+						]
+					},
+					{
+						name: 'version by',
+						entities: [
+							{
+								name: 'Beatrice Bar Jr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sub-Stagecraft Ltd'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sur-Plugh',
+				differentiator: '2',
+				format: 'collection of plays',
+				year: '2009',
+				originalVersionMaterial: {
+					name: 'Sur-Plugh',
+					differentiator: '1'
+				},
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Francis Flob Sr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sur-Curtain Up Ltd'
+							}
+						]
+					},
+					{
+						name: 'version by',
+						entities: [
+							{
+								name: 'Beatrice Bar Sr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sur-Stagecraft Ltd'
+							}
+						]
+					}
+				],
+				subMaterials: [
+					{
+						name: 'Sub-Plugh',
+						differentiator: '2'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sub-Waldo',
+				format: 'novel',
+				year: '1974',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Jane Roe Jr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sub-Fictioneers Ltd'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sur-Waldo',
+				format: 'trilogy of novels',
+				year: '1974',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Jane Roe Sr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sur-Fictioneers Ltd'
+							}
+						]
+					}
+				],
+				subMaterials: [
+					{
+						name: 'Sub-Waldo'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sub-Wibble',
+				format: 'play',
+				year: '2009',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Quincy Qux Jr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sub-Theatricals Ltd'
+							}
+						]
+					},
+					{
+						name: 'based on',
+						entities: [
+							{
+								model: 'MATERIAL',
+								name: 'Sub-Waldo'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sur-Wibble',
+				format: 'trilogy of plays',
+				year: '2009',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Quincy Qux Sr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sur-Theatricals Ltd'
+							}
+						]
+					},
+					{
+						name: 'based on',
+						entities: [
+							{
+								model: 'MATERIAL',
+								name: 'Sur-Waldo'
+							}
+						]
+					}
+				],
+				subMaterials: [
+					{
+						name: 'Sub-Wibble'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sub-Hoge',
+				format: 'play',
+				year: '2008',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Beatrice Bar Jr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sub-Theatricals Ltd'
+							}
+						]
+					},
+					{
+						name: 'by arrangement with',
+						creditType: 'RIGHTS_GRANTOR',
+						entities: [
+							{
+								model: 'COMPANY',
+								name: 'Sub-Cinerights Ltd'
+							},
+							{
+								name: 'Talyse Tata Jr'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sur-Hoge',
+				format: 'collection of plays',
+				year: '2008',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Beatrice Bar Sr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sur-Theatricals Ltd'
+							}
+						]
+					},
+					{
+						name: 'by arrangement with',
+						creditType: 'RIGHTS_GRANTOR',
+						entities: [
+							{
+								model: 'COMPANY',
+								name: 'Sur-Cinerights Ltd'
+							},
+							{
+								name: 'Talyse Tata Sr'
+							}
+						]
+					}
+				],
+				subMaterials: [
+					{
+						name: 'Sub-Hoge'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/venues')
+			.send({
+				name: 'National Theatre',
+				subVenues: [
+					{
+						name: 'Olivier Theatre'
+					},
+					{
+						name: 'Lyttelton Theatre'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/venues')
+			.send({
+				name: 'Royal Court Theatre',
+				subVenues: [
+					{
+						name: 'Jerwood Theatre Downstairs'
+					},
+					{
+						name: 'Jerwood Theatre Upstairs'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sub-Fred',
+				startDate: '2010-02-01',
+				endDate: '2010-02-28',
+				venue: {
+					name: 'Lyttelton Theatre'
+				}
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sur-Fred',
+				startDate: '2010-02-01',
+				endDate: '2010-02-28',
+				venue: {
+					name: 'Lyttelton Theatre'
+				},
+				subProductions: [
+					{
+						uuid: SUB_FRED_LYTTELTON_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sub-Fred',
+				startDate: '2010-03-01',
+				endDate: '2010-03-31',
+				venue: {
+					name: 'Noël Coward Theatre'
+				}
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sur-Fred',
+				startDate: '2010-03-01',
+				endDate: '2010-03-31',
+				venue: {
+					name: 'Noël Coward Theatre'
+				},
+				subProductions: [
+					{
+						uuid: SUB_FRED_NOËL_COWARD_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sub-Plugh',
+				startDate: '2009-07-01',
+				endDate: '2009-07-31',
+				venue: {
+					name: 'Olivier Theatre'
+				}
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sur-Plugh',
+				startDate: '2009-07-01',
+				endDate: '2009-07-31',
+				venue: {
+					name: 'Olivier Theatre'
+				},
+				subProductions: [
+					{
+						uuid: SUB_PLUGH_OLIVIER_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sub-Plugh',
+				startDate: '2009-08-01',
+				endDate: '2009-08-31',
+				venue: {
+					name: 'Wyndham\'s Theatre'
+				}
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sur-Plugh',
+				startDate: '2009-08-01',
+				endDate: '2009-08-31',
+				venue: {
+					name: 'Wyndham\'s Theatre'
+				},
+				subProductions: [
+					{
+						uuid: SUB_PLUGH_WYNDHAMS_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sub-Wibble',
+				startDate: '2009-05-01',
+				endDate: '2009-05-31',
+				venue: {
+					name: 'Jerwood Theatre Upstairs'
+				}
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sur-Wibble',
+				startDate: '2009-05-01',
+				endDate: '2009-05-31',
+				venue: {
+					name: 'Jerwood Theatre Upstairs'
+				},
+				subProductions: [
+					{
+						uuid: SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sub-Wibble',
+				startDate: '2009-06-01',
+				endDate: '2009-06-30',
+				venue: {
+					name: 'Duke of York\'s Theatre'
+				}
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sur-Wibble',
+				startDate: '2009-06-01',
+				endDate: '2009-06-30',
+				venue: {
+					name: 'Duke of York\'s Theatre'
+				},
+				subProductions: [
+					{
+						uuid: SUB_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sub-Hoge',
+				startDate: '2008-05-01',
+				endDate: '2008-05-31',
+				venue: {
+					name: 'Jerwood Theatre Downstairs'
+				}
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sur-Hoge',
+				startDate: '2008-05-01',
+				endDate: '2008-05-31',
+				venue: {
+					name: 'Jerwood Theatre Downstairs'
+				},
+				subProductions: [
+					{
+						uuid: SUB_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sub-Hoge',
+				startDate: '2008-06-01',
+				endDate: '2008-06-30',
+				venue: {
+					name: 'Noël Coward Theatre'
+				}
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sur-Hoge',
+				startDate: '2008-06-01',
+				endDate: '2008-06-30',
+				venue: {
+					name: 'Noël Coward Theatre'
+				},
+				subProductions: [
+					{
+						uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/award-ceremonies')
+			.send({
+				name: '2010',
+				award: {
+					name: 'Wordsmith Award'
+				},
+				categories: [
+					{
+						name: 'Best Miscellaneous Play',
+						nominations: [
+							{
+								productions: [
+									{
+										uuid: SUB_FRED_LYTTELTON_PRODUCTION_UUID
+									},
+									{
+										uuid: SUB_FRED_NOËL_COWARD_PRODUCTION_UUID
+									}
+								],
+								materials: [
+									{
+										name: 'Sub-Fred'
+									}
+								]
+							},
+							{
+								productions: [
+									{
+										uuid: SUB_PLUGH_OLIVIER_PRODUCTION_UUID
+									},
+									{
+										uuid: SUB_PLUGH_WYNDHAMS_PRODUCTION_UUID
+									}
+								],
+								materials: [
+									{
+										name: 'Sub-Plugh',
+										differentiator: '2'
+									}
+								]
+							},
+							{
+								productions: [
+									{
+										uuid: SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID
+									},
+									{
+										uuid: SUB_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID
+									}
+								],
+								materials: [
+									{
+										name: 'Sub-Wibble'
+									}
+								]
+							},
+							{
+								isWinner: true,
+								productions: [
+									{
+										uuid: SUB_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID
+									},
+									{
+										uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID
+									}
+								],
+								materials: [
+									{
+										name: 'Sub-Hoge'
+									}
+								]
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/award-ceremonies')
+			.send({
+				name: '2009',
+				award: {
+					name: 'Playwriting Prize'
+				},
+				categories: [
+					{
+						name: 'Best Random Play',
+						nominations: [
+							{
+								productions: [
+									{
+										uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID
+									},
+									{
+										uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID
+									}
+								],
+								materials: [
+									{
+										name: 'Sur-Fred'
+									}
+								]
+							},
+							{
+								isWinner: true,
+								productions: [
+									{
+										uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID
+									},
+									{
+										uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID
+									}
+								],
+								materials: [
+									{
+										name: 'Sur-Plugh',
+										differentiator: '2'
+									}
+								]
+							},
+							{
+								productions: [
+									{
+										uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID
+									},
+									{
+										uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID
+									}
+								],
+								materials: [
+									{
+										name: 'Sur-Wibble'
+									}
+								]
+							},
+							{
+								productions: [
+									{
+										uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID
+									},
+									{
+										uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID
+									}
+								],
+								materials: [
+									{
+										name: 'Sur-Hoge'
+									}
+								]
+							}
+						]
+					}
+				]
+			});
+
+		johnDoeJrPerson = await chai.request(app)
+			.get(`/people/${JOHN_DOE_JR_PERSON_UUID}`);
+
+		johnDoeSrPerson = await chai.request(app)
+			.get(`/people/${JOHN_DOE_SR_PERSON_UUID}`);
+
+		subPlaywrightsLtdCompany = await chai.request(app)
+			.get(`/companies/${SUB_PLAYWRIGHTS_LTD_COMPANY_UUID}`);
+
+		surPlaywrightsLtdCompany = await chai.request(app)
+			.get(`/companies/${SUR_PLAYWRIGHTS_LTD_COMPANY_UUID}`);
+
+		francisFlobJrPerson = await chai.request(app)
+			.get(`/people/${FRANCIS_FLOB_JR_PERSON_UUID}`);
+
+		francisFlobSrPerson = await chai.request(app)
+			.get(`/people/${FRANCIS_FLOB_SR_PERSON_UUID}`);
+
+		subCurtainUpLtdCompany = await chai.request(app)
+			.get(`/companies/${SUB_CURTAIN_UP_LTD_COMPANY_UUID}`);
+
+		surCurtainUpLtdCompany = await chai.request(app)
+			.get(`/companies/${SUR_CURTAIN_UP_LTD_COMPANY_UUID}`);
+
+		janeRoeJrPerson = await chai.request(app)
+			.get(`/people/${JANE_ROE_JR_PERSON_UUID}`);
+
+		janeRoeSrPerson = await chai.request(app)
+			.get(`/people/${JANE_ROE_SR_PERSON_UUID}`);
+
+		subFictioneersLtdCompany = await chai.request(app)
+			.get(`/companies/${SUB_FICTIONEERS_LTD_COMPANY_UUID}`);
+
+		surFictioneersLtdCompany = await chai.request(app)
+			.get(`/companies/${SUR_FICTIONEERS_LTD_COMPANY_UUID}`);
+
+		talyseTataJrPerson = await chai.request(app)
+			.get(`/people/${TALYSE_TATA_JR_PERSON_UUID}`);
+
+		talyseTataSrPerson = await chai.request(app)
+			.get(`/people/${TALYSE_TATA_SR_PERSON_UUID}`);
+
+		subCinerightsLtdCompany = await chai.request(app)
+			.get(`/companies/${SUB_CINERIGHTS_LTD_COMPANY_UUID}`);
+
+		surCinerightsLtdCompany = await chai.request(app)
+			.get(`/companies/${SUR_CINERIGHTS_LTD_COMPANY_UUID}`);
+
+	});
+
+	after(() => {
+
+		sandbox.restore();
+
+	});
+
+	describe('John Doe Jr (person): credit for directly nominated material and their associated sur-material', () => {
+
+		it('includes their award nominations', () => {
+
+			const expectedAwards = [
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											employerCompany: null,
+											coEntities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
+													name: 'Sur-Fred',
+													startDate: '2010-02-01',
+													endDate: '2010-02-28',
+													venue: {
+														model: 'VENUE',
+														uuid: LYTTELTON_THEATRE_VENUE_UUID,
+														name: 'Lyttelton Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sur-Fred',
+													startDate: '2010-03-01',
+													endDate: '2010-03-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_FRED_MATERIAL_UUID,
+													name: 'Sur-Fred',
+													format: 'collection of plays',
+													year: 2010,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											employerCompany: null,
+											coEntities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_FRED_LYTTELTON_PRODUCTION_UUID,
+													name: 'Sub-Fred',
+													startDate: '2010-02-01',
+													endDate: '2010-02-28',
+													venue: {
+														model: 'VENUE',
+														uuid: LYTTELTON_THEATRE_VENUE_UUID,
+														name: 'Lyttelton Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
+														name: 'Sur-Fred',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_FRED_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sub-Fred',
+													startDate: '2010-03-01',
+													endDate: '2010-03-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Sur-Fred',
+														surProduction: null
+													}
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_FRED_MATERIAL_UUID,
+													name: 'Sub-Fred',
+													format: 'play',
+													year: 2010,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_FRED_MATERIAL_UUID,
+														name: 'Sur-Fred',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards } = johnDoeJrPerson.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+
+		});
+
+	});
+
+	describe('John Doe Sr (person): credit for directly nominated material and their associated sub-material', () => {
+
+		it('includes their award nominations', () => {
+
+			const expectedAwards = [
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											employerCompany: null,
+											coEntities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
+													name: 'Sur-Fred',
+													startDate: '2010-02-01',
+													endDate: '2010-02-28',
+													venue: {
+														model: 'VENUE',
+														uuid: LYTTELTON_THEATRE_VENUE_UUID,
+														name: 'Lyttelton Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sur-Fred',
+													startDate: '2010-03-01',
+													endDate: '2010-03-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_FRED_MATERIAL_UUID,
+													name: 'Sur-Fred',
+													format: 'collection of plays',
+													year: 2010,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											employerCompany: null,
+											coEntities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_FRED_LYTTELTON_PRODUCTION_UUID,
+													name: 'Sub-Fred',
+													startDate: '2010-02-01',
+													endDate: '2010-02-28',
+													venue: {
+														model: 'VENUE',
+														uuid: LYTTELTON_THEATRE_VENUE_UUID,
+														name: 'Lyttelton Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
+														name: 'Sur-Fred',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_FRED_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sub-Fred',
+													startDate: '2010-03-01',
+													endDate: '2010-03-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Sur-Fred',
+														surProduction: null
+													}
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_FRED_MATERIAL_UUID,
+													name: 'Sub-Fred',
+													format: 'play',
+													year: 2010,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_FRED_MATERIAL_UUID,
+														name: 'Sur-Fred',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards } = johnDoeSrPerson.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+
+		});
+
+	});
+
+	describe('Sub-Playwrights Ltd (company): credit for directly nominated material and their associated sur-material', () => {
+
+		it('includes their award nominations', () => {
+
+			const expectedAwards = [
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											members: [],
+											coEntities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
+													name: 'Sur-Fred',
+													startDate: '2010-02-01',
+													endDate: '2010-02-28',
+													venue: {
+														model: 'VENUE',
+														uuid: LYTTELTON_THEATRE_VENUE_UUID,
+														name: 'Lyttelton Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sur-Fred',
+													startDate: '2010-03-01',
+													endDate: '2010-03-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_FRED_MATERIAL_UUID,
+													name: 'Sur-Fred',
+													format: 'collection of plays',
+													year: 2010,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											members: [],
+											coEntities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_FRED_LYTTELTON_PRODUCTION_UUID,
+													name: 'Sub-Fred',
+													startDate: '2010-02-01',
+													endDate: '2010-02-28',
+													venue: {
+														model: 'VENUE',
+														uuid: LYTTELTON_THEATRE_VENUE_UUID,
+														name: 'Lyttelton Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
+														name: 'Sur-Fred',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_FRED_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sub-Fred',
+													startDate: '2010-03-01',
+													endDate: '2010-03-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Sur-Fred',
+														surProduction: null
+													}
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_FRED_MATERIAL_UUID,
+													name: 'Sub-Fred',
+													format: 'play',
+													year: 2010,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_FRED_MATERIAL_UUID,
+														name: 'Sur-Fred',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards } = subPlaywrightsLtdCompany.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+
+		});
+
+	});
+
+	describe('Sur-Playwrights Ltd (company): credit for directly nominated material and their associated sub-material', () => {
+
+		it('includes their award nominations', () => {
+
+			const expectedAwards = [
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											members: [],
+											coEntities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
+													name: 'Sur-Fred',
+													startDate: '2010-02-01',
+													endDate: '2010-02-28',
+													venue: {
+														model: 'VENUE',
+														uuid: LYTTELTON_THEATRE_VENUE_UUID,
+														name: 'Lyttelton Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sur-Fred',
+													startDate: '2010-03-01',
+													endDate: '2010-03-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_FRED_MATERIAL_UUID,
+													name: 'Sur-Fred',
+													format: 'collection of plays',
+													year: 2010,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											members: [],
+											coEntities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_FRED_LYTTELTON_PRODUCTION_UUID,
+													name: 'Sub-Fred',
+													startDate: '2010-02-01',
+													endDate: '2010-02-28',
+													venue: {
+														model: 'VENUE',
+														uuid: LYTTELTON_THEATRE_VENUE_UUID,
+														name: 'Lyttelton Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
+														name: 'Sur-Fred',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_FRED_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sub-Fred',
+													startDate: '2010-03-01',
+													endDate: '2010-03-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Sur-Fred',
+														surProduction: null
+													}
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_FRED_MATERIAL_UUID,
+													name: 'Sub-Fred',
+													format: 'play',
+													year: 2010,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_FRED_MATERIAL_UUID,
+														name: 'Sur-Fred',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards } = surPlaywrightsLtdCompany.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+
+		});
+
+	});
+
+	describe('Francis Flob Jr (person): subsequent versions (and their associated sur-material) of their work have nominations', () => {
+
+		it('includes awards of subsequent versions (and their associated sur-material) of their work', () => {
+
+			const expectedAwards = [];
+
+			const expectedSubsequentVersionMaterialAwards = [
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: true,
+											type: 'Winner',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+													name: 'Sur-Plugh',
+													startDate: '2009-07-01',
+													endDate: '2009-07-31',
+													venue: {
+														model: 'VENUE',
+														uuid: OLIVIER_THEATRE_VENUE_UUID,
+														name: 'Olivier Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+													name: 'Sur-Plugh',
+													startDate: '2009-08-01',
+													endDate: '2009-08-31',
+													venue: {
+														model: 'VENUE',
+														uuid: WYNDHAMS_THEATRE_VENUE_UUID,
+														name: 'Wyndham\'s Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [],
+											subsequentVersionMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+													name: 'Sur-Plugh',
+													format: 'collection of plays',
+													year: 2009,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_PLUGH_OLIVIER_PRODUCTION_UUID,
+													name: 'Sub-Plugh',
+													startDate: '2009-07-01',
+													endDate: '2009-07-31',
+													venue: {
+														model: 'VENUE',
+														uuid: OLIVIER_THEATRE_VENUE_UUID,
+														name: 'Olivier Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+														name: 'Sur-Plugh',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+													name: 'Sub-Plugh',
+													startDate: '2009-08-01',
+													endDate: '2009-08-31',
+													venue: {
+														model: 'VENUE',
+														uuid: WYNDHAMS_THEATRE_VENUE_UUID,
+														name: 'Wyndham\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+														name: 'Sur-Plugh',
+														surProduction: null
+													}
+												}
+											],
+											materials: [],
+											subsequentVersionMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+													name: 'Sub-Plugh',
+													format: 'play',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards, subsequentVersionMaterialAwards } = francisFlobJrPerson.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+			expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+		});
+
+	});
+
+	describe('Francis Flob Sr (person): subsequent versions (and their associated sub-materials) of their work have nominations', () => {
+
+		it('includes awards of subsequent versions (and their associated sub-materials) of their work', () => {
+
+			const expectedAwards = [];
+
+			const expectedSubsequentVersionMaterialAwards = [
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: true,
+											type: 'Winner',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+													name: 'Sur-Plugh',
+													startDate: '2009-07-01',
+													endDate: '2009-07-31',
+													venue: {
+														model: 'VENUE',
+														uuid: OLIVIER_THEATRE_VENUE_UUID,
+														name: 'Olivier Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+													name: 'Sur-Plugh',
+													startDate: '2009-08-01',
+													endDate: '2009-08-31',
+													venue: {
+														model: 'VENUE',
+														uuid: WYNDHAMS_THEATRE_VENUE_UUID,
+														name: 'Wyndham\'s Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [],
+											subsequentVersionMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+													name: 'Sur-Plugh',
+													format: 'collection of plays',
+													year: 2009,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_PLUGH_OLIVIER_PRODUCTION_UUID,
+													name: 'Sub-Plugh',
+													startDate: '2009-07-01',
+													endDate: '2009-07-31',
+													venue: {
+														model: 'VENUE',
+														uuid: OLIVIER_THEATRE_VENUE_UUID,
+														name: 'Olivier Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+														name: 'Sur-Plugh',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+													name: 'Sub-Plugh',
+													startDate: '2009-08-01',
+													endDate: '2009-08-31',
+													venue: {
+														model: 'VENUE',
+														uuid: WYNDHAMS_THEATRE_VENUE_UUID,
+														name: 'Wyndham\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+														name: 'Sur-Plugh',
+														surProduction: null
+													}
+												}
+											],
+											materials: [],
+											subsequentVersionMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+													name: 'Sub-Plugh',
+													format: 'play',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards, subsequentVersionMaterialAwards } = francisFlobSrPerson.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+			expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+		});
+
+	});
+
+	describe('Sub-Curtain Up Ltd (company): subsequent versions (and their associated sur-material) of their work have nominations', () => {
+
+		it('includes awards of subsequent versions (and their associated sur-material) of their work', () => {
+
+			const expectedAwards = [];
+
+			const expectedSubsequentVersionMaterialAwards = [
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: true,
+											type: 'Winner',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+													name: 'Sur-Plugh',
+													startDate: '2009-07-01',
+													endDate: '2009-07-31',
+													venue: {
+														model: 'VENUE',
+														uuid: OLIVIER_THEATRE_VENUE_UUID,
+														name: 'Olivier Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+													name: 'Sur-Plugh',
+													startDate: '2009-08-01',
+													endDate: '2009-08-31',
+													venue: {
+														model: 'VENUE',
+														uuid: WYNDHAMS_THEATRE_VENUE_UUID,
+														name: 'Wyndham\'s Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [],
+											subsequentVersionMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+													name: 'Sur-Plugh',
+													format: 'collection of plays',
+													year: 2009,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_PLUGH_OLIVIER_PRODUCTION_UUID,
+													name: 'Sub-Plugh',
+													startDate: '2009-07-01',
+													endDate: '2009-07-31',
+													venue: {
+														model: 'VENUE',
+														uuid: OLIVIER_THEATRE_VENUE_UUID,
+														name: 'Olivier Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+														name: 'Sur-Plugh',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+													name: 'Sub-Plugh',
+													startDate: '2009-08-01',
+													endDate: '2009-08-31',
+													venue: {
+														model: 'VENUE',
+														uuid: WYNDHAMS_THEATRE_VENUE_UUID,
+														name: 'Wyndham\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+														name: 'Sur-Plugh',
+														surProduction: null
+													}
+												}
+											],
+											materials: [],
+											subsequentVersionMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+													name: 'Sub-Plugh',
+													format: 'play',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards, subsequentVersionMaterialAwards } = subCurtainUpLtdCompany.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+			expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+		});
+
+	});
+
+	describe('Sur-Curtain Up Ltd (company): subsequent versions (and their associated sub-materials) of their work have nominations', () => {
+
+		it('includes awards of subsequent versions (and their associated sub-materials) of their work', () => {
+
+			const expectedAwards = [];
+
+			const expectedSubsequentVersionMaterialAwards = [
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: true,
+											type: 'Winner',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+													name: 'Sur-Plugh',
+													startDate: '2009-07-01',
+													endDate: '2009-07-31',
+													venue: {
+														model: 'VENUE',
+														uuid: OLIVIER_THEATRE_VENUE_UUID,
+														name: 'Olivier Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+													name: 'Sur-Plugh',
+													startDate: '2009-08-01',
+													endDate: '2009-08-31',
+													venue: {
+														model: 'VENUE',
+														uuid: WYNDHAMS_THEATRE_VENUE_UUID,
+														name: 'Wyndham\'s Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [],
+											subsequentVersionMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+													name: 'Sur-Plugh',
+													format: 'collection of plays',
+													year: 2009,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_PLUGH_OLIVIER_PRODUCTION_UUID,
+													name: 'Sub-Plugh',
+													startDate: '2009-07-01',
+													endDate: '2009-07-31',
+													venue: {
+														model: 'VENUE',
+														uuid: OLIVIER_THEATRE_VENUE_UUID,
+														name: 'Olivier Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+														name: 'Sur-Plugh',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+													name: 'Sub-Plugh',
+													startDate: '2009-08-01',
+													endDate: '2009-08-31',
+													venue: {
+														model: 'VENUE',
+														uuid: WYNDHAMS_THEATRE_VENUE_UUID,
+														name: 'Wyndham\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+														name: 'Sur-Plugh',
+														surProduction: null
+													}
+												}
+											],
+											materials: [],
+											subsequentVersionMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+													name: 'Sub-Plugh',
+													format: 'play',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards, subsequentVersionMaterialAwards } = surCurtainUpLtdCompany.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+			expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+		});
+
+	});
+
+	describe('Jane Roe Jr (person): materials (and their associated sur-material) that used their (specific) work as source material have nominations', () => {
+
+		it('includes awards of materials (and their associated sur-material) that used their (specific) work as source material', () => {
+
+			const expectedSourcingMaterialAwards = [
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sur-Wibble',
+													startDate: '2009-05-01',
+													endDate: '2009-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+													name: 'Sur-Wibble',
+													startDate: '2009-06-01',
+													endDate: '2009-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
+														name: 'Duke of York\'s Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [],
+											sourcingMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_WIBBLE_MATERIAL_UUID,
+													name: 'Sur-Wibble',
+													format: 'trilogy of plays',
+													year: 2009,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sub-Wibble',
+													startDate: '2009-05-01',
+													endDate: '2009-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+														name: 'Sur-Wibble',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+													name: 'Sub-Wibble',
+													startDate: '2009-06-01',
+													endDate: '2009-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
+														name: 'Duke of York\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+														name: 'Sur-Wibble',
+														surProduction: null
+													}
+												}
+											],
+											materials: [],
+											sourcingMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_WIBBLE_MATERIAL_UUID,
+													name: 'Sub-Wibble',
+													format: 'play',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { sourcingMaterialAwards } = janeRoeJrPerson.body;
+
+			expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+		});
+
+	});
+
+	describe('Jane Roe Sr (person): materials (and their associated sub-materials) that used their (specific) work as source material have nominations', () => {
+
+		it('includes awards of materials (and their associated sub-materials) that used their (specific) work as source material', () => {
+
+			const expectedSourcingMaterialAwards = [
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sur-Wibble',
+													startDate: '2009-05-01',
+													endDate: '2009-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+													name: 'Sur-Wibble',
+													startDate: '2009-06-01',
+													endDate: '2009-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
+														name: 'Duke of York\'s Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [],
+											sourcingMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_WIBBLE_MATERIAL_UUID,
+													name: 'Sur-Wibble',
+													format: 'trilogy of plays',
+													year: 2009,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sub-Wibble',
+													startDate: '2009-05-01',
+													endDate: '2009-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+														name: 'Sur-Wibble',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+													name: 'Sub-Wibble',
+													startDate: '2009-06-01',
+													endDate: '2009-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
+														name: 'Duke of York\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+														name: 'Sur-Wibble',
+														surProduction: null
+													}
+												}
+											],
+											materials: [],
+											sourcingMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_WIBBLE_MATERIAL_UUID,
+													name: 'Sub-Wibble',
+													format: 'play',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { sourcingMaterialAwards } = janeRoeSrPerson.body;
+
+			expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+		});
+
+	});
+
+	describe('Sub-Fictioneers Ltd (company): materials (and their associated sur-material) that used their (specific) work as source material have nominations', () => {
+
+		it('includes awards of materials (and their associated sur-material) that used their (specific) work as source material', () => {
+
+			const expectedSourcingMaterialAwards = [
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sur-Wibble',
+													startDate: '2009-05-01',
+													endDate: '2009-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+													name: 'Sur-Wibble',
+													startDate: '2009-06-01',
+													endDate: '2009-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
+														name: 'Duke of York\'s Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [],
+											sourcingMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_WIBBLE_MATERIAL_UUID,
+													name: 'Sur-Wibble',
+													format: 'trilogy of plays',
+													year: 2009,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sub-Wibble',
+													startDate: '2009-05-01',
+													endDate: '2009-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+														name: 'Sur-Wibble',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+													name: 'Sub-Wibble',
+													startDate: '2009-06-01',
+													endDate: '2009-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
+														name: 'Duke of York\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+														name: 'Sur-Wibble',
+														surProduction: null
+													}
+												}
+											],
+											materials: [],
+											sourcingMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_WIBBLE_MATERIAL_UUID,
+													name: 'Sub-Wibble',
+													format: 'play',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { sourcingMaterialAwards } = subFictioneersLtdCompany.body;
+
+			expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+		});
+
+	});
+
+	describe('Sur-Fictioneers Ltd (company): materials (and their associated sub-materials) that used their (specific) work as source material have nominations', () => {
+
+		it('includes awards of materials (and their associated sub-materials) that used their (specific) work as source material', () => {
+
+			const expectedSourcingMaterialAwards = [
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sur-Wibble',
+													startDate: '2009-05-01',
+													endDate: '2009-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+													name: 'Sur-Wibble',
+													startDate: '2009-06-01',
+													endDate: '2009-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
+														name: 'Duke of York\'s Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [],
+											sourcingMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_WIBBLE_MATERIAL_UUID,
+													name: 'Sur-Wibble',
+													format: 'trilogy of plays',
+													year: 2009,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sub-Wibble',
+													startDate: '2009-05-01',
+													endDate: '2009-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+														name: 'Sur-Wibble',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+													name: 'Sub-Wibble',
+													startDate: '2009-06-01',
+													endDate: '2009-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
+														name: 'Duke of York\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+														name: 'Sur-Wibble',
+														surProduction: null
+													}
+												}
+											],
+											materials: [],
+											sourcingMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_WIBBLE_MATERIAL_UUID,
+													name: 'Sub-Wibble',
+													format: 'play',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { sourcingMaterialAwards } = surFictioneersLtdCompany.body;
+
+			expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+		});
+
+	});
+
+	describe('Talyse Tata Jr (person): materials (and their associated sur-material) to which they have granted rights have nominations', () => {
+
+		it('includes awards of materials (and their associated sur-material) to which they have granted rights', () => {
+
+			const expectedAwards = [];
+
+			const expectedRightsGrantorMaterialAwards = [
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+													name: 'Sur-Hoge',
+													startDate: '2008-05-01',
+													endDate: '2008-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_DOWNSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Downstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sur-Hoge',
+													startDate: '2008-06-01',
+													endDate: '2008-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [],
+											rightsGrantorMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_HOGE_MATERIAL_UUID,
+													name: 'Sur-Hoge',
+													format: 'collection of plays',
+													year: 2008,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: true,
+											type: 'Winner',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+													name: 'Sub-Hoge',
+													startDate: '2008-05-01',
+													endDate: '2008-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_DOWNSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Downstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+														name: 'Sur-Hoge',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sub-Hoge',
+													startDate: '2008-06-01',
+													endDate: '2008-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Sur-Hoge',
+														surProduction: null
+													}
+												}
+											],
+											materials: [],
+											rightsGrantorMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_HOGE_MATERIAL_UUID,
+													name: 'Sub-Hoge',
+													format: 'play',
+													year: 2008,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_HOGE_MATERIAL_UUID,
+														name: 'Sur-Hoge',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards, rightsGrantorMaterialAwards } = talyseTataJrPerson.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+			expect(rightsGrantorMaterialAwards).to.deep.equal(expectedRightsGrantorMaterialAwards);
+
+		});
+
+	});
+
+	describe('Talyse Tata Sr (person): materials (and their associated sub-materials) to which they have granted rights have nominations', () => {
+
+		it('includes awards of materials (and their associated sub-materials) to which they have granted rights', () => {
+
+			const expectedAwards = [];
+
+			const expectedRightsGrantorMaterialAwards = [
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+													name: 'Sur-Hoge',
+													startDate: '2008-05-01',
+													endDate: '2008-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_DOWNSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Downstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sur-Hoge',
+													startDate: '2008-06-01',
+													endDate: '2008-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [],
+											rightsGrantorMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_HOGE_MATERIAL_UUID,
+													name: 'Sur-Hoge',
+													format: 'collection of plays',
+													year: 2008,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: true,
+											type: 'Winner',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+													name: 'Sub-Hoge',
+													startDate: '2008-05-01',
+													endDate: '2008-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_DOWNSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Downstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+														name: 'Sur-Hoge',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sub-Hoge',
+													startDate: '2008-06-01',
+													endDate: '2008-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Sur-Hoge',
+														surProduction: null
+													}
+												}
+											],
+											materials: [],
+											rightsGrantorMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_HOGE_MATERIAL_UUID,
+													name: 'Sub-Hoge',
+													format: 'play',
+													year: 2008,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_HOGE_MATERIAL_UUID,
+														name: 'Sur-Hoge',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards, rightsGrantorMaterialAwards } = talyseTataSrPerson.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+			expect(rightsGrantorMaterialAwards).to.deep.equal(expectedRightsGrantorMaterialAwards);
+
+		});
+
+	});
+
+	describe('Sub-Cinerights Ltd (company): materials (and their associated sur-material) to which they granted rights have nominations', () => {
+
+		it('includes awards of materials (and their associated sur-material) to which they granted rights', () => {
+
+			const expectedAwards = [];
+
+			const expectedRightsGrantorMaterialAwards = [
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+													name: 'Sur-Hoge',
+													startDate: '2008-05-01',
+													endDate: '2008-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_DOWNSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Downstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sur-Hoge',
+													startDate: '2008-06-01',
+													endDate: '2008-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [],
+											rightsGrantorMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_HOGE_MATERIAL_UUID,
+													name: 'Sur-Hoge',
+													format: 'collection of plays',
+													year: 2008,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: true,
+											type: 'Winner',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+													name: 'Sub-Hoge',
+													startDate: '2008-05-01',
+													endDate: '2008-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_DOWNSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Downstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+														name: 'Sur-Hoge',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sub-Hoge',
+													startDate: '2008-06-01',
+													endDate: '2008-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Sur-Hoge',
+														surProduction: null
+													}
+												}
+											],
+											materials: [],
+											rightsGrantorMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_HOGE_MATERIAL_UUID,
+													name: 'Sub-Hoge',
+													format: 'play',
+													year: 2008,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_HOGE_MATERIAL_UUID,
+														name: 'Sur-Hoge',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards, rightsGrantorMaterialAwards } = subCinerightsLtdCompany.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+			expect(rightsGrantorMaterialAwards).to.deep.equal(expectedRightsGrantorMaterialAwards);
+
+		});
+
+	});
+
+	describe('Sur-Cinerights Ltd (company): materials (and their associated sub-materials) to which they granted rights have nominations', () => {
+
+		it('includes awards of materials (and their associated sub-materials) to which they granted rights', () => {
+
+			const expectedAwards = [];
+
+			const expectedRightsGrantorMaterialAwards = [
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+													name: 'Sur-Hoge',
+													startDate: '2008-05-01',
+													endDate: '2008-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_DOWNSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Downstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sur-Hoge',
+													startDate: '2008-06-01',
+													endDate: '2008-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [],
+											rightsGrantorMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_HOGE_MATERIAL_UUID,
+													name: 'Sur-Hoge',
+													format: 'collection of plays',
+													year: 2008,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: true,
+											type: 'Winner',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+													name: 'Sub-Hoge',
+													startDate: '2008-05-01',
+													endDate: '2008-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_DOWNSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Downstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+														name: 'Sur-Hoge',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sub-Hoge',
+													startDate: '2008-06-01',
+													endDate: '2008-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Sur-Hoge',
+														surProduction: null
+													}
+												}
+											],
+											materials: [],
+											rightsGrantorMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_HOGE_MATERIAL_UUID,
+													name: 'Sub-Hoge',
+													format: 'play',
+													year: 2008,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_HOGE_MATERIAL_UUID,
+														name: 'Sur-Hoge',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards, rightsGrantorMaterialAwards } = surCinerightsLtdCompany.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+			expect(rightsGrantorMaterialAwards).to.deep.equal(expectedRightsGrantorMaterialAwards);
+
+		});
+
+	});
+
+});

--- a/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-sub-materials-via-assocs.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-sub-materials-via-assocs.test.js
@@ -1,0 +1,7889 @@
+import crypto from 'crypto';
+
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import { createSandbox } from 'sinon';
+
+import app from '../../src/app';
+import purgeDatabase from '../test-helpers/neo4j/purge-database';
+
+describe('Award ceremonies with crediting sub-sub-materials (with person/company nominations gained through associations to sur-sur and sub-sub-materials)', () => {
+
+	chai.use(chaiHttp);
+
+	const SUB_FRED_MATERIAL_UUID = '4';
+	const JOHN_DOE_JR_PERSON_UUID = '6';
+	const SUB_PLAYWRIGHTS_LTD_COMPANY_UUID = '7';
+	const MID_FRED_MATERIAL_UUID = '13';
+	const JOHN_DOE_PERSON_UUID = '6';
+	const MID_PLAYWRIGHTS_LTD_COMPANY_UUID = '7';
+	const SUR_FRED_MATERIAL_UUID = '23';
+	const JOHN_DOE_SR_PERSON_UUID = '6';
+	const SUR_PLAYWRIGHTS_LTD_COMPANY_UUID = '7';
+	const FRANCIS_FLOB_JR_PERSON_UUID = '34';
+	const SUB_CURTAIN_UP_LTD_COMPANY_UUID = '35';
+	const FRANCIS_FLOB_PERSON_UUID = '34';
+	const MID_CURTAIN_UP_LTD_COMPANY_UUID = '35';
+	const FRANCIS_FLOB_SR_PERSON_UUID = '34';
+	const SUR_CURTAIN_UP_LTD_COMPANY_UUID = '35';
+	const SUB_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID = '62';
+	const MID_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID = '75';
+	const SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID = '89';
+	const JANE_ROE_JR_PERSON_UUID = '102';
+	const SUB_FICTIONEERS_LTD_COMPANY_UUID = '103';
+	const JANE_ROE_PERSON_UUID = '102';
+	const MID_FICTIONEERS_LTD_COMPANY_UUID = '103';
+	const JANE_ROE_SR_PERSON_UUID = '102';
+	const SUR_FICTIONEERS_LTD_COMPANY_UUID = '103';
+	const SUB_WIBBLE_MATERIAL_UUID = '129';
+	const MID_WIBBLE_MATERIAL_UUID = '140';
+	const SUR_WIBBLE_MATERIAL_UUID = '152';
+	const SUB_HOGE_MATERIAL_UUID = '164';
+	const SUB_CINERIGHTS_LTD_COMPANY_UUID = '168';
+	const TALYSE_TATA_JR_PERSON_UUID = '169';
+	const MID_HOGE_MATERIAL_UUID = '177';
+	const MID_CINERIGHTS_LTD_COMPANY_UUID = '168';
+	const TALYSE_TATA_PERSON_UUID = '169';
+	const SUR_HOGE_MATERIAL_UUID = '191';
+	const SUR_CINERIGHTS_LTD_COMPANY_UUID = '168';
+	const TALYSE_TATA_SR_PERSON_UUID = '169';
+	const NATIONAL_THEATRE_VENUE_UUID = '201';
+	const OLIVIER_THEATRE_VENUE_UUID = '202';
+	const LYTTELTON_THEATRE_VENUE_UUID = '203';
+	const ROYAL_COURT_THEATRE_VENUE_UUID = '207';
+	const JERWOOD_THEATRE_DOWNSTAIRS_VENUE_UUID = '208';
+	const JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID = '209';
+	const SUB_FRED_LYTTELTON_PRODUCTION_UUID = '210';
+	const MID_FRED_LYTTELTON_PRODUCTION_UUID = '213';
+	const SUR_FRED_LYTTELTON_PRODUCTION_UUID = '216';
+	const SUB_FRED_NOËL_COWARD_PRODUCTION_UUID = '219';
+	const NOËL_COWARD_THEATRE_VENUE_UUID = '221';
+	const MID_FRED_NOËL_COWARD_PRODUCTION_UUID = '222';
+	const SUR_FRED_NOËL_COWARD_PRODUCTION_UUID = '225';
+	const SUB_PLUGH_OLIVIER_PRODUCTION_UUID = '228';
+	const MID_PLUGH_OLIVIER_PRODUCTION_UUID = '231';
+	const SUR_PLUGH_OLIVIER_PRODUCTION_UUID = '234';
+	const SUB_PLUGH_WYNDHAMS_PRODUCTION_UUID = '237';
+	const WYNDHAMS_THEATRE_VENUE_UUID = '239';
+	const MID_PLUGH_WYNDHAMS_PRODUCTION_UUID = '240';
+	const SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID = '243';
+	const SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID = '246';
+	const MID_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID = '249';
+	const SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID = '252';
+	const SUB_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID = '255';
+	const DUKE_OF_YORKS_THEATRE_VENUE_UUID = '257';
+	const MID_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID = '258';
+	const SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID = '261';
+	const SUB_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID = '264';
+	const MID_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID = '267';
+	const SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID = '270';
+	const SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID = '273';
+	const MID_HOGE_NOËL_COWARD_PRODUCTION_UUID = '276';
+	const SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID = '279';
+	const WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID = '288';
+	const WORDSMITH_AWARD_UUID = '289';
+	const PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID = '300';
+	const PLAYWRITING_PRIZE_AWARD_UUID = '301';
+	const DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID = '312';
+	const DRAMATISTS_MEDAL_AWARD_UUID = '313';
+
+	let johnDoeJrPerson;
+	let johnDoePerson;
+	let johnDoeSrPerson;
+	let subPlaywrightsLtdCompany;
+	let midPlaywrightsLtdCompany;
+	let surPlaywrightsLtdCompany;
+	let francisFlobJrPerson;
+	let francisFlobPerson;
+	let francisFlobSrPerson;
+	let subCurtainUpLtdCompany;
+	let midCurtainUpLtdCompany;
+	let surCurtainUpLtdCompany;
+	let janeRoeJrPerson;
+	let janeRoePerson;
+	let janeRoeSrPerson;
+	let subFictioneersLtdCompany;
+	let midFictioneersLtdCompany;
+	let surFictioneersLtdCompany;
+	let talyseTataJrPerson;
+	let talyseTataPerson;
+	let talyseTataSrPerson;
+	let subCinerightsLtdCompany;
+	let midCinerightsLtdCompany;
+	let surCinerightsLtdCompany;
+
+	const sandbox = createSandbox();
+
+	before(async () => {
+
+		let uuidCallCount = 0;
+
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
+
+		await purgeDatabase();
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sub-Fred',
+				format: 'play',
+				year: '2010',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'John Doe Jr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sub-Playwrights Ltd'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Mid-Fred',
+				format: 'sub-collection of plays',
+				year: '2010',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'John Doe'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Mid-Playwrights Ltd'
+							}
+						]
+					}
+				],
+				subMaterials: [
+					{
+						name: 'Sub-Fred'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sur-Fred',
+				format: 'collection of plays',
+				year: '2010',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'John Doe Sr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sur-Playwrights Ltd'
+							}
+						]
+					}
+				],
+				subMaterials: [
+					{
+						name: 'Mid-Fred'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sub-Plugh',
+				differentiator: '1',
+				format: 'play',
+				year: '1899',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Francis Flob Jr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sub-Curtain Up Ltd'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Mid-Plugh',
+				differentiator: '1',
+				format: 'sub-collection of plays',
+				year: '1899',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Francis Flob'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Mid-Curtain Up Ltd'
+							}
+						]
+					}
+				],
+				subMaterials: [
+					{
+						name: 'Sub-Plugh',
+						differentiator: '1'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sur-Plugh',
+				differentiator: '1',
+				format: 'collection of plays',
+				year: '1899',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Francis Flob Sr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sur-Curtain Up Ltd'
+							}
+						]
+					}
+				],
+				subMaterials: [
+					{
+						name: 'Mid-Plugh',
+						differentiator: '1'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sub-Plugh',
+				differentiator: '2',
+				format: 'play',
+				year: '2009',
+				originalVersionMaterial: {
+					name: 'Sub-Plugh',
+					differentiator: '1'
+				},
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Francis Flob Jr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sub-Curtain Up Ltd'
+							}
+						]
+					},
+					{
+						name: 'version by',
+						entities: [
+							{
+								name: 'Beatrice Bar Jr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sub-Stagecraft Ltd'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Mid-Plugh',
+				differentiator: '2',
+				format: 'sub-collection of plays',
+				year: '2009',
+				originalVersionMaterial: {
+					name: 'Mid-Plugh',
+					differentiator: '1'
+				},
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Francis Flob'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Mid-Curtain Up Ltd'
+							}
+						]
+					},
+					{
+						name: 'version by',
+						entities: [
+							{
+								name: 'Beatrice Bar'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Mid-Stagecraft Ltd'
+							}
+						]
+					}
+				],
+				subMaterials: [
+					{
+						name: 'Sub-Plugh',
+						differentiator: '2'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sur-Plugh',
+				differentiator: '2',
+				format: 'collection of plays',
+				year: '2009',
+				originalVersionMaterial: {
+					name: 'Sur-Plugh',
+					differentiator: '1'
+				},
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Francis Flob Sr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sur-Curtain Up Ltd'
+							}
+						]
+					},
+					{
+						name: 'version by',
+						entities: [
+							{
+								name: 'Beatrice Bar Sr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sur-Stagecraft Ltd'
+							}
+						]
+					}
+				],
+				subMaterials: [
+					{
+						name: 'Mid-Plugh',
+						differentiator: '2'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sub-Waldo',
+				format: 'novel',
+				year: '1974',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Jane Roe Jr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sub-Fictioneers Ltd'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Mid-Waldo',
+				format: 'sub-trilogy of novels',
+				year: '1974',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Jane Roe'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Mid-Fictioneers Ltd'
+							}
+						]
+					}
+				],
+				subMaterials: [
+					{
+						name: 'Sub-Waldo'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sur-Waldo',
+				format: 'trilogy of trilogies of novels',
+				year: '1974',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Jane Roe Sr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sur-Fictioneers Ltd'
+							}
+						]
+					}
+				],
+				subMaterials: [
+					{
+						name: 'Mid-Waldo'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sub-Wibble',
+				format: 'play',
+				year: '2009',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Quincy Qux Jr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sub-Theatricals Ltd'
+							}
+						]
+					},
+					{
+						name: 'based on',
+						entities: [
+							{
+								model: 'MATERIAL',
+								name: 'Sub-Waldo'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Mid-Wibble',
+				format: 'sub-trilogy of plays',
+				year: '2009',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Quincy Qux'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Mid-Theatricals Ltd'
+							}
+						]
+					},
+					{
+						name: 'based on',
+						entities: [
+							{
+								model: 'MATERIAL',
+								name: 'Mid-Waldo'
+							}
+						]
+					}
+				],
+				subMaterials: [
+					{
+						name: 'Sub-Wibble'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sur-Wibble',
+				format: 'trilogy of trilogies of plays',
+				year: '2009',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Quincy Qux Sr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sur-Theatricals Ltd'
+							}
+						]
+					},
+					{
+						name: 'based on',
+						entities: [
+							{
+								model: 'MATERIAL',
+								name: 'Sur-Waldo'
+							}
+						]
+					}
+				],
+				subMaterials: [
+					{
+						name: 'Mid-Wibble'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sub-Hoge',
+				format: 'play',
+				year: '2008',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Beatrice Bar Jr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sub-Theatricals Ltd'
+							}
+						]
+					},
+					{
+						name: 'by arrangement with',
+						creditType: 'RIGHTS_GRANTOR',
+						entities: [
+							{
+								model: 'COMPANY',
+								name: 'Sub-Cinerights Ltd'
+							},
+							{
+								name: 'Talyse Tata Jr'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Mid-Hoge',
+				format: 'sub-collection of plays',
+				year: '2008',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Beatrice Bar'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Mid-Theatricals Ltd'
+							}
+						]
+					},
+					{
+						name: 'by arrangement with',
+						creditType: 'RIGHTS_GRANTOR',
+						entities: [
+							{
+								model: 'COMPANY',
+								name: 'Mid-Cinerights Ltd'
+							},
+							{
+								name: 'Talyse Tata'
+							}
+						]
+					}
+				],
+				subMaterials: [
+					{
+						name: 'Sub-Hoge'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sur-Hoge',
+				format: 'collection of plays',
+				year: '2008',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Beatrice Bar Sr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sur-Theatricals Ltd'
+							}
+						]
+					},
+					{
+						name: 'by arrangement with',
+						creditType: 'RIGHTS_GRANTOR',
+						entities: [
+							{
+								model: 'COMPANY',
+								name: 'Sur-Cinerights Ltd'
+							},
+							{
+								name: 'Talyse Tata Sr'
+							}
+						]
+					}
+				],
+				subMaterials: [
+					{
+						name: 'Mid-Hoge'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/venues')
+			.send({
+				name: 'National Theatre',
+				subVenues: [
+					{
+						name: 'Olivier Theatre'
+					},
+					{
+						name: 'Lyttelton Theatre'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/venues')
+			.send({
+				name: 'Royal Court Theatre',
+				subVenues: [
+					{
+						name: 'Jerwood Theatre Downstairs'
+					},
+					{
+						name: 'Jerwood Theatre Upstairs'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sub-Fred',
+				startDate: '2010-02-01',
+				endDate: '2010-02-28',
+				venue: {
+					name: 'Lyttelton Theatre'
+				}
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Mid-Fred',
+				startDate: '2010-02-01',
+				endDate: '2010-02-28',
+				venue: {
+					name: 'Lyttelton Theatre'
+				},
+				subProductions: [
+					{
+						uuid: SUB_FRED_LYTTELTON_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sur-Fred',
+				startDate: '2010-02-01',
+				endDate: '2010-02-28',
+				venue: {
+					name: 'Lyttelton Theatre'
+				},
+				subProductions: [
+					{
+						uuid: MID_FRED_LYTTELTON_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sub-Fred',
+				startDate: '2010-03-01',
+				endDate: '2010-03-31',
+				venue: {
+					name: 'Noël Coward Theatre'
+				}
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Mid-Fred',
+				startDate: '2010-03-01',
+				endDate: '2010-03-31',
+				venue: {
+					name: 'Noël Coward Theatre'
+				},
+				subProductions: [
+					{
+						uuid: SUB_FRED_NOËL_COWARD_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sur-Fred',
+				startDate: '2010-03-01',
+				endDate: '2010-03-31',
+				venue: {
+					name: 'Noël Coward Theatre'
+				},
+				subProductions: [
+					{
+						uuid: MID_FRED_NOËL_COWARD_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sub-Plugh',
+				startDate: '2009-07-01',
+				endDate: '2009-07-31',
+				venue: {
+					name: 'Olivier Theatre'
+				}
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Mid-Plugh',
+				startDate: '2009-07-01',
+				endDate: '2009-07-31',
+				venue: {
+					name: 'Olivier Theatre'
+				},
+				subProductions: [
+					{
+						uuid: SUB_PLUGH_OLIVIER_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sur-Plugh',
+				startDate: '2009-07-01',
+				endDate: '2009-07-31',
+				venue: {
+					name: 'Olivier Theatre'
+				},
+				subProductions: [
+					{
+						uuid: MID_PLUGH_OLIVIER_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sub-Plugh',
+				startDate: '2009-08-01',
+				endDate: '2009-08-31',
+				venue: {
+					name: 'Wyndham\'s Theatre'
+				}
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Mid-Plugh',
+				startDate: '2009-08-01',
+				endDate: '2009-08-31',
+				venue: {
+					name: 'Wyndham\'s Theatre'
+				},
+				subProductions: [
+					{
+						uuid: SUB_PLUGH_WYNDHAMS_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sur-Plugh',
+				startDate: '2009-08-01',
+				endDate: '2009-08-31',
+				venue: {
+					name: 'Wyndham\'s Theatre'
+				},
+				subProductions: [
+					{
+						uuid: MID_PLUGH_WYNDHAMS_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sub-Wibble',
+				startDate: '2009-05-01',
+				endDate: '2009-05-31',
+				venue: {
+					name: 'Jerwood Theatre Upstairs'
+				}
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Mid-Wibble',
+				startDate: '2009-05-01',
+				endDate: '2009-05-31',
+				venue: {
+					name: 'Jerwood Theatre Upstairs'
+				},
+				subProductions: [
+					{
+						uuid: SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sur-Wibble',
+				startDate: '2009-05-01',
+				endDate: '2009-05-31',
+				venue: {
+					name: 'Jerwood Theatre Upstairs'
+				},
+				subProductions: [
+					{
+						uuid: MID_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sub-Wibble',
+				startDate: '2009-06-01',
+				endDate: '2009-06-30',
+				venue: {
+					name: 'Duke of York\'s Theatre'
+				}
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Mid-Wibble',
+				startDate: '2009-06-01',
+				endDate: '2009-06-30',
+				venue: {
+					name: 'Duke of York\'s Theatre'
+				},
+				subProductions: [
+					{
+						uuid: SUB_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sur-Wibble',
+				startDate: '2009-06-01',
+				endDate: '2009-06-30',
+				venue: {
+					name: 'Duke of York\'s Theatre'
+				},
+				subProductions: [
+					{
+						uuid: MID_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sub-Hoge',
+				startDate: '2008-05-01',
+				endDate: '2008-05-31',
+				venue: {
+					name: 'Jerwood Theatre Downstairs'
+				}
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Mid-Hoge',
+				startDate: '2008-05-01',
+				endDate: '2008-05-31',
+				venue: {
+					name: 'Jerwood Theatre Downstairs'
+				},
+				subProductions: [
+					{
+						uuid: SUB_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sur-Hoge',
+				startDate: '2008-05-01',
+				endDate: '2008-05-31',
+				venue: {
+					name: 'Jerwood Theatre Downstairs'
+				},
+				subProductions: [
+					{
+						uuid: MID_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sub-Hoge',
+				startDate: '2008-06-01',
+				endDate: '2008-06-30',
+				venue: {
+					name: 'Noël Coward Theatre'
+				}
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Mid-Hoge',
+				startDate: '2008-06-01',
+				endDate: '2008-06-30',
+				venue: {
+					name: 'Noël Coward Theatre'
+				},
+				subProductions: [
+					{
+						uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Sur-Hoge',
+				startDate: '2008-06-01',
+				endDate: '2008-06-30',
+				venue: {
+					name: 'Noël Coward Theatre'
+				},
+				subProductions: [
+					{
+						uuid: MID_HOGE_NOËL_COWARD_PRODUCTION_UUID
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/award-ceremonies')
+			.send({
+				name: '2010',
+				award: {
+					name: 'Wordsmith Award'
+				},
+				categories: [
+					{
+						name: 'Best Miscellaneous Play',
+						nominations: [
+							{
+								productions: [
+									{
+										uuid: SUB_FRED_LYTTELTON_PRODUCTION_UUID
+									},
+									{
+										uuid: SUB_FRED_NOËL_COWARD_PRODUCTION_UUID
+									}
+								],
+								materials: [
+									{
+										name: 'Sub-Fred'
+									}
+								]
+							},
+							{
+								productions: [
+									{
+										uuid: SUB_PLUGH_OLIVIER_PRODUCTION_UUID
+									},
+									{
+										uuid: SUB_PLUGH_WYNDHAMS_PRODUCTION_UUID
+									}
+								],
+								materials: [
+									{
+										name: 'Sub-Plugh',
+										differentiator: '2'
+									}
+								]
+							},
+							{
+								productions: [
+									{
+										uuid: SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID
+									},
+									{
+										uuid: SUB_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID
+									}
+								],
+								materials: [
+									{
+										name: 'Sub-Wibble'
+									}
+								]
+							},
+							{
+								isWinner: true,
+								productions: [
+									{
+										uuid: SUB_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID
+									},
+									{
+										uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID
+									}
+								],
+								materials: [
+									{
+										name: 'Sub-Hoge'
+									}
+								]
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/award-ceremonies')
+			.send({
+				name: '2009',
+				award: {
+					name: 'Playwriting Prize'
+				},
+				categories: [
+					{
+						name: 'Best Random Play',
+						nominations: [
+							{
+								productions: [
+									{
+										uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID
+									},
+									{
+										uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID
+									}
+								],
+								materials: [
+									{
+										name: 'Sur-Fred'
+									}
+								]
+							},
+							{
+								isWinner: true,
+								productions: [
+									{
+										uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID
+									},
+									{
+										uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID
+									}
+								],
+								materials: [
+									{
+										name: 'Sur-Plugh',
+										differentiator: '2'
+									}
+								]
+							},
+							{
+								productions: [
+									{
+										uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID
+									},
+									{
+										uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID
+									}
+								],
+								materials: [
+									{
+										name: 'Sur-Wibble'
+									}
+								]
+							},
+							{
+								productions: [
+									{
+										uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID
+									},
+									{
+										uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID
+									}
+								],
+								materials: [
+									{
+										name: 'Sur-Hoge'
+									}
+								]
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/award-ceremonies')
+			.send({
+				name: '2008',
+				award: {
+					name: 'Dramatists Medal'
+				},
+				categories: [
+					{
+						name: 'Most Remarkable Play',
+						nominations: [
+							{
+								productions: [
+									{
+										uuid: MID_FRED_LYTTELTON_PRODUCTION_UUID
+									},
+									{
+										uuid: MID_FRED_NOËL_COWARD_PRODUCTION_UUID
+									}
+								],
+								materials: [
+									{
+										name: 'Mid-Fred'
+									}
+								]
+							},
+							{
+								productions: [
+									{
+										uuid: MID_PLUGH_OLIVIER_PRODUCTION_UUID
+									},
+									{
+										uuid: MID_PLUGH_WYNDHAMS_PRODUCTION_UUID
+									}
+								],
+								materials: [
+									{
+										name: 'Mid-Plugh',
+										differentiator: '2'
+									}
+								]
+							},
+							{
+								isWinner: true,
+								productions: [
+									{
+										uuid: MID_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID
+									},
+									{
+										uuid: MID_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID
+									}
+								],
+								materials: [
+									{
+										name: 'Mid-Wibble'
+									}
+								]
+							},
+							{
+								productions: [
+									{
+										uuid: MID_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID
+									},
+									{
+										uuid: MID_HOGE_NOËL_COWARD_PRODUCTION_UUID
+									}
+								],
+								materials: [
+									{
+										name: 'Mid-Hoge'
+									}
+								]
+							}
+						]
+					}
+				]
+			});
+
+		johnDoeJrPerson = await chai.request(app)
+			.get(`/people/${JOHN_DOE_JR_PERSON_UUID}`);
+
+		johnDoePerson = await chai.request(app)
+			.get(`/people/${JOHN_DOE_PERSON_UUID}`);
+
+		johnDoeSrPerson = await chai.request(app)
+			.get(`/people/${JOHN_DOE_SR_PERSON_UUID}`);
+
+		subPlaywrightsLtdCompany = await chai.request(app)
+			.get(`/companies/${SUB_PLAYWRIGHTS_LTD_COMPANY_UUID}`);
+
+		midPlaywrightsLtdCompany = await chai.request(app)
+			.get(`/companies/${MID_PLAYWRIGHTS_LTD_COMPANY_UUID}`);
+
+		surPlaywrightsLtdCompany = await chai.request(app)
+			.get(`/companies/${SUR_PLAYWRIGHTS_LTD_COMPANY_UUID}`);
+
+		francisFlobJrPerson = await chai.request(app)
+			.get(`/people/${FRANCIS_FLOB_JR_PERSON_UUID}`);
+
+		francisFlobPerson = await chai.request(app)
+			.get(`/people/${FRANCIS_FLOB_PERSON_UUID}`);
+
+		francisFlobSrPerson = await chai.request(app)
+			.get(`/people/${FRANCIS_FLOB_SR_PERSON_UUID}`);
+
+		subCurtainUpLtdCompany = await chai.request(app)
+			.get(`/companies/${SUB_CURTAIN_UP_LTD_COMPANY_UUID}`);
+
+		midCurtainUpLtdCompany = await chai.request(app)
+			.get(`/companies/${MID_CURTAIN_UP_LTD_COMPANY_UUID}`);
+
+		surCurtainUpLtdCompany = await chai.request(app)
+			.get(`/companies/${SUR_CURTAIN_UP_LTD_COMPANY_UUID}`);
+
+		janeRoeJrPerson = await chai.request(app)
+			.get(`/people/${JANE_ROE_JR_PERSON_UUID}`);
+
+		janeRoePerson = await chai.request(app)
+			.get(`/people/${JANE_ROE_PERSON_UUID}`);
+
+		janeRoeSrPerson = await chai.request(app)
+			.get(`/people/${JANE_ROE_SR_PERSON_UUID}`);
+
+		subFictioneersLtdCompany = await chai.request(app)
+			.get(`/companies/${SUB_FICTIONEERS_LTD_COMPANY_UUID}`);
+
+		midFictioneersLtdCompany = await chai.request(app)
+			.get(`/companies/${MID_FICTIONEERS_LTD_COMPANY_UUID}`);
+
+		surFictioneersLtdCompany = await chai.request(app)
+			.get(`/companies/${SUR_FICTIONEERS_LTD_COMPANY_UUID}`);
+
+		talyseTataJrPerson = await chai.request(app)
+			.get(`/people/${TALYSE_TATA_JR_PERSON_UUID}`);
+
+		talyseTataPerson = await chai.request(app)
+			.get(`/people/${TALYSE_TATA_PERSON_UUID}`);
+
+		talyseTataSrPerson = await chai.request(app)
+			.get(`/people/${TALYSE_TATA_SR_PERSON_UUID}`);
+
+		subCinerightsLtdCompany = await chai.request(app)
+			.get(`/companies/${SUB_CINERIGHTS_LTD_COMPANY_UUID}`);
+
+		midCinerightsLtdCompany = await chai.request(app)
+			.get(`/companies/${MID_CINERIGHTS_LTD_COMPANY_UUID}`);
+
+		surCinerightsLtdCompany = await chai.request(app)
+			.get(`/companies/${SUR_CINERIGHTS_LTD_COMPANY_UUID}`);
+
+	});
+
+	after(() => {
+
+		sandbox.restore();
+
+	});
+
+	describe('John Doe Jr (person): credit for directly nominated material and their associated sur-material and sur-sur-material', () => {
+
+		it('includes their award nominations', () => {
+
+			const expectedAwards = [
+				{
+					model: 'AWARD',
+					uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+					name: 'Dramatists Medal',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+							name: '2008',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Most Remarkable Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											employerCompany: null,
+											coEntities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: MID_FRED_LYTTELTON_PRODUCTION_UUID,
+													name: 'Mid-Fred',
+													startDate: '2010-02-01',
+													endDate: '2010-02-28',
+													venue: {
+														model: 'VENUE',
+														uuid: LYTTELTON_THEATRE_VENUE_UUID,
+														name: 'Lyttelton Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
+														name: 'Sur-Fred',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: MID_FRED_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Mid-Fred',
+													startDate: '2010-03-01',
+													endDate: '2010-03-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Sur-Fred',
+														surProduction: null
+													}
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: MID_FRED_MATERIAL_UUID,
+													name: 'Mid-Fred',
+													format: 'sub-collection of plays',
+													year: 2010,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_FRED_MATERIAL_UUID,
+														name: 'Sur-Fred',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											employerCompany: null,
+											coEntities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
+													name: 'Sur-Fred',
+													startDate: '2010-02-01',
+													endDate: '2010-02-28',
+													venue: {
+														model: 'VENUE',
+														uuid: LYTTELTON_THEATRE_VENUE_UUID,
+														name: 'Lyttelton Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sur-Fred',
+													startDate: '2010-03-01',
+													endDate: '2010-03-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_FRED_MATERIAL_UUID,
+													name: 'Sur-Fred',
+													format: 'collection of plays',
+													year: 2010,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											employerCompany: null,
+											coEntities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_FRED_LYTTELTON_PRODUCTION_UUID,
+													name: 'Sub-Fred',
+													startDate: '2010-02-01',
+													endDate: '2010-02-28',
+													venue: {
+														model: 'VENUE',
+														uuid: LYTTELTON_THEATRE_VENUE_UUID,
+														name: 'Lyttelton Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_FRED_LYTTELTON_PRODUCTION_UUID,
+														name: 'Mid-Fred',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
+															name: 'Sur-Fred'
+														}
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_FRED_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sub-Fred',
+													startDate: '2010-03-01',
+													endDate: '2010-03-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_FRED_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Mid-Fred',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
+															name: 'Sur-Fred'
+														}
+													}
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_FRED_MATERIAL_UUID,
+													name: 'Sub-Fred',
+													format: 'play',
+													year: 2010,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: MID_FRED_MATERIAL_UUID,
+														name: 'Mid-Fred',
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_FRED_MATERIAL_UUID,
+															name: 'Sur-Fred'
+														}
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards } = johnDoeJrPerson.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+
+		});
+
+	});
+
+	describe('John Doe (person): credit for directly nominated material and their associated sur-material and sub-materials', () => {
+
+		it('includes their award nominations', () => {
+
+			const expectedAwards = [
+				{
+					model: 'AWARD',
+					uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+					name: 'Dramatists Medal',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+							name: '2008',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Most Remarkable Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											employerCompany: null,
+											coEntities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: MID_FRED_LYTTELTON_PRODUCTION_UUID,
+													name: 'Mid-Fred',
+													startDate: '2010-02-01',
+													endDate: '2010-02-28',
+													venue: {
+														model: 'VENUE',
+														uuid: LYTTELTON_THEATRE_VENUE_UUID,
+														name: 'Lyttelton Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
+														name: 'Sur-Fred',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: MID_FRED_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Mid-Fred',
+													startDate: '2010-03-01',
+													endDate: '2010-03-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Sur-Fred',
+														surProduction: null
+													}
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: MID_FRED_MATERIAL_UUID,
+													name: 'Mid-Fred',
+													format: 'sub-collection of plays',
+													year: 2010,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_FRED_MATERIAL_UUID,
+														name: 'Sur-Fred',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											employerCompany: null,
+											coEntities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
+													name: 'Sur-Fred',
+													startDate: '2010-02-01',
+													endDate: '2010-02-28',
+													venue: {
+														model: 'VENUE',
+														uuid: LYTTELTON_THEATRE_VENUE_UUID,
+														name: 'Lyttelton Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sur-Fred',
+													startDate: '2010-03-01',
+													endDate: '2010-03-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_FRED_MATERIAL_UUID,
+													name: 'Sur-Fred',
+													format: 'collection of plays',
+													year: 2010,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											employerCompany: null,
+											coEntities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_FRED_LYTTELTON_PRODUCTION_UUID,
+													name: 'Sub-Fred',
+													startDate: '2010-02-01',
+													endDate: '2010-02-28',
+													venue: {
+														model: 'VENUE',
+														uuid: LYTTELTON_THEATRE_VENUE_UUID,
+														name: 'Lyttelton Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_FRED_LYTTELTON_PRODUCTION_UUID,
+														name: 'Mid-Fred',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
+															name: 'Sur-Fred'
+														}
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_FRED_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sub-Fred',
+													startDate: '2010-03-01',
+													endDate: '2010-03-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_FRED_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Mid-Fred',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
+															name: 'Sur-Fred'
+														}
+													}
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_FRED_MATERIAL_UUID,
+													name: 'Sub-Fred',
+													format: 'play',
+													year: 2010,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: MID_FRED_MATERIAL_UUID,
+														name: 'Mid-Fred',
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_FRED_MATERIAL_UUID,
+															name: 'Sur-Fred'
+														}
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards } = johnDoePerson.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+
+		});
+
+	});
+
+	describe('John Doe Sr (person): credit for directly nominated material and their associated sub-materials and sub-sub-materials', () => {
+
+		it('includes their award nominations', () => {
+
+			const expectedAwards = [
+				{
+					model: 'AWARD',
+					uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+					name: 'Dramatists Medal',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+							name: '2008',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Most Remarkable Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											employerCompany: null,
+											coEntities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: MID_FRED_LYTTELTON_PRODUCTION_UUID,
+													name: 'Mid-Fred',
+													startDate: '2010-02-01',
+													endDate: '2010-02-28',
+													venue: {
+														model: 'VENUE',
+														uuid: LYTTELTON_THEATRE_VENUE_UUID,
+														name: 'Lyttelton Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
+														name: 'Sur-Fred',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: MID_FRED_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Mid-Fred',
+													startDate: '2010-03-01',
+													endDate: '2010-03-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Sur-Fred',
+														surProduction: null
+													}
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: MID_FRED_MATERIAL_UUID,
+													name: 'Mid-Fred',
+													format: 'sub-collection of plays',
+													year: 2010,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_FRED_MATERIAL_UUID,
+														name: 'Sur-Fred',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											employerCompany: null,
+											coEntities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
+													name: 'Sur-Fred',
+													startDate: '2010-02-01',
+													endDate: '2010-02-28',
+													venue: {
+														model: 'VENUE',
+														uuid: LYTTELTON_THEATRE_VENUE_UUID,
+														name: 'Lyttelton Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sur-Fred',
+													startDate: '2010-03-01',
+													endDate: '2010-03-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_FRED_MATERIAL_UUID,
+													name: 'Sur-Fred',
+													format: 'collection of plays',
+													year: 2010,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											employerCompany: null,
+											coEntities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_FRED_LYTTELTON_PRODUCTION_UUID,
+													name: 'Sub-Fred',
+													startDate: '2010-02-01',
+													endDate: '2010-02-28',
+													venue: {
+														model: 'VENUE',
+														uuid: LYTTELTON_THEATRE_VENUE_UUID,
+														name: 'Lyttelton Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_FRED_LYTTELTON_PRODUCTION_UUID,
+														name: 'Mid-Fred',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
+															name: 'Sur-Fred'
+														}
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_FRED_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sub-Fred',
+													startDate: '2010-03-01',
+													endDate: '2010-03-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_FRED_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Mid-Fred',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
+															name: 'Sur-Fred'
+														}
+													}
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_FRED_MATERIAL_UUID,
+													name: 'Sub-Fred',
+													format: 'play',
+													year: 2010,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: MID_FRED_MATERIAL_UUID,
+														name: 'Mid-Fred',
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_FRED_MATERIAL_UUID,
+															name: 'Sur-Fred'
+														}
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards } = johnDoeSrPerson.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+
+		});
+
+	});
+
+	describe('Sub-Playwrights Ltd (company): credit for directly nominated material and their associated sur-material and sur-sur-material', () => {
+
+		it('includes their award nominations', () => {
+
+			const expectedAwards = [
+				{
+					model: 'AWARD',
+					uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+					name: 'Dramatists Medal',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+							name: '2008',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Most Remarkable Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											members: [],
+											coEntities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: MID_FRED_LYTTELTON_PRODUCTION_UUID,
+													name: 'Mid-Fred',
+													startDate: '2010-02-01',
+													endDate: '2010-02-28',
+													venue: {
+														model: 'VENUE',
+														uuid: LYTTELTON_THEATRE_VENUE_UUID,
+														name: 'Lyttelton Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
+														name: 'Sur-Fred',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: MID_FRED_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Mid-Fred',
+													startDate: '2010-03-01',
+													endDate: '2010-03-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Sur-Fred',
+														surProduction: null
+													}
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: MID_FRED_MATERIAL_UUID,
+													name: 'Mid-Fred',
+													format: 'sub-collection of plays',
+													year: 2010,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_FRED_MATERIAL_UUID,
+														name: 'Sur-Fred',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											members: [],
+											coEntities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
+													name: 'Sur-Fred',
+													startDate: '2010-02-01',
+													endDate: '2010-02-28',
+													venue: {
+														model: 'VENUE',
+														uuid: LYTTELTON_THEATRE_VENUE_UUID,
+														name: 'Lyttelton Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sur-Fred',
+													startDate: '2010-03-01',
+													endDate: '2010-03-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_FRED_MATERIAL_UUID,
+													name: 'Sur-Fred',
+													format: 'collection of plays',
+													year: 2010,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											members: [],
+											coEntities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_FRED_LYTTELTON_PRODUCTION_UUID,
+													name: 'Sub-Fred',
+													startDate: '2010-02-01',
+													endDate: '2010-02-28',
+													venue: {
+														model: 'VENUE',
+														uuid: LYTTELTON_THEATRE_VENUE_UUID,
+														name: 'Lyttelton Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_FRED_LYTTELTON_PRODUCTION_UUID,
+														name: 'Mid-Fred',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
+															name: 'Sur-Fred'
+														}
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_FRED_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sub-Fred',
+													startDate: '2010-03-01',
+													endDate: '2010-03-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_FRED_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Mid-Fred',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
+															name: 'Sur-Fred'
+														}
+													}
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_FRED_MATERIAL_UUID,
+													name: 'Sub-Fred',
+													format: 'play',
+													year: 2010,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: MID_FRED_MATERIAL_UUID,
+														name: 'Mid-Fred',
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_FRED_MATERIAL_UUID,
+															name: 'Sur-Fred'
+														}
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards } = subPlaywrightsLtdCompany.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+
+		});
+
+	});
+
+	describe('Mid-Playwrights Ltd (company): credit for directly nominated material and their associated sur-material and sub-materials', () => {
+
+		it('includes their award nominations', () => {
+
+			const expectedAwards = [
+				{
+					model: 'AWARD',
+					uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+					name: 'Dramatists Medal',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+							name: '2008',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Most Remarkable Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											members: [],
+											coEntities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: MID_FRED_LYTTELTON_PRODUCTION_UUID,
+													name: 'Mid-Fred',
+													startDate: '2010-02-01',
+													endDate: '2010-02-28',
+													venue: {
+														model: 'VENUE',
+														uuid: LYTTELTON_THEATRE_VENUE_UUID,
+														name: 'Lyttelton Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
+														name: 'Sur-Fred',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: MID_FRED_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Mid-Fred',
+													startDate: '2010-03-01',
+													endDate: '2010-03-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Sur-Fred',
+														surProduction: null
+													}
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: MID_FRED_MATERIAL_UUID,
+													name: 'Mid-Fred',
+													format: 'sub-collection of plays',
+													year: 2010,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_FRED_MATERIAL_UUID,
+														name: 'Sur-Fred',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											members: [],
+											coEntities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
+													name: 'Sur-Fred',
+													startDate: '2010-02-01',
+													endDate: '2010-02-28',
+													venue: {
+														model: 'VENUE',
+														uuid: LYTTELTON_THEATRE_VENUE_UUID,
+														name: 'Lyttelton Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sur-Fred',
+													startDate: '2010-03-01',
+													endDate: '2010-03-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_FRED_MATERIAL_UUID,
+													name: 'Sur-Fred',
+													format: 'collection of plays',
+													year: 2010,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											members: [],
+											coEntities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_FRED_LYTTELTON_PRODUCTION_UUID,
+													name: 'Sub-Fred',
+													startDate: '2010-02-01',
+													endDate: '2010-02-28',
+													venue: {
+														model: 'VENUE',
+														uuid: LYTTELTON_THEATRE_VENUE_UUID,
+														name: 'Lyttelton Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_FRED_LYTTELTON_PRODUCTION_UUID,
+														name: 'Mid-Fred',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
+															name: 'Sur-Fred'
+														}
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_FRED_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sub-Fred',
+													startDate: '2010-03-01',
+													endDate: '2010-03-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_FRED_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Mid-Fred',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
+															name: 'Sur-Fred'
+														}
+													}
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_FRED_MATERIAL_UUID,
+													name: 'Sub-Fred',
+													format: 'play',
+													year: 2010,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: MID_FRED_MATERIAL_UUID,
+														name: 'Mid-Fred',
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_FRED_MATERIAL_UUID,
+															name: 'Sur-Fred'
+														}
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards } = midPlaywrightsLtdCompany.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+
+		});
+
+	});
+
+	describe('Sur-Playwrights Ltd (company): credit for directly nominated material and their associated sub-materials and sub-sub-materials', () => {
+
+		it('includes their award nominations', () => {
+
+			const expectedAwards = [
+				{
+					model: 'AWARD',
+					uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+					name: 'Dramatists Medal',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+							name: '2008',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Most Remarkable Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											members: [],
+											coEntities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: MID_FRED_LYTTELTON_PRODUCTION_UUID,
+													name: 'Mid-Fred',
+													startDate: '2010-02-01',
+													endDate: '2010-02-28',
+													venue: {
+														model: 'VENUE',
+														uuid: LYTTELTON_THEATRE_VENUE_UUID,
+														name: 'Lyttelton Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
+														name: 'Sur-Fred',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: MID_FRED_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Mid-Fred',
+													startDate: '2010-03-01',
+													endDate: '2010-03-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Sur-Fred',
+														surProduction: null
+													}
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: MID_FRED_MATERIAL_UUID,
+													name: 'Mid-Fred',
+													format: 'sub-collection of plays',
+													year: 2010,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_FRED_MATERIAL_UUID,
+														name: 'Sur-Fred',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											members: [],
+											coEntities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
+													name: 'Sur-Fred',
+													startDate: '2010-02-01',
+													endDate: '2010-02-28',
+													venue: {
+														model: 'VENUE',
+														uuid: LYTTELTON_THEATRE_VENUE_UUID,
+														name: 'Lyttelton Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sur-Fred',
+													startDate: '2010-03-01',
+													endDate: '2010-03-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_FRED_MATERIAL_UUID,
+													name: 'Sur-Fred',
+													format: 'collection of plays',
+													year: 2010,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											members: [],
+											coEntities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_FRED_LYTTELTON_PRODUCTION_UUID,
+													name: 'Sub-Fred',
+													startDate: '2010-02-01',
+													endDate: '2010-02-28',
+													venue: {
+														model: 'VENUE',
+														uuid: LYTTELTON_THEATRE_VENUE_UUID,
+														name: 'Lyttelton Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_FRED_LYTTELTON_PRODUCTION_UUID,
+														name: 'Mid-Fred',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_FRED_LYTTELTON_PRODUCTION_UUID,
+															name: 'Sur-Fred'
+														}
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_FRED_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sub-Fred',
+													startDate: '2010-03-01',
+													endDate: '2010-03-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_FRED_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Mid-Fred',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_FRED_NOËL_COWARD_PRODUCTION_UUID,
+															name: 'Sur-Fred'
+														}
+													}
+												}
+											],
+											materials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_FRED_MATERIAL_UUID,
+													name: 'Sub-Fred',
+													format: 'play',
+													year: 2010,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: MID_FRED_MATERIAL_UUID,
+														name: 'Mid-Fred',
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_FRED_MATERIAL_UUID,
+															name: 'Sur-Fred'
+														}
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards } = surPlaywrightsLtdCompany.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+
+		});
+
+	});
+
+	describe('Francis Flob Jr (person): subsequent versions (and their associated sur-material and sur-sur-material) of their work have nominations', () => {
+
+		it('includes awards of subsequent versions (and their associated sur-material and sur-sur-material) of their work', () => {
+
+			const expectedAwards = [];
+
+			const expectedSubsequentVersionMaterialAwards = [
+				{
+					model: 'AWARD',
+					uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+					name: 'Dramatists Medal',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+							name: '2008',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Most Remarkable Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: MID_PLUGH_OLIVIER_PRODUCTION_UUID,
+													name: 'Mid-Plugh',
+													startDate: '2009-07-01',
+													endDate: '2009-07-31',
+													venue: {
+														model: 'VENUE',
+														uuid: OLIVIER_THEATRE_VENUE_UUID,
+														name: 'Olivier Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+														name: 'Sur-Plugh',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: MID_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+													name: 'Mid-Plugh',
+													startDate: '2009-08-01',
+													endDate: '2009-08-31',
+													venue: {
+														model: 'VENUE',
+														uuid: WYNDHAMS_THEATRE_VENUE_UUID,
+														name: 'Wyndham\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+														name: 'Sur-Plugh',
+														surProduction: null
+													}
+												}
+											],
+											materials: [],
+											subsequentVersionMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: MID_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+													name: 'Mid-Plugh',
+													format: 'sub-collection of plays',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: true,
+											type: 'Winner',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+													name: 'Sur-Plugh',
+													startDate: '2009-07-01',
+													endDate: '2009-07-31',
+													venue: {
+														model: 'VENUE',
+														uuid: OLIVIER_THEATRE_VENUE_UUID,
+														name: 'Olivier Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+													name: 'Sur-Plugh',
+													startDate: '2009-08-01',
+													endDate: '2009-08-31',
+													venue: {
+														model: 'VENUE',
+														uuid: WYNDHAMS_THEATRE_VENUE_UUID,
+														name: 'Wyndham\'s Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [],
+											subsequentVersionMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+													name: 'Sur-Plugh',
+													format: 'collection of plays',
+													year: 2009,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_PLUGH_OLIVIER_PRODUCTION_UUID,
+													name: 'Sub-Plugh',
+													startDate: '2009-07-01',
+													endDate: '2009-07-31',
+													venue: {
+														model: 'VENUE',
+														uuid: OLIVIER_THEATRE_VENUE_UUID,
+														name: 'Olivier Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_PLUGH_OLIVIER_PRODUCTION_UUID,
+														name: 'Mid-Plugh',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+															name: 'Sur-Plugh'
+														}
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+													name: 'Sub-Plugh',
+													startDate: '2009-08-01',
+													endDate: '2009-08-31',
+													venue: {
+														model: 'VENUE',
+														uuid: WYNDHAMS_THEATRE_VENUE_UUID,
+														name: 'Wyndham\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+														name: 'Mid-Plugh',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+															name: 'Sur-Plugh'
+														}
+													}
+												}
+											],
+											materials: [],
+											subsequentVersionMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+													name: 'Sub-Plugh',
+													format: 'play',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: MID_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Mid-Plugh',
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Sur-Plugh'
+														}
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards, subsequentVersionMaterialAwards } = francisFlobJrPerson.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+			expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+		});
+
+	});
+
+	describe('Francis Flob (person): subsequent versions (and their associated sur-material and sub-materials) of their work have nominations', () => {
+
+		it('includes awards of subsequent versions (and their associated sur-material and sub-materials) of their work', () => {
+
+			const expectedAwards = [];
+
+			const expectedSubsequentVersionMaterialAwards = [
+				{
+					model: 'AWARD',
+					uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+					name: 'Dramatists Medal',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+							name: '2008',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Most Remarkable Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: MID_PLUGH_OLIVIER_PRODUCTION_UUID,
+													name: 'Mid-Plugh',
+													startDate: '2009-07-01',
+													endDate: '2009-07-31',
+													venue: {
+														model: 'VENUE',
+														uuid: OLIVIER_THEATRE_VENUE_UUID,
+														name: 'Olivier Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+														name: 'Sur-Plugh',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: MID_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+													name: 'Mid-Plugh',
+													startDate: '2009-08-01',
+													endDate: '2009-08-31',
+													venue: {
+														model: 'VENUE',
+														uuid: WYNDHAMS_THEATRE_VENUE_UUID,
+														name: 'Wyndham\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+														name: 'Sur-Plugh',
+														surProduction: null
+													}
+												}
+											],
+											materials: [],
+											subsequentVersionMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: MID_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+													name: 'Mid-Plugh',
+													format: 'sub-collection of plays',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: true,
+											type: 'Winner',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+													name: 'Sur-Plugh',
+													startDate: '2009-07-01',
+													endDate: '2009-07-31',
+													venue: {
+														model: 'VENUE',
+														uuid: OLIVIER_THEATRE_VENUE_UUID,
+														name: 'Olivier Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+													name: 'Sur-Plugh',
+													startDate: '2009-08-01',
+													endDate: '2009-08-31',
+													venue: {
+														model: 'VENUE',
+														uuid: WYNDHAMS_THEATRE_VENUE_UUID,
+														name: 'Wyndham\'s Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [],
+											subsequentVersionMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+													name: 'Sur-Plugh',
+													format: 'collection of plays',
+													year: 2009,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_PLUGH_OLIVIER_PRODUCTION_UUID,
+													name: 'Sub-Plugh',
+													startDate: '2009-07-01',
+													endDate: '2009-07-31',
+													venue: {
+														model: 'VENUE',
+														uuid: OLIVIER_THEATRE_VENUE_UUID,
+														name: 'Olivier Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_PLUGH_OLIVIER_PRODUCTION_UUID,
+														name: 'Mid-Plugh',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+															name: 'Sur-Plugh'
+														}
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+													name: 'Sub-Plugh',
+													startDate: '2009-08-01',
+													endDate: '2009-08-31',
+													venue: {
+														model: 'VENUE',
+														uuid: WYNDHAMS_THEATRE_VENUE_UUID,
+														name: 'Wyndham\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+														name: 'Mid-Plugh',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+															name: 'Sur-Plugh'
+														}
+													}
+												}
+											],
+											materials: [],
+											subsequentVersionMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+													name: 'Sub-Plugh',
+													format: 'play',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: MID_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Mid-Plugh',
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Sur-Plugh'
+														}
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards, subsequentVersionMaterialAwards } = francisFlobPerson.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+			expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+		});
+
+	});
+
+	describe('Francis Flob Sr (person): subsequent versions (and their associated sub-materials and sub-sub-materials) of their work have nominations', () => {
+
+		it('includes awards of subsequent versions (and their associated sub-materials and sub-sub-materials) of their work', () => {
+
+			const expectedAwards = [];
+
+			const expectedSubsequentVersionMaterialAwards = [
+				{
+					model: 'AWARD',
+					uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+					name: 'Dramatists Medal',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+							name: '2008',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Most Remarkable Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: MID_PLUGH_OLIVIER_PRODUCTION_UUID,
+													name: 'Mid-Plugh',
+													startDate: '2009-07-01',
+													endDate: '2009-07-31',
+													venue: {
+														model: 'VENUE',
+														uuid: OLIVIER_THEATRE_VENUE_UUID,
+														name: 'Olivier Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+														name: 'Sur-Plugh',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: MID_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+													name: 'Mid-Plugh',
+													startDate: '2009-08-01',
+													endDate: '2009-08-31',
+													venue: {
+														model: 'VENUE',
+														uuid: WYNDHAMS_THEATRE_VENUE_UUID,
+														name: 'Wyndham\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+														name: 'Sur-Plugh',
+														surProduction: null
+													}
+												}
+											],
+											materials: [],
+											subsequentVersionMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: MID_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+													name: 'Mid-Plugh',
+													format: 'sub-collection of plays',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: true,
+											type: 'Winner',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+													name: 'Sur-Plugh',
+													startDate: '2009-07-01',
+													endDate: '2009-07-31',
+													venue: {
+														model: 'VENUE',
+														uuid: OLIVIER_THEATRE_VENUE_UUID,
+														name: 'Olivier Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+													name: 'Sur-Plugh',
+													startDate: '2009-08-01',
+													endDate: '2009-08-31',
+													venue: {
+														model: 'VENUE',
+														uuid: WYNDHAMS_THEATRE_VENUE_UUID,
+														name: 'Wyndham\'s Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [],
+											subsequentVersionMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+													name: 'Sur-Plugh',
+													format: 'collection of plays',
+													year: 2009,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_PLUGH_OLIVIER_PRODUCTION_UUID,
+													name: 'Sub-Plugh',
+													startDate: '2009-07-01',
+													endDate: '2009-07-31',
+													venue: {
+														model: 'VENUE',
+														uuid: OLIVIER_THEATRE_VENUE_UUID,
+														name: 'Olivier Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_PLUGH_OLIVIER_PRODUCTION_UUID,
+														name: 'Mid-Plugh',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+															name: 'Sur-Plugh'
+														}
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+													name: 'Sub-Plugh',
+													startDate: '2009-08-01',
+													endDate: '2009-08-31',
+													venue: {
+														model: 'VENUE',
+														uuid: WYNDHAMS_THEATRE_VENUE_UUID,
+														name: 'Wyndham\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+														name: 'Mid-Plugh',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+															name: 'Sur-Plugh'
+														}
+													}
+												}
+											],
+											materials: [],
+											subsequentVersionMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+													name: 'Sub-Plugh',
+													format: 'play',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: MID_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Mid-Plugh',
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Sur-Plugh'
+														}
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards, subsequentVersionMaterialAwards } = francisFlobSrPerson.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+			expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+		});
+
+	});
+
+	describe('Sub-Curtain Up Ltd (company): subsequent versions (and their associated sur-material and sur-sur-material) of their work have nominations', () => {
+
+		it('includes awards of subsequent versions (and their associated sur-material and sur-sur-material) of their work', () => {
+
+			const expectedAwards = [];
+
+			const expectedSubsequentVersionMaterialAwards = [
+				{
+					model: 'AWARD',
+					uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+					name: 'Dramatists Medal',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+							name: '2008',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Most Remarkable Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: MID_PLUGH_OLIVIER_PRODUCTION_UUID,
+													name: 'Mid-Plugh',
+													startDate: '2009-07-01',
+													endDate: '2009-07-31',
+													venue: {
+														model: 'VENUE',
+														uuid: OLIVIER_THEATRE_VENUE_UUID,
+														name: 'Olivier Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+														name: 'Sur-Plugh',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: MID_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+													name: 'Mid-Plugh',
+													startDate: '2009-08-01',
+													endDate: '2009-08-31',
+													venue: {
+														model: 'VENUE',
+														uuid: WYNDHAMS_THEATRE_VENUE_UUID,
+														name: 'Wyndham\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+														name: 'Sur-Plugh',
+														surProduction: null
+													}
+												}
+											],
+											materials: [],
+											subsequentVersionMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: MID_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+													name: 'Mid-Plugh',
+													format: 'sub-collection of plays',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: true,
+											type: 'Winner',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+													name: 'Sur-Plugh',
+													startDate: '2009-07-01',
+													endDate: '2009-07-31',
+													venue: {
+														model: 'VENUE',
+														uuid: OLIVIER_THEATRE_VENUE_UUID,
+														name: 'Olivier Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+													name: 'Sur-Plugh',
+													startDate: '2009-08-01',
+													endDate: '2009-08-31',
+													venue: {
+														model: 'VENUE',
+														uuid: WYNDHAMS_THEATRE_VENUE_UUID,
+														name: 'Wyndham\'s Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [],
+											subsequentVersionMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+													name: 'Sur-Plugh',
+													format: 'collection of plays',
+													year: 2009,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_PLUGH_OLIVIER_PRODUCTION_UUID,
+													name: 'Sub-Plugh',
+													startDate: '2009-07-01',
+													endDate: '2009-07-31',
+													venue: {
+														model: 'VENUE',
+														uuid: OLIVIER_THEATRE_VENUE_UUID,
+														name: 'Olivier Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_PLUGH_OLIVIER_PRODUCTION_UUID,
+														name: 'Mid-Plugh',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+															name: 'Sur-Plugh'
+														}
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+													name: 'Sub-Plugh',
+													startDate: '2009-08-01',
+													endDate: '2009-08-31',
+													venue: {
+														model: 'VENUE',
+														uuid: WYNDHAMS_THEATRE_VENUE_UUID,
+														name: 'Wyndham\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+														name: 'Mid-Plugh',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+															name: 'Sur-Plugh'
+														}
+													}
+												}
+											],
+											materials: [],
+											subsequentVersionMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+													name: 'Sub-Plugh',
+													format: 'play',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: MID_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Mid-Plugh',
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Sur-Plugh'
+														}
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards, subsequentVersionMaterialAwards } = subCurtainUpLtdCompany.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+			expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+		});
+
+	});
+
+	describe('Mid-Curtain Up Ltd (company): subsequent versions (and their associated sur-material and sub-materials) of their work have nominations', () => {
+
+		it('includes awards of subsequent versions (and their associated sur-material and sub-materials) of their work', () => {
+
+			const expectedAwards = [];
+
+			const expectedSubsequentVersionMaterialAwards = [
+				{
+					model: 'AWARD',
+					uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+					name: 'Dramatists Medal',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+							name: '2008',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Most Remarkable Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: MID_PLUGH_OLIVIER_PRODUCTION_UUID,
+													name: 'Mid-Plugh',
+													startDate: '2009-07-01',
+													endDate: '2009-07-31',
+													venue: {
+														model: 'VENUE',
+														uuid: OLIVIER_THEATRE_VENUE_UUID,
+														name: 'Olivier Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+														name: 'Sur-Plugh',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: MID_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+													name: 'Mid-Plugh',
+													startDate: '2009-08-01',
+													endDate: '2009-08-31',
+													venue: {
+														model: 'VENUE',
+														uuid: WYNDHAMS_THEATRE_VENUE_UUID,
+														name: 'Wyndham\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+														name: 'Sur-Plugh',
+														surProduction: null
+													}
+												}
+											],
+											materials: [],
+											subsequentVersionMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: MID_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+													name: 'Mid-Plugh',
+													format: 'sub-collection of plays',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: true,
+											type: 'Winner',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+													name: 'Sur-Plugh',
+													startDate: '2009-07-01',
+													endDate: '2009-07-31',
+													venue: {
+														model: 'VENUE',
+														uuid: OLIVIER_THEATRE_VENUE_UUID,
+														name: 'Olivier Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+													name: 'Sur-Plugh',
+													startDate: '2009-08-01',
+													endDate: '2009-08-31',
+													venue: {
+														model: 'VENUE',
+														uuid: WYNDHAMS_THEATRE_VENUE_UUID,
+														name: 'Wyndham\'s Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [],
+											subsequentVersionMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+													name: 'Sur-Plugh',
+													format: 'collection of plays',
+													year: 2009,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_PLUGH_OLIVIER_PRODUCTION_UUID,
+													name: 'Sub-Plugh',
+													startDate: '2009-07-01',
+													endDate: '2009-07-31',
+													venue: {
+														model: 'VENUE',
+														uuid: OLIVIER_THEATRE_VENUE_UUID,
+														name: 'Olivier Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_PLUGH_OLIVIER_PRODUCTION_UUID,
+														name: 'Mid-Plugh',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+															name: 'Sur-Plugh'
+														}
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+													name: 'Sub-Plugh',
+													startDate: '2009-08-01',
+													endDate: '2009-08-31',
+													venue: {
+														model: 'VENUE',
+														uuid: WYNDHAMS_THEATRE_VENUE_UUID,
+														name: 'Wyndham\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+														name: 'Mid-Plugh',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+															name: 'Sur-Plugh'
+														}
+													}
+												}
+											],
+											materials: [],
+											subsequentVersionMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+													name: 'Sub-Plugh',
+													format: 'play',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: MID_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Mid-Plugh',
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Sur-Plugh'
+														}
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards, subsequentVersionMaterialAwards } = midCurtainUpLtdCompany.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+			expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+		});
+
+	});
+
+	describe('Sur-Curtain Up Ltd (company): subsequent versions (and their associated sub-materials and sub-sub-materials) of their work have nominations', () => {
+
+		it('includes awards of subsequent versions (and their associated sub-materials and sub-sub-materials) of their work', () => {
+
+			const expectedAwards = [];
+
+			const expectedSubsequentVersionMaterialAwards = [
+				{
+					model: 'AWARD',
+					uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+					name: 'Dramatists Medal',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+							name: '2008',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Most Remarkable Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: MID_PLUGH_OLIVIER_PRODUCTION_UUID,
+													name: 'Mid-Plugh',
+													startDate: '2009-07-01',
+													endDate: '2009-07-31',
+													venue: {
+														model: 'VENUE',
+														uuid: OLIVIER_THEATRE_VENUE_UUID,
+														name: 'Olivier Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+														name: 'Sur-Plugh',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: MID_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+													name: 'Mid-Plugh',
+													startDate: '2009-08-01',
+													endDate: '2009-08-31',
+													venue: {
+														model: 'VENUE',
+														uuid: WYNDHAMS_THEATRE_VENUE_UUID,
+														name: 'Wyndham\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+														name: 'Sur-Plugh',
+														surProduction: null
+													}
+												}
+											],
+											materials: [],
+											subsequentVersionMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: MID_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+													name: 'Mid-Plugh',
+													format: 'sub-collection of plays',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: true,
+											type: 'Winner',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+													name: 'Sur-Plugh',
+													startDate: '2009-07-01',
+													endDate: '2009-07-31',
+													venue: {
+														model: 'VENUE',
+														uuid: OLIVIER_THEATRE_VENUE_UUID,
+														name: 'Olivier Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+													name: 'Sur-Plugh',
+													startDate: '2009-08-01',
+													endDate: '2009-08-31',
+													venue: {
+														model: 'VENUE',
+														uuid: WYNDHAMS_THEATRE_VENUE_UUID,
+														name: 'Wyndham\'s Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [],
+											subsequentVersionMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+													name: 'Sur-Plugh',
+													format: 'collection of plays',
+													year: 2009,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_PLUGH_OLIVIER_PRODUCTION_UUID,
+													name: 'Sub-Plugh',
+													startDate: '2009-07-01',
+													endDate: '2009-07-31',
+													venue: {
+														model: 'VENUE',
+														uuid: OLIVIER_THEATRE_VENUE_UUID,
+														name: 'Olivier Theatre',
+														surVenue: {
+															model: 'VENUE',
+															uuid: NATIONAL_THEATRE_VENUE_UUID,
+															name: 'National Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_PLUGH_OLIVIER_PRODUCTION_UUID,
+														name: 'Mid-Plugh',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_PLUGH_OLIVIER_PRODUCTION_UUID,
+															name: 'Sur-Plugh'
+														}
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+													name: 'Sub-Plugh',
+													startDate: '2009-08-01',
+													endDate: '2009-08-31',
+													venue: {
+														model: 'VENUE',
+														uuid: WYNDHAMS_THEATRE_VENUE_UUID,
+														name: 'Wyndham\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+														name: 'Mid-Plugh',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_PLUGH_WYNDHAMS_PRODUCTION_UUID,
+															name: 'Sur-Plugh'
+														}
+													}
+												}
+											],
+											materials: [],
+											subsequentVersionMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+													name: 'Sub-Plugh',
+													format: 'play',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: MID_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Mid-Plugh',
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Sur-Plugh'
+														}
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards, subsequentVersionMaterialAwards } = surCurtainUpLtdCompany.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+			expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+		});
+
+	});
+
+	describe('Jane Roe Jr (person): materials (and their associated sur-material and sur-sur-material) that used their (specific) work as source material have nominations', () => {
+
+		it('includes awards of materials (and their associated sur-material and sur-sur-material) that used their (specific) work as source material', () => {
+
+			const expectedSourcingMaterialAwards = [
+				{
+					model: 'AWARD',
+					uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+					name: 'Dramatists Medal',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+							name: '2008',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Most Remarkable Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: true,
+											type: 'Winner',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: MID_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Mid-Wibble',
+													startDate: '2009-05-01',
+													endDate: '2009-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+														name: 'Sur-Wibble',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: MID_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+													name: 'Mid-Wibble',
+													startDate: '2009-06-01',
+													endDate: '2009-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
+														name: 'Duke of York\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+														name: 'Sur-Wibble',
+														surProduction: null
+													}
+												}
+											],
+											materials: [],
+											sourcingMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: MID_WIBBLE_MATERIAL_UUID,
+													name: 'Mid-Wibble',
+													format: 'sub-trilogy of plays',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sur-Wibble',
+													startDate: '2009-05-01',
+													endDate: '2009-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+													name: 'Sur-Wibble',
+													startDate: '2009-06-01',
+													endDate: '2009-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
+														name: 'Duke of York\'s Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [],
+											sourcingMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_WIBBLE_MATERIAL_UUID,
+													name: 'Sur-Wibble',
+													format: 'trilogy of trilogies of plays',
+													year: 2009,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sub-Wibble',
+													startDate: '2009-05-01',
+													endDate: '2009-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+														name: 'Mid-Wibble',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+															name: 'Sur-Wibble'
+														}
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+													name: 'Sub-Wibble',
+													startDate: '2009-06-01',
+													endDate: '2009-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
+														name: 'Duke of York\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+														name: 'Mid-Wibble',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+															name: 'Sur-Wibble'
+														}
+													}
+												}
+											],
+											materials: [],
+											sourcingMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_WIBBLE_MATERIAL_UUID,
+													name: 'Sub-Wibble',
+													format: 'play',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_MATERIAL_UUID,
+														name: 'Mid-Wibble',
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble'
+														}
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { sourcingMaterialAwards } = janeRoeJrPerson.body;
+
+			expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+		});
+
+	});
+
+	describe('Jane Roe (person): materials (and their associated sur-material and sub-materials) that used their (specific) work as source material have nominations', () => {
+
+		it('includes awards of materials (and their associated sur-material and sub-materials) that used their (specific) work as source material', () => {
+
+			const expectedSourcingMaterialAwards = [
+				{
+					model: 'AWARD',
+					uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+					name: 'Dramatists Medal',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+							name: '2008',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Most Remarkable Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: true,
+											type: 'Winner',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: MID_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Mid-Wibble',
+													startDate: '2009-05-01',
+													endDate: '2009-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+														name: 'Sur-Wibble',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: MID_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+													name: 'Mid-Wibble',
+													startDate: '2009-06-01',
+													endDate: '2009-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
+														name: 'Duke of York\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+														name: 'Sur-Wibble',
+														surProduction: null
+													}
+												}
+											],
+											materials: [],
+											sourcingMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: MID_WIBBLE_MATERIAL_UUID,
+													name: 'Mid-Wibble',
+													format: 'sub-trilogy of plays',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sur-Wibble',
+													startDate: '2009-05-01',
+													endDate: '2009-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+													name: 'Sur-Wibble',
+													startDate: '2009-06-01',
+													endDate: '2009-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
+														name: 'Duke of York\'s Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [],
+											sourcingMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_WIBBLE_MATERIAL_UUID,
+													name: 'Sur-Wibble',
+													format: 'trilogy of trilogies of plays',
+													year: 2009,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sub-Wibble',
+													startDate: '2009-05-01',
+													endDate: '2009-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+														name: 'Mid-Wibble',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+															name: 'Sur-Wibble'
+														}
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+													name: 'Sub-Wibble',
+													startDate: '2009-06-01',
+													endDate: '2009-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
+														name: 'Duke of York\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+														name: 'Mid-Wibble',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+															name: 'Sur-Wibble'
+														}
+													}
+												}
+											],
+											materials: [],
+											sourcingMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_WIBBLE_MATERIAL_UUID,
+													name: 'Sub-Wibble',
+													format: 'play',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_MATERIAL_UUID,
+														name: 'Mid-Wibble',
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble'
+														}
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { sourcingMaterialAwards } = janeRoePerson.body;
+
+			expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+		});
+
+	});
+
+	describe('Jane Roe Sr (person): materials (and their associated sub-materials and sub-sub-materials) that used their (specific) work as source material have nominations', () => {
+
+		it('includes awards of materials (and their associated sub-materials and sub-sub-materials) that used their (specific) work as source material', () => {
+
+			const expectedSourcingMaterialAwards = [
+				{
+					model: 'AWARD',
+					uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+					name: 'Dramatists Medal',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+							name: '2008',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Most Remarkable Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: true,
+											type: 'Winner',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: MID_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Mid-Wibble',
+													startDate: '2009-05-01',
+													endDate: '2009-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+														name: 'Sur-Wibble',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: MID_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+													name: 'Mid-Wibble',
+													startDate: '2009-06-01',
+													endDate: '2009-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
+														name: 'Duke of York\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+														name: 'Sur-Wibble',
+														surProduction: null
+													}
+												}
+											],
+											materials: [],
+											sourcingMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: MID_WIBBLE_MATERIAL_UUID,
+													name: 'Mid-Wibble',
+													format: 'sub-trilogy of plays',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sur-Wibble',
+													startDate: '2009-05-01',
+													endDate: '2009-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+													name: 'Sur-Wibble',
+													startDate: '2009-06-01',
+													endDate: '2009-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
+														name: 'Duke of York\'s Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [],
+											sourcingMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_WIBBLE_MATERIAL_UUID,
+													name: 'Sur-Wibble',
+													format: 'trilogy of trilogies of plays',
+													year: 2009,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sub-Wibble',
+													startDate: '2009-05-01',
+													endDate: '2009-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+														name: 'Mid-Wibble',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+															name: 'Sur-Wibble'
+														}
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+													name: 'Sub-Wibble',
+													startDate: '2009-06-01',
+													endDate: '2009-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
+														name: 'Duke of York\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+														name: 'Mid-Wibble',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+															name: 'Sur-Wibble'
+														}
+													}
+												}
+											],
+											materials: [],
+											sourcingMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_WIBBLE_MATERIAL_UUID,
+													name: 'Sub-Wibble',
+													format: 'play',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_MATERIAL_UUID,
+														name: 'Mid-Wibble',
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble'
+														}
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { sourcingMaterialAwards } = janeRoeSrPerson.body;
+
+			expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+		});
+
+	});
+
+	describe('Sub-Fictioneers Ltd (company): materials (and their associated sur-material and sur-sur-material) that used their (specific) work as source material have nominations', () => {
+
+		it('includes awards of materials (and their associated sur-material and sur-sur-material) that used their (specific) work as source material', () => {
+
+			const expectedSourcingMaterialAwards = [
+				{
+					model: 'AWARD',
+					uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+					name: 'Dramatists Medal',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+							name: '2008',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Most Remarkable Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: true,
+											type: 'Winner',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: MID_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Mid-Wibble',
+													startDate: '2009-05-01',
+													endDate: '2009-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+														name: 'Sur-Wibble',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: MID_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+													name: 'Mid-Wibble',
+													startDate: '2009-06-01',
+													endDate: '2009-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
+														name: 'Duke of York\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+														name: 'Sur-Wibble',
+														surProduction: null
+													}
+												}
+											],
+											materials: [],
+											sourcingMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: MID_WIBBLE_MATERIAL_UUID,
+													name: 'Mid-Wibble',
+													format: 'sub-trilogy of plays',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sur-Wibble',
+													startDate: '2009-05-01',
+													endDate: '2009-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+													name: 'Sur-Wibble',
+													startDate: '2009-06-01',
+													endDate: '2009-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
+														name: 'Duke of York\'s Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [],
+											sourcingMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_WIBBLE_MATERIAL_UUID,
+													name: 'Sur-Wibble',
+													format: 'trilogy of trilogies of plays',
+													year: 2009,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sub-Wibble',
+													startDate: '2009-05-01',
+													endDate: '2009-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+														name: 'Mid-Wibble',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+															name: 'Sur-Wibble'
+														}
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+													name: 'Sub-Wibble',
+													startDate: '2009-06-01',
+													endDate: '2009-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
+														name: 'Duke of York\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+														name: 'Mid-Wibble',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+															name: 'Sur-Wibble'
+														}
+													}
+												}
+											],
+											materials: [],
+											sourcingMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_WIBBLE_MATERIAL_UUID,
+													name: 'Sub-Wibble',
+													format: 'play',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_MATERIAL_UUID,
+														name: 'Mid-Wibble',
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble'
+														}
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { sourcingMaterialAwards } = subFictioneersLtdCompany.body;
+
+			expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+		});
+
+	});
+
+	describe('Mid-Fictioneers Ltd (company): materials (and their associated sur-material and sub-materials) that used their (specific) work as source material have nominations', () => {
+
+		it('includes awards of materials (and their associated sur-material and sub-materials) that used their (specific) work as source material', () => {
+
+			const expectedSourcingMaterialAwards = [
+				{
+					model: 'AWARD',
+					uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+					name: 'Dramatists Medal',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+							name: '2008',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Most Remarkable Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: true,
+											type: 'Winner',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: MID_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Mid-Wibble',
+													startDate: '2009-05-01',
+													endDate: '2009-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+														name: 'Sur-Wibble',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: MID_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+													name: 'Mid-Wibble',
+													startDate: '2009-06-01',
+													endDate: '2009-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
+														name: 'Duke of York\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+														name: 'Sur-Wibble',
+														surProduction: null
+													}
+												}
+											],
+											materials: [],
+											sourcingMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: MID_WIBBLE_MATERIAL_UUID,
+													name: 'Mid-Wibble',
+													format: 'sub-trilogy of plays',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sur-Wibble',
+													startDate: '2009-05-01',
+													endDate: '2009-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+													name: 'Sur-Wibble',
+													startDate: '2009-06-01',
+													endDate: '2009-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
+														name: 'Duke of York\'s Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [],
+											sourcingMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_WIBBLE_MATERIAL_UUID,
+													name: 'Sur-Wibble',
+													format: 'trilogy of trilogies of plays',
+													year: 2009,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sub-Wibble',
+													startDate: '2009-05-01',
+													endDate: '2009-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+														name: 'Mid-Wibble',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+															name: 'Sur-Wibble'
+														}
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+													name: 'Sub-Wibble',
+													startDate: '2009-06-01',
+													endDate: '2009-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
+														name: 'Duke of York\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+														name: 'Mid-Wibble',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+															name: 'Sur-Wibble'
+														}
+													}
+												}
+											],
+											materials: [],
+											sourcingMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_WIBBLE_MATERIAL_UUID,
+													name: 'Sub-Wibble',
+													format: 'play',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_MATERIAL_UUID,
+														name: 'Mid-Wibble',
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble'
+														}
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { sourcingMaterialAwards } = midFictioneersLtdCompany.body;
+
+			expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+		});
+
+	});
+
+	describe('Sur-Fictioneers Ltd (company): materials (and their associated sub-materials and sub-sub-materials) that used their (specific) work as source material have nominations', () => {
+
+		it('includes awards of materials (and their associated sub-materials and sub-sub-materials) that used their (specific) work as source material', () => {
+
+			const expectedSourcingMaterialAwards = [
+				{
+					model: 'AWARD',
+					uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+					name: 'Dramatists Medal',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+							name: '2008',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Most Remarkable Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: true,
+											type: 'Winner',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: MID_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Mid-Wibble',
+													startDate: '2009-05-01',
+													endDate: '2009-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+														name: 'Sur-Wibble',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: MID_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+													name: 'Mid-Wibble',
+													startDate: '2009-06-01',
+													endDate: '2009-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
+														name: 'Duke of York\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+														name: 'Sur-Wibble',
+														surProduction: null
+													}
+												}
+											],
+											materials: [],
+											sourcingMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: MID_WIBBLE_MATERIAL_UUID,
+													name: 'Mid-Wibble',
+													format: 'sub-trilogy of plays',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sur-Wibble',
+													startDate: '2009-05-01',
+													endDate: '2009-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+													name: 'Sur-Wibble',
+													startDate: '2009-06-01',
+													endDate: '2009-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
+														name: 'Duke of York\'s Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [],
+											sourcingMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_WIBBLE_MATERIAL_UUID,
+													name: 'Sur-Wibble',
+													format: 'trilogy of trilogies of plays',
+													year: 2009,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sub-Wibble',
+													startDate: '2009-05-01',
+													endDate: '2009-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+														name: 'Mid-Wibble',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+															name: 'Sur-Wibble'
+														}
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+													name: 'Sub-Wibble',
+													startDate: '2009-06-01',
+													endDate: '2009-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: DUKE_OF_YORKS_THEATRE_VENUE_UUID,
+														name: 'Duke of York\'s Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+														name: 'Mid-Wibble',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_WIBBLE_DUKE_OF_YORKS_PRODUCTION_UUID,
+															name: 'Sur-Wibble'
+														}
+													}
+												}
+											],
+											materials: [],
+											sourcingMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_WIBBLE_MATERIAL_UUID,
+													name: 'Sub-Wibble',
+													format: 'play',
+													year: 2009,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_MATERIAL_UUID,
+														name: 'Mid-Wibble',
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble'
+														}
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { sourcingMaterialAwards } = surFictioneersLtdCompany.body;
+
+			expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+		});
+
+	});
+
+	describe('Talyse Tata Jr (person): materials (and their associated sur-material and sur-sur-material) to which they have granted rights have nominations', () => {
+
+		it('includes awards of materials (and their associated sur-material and sur-sur-material) to which they have granted rights', () => {
+
+			const expectedAwards = [];
+
+			const expectedRightsGrantorMaterialAwards = [
+				{
+					model: 'AWARD',
+					uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+					name: 'Dramatists Medal',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+							name: '2008',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Most Remarkable Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: MID_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+													name: 'Mid-Hoge',
+													startDate: '2008-05-01',
+													endDate: '2008-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_DOWNSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Downstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+														name: 'Sur-Hoge',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: MID_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Mid-Hoge',
+													startDate: '2008-06-01',
+													endDate: '2008-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Sur-Hoge',
+														surProduction: null
+													}
+												}
+											],
+											materials: [],
+											rightsGrantorMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: MID_HOGE_MATERIAL_UUID,
+													name: 'Mid-Hoge',
+													format: 'sub-collection of plays',
+													year: 2008,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_HOGE_MATERIAL_UUID,
+														name: 'Sur-Hoge',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+													name: 'Sur-Hoge',
+													startDate: '2008-05-01',
+													endDate: '2008-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_DOWNSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Downstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sur-Hoge',
+													startDate: '2008-06-01',
+													endDate: '2008-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [],
+											rightsGrantorMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_HOGE_MATERIAL_UUID,
+													name: 'Sur-Hoge',
+													format: 'collection of plays',
+													year: 2008,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: true,
+											type: 'Winner',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+													name: 'Sub-Hoge',
+													startDate: '2008-05-01',
+													endDate: '2008-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_DOWNSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Downstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+														name: 'Mid-Hoge',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+															name: 'Sur-Hoge'
+														}
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sub-Hoge',
+													startDate: '2008-06-01',
+													endDate: '2008-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Mid-Hoge',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+															name: 'Sur-Hoge'
+														}
+													}
+												}
+											],
+											materials: [],
+											rightsGrantorMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_HOGE_MATERIAL_UUID,
+													name: 'Sub-Hoge',
+													format: 'play',
+													year: 2008,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: MID_HOGE_MATERIAL_UUID,
+														name: 'Mid-Hoge',
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_HOGE_MATERIAL_UUID,
+															name: 'Sur-Hoge'
+														}
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards, rightsGrantorMaterialAwards } = talyseTataJrPerson.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+			expect(rightsGrantorMaterialAwards).to.deep.equal(expectedRightsGrantorMaterialAwards);
+
+		});
+
+	});
+
+	describe('Talyse Tata (person): materials (and their associated sur-material and sub-materials) to which they have granted rights have nominations', () => {
+
+		it('includes awards of materials (and their associated sur-material and sub-materials) to which they have granted rights', () => {
+
+			const expectedAwards = [];
+
+			const expectedRightsGrantorMaterialAwards = [
+				{
+					model: 'AWARD',
+					uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+					name: 'Dramatists Medal',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+							name: '2008',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Most Remarkable Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: MID_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+													name: 'Mid-Hoge',
+													startDate: '2008-05-01',
+													endDate: '2008-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_DOWNSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Downstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+														name: 'Sur-Hoge',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: MID_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Mid-Hoge',
+													startDate: '2008-06-01',
+													endDate: '2008-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Sur-Hoge',
+														surProduction: null
+													}
+												}
+											],
+											materials: [],
+											rightsGrantorMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: MID_HOGE_MATERIAL_UUID,
+													name: 'Mid-Hoge',
+													format: 'sub-collection of plays',
+													year: 2008,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_HOGE_MATERIAL_UUID,
+														name: 'Sur-Hoge',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+													name: 'Sur-Hoge',
+													startDate: '2008-05-01',
+													endDate: '2008-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_DOWNSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Downstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sur-Hoge',
+													startDate: '2008-06-01',
+													endDate: '2008-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [],
+											rightsGrantorMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_HOGE_MATERIAL_UUID,
+													name: 'Sur-Hoge',
+													format: 'collection of plays',
+													year: 2008,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: true,
+											type: 'Winner',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+													name: 'Sub-Hoge',
+													startDate: '2008-05-01',
+													endDate: '2008-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_DOWNSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Downstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+														name: 'Mid-Hoge',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+															name: 'Sur-Hoge'
+														}
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sub-Hoge',
+													startDate: '2008-06-01',
+													endDate: '2008-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Mid-Hoge',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+															name: 'Sur-Hoge'
+														}
+													}
+												}
+											],
+											materials: [],
+											rightsGrantorMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_HOGE_MATERIAL_UUID,
+													name: 'Sub-Hoge',
+													format: 'play',
+													year: 2008,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: MID_HOGE_MATERIAL_UUID,
+														name: 'Mid-Hoge',
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_HOGE_MATERIAL_UUID,
+															name: 'Sur-Hoge'
+														}
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards, rightsGrantorMaterialAwards } = talyseTataPerson.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+			expect(rightsGrantorMaterialAwards).to.deep.equal(expectedRightsGrantorMaterialAwards);
+
+		});
+
+	});
+
+	describe('Talyse Tata Sr (person): materials (and their associated sub-materials and sub-sub-materials) to which they have granted rights have nominations', () => {
+
+		it('includes awards of materials (and their associated sub-materials and sub-sub-materials) to which they have granted rights', () => {
+
+			const expectedAwards = [];
+
+			const expectedRightsGrantorMaterialAwards = [
+				{
+					model: 'AWARD',
+					uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+					name: 'Dramatists Medal',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+							name: '2008',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Most Remarkable Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: MID_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+													name: 'Mid-Hoge',
+													startDate: '2008-05-01',
+													endDate: '2008-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_DOWNSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Downstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+														name: 'Sur-Hoge',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: MID_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Mid-Hoge',
+													startDate: '2008-06-01',
+													endDate: '2008-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Sur-Hoge',
+														surProduction: null
+													}
+												}
+											],
+											materials: [],
+											rightsGrantorMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: MID_HOGE_MATERIAL_UUID,
+													name: 'Mid-Hoge',
+													format: 'sub-collection of plays',
+													year: 2008,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_HOGE_MATERIAL_UUID,
+														name: 'Sur-Hoge',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+													name: 'Sur-Hoge',
+													startDate: '2008-05-01',
+													endDate: '2008-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_DOWNSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Downstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sur-Hoge',
+													startDate: '2008-06-01',
+													endDate: '2008-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [],
+											rightsGrantorMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_HOGE_MATERIAL_UUID,
+													name: 'Sur-Hoge',
+													format: 'collection of plays',
+													year: 2008,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: true,
+											type: 'Winner',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+													name: 'Sub-Hoge',
+													startDate: '2008-05-01',
+													endDate: '2008-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_DOWNSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Downstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+														name: 'Mid-Hoge',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+															name: 'Sur-Hoge'
+														}
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sub-Hoge',
+													startDate: '2008-06-01',
+													endDate: '2008-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Mid-Hoge',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+															name: 'Sur-Hoge'
+														}
+													}
+												}
+											],
+											materials: [],
+											rightsGrantorMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_HOGE_MATERIAL_UUID,
+													name: 'Sub-Hoge',
+													format: 'play',
+													year: 2008,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: MID_HOGE_MATERIAL_UUID,
+														name: 'Mid-Hoge',
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_HOGE_MATERIAL_UUID,
+															name: 'Sur-Hoge'
+														}
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards, rightsGrantorMaterialAwards } = talyseTataSrPerson.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+			expect(rightsGrantorMaterialAwards).to.deep.equal(expectedRightsGrantorMaterialAwards);
+
+		});
+
+	});
+
+	describe('Sub-Cinerights Ltd (company): materials (and their associated sur-material and sur-sur-material) to which they granted rights have nominations', () => {
+
+		it('includes awards of materials (and their associated sur-material and sur-sur-material) to which they granted rights', () => {
+
+			const expectedAwards = [];
+
+			const expectedRightsGrantorMaterialAwards = [
+				{
+					model: 'AWARD',
+					uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+					name: 'Dramatists Medal',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+							name: '2008',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Most Remarkable Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: MID_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+													name: 'Mid-Hoge',
+													startDate: '2008-05-01',
+													endDate: '2008-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_DOWNSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Downstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+														name: 'Sur-Hoge',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: MID_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Mid-Hoge',
+													startDate: '2008-06-01',
+													endDate: '2008-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Sur-Hoge',
+														surProduction: null
+													}
+												}
+											],
+											materials: [],
+											rightsGrantorMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: MID_HOGE_MATERIAL_UUID,
+													name: 'Mid-Hoge',
+													format: 'sub-collection of plays',
+													year: 2008,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_HOGE_MATERIAL_UUID,
+														name: 'Sur-Hoge',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+													name: 'Sur-Hoge',
+													startDate: '2008-05-01',
+													endDate: '2008-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_DOWNSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Downstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sur-Hoge',
+													startDate: '2008-06-01',
+													endDate: '2008-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [],
+											rightsGrantorMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_HOGE_MATERIAL_UUID,
+													name: 'Sur-Hoge',
+													format: 'collection of plays',
+													year: 2008,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: true,
+											type: 'Winner',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+													name: 'Sub-Hoge',
+													startDate: '2008-05-01',
+													endDate: '2008-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_DOWNSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Downstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+														name: 'Mid-Hoge',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+															name: 'Sur-Hoge'
+														}
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sub-Hoge',
+													startDate: '2008-06-01',
+													endDate: '2008-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Mid-Hoge',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+															name: 'Sur-Hoge'
+														}
+													}
+												}
+											],
+											materials: [],
+											rightsGrantorMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_HOGE_MATERIAL_UUID,
+													name: 'Sub-Hoge',
+													format: 'play',
+													year: 2008,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: MID_HOGE_MATERIAL_UUID,
+														name: 'Mid-Hoge',
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_HOGE_MATERIAL_UUID,
+															name: 'Sur-Hoge'
+														}
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards, rightsGrantorMaterialAwards } = subCinerightsLtdCompany.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+			expect(rightsGrantorMaterialAwards).to.deep.equal(expectedRightsGrantorMaterialAwards);
+
+		});
+
+	});
+
+	describe('Mid-Cinerights Ltd (company): materials (and their associated sur-material and sub-materials) to which they granted rights have nominations', () => {
+
+		it('includes awards of materials (and their associated sur-material and sub-materials) to which they granted rights', () => {
+
+			const expectedAwards = [];
+
+			const expectedRightsGrantorMaterialAwards = [
+				{
+					model: 'AWARD',
+					uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+					name: 'Dramatists Medal',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+							name: '2008',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Most Remarkable Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: MID_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+													name: 'Mid-Hoge',
+													startDate: '2008-05-01',
+													endDate: '2008-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_DOWNSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Downstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+														name: 'Sur-Hoge',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: MID_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Mid-Hoge',
+													startDate: '2008-06-01',
+													endDate: '2008-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Sur-Hoge',
+														surProduction: null
+													}
+												}
+											],
+											materials: [],
+											rightsGrantorMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: MID_HOGE_MATERIAL_UUID,
+													name: 'Mid-Hoge',
+													format: 'sub-collection of plays',
+													year: 2008,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_HOGE_MATERIAL_UUID,
+														name: 'Sur-Hoge',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+													name: 'Sur-Hoge',
+													startDate: '2008-05-01',
+													endDate: '2008-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_DOWNSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Downstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sur-Hoge',
+													startDate: '2008-06-01',
+													endDate: '2008-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [],
+											rightsGrantorMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_HOGE_MATERIAL_UUID,
+													name: 'Sur-Hoge',
+													format: 'collection of plays',
+													year: 2008,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: true,
+											type: 'Winner',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+													name: 'Sub-Hoge',
+													startDate: '2008-05-01',
+													endDate: '2008-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_DOWNSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Downstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+														name: 'Mid-Hoge',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+															name: 'Sur-Hoge'
+														}
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sub-Hoge',
+													startDate: '2008-06-01',
+													endDate: '2008-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Mid-Hoge',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+															name: 'Sur-Hoge'
+														}
+													}
+												}
+											],
+											materials: [],
+											rightsGrantorMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_HOGE_MATERIAL_UUID,
+													name: 'Sub-Hoge',
+													format: 'play',
+													year: 2008,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: MID_HOGE_MATERIAL_UUID,
+														name: 'Mid-Hoge',
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_HOGE_MATERIAL_UUID,
+															name: 'Sur-Hoge'
+														}
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards, rightsGrantorMaterialAwards } = midCinerightsLtdCompany.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+			expect(rightsGrantorMaterialAwards).to.deep.equal(expectedRightsGrantorMaterialAwards);
+
+		});
+
+	});
+
+	describe('Sur-Cinerights Ltd (company): materials (and their associated sub-material and sub-sub-materials) to which they granted rights have nominations', () => {
+
+		it('includes awards of materials (and their associated sub-material and sub-sub-materials) to which they granted rights', () => {
+
+			const expectedAwards = [];
+
+			const expectedRightsGrantorMaterialAwards = [
+				{
+					model: 'AWARD',
+					uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+					name: 'Dramatists Medal',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+							name: '2008',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Most Remarkable Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: MID_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+													name: 'Mid-Hoge',
+													startDate: '2008-05-01',
+													endDate: '2008-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_DOWNSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Downstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+														name: 'Sur-Hoge',
+														surProduction: null
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: MID_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Mid-Hoge',
+													startDate: '2008-06-01',
+													endDate: '2008-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Sur-Hoge',
+														surProduction: null
+													}
+												}
+											],
+											materials: [],
+											rightsGrantorMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: MID_HOGE_MATERIAL_UUID,
+													name: 'Mid-Hoge',
+													format: 'sub-collection of plays',
+													year: 2008,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: SUR_HOGE_MATERIAL_UUID,
+														name: 'Sur-Hoge',
+														surMaterial: null
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+					name: 'Playwriting Prize',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+							name: '2009',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Random Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: false,
+											type: 'Nomination',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+													name: 'Sur-Hoge',
+													startDate: '2008-05-01',
+													endDate: '2008-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_DOWNSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Downstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: null
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sur-Hoge',
+													startDate: '2008-06-01',
+													endDate: '2008-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: null
+												}
+											],
+											materials: [],
+											rightsGrantorMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_HOGE_MATERIAL_UUID,
+													name: 'Sur-Hoge',
+													format: 'collection of plays',
+													year: 2008,
+													surMaterial: null
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'AWARD',
+					uuid: WORDSMITH_AWARD_UUID,
+					name: 'Wordsmith Award',
+					ceremonies: [
+						{
+							model: 'AWARD_CEREMONY',
+							uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+							name: '2010',
+							categories: [
+								{
+									model: 'AWARD_CEREMONY_CATEGORY',
+									name: 'Best Miscellaneous Play',
+									nominations: [
+										{
+											model: 'NOMINATION',
+											isWinner: true,
+											type: 'Winner',
+											entities: [],
+											productions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+													name: 'Sub-Hoge',
+													startDate: '2008-05-01',
+													endDate: '2008-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: JERWOOD_THEATRE_DOWNSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Downstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+														name: 'Mid-Hoge',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_HOGE_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID,
+															name: 'Sur-Hoge'
+														}
+													}
+												},
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sub-Hoge',
+													startDate: '2008-06-01',
+													endDate: '2008-06-30',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													},
+													surProduction: {
+														model: 'PRODUCTION',
+														uuid: MID_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+														name: 'Mid-Hoge',
+														surProduction: {
+															model: 'PRODUCTION',
+															uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+															name: 'Sur-Hoge'
+														}
+													}
+												}
+											],
+											materials: [],
+											rightsGrantorMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_HOGE_MATERIAL_UUID,
+													name: 'Sub-Hoge',
+													format: 'play',
+													year: 2008,
+													surMaterial: {
+														model: 'MATERIAL',
+														uuid: MID_HOGE_MATERIAL_UUID,
+														name: 'Mid-Hoge',
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_HOGE_MATERIAL_UUID,
+															name: 'Sur-Hoge'
+														}
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { awards, rightsGrantorMaterialAwards } = surCinerightsLtdCompany.body;
+
+			expect(awards).to.deep.equal(expectedAwards);
+			expect(rightsGrantorMaterialAwards).to.deep.equal(expectedRightsGrantorMaterialAwards);
+
+		});
+
+	});
+
+});


### PR DESCRIPTION
Currently, materials will capture the nominations/awards of their sur-sur, sur, sub, and sub-sub-materials via association. This PR modifies the Cypher queries so that the credited writers of materials accordingly capture associated nominations/awards in the same way, e.g.

If a collection of plays was nominated for or won an award then the credited writers of the individual plays of which the collection is comprised should also capture that nomination/win in their listed nominations/awards because of their contribution to the whole.

On the flip side, if one of the individual plays was nominated or won then any credited writers of the collection (e.g. curator) should capture that nomination/win in their listed nominations/awards because it is an aspect of the whole which should be surfaced.

In these cases, the material that was directly nominated/awarded is the one that is included in the credited writer's listed nominations/awards, e.g. if a sur-material was nominated/awarded then a sub-material's credited writer's listed nominations/awards will specify the sur-material.

---

## Test examples

### `award-ceremonies-with-crediting-sub-materials-assocs.test.js`

#### John Doe Jr (person): credit for directly nominated material and their associated sur-material
N.B. Nominations/awards for their credited materials' sur-material are now captured via association
<img width="946" alt="john-doe-jr-person" src="https://user-images.githubusercontent.com/10484515/228039053-342c8eac-ac38-4c8b-97dc-a2a2bad8e084.png">

---

#### John Doe Sr (person): credit for directly nominated material and their associated sub-material
N.B. Nominations/awards for their credited materials' sub-materials are now captured via association
<img width="953" alt="john-doe-sr-person" src="https://user-images.githubusercontent.com/10484515/228039072-8cf95985-bb19-486c-acb6-02fe6b04dcdb.png">

---

#### Sub-Playwrights Ltd (company): credit for directly nominated material and their associated sur-material
N.B. Nominations/awards for its credited materials' sur-material are now captured via association
<img width="944" alt="sub-playwrights-ltd-company" src="https://user-images.githubusercontent.com/10484515/228039097-77b88be4-844c-4786-9603-081d532222e4.png">

---

#### Sur-Playwrights Ltd (company): credit for directly nominated material and their associated sub-material
N.B. Nominations/awards for its credited materials' sub-materials are now captured via association
<img width="943" alt="sur-playwrights-ltd-company" src="https://user-images.githubusercontent.com/10484515/228039113-e2a5502f-e53e-47f8-86fa-35f0154932f4.png">

---

#### Francis Flob Jr (person): subsequent versions (and their associated sur-material) of their work have nominations
N.B. Nominations/awards for their credited materials' subsequent versions' sur-material are now captured via association
<img width="939" alt="francis-flob-jr-person" src="https://user-images.githubusercontent.com/10484515/228039126-a10ca1dd-aebd-43c7-8b77-7e54db1dec4c.png">

---

#### Francis Flob Sr (person): subsequent versions (and their associated sub-materials) of their work have nominations
N.B. Nominations/awards for their credited materials' subsequent versions' sub-materials are now captured via association
<img width="930" alt="francis-flob-sr-person" src="https://user-images.githubusercontent.com/10484515/228039143-a51f306c-abcf-4e42-a1e5-3587ab09910a.png">

---

#### Sub-Curtain Up Ltd (company): subsequent versions (and their associated sur-material) of their work have nominations
N.B. Nominations/awards for its credited materials' subsequent versions' sur-material are now captured via association
<img width="950" alt="sub-curtain-up-ltd-company" src="https://user-images.githubusercontent.com/10484515/228039152-a93a6ac0-17df-428a-8fca-8f6058748587.png">

---

#### Sur-Curtain Up Ltd (company): subsequent versions (and their associated sub-materials) of their work have nominations
N.B. Nominations/awards for its credited materials' subsequent versions' sub-materials are now captured via association
<img width="942" alt="sur-curtain-up-ltd-company" src="https://user-images.githubusercontent.com/10484515/228039176-9c3bd67a-7f5b-4699-a13a-da37cc3d6bc8.png">

---

#### Jane Roe Jr (person): materials (and their associated sur-material) that used their (specific) work as source material have nominations
N.B. Nominations/awards for their credited materials' sourcing materials' sur-material are now captured via association
<img width="943" alt="jane-roe-jr-person" src="https://user-images.githubusercontent.com/10484515/228039189-ce3266fe-874d-4abc-8711-f880c5371c33.png">

---

#### Jane Roe Sr (person): materials (and their associated sub-materials) that used their (specific) work as source material have nominations
N.B. Nominations/awards for their credited materials' sourcing materials' sub-materials are now captured via association
<img width="938" alt="jane-roe-sr-person" src="https://user-images.githubusercontent.com/10484515/228039205-f4590a61-d632-4543-b767-9c92c1710aec.png">

---

#### Sub-Fictioneers Ltd (company): materials (and their associated sur-material) that used their (specific) work as source material have nominations
N.B. Nominations/awards for its credited materials' sourcing materials' sur-material are now captured via association
<img width="943" alt="sub-fictioneers-ltd-company" src="https://user-images.githubusercontent.com/10484515/228039219-edeca2d8-2a6c-44aa-a3a5-450bd6ea610f.png">

---

#### Sur-Fictioneers Ltd (company): materials (and their associated sub-materials) that used their (specific) work as source material have nominations
N.B. Nominations/awards for its credited materials' sourcing materials' sub-materials are now captured via association
<img width="946" alt="sur-fictioneers-ltd-company" src="https://user-images.githubusercontent.com/10484515/228039229-d355055d-bb74-4956-8e90-8905759cf891.png">

---

#### Talyse Tata Jr (person): materials (and their associated sur-material) to which they have granted rights have nominations
N.B. Nominations/awards for their rights grantor materials' sur-material are now captured via association
<img width="937" alt="talyse-tata-jr" src="https://user-images.githubusercontent.com/10484515/228039232-8b70d116-7642-400b-ba58-43a34672fc93.png">

---

#### Talyse Tata Sr (person): materials (and their associated sub-materials) to which they have granted rights have nominations
N.B. Nominations/awards for their rights grantor materials' sub-materials are now captured via association
<img width="939" alt="talyse-tata-sr" src="https://user-images.githubusercontent.com/10484515/228039245-4923a057-8fbe-45f1-a75b-28eb5345ed38.png">

---

#### Sub-Cinerights Ltd (company): materials (and their associated sur-material) to which they granted rights have nominations
N.B. Nominations/awards for its rights grantor materials' sur-material are now captured via association
<img width="931" alt="sub-cinerights-ltd" src="https://user-images.githubusercontent.com/10484515/228039252-6620e79e-af03-473f-a518-9c811e26daec.png">

---

#### Sur-Cinerights Ltd (company): materials (and their associated sub-materials) to which they granted rights have nominations
N.B. Nominations/awards for its rights grantor materials' sub-materials are now captured via association
<img width="938" alt="sur-cinerights-ltd" src="https://user-images.githubusercontent.com/10484515/228039260-744ce142-fc44-4a44-9fce-bd8deb233908.png">

---

### `award-ceremonies-with-crediting-sub-sub-materials-via-assocs.test.js`

#### John Doe Jr (person): credit for directly nominated material and their associated sur-material and sur-sur-material
N.B. Nominations/awards for their credited materials' sur-material and sur-sur-material are now captured via association
<img width="940" alt="john-doe-jr-person" src="https://user-images.githubusercontent.com/10484515/228367325-c13e9cf8-1ba1-4f48-961e-296b94ca0531.png">

---

#### John Doe (person): credit for directly nominated material and their associated sur-material and sub-materials
N.B. Nominations/awards for their credited materials' sur-material and sub-materials are now captured via association
<img width="945" alt="john-doe-person" src="https://user-images.githubusercontent.com/10484515/228367348-4506d41e-cb1e-44b2-b4df-e464691341e6.png">

---

#### John Doe Sr (person): credit for directly nominated material and their associated sub-materials and sub-sub-materials
N.B. Nominations/awards for their credited materials' sub-materials and sub-sub-materials are now captured via association
<img width="937" alt="john-doe-sr-person" src="https://user-images.githubusercontent.com/10484515/228367369-16602a91-336b-4180-b701-8397e03b2ee4.png">

---

#### Sub-Playwrights Ltd (company): credit for directly nominated material and their associated sur-material and sur-sur-material
N.B. Nominations/awards for its credited materials' sur-material and sur-sur-material are now captured via association
<img width="946" alt="sub-playwrights-ltd-company" src="https://user-images.githubusercontent.com/10484515/228367387-672adabc-8316-41df-8970-817d2936bb83.png">

---

#### Mid-Playwrights Ltd (company): credit for directly nominated material and their associated sur-material and sub-materials
N.B. Nominations/awards for its credited materials' sur-material and sub-materials are now captured via association
<img width="947" alt="mid-playwrights-ltd-company" src="https://user-images.githubusercontent.com/10484515/228367412-bc83a5d4-bda1-4c8b-be07-14d10d266046.png">

---

#### Sur-Playwrights Ltd (company): credit for directly nominated material and their associated sub-materials and sub-sub-materials
N.B. Nominations/awards for its credited materials' sub-materials and sub-sub-materials are now captured via association
<img width="952" alt="sur-playwrights-ltd-company" src="https://user-images.githubusercontent.com/10484515/228367468-f3fdef37-0324-48bb-98f5-9f3b2b2e6470.png">

---

#### Francis Flob Jr (person): subsequent versions (and their associated sur-material and sur-sur-material) of their work have nominations
N.B. Nominations/awards for their credited materials' subsequent versions' sur-material and sur-sur-material are now captured via association
<img width="929" alt="francis-flob-jr-person" src="https://user-images.githubusercontent.com/10484515/228367491-d3937756-4f12-49d1-80dc-390bd71b2179.png">

---

#### Francis Flob (person): subsequent versions (and their associated sur-material and sub-materials) of their work have nominations
N.B. Nominations/awards for their credited materials' subsequent versions' sur-material and sub-materials are now captured via association
<img width="932" alt="francis-flob-person" src="https://user-images.githubusercontent.com/10484515/228367508-a0f89574-b00c-4328-8487-868e486e3623.png">

---

#### Francis Flob Sr (person): subsequent versions (and their associated sub-materials and sub-sub-materials) of their work have nominations
N.B. Nominations/awards for their credited materials' subsequent versions' sub-materials and sub-sub-materials are now captured via association
<img width="935" alt="francis-flob-sr-person" src="https://user-images.githubusercontent.com/10484515/228367550-42ac086c-2534-4d3e-ab32-19c68b30be96.png">

---

#### Sub-Curtain Up Ltd (company): subsequent versions (and their associated sur-material and sur-sur-material) of their work have nominations
N.B. Nominations/awards for its credited materials' subsequent versions' sur-material and sur-sur-material are now captured via association
<img width="933" alt="sub-curtain-up-ltd-company" src="https://user-images.githubusercontent.com/10484515/228367563-36da14c0-d8b7-4a9c-9a1c-5878cda4aa7a.png">

---

#### Mid-Curtain Up Ltd (company): subsequent versions (and their associated sur-material and sub-materials) of their work have nominations
N.B. Nominations/awards for its credited materials' subsequent versions' sur-material and sub-materials are now captured via association
<img width="939" alt="mid-curtain-up-ltd-company" src="https://user-images.githubusercontent.com/10484515/228367579-3b4e8079-8c91-4124-8894-76ea142b3b30.png">

---

#### Sur-Curtain Up Ltd (company): subsequent versions (and their associated sub-materials and sub-sub-materials) of their work have nominations
N.B. Nominations/awards for its credited materials' subsequent versions' sub-materials and sub-sub-materials are now captured via association
<img width="934" alt="sur-curtain-up-ltd-company" src="https://user-images.githubusercontent.com/10484515/228367612-5e91834f-016b-4c18-a13d-07e13a92501f.png">

---

#### Jane Roe Jr (person): materials (and their associated sur-material and sur-sur-material) that used their (specific) work as source material have nominations
N.B. Nominations/awards for their credited materials' sourcing materials' sur-material and sur-sur-material are now captured via association
<img width="948" alt="jane-roe-jr-person" src="https://user-images.githubusercontent.com/10484515/228367644-80d50395-4379-4775-9b01-cc2b670d7960.png">

---

#### Jane Roe (person): materials (and their associated sur-material and sub-materials) that used their (specific) work as source material have nominations
N.B. Nominations/awards for their credited materials' sourcing materials' sur-material and sub-materials are now captured via association
<img width="934" alt="jane-roe-person" src="https://user-images.githubusercontent.com/10484515/228367661-c0aa0551-cf86-4972-a867-f9d9a818646a.png">

---

#### Jane Roe Sr (person): materials (and their associated sub-materials and sub-sub-materials) that used their (specific) work as source material have nominations
N.B. Nominations/awards for their credited materials' sourcing materials' sub-materials and sub-sub-materials are now captured via association
<img width="944" alt="jane-roe-sr-person" src="https://user-images.githubusercontent.com/10484515/228367679-f0e99820-fb61-432c-94bb-be1ec1603aa7.png">

---

#### Sub-Fictioneers Ltd (company): materials (and their associated sur-material and sur-sur-material) that used their (specific) work as source material have nominations
N.B. Nominations/awards for its credited materials' sourcing materials' sur-material and sur-sur-material are now captured via association
<img width="955" alt="sub-fictioneers-ltd-company" src="https://user-images.githubusercontent.com/10484515/228367706-94786758-9f84-49f4-bff9-024cc04d64d2.png">

---

#### Mid-Fictioneers Ltd (company): materials (and their associated sur-material and sub-materials) that used their (specific) work as source material have nominations
N.B. Nominations/awards for its credited materials' sourcing materials' sur-material and sub-materials are now captured via association
<img width="945" alt="mid-fictioneers-ltd-company" src="https://user-images.githubusercontent.com/10484515/228367717-507699e5-08b1-483d-8cd9-c6b20c8e39d0.png">

---

#### Sur-Fictioneers Ltd (company): materials (and their associated sub-materials and sub-sub-materials) that used their (specific) work as source material have nominations
N.B. Nominations/awards for its credited materials' sourcing materials' sub-materials and sub-sub-materials are now captured via association
<img width="944" alt="sur-fictioneers-ltd-company" src="https://user-images.githubusercontent.com/10484515/228367739-9a5f8cfd-5486-4c3f-b5c3-18272fe8d0ed.png">

---

#### Talyse Tata Jr (person): materials (and their associated sur-material and sur-sur-material) to which they have granted rights have nominations
N.B. Nominations/awards for their rights grantor materials' sur-material and sur-sur-material are now captured via association
<img width="949" alt="talyse-tata-jr-person" src="https://user-images.githubusercontent.com/10484515/228367757-21e33dd2-44e2-47f2-9b1f-70efe431a3e1.png">

---

#### Talyse Tata (person): materials (and their associated sur-material and sub-materials) to which they have granted rights have nominations
N.B. Nominations/awards for their rights grantor materials' sur-material and sub-materials are now captured via association
<img width="946" alt="talyse-tata-person" src="https://user-images.githubusercontent.com/10484515/228367779-8bd8293a-cd26-48e7-8202-1ca3ded4fe1b.png">

---

#### Talyse Tata Sr (person): materials (and their associated sub-materials and sub-sub-materials) to which they have granted rights have nominations
N.B. Nominations/awards for their rights grantor materials' sub-materials and sub-sub-materials are now captured via association
<img width="947" alt="talyse-tata-sr-person" src="https://user-images.githubusercontent.com/10484515/228367796-73e20c3d-d69f-4a6b-b1ed-f707ce9431ce.png">

---

#### Sub-Cinerights Ltd (company): materials (and their associated sur-material and sur-sur-material) to which they granted rights have nominations
N.B. Nominations/awards for its rights grantor materials' sur-material and sur-sur-material are now captured via association
<img width="942" alt="sub-cinerights-ltd-company" src="https://user-images.githubusercontent.com/10484515/228367819-0e835c0d-970c-4437-9b5a-1583b8869836.png">

---

#### Mid-Cinerights Ltd (company): materials (and their associated sur-material and sub-materials) to which they granted rights have nominations
N.B. Nominations/awards for its rights grantor materials' sur-material and sub-materials are now captured via association
<img width="945" alt="mid-cinerights-ltd-company" src="https://user-images.githubusercontent.com/10484515/228367839-4f777fe4-ce72-4aa9-8eb0-cd225ceb1918.png">

---

#### Sur-Cinerights Ltd (company): materials (and their associated sub-material and sub-sub-materials) to which they granted rights have nominations
N.B. Nominations/awards for its rights grantor materials' sub-materials and sub-sub-materials are now captured via association
<img width="944" alt="sur-cinerights-ltd-company" src="https://user-images.githubusercontent.com/10484515/228367854-fc985d51-29d6-4d85-88c9-e6154c816ee7.png">