### PR TITLE
Add E2E tests for material sur-materials with source materials

### DIFF
--- a/test-e2e/model-interaction/mat-with-sub-mats-source-mats.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-mats-source-mats.test.js
@@ -420,6 +420,73 @@ describe('Material with sub-materials and source materials thereof', () => {
 
 		});
 
+		it('includes writers and source material of this material\'s sur-material', () => {
+
+			const expectedSurMaterial = {
+				model: 'MATERIAL',
+				uuid: THE_WOLF_HALL_TRILOGY_PLAYS_MATERIAL_UUID,
+				name: 'The Wolf Hall Trilogy',
+				format: 'trilogy of plays',
+				year: 2021,
+				surMaterial: null,
+				writingCredits: [
+					{
+						model: 'WRITING_CREDIT',
+						name: 'by',
+						entities: [
+							{
+								model: 'PERSON',
+								uuid: MIKE_POULTON_PERSON_UUID,
+								name: 'Mike Poulton'
+							},
+							{
+								model: 'COMPANY',
+								uuid: ROYAL_SHAKESPEARE_COMPANY_UUID,
+								name: 'Royal Shakespeare Company'
+							}
+						]
+					},
+					{
+						model: 'WRITING_CREDIT',
+						name: 'adapted from',
+						entities: [
+							{
+								model: 'MATERIAL',
+								uuid: THE_WOLF_HALL_TRILOGY_NOVELS_MATERIAL_UUID,
+								name: 'The Wolf Hall Trilogy',
+								format: 'trilogy of novels',
+								year: 2020,
+								surMaterial: null,
+								writingCredits: [
+									{
+										model: 'WRITING_CREDIT',
+										name: 'by',
+										entities: [
+											{
+												model: 'PERSON',
+												uuid: HILARY_MANTEL_PERSON_UUID,
+												name: 'Hilary Mantel'
+											},
+											{
+												model: 'COMPANY',
+												uuid: THE_MANTEL_GROUP_COMPANY_UUID,
+												name: 'The Mantel Group'
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			};
+
+			const { surMaterial } = bringUpTheBodiesPlayMaterial.body;
+
+			expect(surMaterial).to.deep.equal(expectedSurMaterial);
+
+		});
+
 	});
 
 	describe('Hilary Mantel (person)', () => {

--- a/test-e2e/model-interaction/mat-with-sub-sub-mats-source-mats.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-sub-mats-source-mats.test.js
@@ -29,6 +29,7 @@ describe('Material with sub-sub-materials and source materials thereof', () => {
 
 	let genesisReligiousTextMaterial;
 	let godblogPlayMaterial;
+	let theBooksOfTheOldTestamentPlaysMaterial;
 	let richardBancroftPerson;
 	let jeanetteWintersonPerson;
 	let theCanterburyEditorsCompany;
@@ -267,6 +268,9 @@ describe('Material with sub-sub-materials and source materials thereof', () => {
 		godblogPlayMaterial = await chai.request(app)
 			.get(`/materials/${GODBLOG_PLAY_MATERIAL_UUID}`);
 
+		theBooksOfTheOldTestamentPlaysMaterial = await chai.request(app)
+			.get(`/materials/${THE_BOOKS_OF_THE_OLD_TESTAMENT_PLAYS_MATERIAL_UUID}`);
+
 		richardBancroftPerson = await chai.request(app)
 			.get(`/people/${RICHARD_BANCROFT_PERSON_UUID}`);
 
@@ -485,6 +489,121 @@ describe('Material with sub-sub-materials and source materials thereof', () => {
 			const { writingCredits } = godblogPlayMaterial.body;
 
 			expect(writingCredits).to.deep.equal(expectedWritingCredits);
+
+		});
+
+		it('includes writers and source material (with corresponding sur-material) of this material\'s sur-material', () => {
+
+			const expectedSurMaterial = {
+				model: 'MATERIAL',
+				uuid: THE_BOOKS_OF_THE_OLD_TESTAMENT_PLAYS_MATERIAL_UUID,
+				name: 'The Books of the Old Testament',
+				format: 'sub-collection of plays',
+				year: 2011,
+				surMaterial: {
+					model: 'MATERIAL',
+					uuid: SIXTY_SIX_BOOKS_PLAYS_MATERIAL_UUID,
+					name: 'Sixty-Six Books'
+				},
+				writingCredits: [
+					{
+						model: 'WRITING_CREDIT',
+						name: 'written in response to',
+						entities: [
+							{
+								model: 'MATERIAL',
+								uuid: THE_OLD_TESTAMENT_RELIGIOUS_TEXT_MATERIAL_UUID,
+								name: 'The Old Testament',
+								format: 'religious text',
+								year: 1611,
+								surMaterial: {
+									model: 'MATERIAL',
+									uuid: THE_BIBLE_KING_JAMES_VERSION_RELIGIOUS_TEXT_MATERIAL_UUID,
+									name: 'The Bible: King James Version',
+									surMaterial: null
+								},
+								writingCredits: [
+									{
+										model: 'WRITING_CREDIT',
+										name: 'by',
+										entities: [
+											{
+												model: 'PERSON',
+												uuid: RICHARD_BANCROFT_PERSON_UUID,
+												name: 'Richard Bancroft'
+											},
+											{
+												model: 'COMPANY',
+												uuid: THE_CANTERBURY_EDITORS_COMPANY_UUID,
+												name: 'The Canterbury Editors'
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			};
+
+			const { surMaterial } = godblogPlayMaterial.body;
+
+			expect(surMaterial).to.deep.equal(expectedSurMaterial);
+
+		});
+
+	});
+
+	describe('The Books of the Old Testament (sub-collection of plays) (material)', () => {
+
+		it('includes writers and source material of this material\'s sur-material', () => {
+
+			const expectedSurMaterial = {
+				model: 'MATERIAL',
+				uuid: SIXTY_SIX_BOOKS_PLAYS_MATERIAL_UUID,
+				name: 'Sixty-Six Books',
+				format: 'collection of plays',
+				year: 2011,
+				surMaterial: null,
+				writingCredits: [
+					{
+						model: 'WRITING_CREDIT',
+						name: 'written in response to',
+						entities: [
+							{
+								model: 'MATERIAL',
+								uuid: THE_BIBLE_KING_JAMES_VERSION_RELIGIOUS_TEXT_MATERIAL_UUID,
+								name: 'The Bible: King James Version',
+								format: 'religious text',
+								year: 1611,
+								surMaterial: null,
+								writingCredits: [
+									{
+										model: 'WRITING_CREDIT',
+										name: 'by',
+										entities: [
+											{
+												model: 'PERSON',
+												uuid: RICHARD_BANCROFT_PERSON_UUID,
+												name: 'Richard Bancroft'
+											},
+											{
+												model: 'COMPANY',
+												uuid: THE_CANTERBURY_EDITORS_COMPANY_UUID,
+												name: 'The Canterbury Editors'
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			};
+
+			const { surMaterial } = theBooksOfTheOldTestamentPlaysMaterial.body;
+
+			expect(surMaterial).to.deep.equal(expectedSurMaterial);
 
 		});
 


### PR DESCRIPTION
This PR adds some additional end-to-end tests for materials that have sub and sub-sub materials with source materials.

---

## Test examples

### `mat-with-sub-mats-source-mats.test.js`

#### Bring Up the Bodies (play) (material)

This tests that a sur-material can include a source material.

<img width="918" alt="bring-up-the-bodies-play-material" src="https://user-images.githubusercontent.com/10484515/229301335-728be9c9-0a3f-46b3-8b9f-1b1492df1a66.png">

---

### `mat-with-sub-sub-mats-source-mats.test.js`

This tests that a sur-material can include a source material which in turn has its own sur-material.

#### Godblog (play) (material)
<img width="945" alt="godblog-play-material" src="https://user-images.githubusercontent.com/10484515/229301388-94c56ea0-df32-4003-9f8e-0f7dfff10111.png">

---

#### The Books of the Old Testament (sub-collection of plays) (material)

This tests that a sur-material can include a source material (i.e. this is essentially the same test as the above one for Bring Up the Bodies (play)).

<img width="906" alt="the-books-of-the-old-testament-plays-material" src="https://user-images.githubusercontent.com/10484515/229301383-f5289eee-8167-4e14-9273-81de9fac1bc2.png">