### PR TITLE
Fix materials show-productions Cypher query

### DIFF
--- a/src/neo4j/cypher-queries/material/show/show-productions.js
+++ b/src/neo4j/cypher-queries/material/show/show-productions.js
@@ -3,7 +3,7 @@ export default () => `
 
 	OPTIONAL MATCH (material)<-[:USES_SOURCE_MATERIAL*0..1]-(:Material)<-[:PRODUCTION_OF]-(production:Production)
 
-	WITH COLLECT(production) AS productions
+	WITH material, COLLECT(production) AS productions
 
 	UNWIND (CASE productions WHEN [] THEN [null] ELSE productions END) AS production
 

--- a/test-e2e/model-interaction/mats-with-source-mat.test.js
+++ b/test-e2e/model-interaction/mats-with-source-mat.test.js
@@ -36,6 +36,7 @@ describe('Materials with source material', () => {
 	const THE_INDIAN_BOY_ROYAL_SHAKESPEARE_THEATRE_PRODUCTION_UUID = '74';
 	const SHAKESPEARES_VILLAINS_THEATRE_ROYAL_HAYMARKET_PRODUCTION_UUID = '77';
 	const OTHELLO_DONMAR_WAREHOUSE_PRODUCTION_UUID = '80';
+	const DONMAR_WAREHOUSE_VENUE_UUID = '82';
 
 	let aMidsummerNightsDreamMaterial;
 	let theIndianBoyMaterial;
@@ -841,6 +842,31 @@ describe('Materials with source material', () => {
 			const { writingCredits } = othelloMaterial.body;
 
 			expect(writingCredits).to.deep.equal(expectedWritingCredits);
+
+		});
+
+		it('includes productions of material', () => {
+
+			const expectedProductions = [
+				{
+					model: 'PRODUCTION',
+					uuid: OTHELLO_DONMAR_WAREHOUSE_PRODUCTION_UUID,
+					name: 'Othello',
+					startDate: '2007-11-30',
+					endDate: '2008-02-23',
+					venue: {
+						model: 'VENUE',
+						uuid: DONMAR_WAREHOUSE_VENUE_UUID,
+						name: 'Donmar Warehouse',
+						surVenue: null
+					},
+					surProduction: null
+				}
+			];
+
+			const { productions } = othelloMaterial.body;
+
+			expect(productions).to.deep.equal(expectedProductions);
 
 		});
 


### PR DESCRIPTION
This PR fixes an issue with the materials show-productions Cypher query.

The result of the bug is that when listing the productions of materials that are based on source materials, it lists them under `sourcingMaterialProductions` rather than `productions`, e.g. The Life and Adventures of Nicholas Nickleby (play) by David Edgar, which is based on The Life and Adventures of Nicholas Nickleby (novel) by Charles Dickens will list The Life and Adventures of Nicholas Nickleby at Gielgud Theatre under **Productions of materials as source material** rather than **Productions**.

This was caused by the `material` identified in the opening `MATCH` statement not carried through to the next portion of the query via the `WITH` statement (i.e. `WITH COLLECT(production) AS productions`), so when the below line of the query runs, there is no reference for `material`, only for `production`, and consequently the pattern is matched (where `material` is assigned the value of the source material node), meaning `sourcingMaterialRel` exists, which then evaluates to true when setting the production's `usesSourcingMaterial` value.

```cypher
OPTIONAL MATCH (material)<-[:USES_SOURCE_MATERIAL]-(:Material)<-[sourcingMaterialRel:PRODUCTION_OF]-(production)
```

An additional end-to-end test is added to the existing `test-e2e/model-interaction/mats-with-source-mat.test.js` test suite to capture this logic (it fails if the Cypher query change is reverted).