### PR TITLE
Modify Cypher queries to omit unwanted sur-instances

### DIFF
--- a/src/neo4j/cypher-queries/company/show/show-materials.js
+++ b/src/neo4j/cypher-queries/company/show/show-materials.js
@@ -2,8 +2,10 @@ export default () => `
 	MATCH (company:Company { uuid: $uuid })
 
 	OPTIONAL MATCH (company)<-[:HAS_WRITING_ENTITY]-(:Material)<-[:USES_SOURCE_MATERIAL*0..1]-(material:Material)
-		WHERE NOT EXISTS((company)<-[:HAS_WRITING_ENTITY]-(:Material)<-[:USES_SOURCE_MATERIAL*0..1]-(:Material)
-			<-[:HAS_SUB_MATERIAL]-(material))
+		WHERE NOT EXISTS(
+			(company)<-[:HAS_WRITING_ENTITY]-(:Material)<-[:USES_SOURCE_MATERIAL*0..1]-(:Material)
+			<-[:HAS_SUB_MATERIAL*1..2]-(material)
+		)
 
 	WITH company, COLLECT(DISTINCT(material)) AS materials
 

--- a/src/neo4j/cypher-queries/person/show/show-materials.js
+++ b/src/neo4j/cypher-queries/person/show/show-materials.js
@@ -4,7 +4,7 @@ export default () => `
 	OPTIONAL MATCH (person)<-[:HAS_WRITING_ENTITY]-(:Material)<-[:USES_SOURCE_MATERIAL*0..1]-(material:Material)
 		WHERE NOT EXISTS(
 			(person)<-[:HAS_WRITING_ENTITY]-(:Material)<-[:USES_SOURCE_MATERIAL*0..1]-(:Material)
-			<-[:HAS_SUB_MATERIAL]-(material)
+			<-[:HAS_SUB_MATERIAL*1..2]-(material)
 		)
 
 	WITH person, COLLECT(DISTINCT(material)) AS materials

--- a/src/neo4j/cypher-queries/venue/show.js
+++ b/src/neo4j/cypher-queries/venue/show.js
@@ -25,7 +25,7 @@ export default () => [`
 	OPTIONAL MATCH (venue)-[:HAS_SUB_VENUE*0..1]->(venueLinkedToProduction:Venue)<-[:PLAYS_AT]-(production:Production)
 		WHERE NOT EXISTS(
 			(venue)-[:HAS_SUB_VENUE*0..1]->(venueLinkedToProduction)
-			<-[:PLAYS_AT]-(:Production)<-[:HAS_SUB_PRODUCTION]-(production)
+			<-[:PLAYS_AT]-(:Production)<-[:HAS_SUB_PRODUCTION*1..2]-(production)
 		)
 
 	OPTIONAL MATCH (production)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)


### PR DESCRIPTION
Some credit listings exclude sur-instances where a sub-instance also exists:
- material credits for company instances
- material credits for person instances
- production credits for venue instances

In the unlikely scenario of one of these instances having credits on a three-tiered material/production but only on the top and bottom tier (i.e. not the middle tier), the unwanted sur-instance would currently still appear in the credits.

This PR adjusts the Cypher queries to prevent this. Even though the scenario is unlikely, it handles the data in the anticipated forms it can take and so means it does a better job of representing those forms through the Cypher query.

Here is a scenario of Amit Gupta being credited to both the top and bottom tiers of a three-tiered material:
- The Bomb: A Partial History (material) (collection of plays)
- The Bomb: A Partial History: First Blast: Proliferation (1940-1992): Option (material) (play)

But not credited to the middle tier:
- The Bomb: A Partial History: First Blast: Proliferation (1940-1992) (material) (sub-collection of plays)

---

#### Before
The Bomb: A Partial History (material) (collection of plays) is unwanted
<img width="714" alt="before" src="https://user-images.githubusercontent.com/10484515/234379906-3c28cfab-e3c3-4ecd-9a64-2943b7aa946c.png">

---

#### After
<img width="712" alt="after" src="https://user-images.githubusercontent.com/10484515/234379929-25fb1a16-0d1b-49f9-9af2-bcf397e49add.png">