### PR TITLE
Enable multi-tiered materials to derive sur and sub-material credits

### DIFF
--- a/src/neo4j/cypher-queries/material/show/index.js
+++ b/src/neo4j/cypher-queries/material/show/index.js
@@ -2,6 +2,7 @@ import getShowQuery from './show';
 import getShowAwardsQuery from './show-awards';
 import getShowAwardsSubsequentVersionMaterialQuery from './show-awards-subsequent-version-material';
 import getShowAwardsSourcingMaterialQuery from './show-awards-sourcing-material';
+import getShowMaterialsQuery from './show-materials';
 import getShowProductionsQuery from './show-productions';
 
 export default () => [
@@ -9,5 +10,6 @@ export default () => [
 	getShowAwardsQuery(),
 	getShowAwardsSubsequentVersionMaterialQuery(),
 	getShowAwardsSourcingMaterialQuery(),
+	getShowMaterialsQuery(),
 	getShowProductionsQuery()
 ];

--- a/src/neo4j/cypher-queries/material/show/show-materials.js
+++ b/src/neo4j/cypher-queries/material/show/show-materials.js
@@ -1,0 +1,193 @@
+export default () => `
+	MATCH (material:Material { uuid: $uuid })
+
+	OPTIONAL MATCH (material)<-[:SUBSEQUENT_VERSION_OF]-(subsequentVersionMaterial)
+
+	WITH
+		material,
+		COLLECT(subsequentVersionMaterial) AS subsequentVersionMaterials
+
+	OPTIONAL MATCH (material)<-[:USES_SOURCE_MATERIAL]-(sourcingMaterial:Material)
+
+	WITH
+		material,
+		[material] +
+		subsequentVersionMaterials +
+		COLLECT(sourcingMaterial)
+			AS relatedMaterials
+
+	UNWIND (CASE relatedMaterials WHEN [] THEN [null] ELSE relatedMaterials END) AS relatedMaterial
+
+		OPTIONAL MATCH (relatedMaterial)-[subsequentVersionRel:SUBSEQUENT_VERSION_OF]->(material)
+
+		OPTIONAL MATCH (relatedMaterial)-[sourcingMaterialRel:USES_SOURCE_MATERIAL]->(material)
+
+		OPTIONAL MATCH (relatedMaterial)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity)
+			WHERE entity:Person OR entity:Company OR entity:Material
+
+		OPTIONAL MATCH (entity)<-[originalVersionWritingEntityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]-(material)
+
+		OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->(sourceMaterialWriter)
+			WHERE sourceMaterialWriter:Person OR sourceMaterialWriter:Company
+
+		OPTIONAL MATCH (entity:Material)<-[:HAS_SUB_MATERIAL]-(entitySurMaterial:Material)
+
+		OPTIONAL MATCH (entitySurMaterial)<-[:HAS_SUB_MATERIAL]-(entitySurSurMaterial:Material)
+
+		WITH
+			material,
+			relatedMaterial,
+			CASE subsequentVersionRel WHEN NULL THEN false ELSE true END AS isSubsequentVersion,
+			CASE sourcingMaterialRel WHEN NULL THEN false ELSE true END AS isSourcingMaterial,
+			entityRel,
+			entity,
+			entitySurMaterial,
+			entitySurSurMaterial,
+			CASE originalVersionWritingEntityRel WHEN NULL THEN false ELSE true END AS isOriginalVersionWritingEntity,
+			sourceMaterialWriterRel,
+			sourceMaterialWriter
+			ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriterRel.entityPosition
+
+		WITH
+			material,
+			relatedMaterial,
+			isSubsequentVersion,
+			isSourcingMaterial,
+			entityRel,
+			entity,
+			entitySurMaterial,
+			entitySurSurMaterial,
+			isOriginalVersionWritingEntity,
+			sourceMaterialWriterRel.credit AS sourceMaterialWritingCreditName,
+			COLLECT(
+				CASE sourceMaterialWriter WHEN NULL
+					THEN null
+					ELSE sourceMaterialWriter { model: TOUPPER(HEAD(LABELS(sourceMaterialWriter))), .uuid, .name }
+				END
+			) AS sourceMaterialWriters
+
+		WITH
+			material,
+			relatedMaterial,
+			isSubsequentVersion,
+			isSourcingMaterial,
+			entityRel,
+			entity,
+			entitySurMaterial,
+			entitySurSurMaterial,
+			isOriginalVersionWritingEntity,
+			COLLECT(
+				CASE SIZE(sourceMaterialWriters) WHEN 0
+					THEN null
+					ELSE {
+						model: 'WRITING_CREDIT',
+						name: COALESCE(sourceMaterialWritingCreditName, 'by'),
+						entities: sourceMaterialWriters
+					}
+				END
+			) AS sourceMaterialWritingCredits
+			ORDER BY entityRel.creditPosition, entityRel.entityPosition
+
+		WITH
+			material,
+			relatedMaterial,
+			isSubsequentVersion,
+			isSourcingMaterial,
+			entityRel.credit AS writingCreditName,
+			COLLECT(
+				CASE WHEN entity IS NULL OR (isSubsequentVersion AND isOriginalVersionWritingEntity)
+					THEN null
+					ELSE entity {
+						model: TOUPPER(HEAD(LABELS(entity))),
+						.uuid,
+						.name,
+						.format,
+						.year,
+						surMaterial: CASE entitySurMaterial WHEN NULL
+							THEN null
+							ELSE entitySurMaterial {
+								model: 'MATERIAL',
+								.uuid,
+								.name,
+								surMaterial: CASE entitySurSurMaterial WHEN NULL
+									THEN null
+									ELSE entitySurSurMaterial { model: 'MATERIAL', .uuid, .name }
+								END
+							}
+						END,
+						writingCredits: sourceMaterialWritingCredits
+					}
+				END
+			) AS entities
+
+		WITH
+			material,
+			relatedMaterial,
+			isSubsequentVersion,
+			isSourcingMaterial,
+			writingCreditName,
+			[entity IN entities | CASE entity.model WHEN 'MATERIAL'
+				THEN entity
+				ELSE entity { .model, .uuid, .name }
+			END] AS entities
+
+		WITH
+			material,
+			relatedMaterial,
+			isSubsequentVersion,
+			isSourcingMaterial,
+			COLLECT(
+				CASE SIZE(entities) WHEN 0
+					THEN null
+					ELSE {
+						model: 'WRITING_CREDIT',
+						name: COALESCE(writingCreditName, 'by'),
+						entities: entities
+					}
+				END
+			) AS writingCredits
+			ORDER BY relatedMaterial.year DESC, relatedMaterial.name
+
+		OPTIONAL MATCH (relatedMaterial)<-[:HAS_SUB_MATERIAL]-(surMaterial:Material)
+
+		OPTIONAL MATCH (surMaterial)<-[:HAS_SUB_MATERIAL]-(surSurMaterial:Material)
+
+		WITH material,
+			COLLECT(
+				CASE relatedMaterial WHEN NULL
+					THEN null
+					ELSE relatedMaterial {
+						model: 'MATERIAL',
+						.uuid,
+						.name,
+						.format,
+						.year,
+						surMaterial: CASE surMaterial WHEN NULL
+							THEN null
+							ELSE surMaterial {
+								model: 'MATERIAL',
+								.uuid,
+								.name,
+								surMaterial: CASE surSurMaterial WHEN NULL
+									THEN null
+									ELSE surSurMaterial { model: 'MATERIAL', .uuid, .name }
+								END
+							}
+						END,
+						writingCredits,
+						isSubsequentVersion,
+						isSourcingMaterial
+					}
+				END
+			) AS relatedMaterials
+
+	RETURN
+		[
+			relatedMaterial IN relatedMaterials WHERE relatedMaterial.isSubsequentVersion |
+			relatedMaterial { .model, .uuid, .name, .format, .year, .surMaterial, .writingCredits }
+		] AS subsequentVersionMaterials,
+		[
+			relatedMaterial IN relatedMaterials WHERE relatedMaterial.isSourcingMaterial |
+			relatedMaterial { .model, .uuid, .name, .format, .year, .surMaterial, .writingCredits }
+		] AS sourcingMaterials
+`;

--- a/src/neo4j/cypher-queries/material/show/show.js
+++ b/src/neo4j/cypher-queries/material/show/show.js
@@ -1,291 +1,445 @@
 export default () => `
 	MATCH (material:Material { uuid: $uuid })
 
-	OPTIONAL MATCH (material)-[:SUBSEQUENT_VERSION_OF]-(originalOrSubsequentVersionMaterial)
+	OPTIONAL MATCH (material)<-[:HAS_SUB_MATERIAL*1..2]-(surMaterial:Material)
+
+	OPTIONAL MATCH (material)-[:HAS_SUB_MATERIAL*1..2]->(subMaterial:Material)
 
 	WITH
 		material,
-		COLLECT(originalOrSubsequentVersionMaterial) AS originalOrSubsequentVersionMaterials
+		[material] + COLLECT(surMaterial) + COLLECT(subMaterial) AS collectionMaterials
 
-	OPTIONAL MATCH (material)<-[:USES_SOURCE_MATERIAL]-(sourcingMaterial:Material)
+	UNWIND (CASE collectionMaterials WHEN [] THEN [null] ELSE collectionMaterials END) AS collectionMaterial
 
-	WITH
-		material,
-		originalOrSubsequentVersionMaterials,
-		COLLECT(sourcingMaterial) AS sourcingMaterials
+		OPTIONAL MATCH (collectionMaterial)-[surMaterialRel:HAS_SUB_MATERIAL]->(material)
 
-	OPTIONAL MATCH (material)-[:HAS_SUB_MATERIAL*1..2]-(subOrSurMaterial:Material)
-
-	WITH
-		material,
-		[material] +
-		originalOrSubsequentVersionMaterials +
-		sourcingMaterials +
-		COLLECT(subOrSurMaterial)
-			AS relatedMaterials
-
-	UNWIND (CASE relatedMaterials WHEN [] THEN [null] ELSE relatedMaterials END) AS relatedMaterial
-
-		OPTIONAL MATCH (relatedMaterial)<-[originalVersionRel:SUBSEQUENT_VERSION_OF]-(material)
-
-		OPTIONAL MATCH (relatedMaterial)-[subsequentVersionRel:SUBSEQUENT_VERSION_OF]->(material)
-
-		OPTIONAL MATCH (relatedMaterial)-[sourcingMaterialRel:USES_SOURCE_MATERIAL]->(material)
-
-		OPTIONAL MATCH (relatedMaterial)-[surMaterialRel:HAS_SUB_MATERIAL]->(material)
-
-		OPTIONAL MATCH (relatedMaterial)-[surSurMaterialRel:HAS_SUB_MATERIAL]->
+		OPTIONAL MATCH (collectionMaterial)-[surSurMaterialRel:HAS_SUB_MATERIAL]->
 			(:Material)-[:HAS_SUB_MATERIAL]->(material)
 
-		OPTIONAL MATCH (relatedMaterial)<-[subMaterialRel:HAS_SUB_MATERIAL]-(material)
+		OPTIONAL MATCH (collectionMaterial)<-[subMaterialRel:HAS_SUB_MATERIAL]-(material)
 
-		OPTIONAL MATCH (relatedMaterial)<-[subSubMaterialRel:HAS_SUB_MATERIAL]-
-			(:Material)<-[:HAS_SUB_MATERIAL]-(material)
-
-		OPTIONAL MATCH (relatedMaterial)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity)
-			WHERE entity:Person OR entity:Company OR entity:Material
-
-		OPTIONAL MATCH (entity)<-[originalVersionWritingEntityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]-(material)
-
-		OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->(sourceMaterialWriter)
-			WHERE sourceMaterialWriter:Person OR sourceMaterialWriter:Company
-
-		OPTIONAL MATCH (entity:Material)<-[:HAS_SUB_MATERIAL]-(entitySurMaterial:Material)
-
-		OPTIONAL MATCH (entitySurMaterial)<-[:HAS_SUB_MATERIAL]-(entitySurSurMaterial:Material)
+		OPTIONAL MATCH (collectionMaterial)<-[subSubMaterialRel:HAS_SUB_MATERIAL]-
+			(subSubMaterialSurMaterial:Material)<-[:HAS_SUB_MATERIAL]-(material)
 
 		WITH
 			material,
-			relatedMaterial,
-			CASE originalVersionRel WHEN NULL THEN false ELSE true END AS isOriginalVersion,
-			CASE subsequentVersionRel WHEN NULL THEN false ELSE true END AS isSubsequentVersion,
-			CASE sourcingMaterialRel WHEN NULL THEN false ELSE true END AS isSourcingMaterial,
+			collectionMaterial,
+			CASE WHEN material = collectionMaterial THEN true ELSE false END AS isSubjectMaterial,
 			CASE surMaterialRel WHEN NULL THEN false ELSE true END AS isSurMaterial,
 			CASE surSurMaterialRel WHEN NULL THEN false ELSE true END AS isSurSurMaterial,
 			CASE subMaterialRel WHEN NULL THEN false ELSE true END AS isSubMaterial,
-			CASE subSubMaterialRel WHEN NULL THEN false ELSE true END AS isSubSubMaterial,
 			subMaterialRel.position AS subMaterialPosition,
+			CASE subSubMaterialRel WHEN NULL THEN false ELSE true END AS isSubSubMaterial,
 			subSubMaterialRel.position AS subSubMaterialPosition,
-			entityRel,
-			entity,
-			entitySurMaterial,
-			entitySurSurMaterial,
-			CASE originalVersionWritingEntityRel WHEN NULL THEN false ELSE true END AS isOriginalVersionWritingEntity,
-			sourceMaterialWriterRel,
-			sourceMaterialWriter
-			ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriterRel.entityPosition
+			subSubMaterialSurMaterial.uuid AS subSubMaterialSurMaterialUuid
+
+		OPTIONAL MATCH (collectionMaterial)-[:SUBSEQUENT_VERSION_OF]->(originalVersionMaterial)
 
 		WITH
 			material,
-			relatedMaterial,
-			isOriginalVersion,
-			isSubsequentVersion,
-			isSourcingMaterial,
+			collectionMaterial,
+			isSubjectMaterial,
 			isSurMaterial,
 			isSurSurMaterial,
 			isSubMaterial,
-			isSubSubMaterial,
 			subMaterialPosition,
+			isSubSubMaterial,
 			subSubMaterialPosition,
-			entityRel,
-			entity,
-			entitySurMaterial,
-			entitySurSurMaterial,
-			isOriginalVersionWritingEntity,
-			sourceMaterialWriterRel.credit AS sourceMaterialWritingCreditName,
-			COLLECT(
-				CASE sourceMaterialWriter WHEN NULL
-					THEN null
-					ELSE sourceMaterialWriter { model: TOUPPER(HEAD(LABELS(sourceMaterialWriter))), .uuid, .name }
-				END
-			) AS sourceMaterialWriters
+			subSubMaterialSurMaterialUuid,
+			[collectionMaterial, originalVersionMaterial] AS relatedMaterials
+
+		UNWIND (CASE relatedMaterials WHEN [] THEN [null] ELSE relatedMaterials END) AS relatedMaterial
+
+			OPTIONAL MATCH (relatedMaterial)<-[originalVersionRel:SUBSEQUENT_VERSION_OF]-(collectionMaterial)
+
+			OPTIONAL MATCH (relatedMaterial)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity)
+				WHERE entity:Person OR entity:Company OR entity:Material
+
+			OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->(sourceMaterialWriter)
+				WHERE sourceMaterialWriter:Person OR sourceMaterialWriter:Company
+
+			OPTIONAL MATCH (entity:Material)<-[:HAS_SUB_MATERIAL]-(entitySurMaterial:Material)
+
+			OPTIONAL MATCH (entitySurMaterial)<-[:HAS_SUB_MATERIAL]-(entitySurSurMaterial:Material)
+
+			WITH
+				material,
+				collectionMaterial,
+				isSubjectMaterial,
+				isSurMaterial,
+				isSurSurMaterial,
+				isSubMaterial,
+				subMaterialPosition,
+				isSubSubMaterial,
+				subSubMaterialPosition,
+				subSubMaterialSurMaterialUuid,
+				relatedMaterial,
+				CASE originalVersionRel WHEN NULL THEN false ELSE true END AS isOriginalVersion,
+				entityRel,
+				entity,
+				entitySurMaterial,
+				entitySurSurMaterial,
+				sourceMaterialWriterRel,
+				sourceMaterialWriter
+				ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriterRel.entityPosition
+
+			WITH
+				material,
+				collectionMaterial,
+				isSubjectMaterial,
+				isSurMaterial,
+				isSurSurMaterial,
+				isSubMaterial,
+				subMaterialPosition,
+				isSubSubMaterial,
+				subSubMaterialPosition,
+				subSubMaterialSurMaterialUuid,
+				relatedMaterial,
+				isOriginalVersion,
+				entityRel,
+				entity,
+				entitySurMaterial,
+				entitySurSurMaterial,
+				sourceMaterialWriterRel.credit AS sourceMaterialWritingCreditName,
+				COLLECT(
+					CASE sourceMaterialWriter WHEN NULL
+						THEN null
+						ELSE sourceMaterialWriter { model: TOUPPER(HEAD(LABELS(sourceMaterialWriter))), .uuid, .name }
+					END
+				) AS sourceMaterialWriters
+
+			WITH
+				material,
+				collectionMaterial,
+				isSubjectMaterial,
+				isSurMaterial,
+				isSurSurMaterial,
+				isSubMaterial,
+				subMaterialPosition,
+				isSubSubMaterial,
+				subSubMaterialPosition,
+				subSubMaterialSurMaterialUuid,
+				relatedMaterial,
+				isOriginalVersion,
+				entityRel,
+				entity,
+				entitySurMaterial,
+				entitySurSurMaterial,
+				COLLECT(
+					CASE SIZE(sourceMaterialWriters) WHEN 0
+						THEN null
+						ELSE {
+							model: 'WRITING_CREDIT',
+							name: COALESCE(sourceMaterialWritingCreditName, 'by'),
+							entities: sourceMaterialWriters
+						}
+					END
+				) AS sourceMaterialWritingCredits
+				ORDER BY entityRel.creditPosition, entityRel.entityPosition
+
+			WITH
+				material,
+				collectionMaterial,
+				isSubjectMaterial,
+				isSurMaterial,
+				isSurSurMaterial,
+				isSubMaterial,
+				subMaterialPosition,
+				isSubSubMaterial,
+				subSubMaterialPosition,
+				subSubMaterialSurMaterialUuid,
+				relatedMaterial,
+				isOriginalVersion,
+				entityRel.credit AS writingCreditName,
+				COLLECT(
+					CASE WHEN entity IS NULL
+						THEN null
+						ELSE entity {
+							model: TOUPPER(HEAD(LABELS(entity))),
+							.uuid,
+							.name,
+							.format,
+							.year,
+							surMaterial: CASE entitySurMaterial WHEN NULL
+								THEN null
+								ELSE entitySurMaterial {
+									model: 'MATERIAL',
+									.uuid,
+									.name,
+									surMaterial: CASE entitySurSurMaterial WHEN NULL
+										THEN null
+										ELSE entitySurSurMaterial { model: 'MATERIAL', .uuid, .name }
+									END
+								}
+							END,
+							writingCredits: sourceMaterialWritingCredits
+						}
+					END
+				) AS entities
+
+			WITH
+				material,
+				collectionMaterial,
+				isSubjectMaterial,
+				isSurMaterial,
+				isSurSurMaterial,
+				isSubMaterial,
+				subMaterialPosition,
+				isSubSubMaterial,
+				subSubMaterialPosition,
+				subSubMaterialSurMaterialUuid,
+				relatedMaterial,
+				isOriginalVersion,
+				writingCreditName,
+				[entity IN entities | CASE entity.model WHEN 'MATERIAL'
+					THEN entity
+					ELSE entity { .model, .uuid, .name }
+				END] AS entities
+
+			WITH
+				material,
+				collectionMaterial,
+				isSubjectMaterial,
+				isSurMaterial,
+				isSurSurMaterial,
+				isSubMaterial,
+				subMaterialPosition,
+				isSubSubMaterial,
+				subSubMaterialPosition,
+				subSubMaterialSurMaterialUuid,
+				relatedMaterial,
+				isOriginalVersion,
+				COLLECT(
+					CASE SIZE(entities) WHEN 0
+						THEN null
+						ELSE {
+							model: 'WRITING_CREDIT',
+							name: COALESCE(writingCreditName, 'by'),
+							entities: entities
+						}
+					END
+				) AS writingCredits
+				ORDER BY relatedMaterial.year DESC, relatedMaterial.name
+
+			OPTIONAL MATCH (relatedMaterial)<-[:HAS_SUB_MATERIAL]-(surMaterial:Material)
+
+			OPTIONAL MATCH (surMaterial)<-[:HAS_SUB_MATERIAL]-(surSurMaterial:Material)
+
+			WITH
+				material,
+				collectionMaterial,
+				isSubjectMaterial,
+				isSurMaterial,
+				isSurSurMaterial,
+				isSubMaterial,
+				subMaterialPosition,
+				isSubSubMaterial,
+				subSubMaterialPosition,
+				subSubMaterialSurMaterialUuid,
+				COLLECT(
+					CASE relatedMaterial WHEN NULL
+						THEN null
+						ELSE relatedMaterial {
+							model: 'MATERIAL',
+							.uuid,
+							.name,
+							.format,
+							.year,
+							surMaterial: CASE surMaterial WHEN NULL
+								THEN null
+								ELSE surMaterial {
+									model: 'MATERIAL',
+									.uuid,
+									.name,
+									surMaterial: CASE surSurMaterial WHEN NULL
+										THEN null
+										ELSE surSurMaterial { model: 'MATERIAL', .uuid, .name }
+									END
+								}
+							END,
+							writingCredits,
+							isOriginalVersion
+						}
+					END
+				) AS relatedMaterials
 
 		WITH
 			material,
-			relatedMaterial,
-			isOriginalVersion,
-			isSubsequentVersion,
-			isSourcingMaterial,
+			collectionMaterial,
+			isSubjectMaterial,
 			isSurMaterial,
 			isSurSurMaterial,
 			isSubMaterial,
-			isSubSubMaterial,
 			subMaterialPosition,
+			isSubSubMaterial,
 			subSubMaterialPosition,
-			entityRel,
-			entity,
-			entitySurMaterial,
-			entitySurSurMaterial,
-			isOriginalVersionWritingEntity,
-			COLLECT(
-				CASE SIZE(sourceMaterialWriters) WHEN 0
-					THEN null
-					ELSE {
-						model: 'WRITING_CREDIT',
-						name: COALESCE(sourceMaterialWritingCreditName, 'by'),
-						entities: sourceMaterialWriters
-					}
-				END
-			) AS sourceMaterialWritingCredits
-			ORDER BY entityRel.creditPosition, entityRel.entityPosition
+			subSubMaterialSurMaterialUuid,
+			HEAD([
+				relatedMaterial IN relatedMaterials
+					WHERE relatedMaterial.uuid = collectionMaterial.uuid | relatedMaterial.writingCredits
+			]) AS writingCredits,
+			HEAD([
+				relatedMaterial IN relatedMaterials WHERE relatedMaterial.isOriginalVersion |
+				relatedMaterial { .model, .uuid, .name, .format, .year, .surMaterial, .writingCredits }
+			]) AS originalVersionMaterial
+
+		OPTIONAL MATCH (collectionMaterial)-[characterRel:DEPICTS]->(character:Character)
 
 		WITH
 			material,
-			relatedMaterial,
-			isOriginalVersion,
-			isSubsequentVersion,
-			isSourcingMaterial,
+			collectionMaterial,
+			isSubjectMaterial,
 			isSurMaterial,
 			isSurSurMaterial,
 			isSubMaterial,
-			isSubSubMaterial,
 			subMaterialPosition,
+			isSubSubMaterial,
 			subSubMaterialPosition,
-			entityRel.credit AS writingCreditName,
+			subSubMaterialSurMaterialUuid,
+			writingCredits,
+			originalVersionMaterial,
+			characterRel,
+			character
+			ORDER BY characterRel.groupPosition, characterRel.characterPosition
+
+		WITH
+			material,
+			collectionMaterial,
+			isSubjectMaterial,
+			isSurMaterial,
+			isSurSurMaterial,
+			isSubMaterial,
+			subMaterialPosition,
+			isSubSubMaterial,
+			subSubMaterialPosition,
+			subSubMaterialSurMaterialUuid,
+			writingCredits,
+			originalVersionMaterial,
+			characterRel.group AS characterGroupName,
+			characterRel.groupPosition AS characterGroupPosition,
 			COLLECT(
-				CASE WHEN entity IS NULL OR (isSubsequentVersion AND isOriginalVersionWritingEntity)
+				CASE character WHEN NULL
 					THEN null
-					ELSE entity {
-						model: TOUPPER(HEAD(LABELS(entity))),
+					ELSE character {
+						model: 'CHARACTER',
 						.uuid,
-						.name,
-						.format,
-						.year,
-						surMaterial: CASE entitySurMaterial WHEN NULL
-							THEN null
-							ELSE entitySurMaterial {
-								model: 'MATERIAL',
-								.uuid,
-								.name,
-								surMaterial: CASE entitySurSurMaterial WHEN NULL
-									THEN null
-									ELSE entitySurSurMaterial { model: 'MATERIAL', .uuid, .name }
-								END
-							}
-						END,
-						writingCredits: sourceMaterialWritingCredits
+						name: COALESCE(characterRel.displayName, character.name),
+						qualifier: characterRel.qualifier
 					}
 				END
-			) AS entities
+			) AS characters
 
 		WITH
 			material,
-			relatedMaterial,
-			isOriginalVersion,
-			isSubsequentVersion,
-			isSourcingMaterial,
+			collectionMaterial,
+			isSubjectMaterial,
 			isSurMaterial,
 			isSurSurMaterial,
 			isSubMaterial,
-			isSubSubMaterial,
 			subMaterialPosition,
-			subSubMaterialPosition,
-			writingCreditName,
-			[entity IN entities | CASE entity.model WHEN 'MATERIAL'
-				THEN entity
-				ELSE entity { .model, .uuid, .name }
-			END] AS entities
-
-		WITH
-			material,
-			relatedMaterial,
-			isOriginalVersion,
-			isSubsequentVersion,
-			isSourcingMaterial,
-			isSurMaterial,
-			isSurSurMaterial,
-			isSubMaterial,
 			isSubSubMaterial,
-			subMaterialPosition,
 			subSubMaterialPosition,
+			subSubMaterialSurMaterialUuid,
+			writingCredits,
+			originalVersionMaterial,
 			COLLECT(
-				CASE SIZE(entities) WHEN 0
+				CASE SIZE(characters) WHEN 0
 					THEN null
 					ELSE {
-						model: 'WRITING_CREDIT',
-						name: COALESCE(writingCreditName, 'by'),
-						entities: entities
+						model: 'CHARACTER_GROUP',
+						name: characterGroupName,
+						position: characterGroupPosition,
+						characters: characters
 					}
 				END
-			) AS writingCredits
-			ORDER BY subMaterialPosition, subSubMaterialPosition, relatedMaterial.year DESC, relatedMaterial.name
-
-		OPTIONAL MATCH (relatedMaterial)<-[:HAS_SUB_MATERIAL]-(surMaterial:Material)
-
-		OPTIONAL MATCH (surMaterial)<-[:HAS_SUB_MATERIAL]-(surSurMaterial:Material)
+			) AS characterGroups
+			ORDER BY subMaterialPosition, subSubMaterialPosition
 
 		WITH material,
 			COLLECT(
-				CASE relatedMaterial WHEN NULL
-					THEN null
-					ELSE relatedMaterial {
-						model: 'MATERIAL',
-						.uuid,
-						.name,
-						.format,
-						.year,
-						surMaterial: CASE surMaterial WHEN NULL
-							THEN null
-							ELSE surMaterial {
-								model: 'MATERIAL',
+				collectionMaterial {
+					model: 'MATERIAL',
+					.uuid,
+					.name,
+					.differentiator,
+					.format,
+					.year,
+					isSubjectMaterial,
+					isSurMaterial,
+					isSurSurMaterial,
+					isSubMaterial,
+					isSubSubMaterial,
+					subSubMaterialSurMaterialUuid,
+					writingCredits,
+					originalVersionMaterial,
+					characterGroups
+				}
+			) AS collectionMaterials
+
+		WITH material,
+			HEAD([
+				collectionMaterial IN collectionMaterials WHERE collectionMaterial.isSubjectMaterial |
+				collectionMaterial {
+					.writingCredits,
+					.originalVersionMaterial,
+					.characterGroups
+				}
+			]) AS subjectMaterial,
+			HEAD([
+				collectionMaterial IN collectionMaterials WHERE collectionMaterial.isSurMaterial |
+				collectionMaterial {
+					.model,
+					.uuid,
+					.name,
+					.format,
+					.year,
+					.writingCredits,
+					.originalVersionMaterial,
+					surMaterial: HEAD([
+						surSurMaterial IN collectionMaterials WHERE surSurMaterial.isSurSurMaterial |
+							surSurMaterial {
+								.model,
 								.uuid,
 								.name,
-								surMaterial: CASE surSurMaterial WHEN NULL
-									THEN null
-									ELSE surSurMaterial { model: 'MATERIAL', .uuid, .name }
-								END
+								.format,
+								.year,
+								.writingCredits,
+								.originalVersionMaterial,
+								.characterGroups
 							}
-						END,
-						writingCredits,
-						isOriginalVersion,
-						isSubsequentVersion,
-						isSourcingMaterial,
-						isSurMaterial,
-						isSurSurMaterial,
-						isSubMaterial,
-						isSubSubMaterial
-					}
-				END
-			) AS relatedMaterials
-
-	OPTIONAL MATCH (material)-[characterRel:DEPICTS]->(character:Character)
-
-	WITH
-		material,
-		relatedMaterials,
-		characterRel,
-		character
-		ORDER BY characterRel.groupPosition, characterRel.characterPosition
-
-	WITH
-		material,
-		relatedMaterials,
-		characterRel.group AS characterGroupName,
-		characterRel.groupPosition AS characterGroupPosition,
-		COLLECT(
-			CASE character WHEN NULL
-				THEN null
-				ELSE character {
-					model: 'CHARACTER',
+					]),
+					.characterGroups
+				}
+			]) AS surMaterial,
+			[
+				collectionMaterial IN collectionMaterials WHERE collectionMaterial.isSubMaterial |
+				collectionMaterial {
+					.model,
 					.uuid,
-					name: COALESCE(characterRel.displayName, character.name),
-					qualifier: characterRel.qualifier
+					.name,
+					.format,
+					.year,
+					.writingCredits,
+					.originalVersionMaterial,
+					subMaterials: [
+						subSubMaterial IN collectionMaterials
+							WHERE
+								subSubMaterial.isSubSubMaterial AND
+								subSubMaterial.subSubMaterialSurMaterialUuid = collectionMaterial.uuid |
+							subSubMaterial {
+								.model,
+								.uuid,
+								.name,
+								.format,
+								.year,
+								.writingCredits,
+								.originalVersionMaterial,
+								.characterGroups
+							}
+					],
+					.characterGroups
 				}
-			END
-		) AS characters
-
-	WITH material, relatedMaterials,
-		COLLECT(
-			CASE SIZE(characters) WHEN 0
-				THEN null
-				ELSE {
-					model: 'CHARACTER_GROUP',
-					name: characterGroupName,
-					position: characterGroupPosition,
-					characters: characters
-				}
-			END
-		) AS characterGroups
+			] AS subMaterials
 
 	RETURN
 		'MATERIAL' AS model,
@@ -294,57 +448,9 @@ export default () => `
 		material.differentiator AS differentiator,
 		material.format AS format,
 		material.year AS year,
-		HEAD([
-			relatedMaterial IN relatedMaterials
-				WHERE relatedMaterial.uuid = material.uuid | relatedMaterial.writingCredits
-		]) AS writingCredits,
-		HEAD([
-			relatedMaterial IN relatedMaterials WHERE relatedMaterial.isOriginalVersion |
-			relatedMaterial { .model, .uuid, .name, .format, .year, .surMaterial, .writingCredits }
-		]) AS originalVersionMaterial,
-		[
-			relatedMaterial IN relatedMaterials WHERE relatedMaterial.isSubsequentVersion |
-			relatedMaterial { .model, .uuid, .name, .format, .year, .surMaterial, .writingCredits }
-		] AS subsequentVersionMaterials,
-		[
-			relatedMaterial IN relatedMaterials WHERE relatedMaterial.isSourcingMaterial |
-			relatedMaterial { .model, .uuid, .name, .format, .year, .surMaterial, .writingCredits }
-		] AS sourcingMaterials,
-		HEAD([
-			relatedMaterial IN relatedMaterials WHERE relatedMaterial.isSurMaterial |
-			relatedMaterial {
-				.model,
-				.uuid,
-				.name,
-				.format,
-				.year,
-				surMaterial: CASE WHEN relatedMaterial.surMaterial is NULL
-					THEN null
-					ELSE {
-						model: relatedMaterial.surMaterial.model,
-						uuid: relatedMaterial.surMaterial.uuid,
-						name: relatedMaterial.surMaterial.name
-					}
-				END,
-				.writingCredits
-			}
-		]) AS surMaterial,
-		[
-			relatedMaterial IN relatedMaterials WHERE relatedMaterial.isSubMaterial |
-			relatedMaterial {
-				.model,
-				.uuid,
-				.name,
-				.format,
-				.year,
-				.writingCredits,
-				subMaterials: [
-					subSubMaterial IN relatedMaterials
-						WHERE subSubMaterial.isSubSubMaterial
-						AND subSubMaterial.surMaterial.uuid = relatedMaterial.uuid |
-					subSubMaterial { .model, .uuid, .name, .format, .year, .writingCredits }
-				]
-			}
-		] AS subMaterials,
-		characterGroups
+		subjectMaterial.writingCredits AS writingCredits,
+		subjectMaterial.originalVersionMaterial AS originalVersionMaterial,
+		surMaterial,
+		subMaterials,
+		subjectMaterial.characterGroups AS characterGroups
 `;

--- a/test-e2e/crud/materials-api.test.js
+++ b/test-e2e/crud/materials-api.test.js
@@ -774,7 +774,9 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 						format: null,
 						year: null,
 						writingCredits: [],
-						subMaterials: []
+						originalVersionMaterial: null,
+						subMaterials: [],
+						characterGroups: []
 					},
 					{
 						model: 'MATERIAL',
@@ -783,7 +785,9 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 						format: null,
 						year: null,
 						writingCredits: [],
-						subMaterials: []
+						originalVersionMaterial: null,
+						subMaterials: [],
+						characterGroups: []
 					},
 					{
 						model: 'MATERIAL',
@@ -792,7 +796,9 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 						format: null,
 						year: null,
 						writingCredits: [],
-						subMaterials: []
+						originalVersionMaterial: null,
+						subMaterials: [],
+						characterGroups: []
 					}
 				],
 				characterGroups: [
@@ -1379,7 +1385,9 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 						format: null,
 						year: null,
 						writingCredits: [],
-						subMaterials: []
+						originalVersionMaterial: null,
+						subMaterials: [],
+						characterGroups: []
 					},
 					{
 						model: 'MATERIAL',
@@ -1388,7 +1396,9 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 						format: null,
 						year: null,
 						writingCredits: [],
-						subMaterials: []
+						originalVersionMaterial: null,
+						subMaterials: [],
+						characterGroups: []
 					},
 					{
 						model: 'MATERIAL',
@@ -1397,7 +1407,9 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 						format: null,
 						year: null,
 						writingCredits: [],
-						subMaterials: []
+						originalVersionMaterial: null,
+						subMaterials: [],
+						characterGroups: []
 					}
 				],
 				characterGroups: [

--- a/test-e2e/model-interaction/mat-with-sub-mats-source-mats.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-mats-source-mats.test.js
@@ -428,7 +428,6 @@ describe('Material with sub-materials and source materials thereof', () => {
 				name: 'The Wolf Hall Trilogy',
 				format: 'trilogy of plays',
 				year: 2021,
-				surMaterial: null,
 				writingCredits: [
 					{
 						model: 'WRITING_CREDIT',
@@ -478,7 +477,10 @@ describe('Material with sub-materials and source materials thereof', () => {
 							}
 						]
 					}
-				]
+				],
+				originalVersionMaterial: null,
+				surMaterial: null,
+				characterGroups: []
 			};
 
 			const { surMaterial } = bringUpTheBodiesPlayMaterial.body;

--- a/test-e2e/model-interaction/mat-with-sub-mats-subsequent-versions.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-mats-subsequent-versions.test.js
@@ -22,6 +22,7 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 
 	let agamemnonOriginalVersionMaterial;
 	let agamemnonSubsequentVersionMaterial;
+	let theOresteiaSubsequentVersionMaterial;
 	let aeschylusPerson;
 	let theFathersOfTragedyCompany;
 
@@ -130,6 +131,10 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 				differentiator: '2',
 				format: 'trilogy of plays',
 				year: '2015',
+				originalVersionMaterial: {
+					name: 'The Oresteia',
+					differentiator: '1'
+				},
 				writingCredits: [
 					{
 						entities: [
@@ -168,6 +173,9 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 
 		agamemnonSubsequentVersionMaterial = await chai.request(app)
 			.get(`/materials/${AGAMEMNON_SUBSEQUENT_VERSION_MATERIAL_UUID}`);
+
+		theOresteiaSubsequentVersionMaterial = await chai.request(app)
+			.get(`/materials/${THE_ORESTEIA_SUBSEQUENT_VERSION_MATERIAL_UUID}`);
 
 		aeschylusPerson = await chai.request(app)
 			.get(`/people/${AESCHYLUS_PERSON_UUID}`);
@@ -268,6 +276,175 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 			const { originalVersionMaterial } = agamemnonSubsequentVersionMaterial.body;
 
 			expect(originalVersionMaterial).to.deep.equal(expectedOriginalVersionMaterial);
+
+		});
+
+		it('includes its sur-material with its corresponding original version', () => {
+
+			const expectedSurMaterial = {
+				model: 'MATERIAL',
+				uuid: THE_ORESTEIA_SUBSEQUENT_VERSION_MATERIAL_UUID,
+				name: 'The Oresteia',
+				format: 'trilogy of plays',
+				year: 2015,
+				writingCredits: [
+					{
+						model: 'WRITING_CREDIT',
+						name: 'by',
+						entities: [
+							{
+								model: 'PERSON',
+								uuid: AESCHYLUS_PERSON_UUID,
+								name: 'Aeschylus'
+							},
+							{
+								model: 'COMPANY',
+								uuid: THE_FATHERS_OF_TRAGEDY_COMPANY_UUID,
+								name: 'The Fathers of Tragedy'
+							}
+						]
+					},
+					{
+						model: 'WRITING_CREDIT',
+						name: 'adapted by',
+						entities: [
+							{
+								model: 'PERSON',
+								uuid: ROBERT_ICKE_PERSON_UUID,
+								name: 'Robert Icke'
+							},
+							{
+								model: 'COMPANY',
+								uuid: THE_GREAT_HOPE_COMPANY_UUID,
+								name: 'The Great Hope Company'
+							}
+						]
+					}
+				],
+				originalVersionMaterial: {
+					model: 'MATERIAL',
+					uuid: THE_ORESTEIA_ORIGINAL_VERSION_MATERIAL_UUID,
+					name: 'The Oresteia',
+					format: 'trilogy of plays',
+					year: 500,
+					writingCredits: [
+						{
+							model: 'WRITING_CREDIT',
+							name: 'by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: AESCHYLUS_PERSON_UUID,
+									name: 'Aeschylus'
+								},
+								{
+									model: 'COMPANY',
+									uuid: THE_FATHERS_OF_TRAGEDY_COMPANY_UUID,
+									name: 'The Fathers of Tragedy'
+								}
+							]
+						}
+					],
+					surMaterial: null
+				},
+				surMaterial: null,
+				characterGroups: []
+
+			};
+
+			const { surMaterial } = agamemnonSubsequentVersionMaterial.body;
+
+			expect(surMaterial).to.deep.equal(expectedSurMaterial);
+
+		});
+
+	});
+
+	describe('The Oresteia (subsequent version) (material)', () => {
+
+		it('includes its sub-materials with their corresponding original versions', () => {
+
+			const expectedSubMaterials = [
+				{
+					model: 'MATERIAL',
+					uuid: AGAMEMNON_SUBSEQUENT_VERSION_MATERIAL_UUID,
+					name: 'Agamemnon',
+					format: 'play',
+					year: 2015,
+					writingCredits: [
+						{
+							model: 'WRITING_CREDIT',
+							name: 'by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: AESCHYLUS_PERSON_UUID,
+									name: 'Aeschylus'
+								},
+								{
+									model: 'COMPANY',
+									uuid: THE_FATHERS_OF_TRAGEDY_COMPANY_UUID,
+									name: 'The Fathers of Tragedy'
+								}
+							]
+						},
+						{
+							model: 'WRITING_CREDIT',
+							name: 'adapted by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: ROBERT_ICKE_PERSON_UUID,
+									name: 'Robert Icke'
+								},
+								{
+									model: 'COMPANY',
+									uuid: THE_GREAT_HOPE_COMPANY_UUID,
+									name: 'The Great Hope Company'
+								}
+							]
+						}
+					],
+					originalVersionMaterial: {
+						model: 'MATERIAL',
+						uuid: AGAMEMNON_ORIGINAL_VERSION_MATERIAL_UUID,
+						name: 'Agamemnon',
+						format: 'play',
+						year: 500,
+						writingCredits: [
+							{
+								model: 'WRITING_CREDIT',
+								name: 'by',
+								entities: [
+									{
+										model: 'PERSON',
+										uuid: AESCHYLUS_PERSON_UUID,
+										name: 'Aeschylus'
+									},
+									{
+										model: 'COMPANY',
+										uuid: THE_FATHERS_OF_TRAGEDY_COMPANY_UUID,
+										name: 'The Fathers of Tragedy'
+									}
+								]
+							}
+						],
+						surMaterial: {
+							model: 'MATERIAL',
+							uuid: THE_ORESTEIA_ORIGINAL_VERSION_MATERIAL_UUID,
+							name: 'The Oresteia',
+							surMaterial: null
+						}
+					},
+					subMaterials: [],
+					characterGroups: []
+
+				}
+			];
+
+			const { subMaterials } = theOresteiaSubsequentVersionMaterial.body;
+
+			expect(subMaterials).to.deep.equal(expectedSubMaterials);
 
 		});
 

--- a/test-e2e/model-interaction/mat-with-sub-mats.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-mats.test.js
@@ -268,7 +268,23 @@ describe('Material with sub-materials', () => {
 							]
 						}
 					],
-					subMaterials: []
+					originalVersionMaterial: null,
+					subMaterials: [],
+					characterGroups: [
+						{
+							model: 'CHARACTER_GROUP',
+							name: null,
+							position: null,
+							characters: [
+								{
+									model: 'CHARACTER',
+									uuid: ALEXANDER_HERZEN_CHARACTER_UUID,
+									name: 'Alexander Herzen',
+									qualifier: null
+								}
+							]
+						}
+					]
 				},
 				{
 					model: 'MATERIAL',
@@ -294,7 +310,23 @@ describe('Material with sub-materials', () => {
 							]
 						}
 					],
-					subMaterials: []
+					originalVersionMaterial: null,
+					subMaterials: [],
+					characterGroups: [
+						{
+							model: 'CHARACTER_GROUP',
+							name: null,
+							position: null,
+							characters: [
+								{
+									model: 'CHARACTER',
+									uuid: ALEXANDER_HERZEN_CHARACTER_UUID,
+									name: 'Alexander Herzen',
+									qualifier: null
+								}
+							]
+						}
+					]
 				},
 				{
 					model: 'MATERIAL',
@@ -320,7 +352,23 @@ describe('Material with sub-materials', () => {
 							]
 						}
 					],
-					subMaterials: []
+					originalVersionMaterial: null,
+					subMaterials: [],
+					characterGroups: [
+						{
+							model: 'CHARACTER_GROUP',
+							name: null,
+							position: null,
+							characters: [
+								{
+									model: 'CHARACTER',
+									uuid: ALEXANDER_HERZEN_CHARACTER_UUID,
+									name: 'Alexander Herzen',
+									qualifier: null
+								}
+							]
+						}
+					]
 				}
 			];
 
@@ -342,7 +390,6 @@ describe('Material with sub-materials', () => {
 				name: 'The Coast of Utopia',
 				format: 'trilogy of plays',
 				year: 2002,
-				surMaterial: null,
 				writingCredits: [
 					{
 						model: 'WRITING_CREDIT',
@@ -357,6 +404,23 @@ describe('Material with sub-materials', () => {
 								model: 'COMPANY',
 								uuid: THE_STRÄUSSLER_GROUP_COMPANY_UUID,
 								name: 'The Sträussler Group'
+							}
+						]
+					}
+				],
+				originalVersionMaterial: null,
+				surMaterial: null,
+				characterGroups: [
+					{
+						model: 'CHARACTER_GROUP',
+						name: null,
+						position: null,
+						characters: [
+							{
+								model: 'CHARACTER',
+								uuid: IVAN_TURGENEV_CHARACTER_UUID,
+								name: 'Ivan Turgenev',
+								qualifier: null
 							}
 						]
 					}

--- a/test-e2e/model-interaction/mat-with-sub-sub-mats-source-mats.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-sub-mats-source-mats.test.js
@@ -500,11 +500,6 @@ describe('Material with sub-sub-materials and source materials thereof', () => {
 				name: 'The Books of the Old Testament',
 				format: 'sub-collection of plays',
 				year: 2011,
-				surMaterial: {
-					model: 'MATERIAL',
-					uuid: SIXTY_SIX_BOOKS_PLAYS_MATERIAL_UUID,
-					name: 'Sixty-Six Books'
-				},
 				writingCredits: [
 					{
 						model: 'WRITING_CREDIT',
@@ -543,7 +538,52 @@ describe('Material with sub-sub-materials and source materials thereof', () => {
 							}
 						]
 					}
-				]
+				],
+				originalVersionMaterial: null,
+				surMaterial: {
+					model: 'MATERIAL',
+					uuid: SIXTY_SIX_BOOKS_PLAYS_MATERIAL_UUID,
+					name: 'Sixty-Six Books',
+					format: 'collection of plays',
+					year: 2011,
+					writingCredits: [
+						{
+							model: 'WRITING_CREDIT',
+							name: 'written in response to',
+							entities: [
+								{
+									model: 'MATERIAL',
+									uuid: THE_BIBLE_KING_JAMES_VERSION_RELIGIOUS_TEXT_MATERIAL_UUID,
+									name: 'The Bible: King James Version',
+									format: 'religious text',
+									year: 1611,
+									surMaterial: null,
+									writingCredits: [
+										{
+											model: 'WRITING_CREDIT',
+											name: 'by',
+											entities: [
+												{
+													model: 'PERSON',
+													uuid: RICHARD_BANCROFT_PERSON_UUID,
+													name: 'Richard Bancroft'
+												},
+												{
+													model: 'COMPANY',
+													uuid: THE_CANTERBURY_EDITORS_COMPANY_UUID,
+													name: 'The Canterbury Editors'
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					],
+					originalVersionMaterial: null,
+					characterGroups: []
+				},
+				characterGroups: []
 			};
 
 			const { surMaterial } = godblogPlayMaterial.body;
@@ -564,7 +604,6 @@ describe('Material with sub-sub-materials and source materials thereof', () => {
 				name: 'Sixty-Six Books',
 				format: 'collection of plays',
 				year: 2011,
-				surMaterial: null,
 				writingCredits: [
 					{
 						model: 'WRITING_CREDIT',
@@ -598,7 +637,10 @@ describe('Material with sub-sub-materials and source materials thereof', () => {
 							}
 						]
 					}
-				]
+				],
+				originalVersionMaterial: null,
+				surMaterial: null,
+				characterGroups: []
 			};
 
 			const { surMaterial } = theBooksOfTheOldTestamentPlaysMaterial.body;

--- a/test-e2e/model-interaction/mat-with-sub-sub-mats-subsequent-versions.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-sub-mats-subsequent-versions.test.js
@@ -24,6 +24,8 @@ describe('Material with sub-sub-materials and subsequent versions thereof', () =
 
 	let richardIIOriginalVersionMaterial;
 	let richardIISubsequentVersionMaterial;
+	let theFirstHenriadSubsequentVersionMaterial;
+	let theHenriadSubsequentVersionMaterial;
 	let williamShakespearePerson;
 	let theKingsMenCompany;
 
@@ -160,6 +162,10 @@ describe('Material with sub-sub-materials and subsequent versions thereof', () =
 				differentiator: '2',
 				format: 'sub-group of plays',
 				year: '2009',
+				originalVersionMaterial: {
+					name: 'The First Henriad',
+					differentiator: '1'
+				},
 				writingCredits: [
 					{
 						entities: [
@@ -200,6 +206,10 @@ describe('Material with sub-sub-materials and subsequent versions thereof', () =
 				differentiator: '2',
 				format: 'group of plays',
 				year: '2009',
+				originalVersionMaterial: {
+					name: 'The Henriad',
+					differentiator: '1'
+				},
 				writingCredits: [
 					{
 						entities: [
@@ -238,6 +248,12 @@ describe('Material with sub-sub-materials and subsequent versions thereof', () =
 
 		richardIISubsequentVersionMaterial = await chai.request(app)
 			.get(`/materials/${RICHARD_II_SUBSEQUENT_VERSION_MATERIAL_UUID}`);
+
+		theFirstHenriadSubsequentVersionMaterial = await chai.request(app)
+			.get(`/materials/${THE_FIRST_HENRIAD_SUBSEQUENT_VERSION_MATERIAL_UUID}`);
+
+		theHenriadSubsequentVersionMaterial = await chai.request(app)
+			.get(`/materials/${THE_HENRIAD_SUBSEQUENT_VERSION_MATERIAL_UUID}`);
 
 		williamShakespearePerson = await chai.request(app)
 			.get(`/people/${WILLIAM_SHAKESPEARE_PERSON_UUID}`);
@@ -346,6 +362,498 @@ describe('Material with sub-sub-materials and subsequent versions thereof', () =
 			const { originalVersionMaterial } = richardIISubsequentVersionMaterial.body;
 
 			expect(originalVersionMaterial).to.deep.equal(expectedOriginalVersionMaterial);
+
+		});
+
+		it('includes its sur-material and sur-sur-material with their corresponding original versions', () => {
+
+			const expectedSurMaterial = {
+				model: 'MATERIAL',
+				uuid: THE_FIRST_HENRIAD_SUBSEQUENT_VERSION_MATERIAL_UUID,
+				name: 'The First Henriad',
+				format: 'sub-group of plays',
+				year: 2009,
+				writingCredits: [
+					{
+						model: 'WRITING_CREDIT',
+						name: 'by',
+						entities: [
+							{
+								model: 'PERSON',
+								uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+								name: 'William Shakespeare'
+							},
+							{
+								model: 'COMPANY',
+								uuid: THE_KINGS_MEN_COMPANY_UUID,
+								name: 'The King\'s Men'
+							}
+						]
+					},
+					{
+						model: 'WRITING_CREDIT',
+						name: 'adapted for young people by',
+						entities: [
+							{
+								model: 'PERSON',
+								uuid: CARL_HEAP_PERSON_UUID,
+								name: 'Carl Heap'
+							},
+							{
+								model: 'COMPANY',
+								uuid: BEGGARS_BELIEF_THEATRE_COMPANY_UUID,
+								name: 'Beggars Belief Theatre Company'
+							}
+						]
+					}
+				],
+				originalVersionMaterial: {
+					model: 'MATERIAL',
+					uuid: THE_FIRST_HENRIAD_ORIGINAL_VERSION_MATERIAL_UUID,
+					name: 'The First Henriad',
+					format: 'sub-group of plays',
+					year: 1599,
+					writingCredits: [
+						{
+							model: 'WRITING_CREDIT',
+							name: 'by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+									name: 'William Shakespeare'
+								},
+								{
+									model: 'COMPANY',
+									uuid: THE_KINGS_MEN_COMPANY_UUID,
+									name: 'The King\'s Men'
+								}
+							]
+						}
+					],
+					surMaterial: {
+						model: 'MATERIAL',
+						uuid: THE_HENRIAD_ORIGINAL_VERSION_MATERIAL_UUID,
+						name: 'The Henriad',
+						surMaterial: null
+					}
+				},
+				surMaterial: {
+					model: 'MATERIAL',
+					uuid: THE_HENRIAD_SUBSEQUENT_VERSION_MATERIAL_UUID,
+					name: 'The Henriad',
+					format: 'group of plays',
+					year: 2009,
+					writingCredits: [
+						{
+							model: 'WRITING_CREDIT',
+							name: 'by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+									name: 'William Shakespeare'
+								},
+								{
+									model: 'COMPANY',
+									uuid: THE_KINGS_MEN_COMPANY_UUID,
+									name: 'The King\'s Men'
+								}
+							]
+						},
+						{
+							model: 'WRITING_CREDIT',
+							name: 'adapted for young people by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: CARL_HEAP_PERSON_UUID,
+									name: 'Carl Heap'
+								},
+								{
+									model: 'COMPANY',
+									uuid: BEGGARS_BELIEF_THEATRE_COMPANY_UUID,
+									name: 'Beggars Belief Theatre Company'
+								}
+							]
+						}
+					],
+					originalVersionMaterial: {
+						model: 'MATERIAL',
+						uuid: THE_HENRIAD_ORIGINAL_VERSION_MATERIAL_UUID,
+						name: 'The Henriad',
+						format: 'group of plays',
+						year: 1599,
+						writingCredits: [
+							{
+								model: 'WRITING_CREDIT',
+								name: 'by',
+								entities: [
+									{
+										model: 'PERSON',
+										uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+										name: 'William Shakespeare'
+									},
+									{
+										model: 'COMPANY',
+										uuid: THE_KINGS_MEN_COMPANY_UUID,
+										name: 'The King\'s Men'
+									}
+								]
+							}
+						],
+						surMaterial: null
+					},
+					characterGroups: []
+				},
+				characterGroups: []
+
+			};
+
+			const { surMaterial } = richardIISubsequentVersionMaterial.body;
+
+			expect(surMaterial).to.deep.equal(expectedSurMaterial);
+
+		});
+
+	});
+
+	describe('The First Henriad (subsequent version) (material)', () => {
+
+		it('includes its sur-material with its corresponding original version', () => {
+
+			const expectedSurMaterial = {
+				model: 'MATERIAL',
+				uuid: THE_HENRIAD_SUBSEQUENT_VERSION_MATERIAL_UUID,
+				name: 'The Henriad',
+				format: 'group of plays',
+				year: 2009,
+				writingCredits: [
+					{
+						model: 'WRITING_CREDIT',
+						name: 'by',
+						entities: [
+							{
+								model: 'PERSON',
+								uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+								name: 'William Shakespeare'
+							},
+							{
+								model: 'COMPANY',
+								uuid: THE_KINGS_MEN_COMPANY_UUID,
+								name: 'The King\'s Men'
+							}
+						]
+					},
+					{
+						model: 'WRITING_CREDIT',
+						name: 'adapted for young people by',
+						entities: [
+							{
+								model: 'PERSON',
+								uuid: CARL_HEAP_PERSON_UUID,
+								name: 'Carl Heap'
+							},
+							{
+								model: 'COMPANY',
+								uuid: BEGGARS_BELIEF_THEATRE_COMPANY_UUID,
+								name: 'Beggars Belief Theatre Company'
+							}
+						]
+					}
+				],
+				originalVersionMaterial: {
+					model: 'MATERIAL',
+					uuid: THE_HENRIAD_ORIGINAL_VERSION_MATERIAL_UUID,
+					name: 'The Henriad',
+					format: 'group of plays',
+					year: 1599,
+					writingCredits: [
+						{
+							model: 'WRITING_CREDIT',
+							name: 'by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+									name: 'William Shakespeare'
+								},
+								{
+									model: 'COMPANY',
+									uuid: THE_KINGS_MEN_COMPANY_UUID,
+									name: 'The King\'s Men'
+								}
+							]
+						}
+					],
+					surMaterial: null
+				},
+				surMaterial: null,
+				characterGroups: []
+
+			};
+
+			const { surMaterial } = theFirstHenriadSubsequentVersionMaterial.body;
+
+			expect(surMaterial).to.deep.equal(expectedSurMaterial);
+
+		});
+
+		it('includes its sub-materials with their corresponding original versions', () => {
+
+			const expectedSubMaterials = [
+				{
+					model: 'MATERIAL',
+					uuid: RICHARD_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
+					name: 'Richard II',
+					format: 'play',
+					year: 2009,
+					writingCredits: [
+						{
+							model: 'WRITING_CREDIT',
+							name: 'by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+									name: 'William Shakespeare'
+								},
+								{
+									model: 'COMPANY',
+									uuid: THE_KINGS_MEN_COMPANY_UUID,
+									name: 'The King\'s Men'
+								}
+							]
+						},
+						{
+							model: 'WRITING_CREDIT',
+							name: 'adapted for young people by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: CARL_HEAP_PERSON_UUID,
+									name: 'Carl Heap'
+								},
+								{
+									model: 'COMPANY',
+									uuid: BEGGARS_BELIEF_THEATRE_COMPANY_UUID,
+									name: 'Beggars Belief Theatre Company'
+								}
+							]
+						}
+					],
+					originalVersionMaterial: {
+						model: 'MATERIAL',
+						uuid: RICHARD_II_ORIGINAL_VERSION_MATERIAL_UUID,
+						name: 'Richard II',
+						format: 'play',
+						year: 1595,
+						writingCredits: [
+							{
+								model: 'WRITING_CREDIT',
+								name: 'by',
+								entities: [
+									{
+										model: 'PERSON',
+										uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+										name: 'William Shakespeare'
+									},
+									{
+										model: 'COMPANY',
+										uuid: THE_KINGS_MEN_COMPANY_UUID,
+										name: 'The King\'s Men'
+									}
+								]
+							}
+						],
+						surMaterial: {
+							model: 'MATERIAL',
+							uuid: THE_FIRST_HENRIAD_ORIGINAL_VERSION_MATERIAL_UUID,
+							name: 'The First Henriad',
+							surMaterial: {
+								model: 'MATERIAL',
+								uuid: THE_HENRIAD_ORIGINAL_VERSION_MATERIAL_UUID,
+								name: 'The Henriad'
+							}
+						}
+					},
+					subMaterials: [],
+					characterGroups: []
+
+				}
+			];
+
+			const { subMaterials } = theFirstHenriadSubsequentVersionMaterial.body;
+
+			expect(subMaterials).to.deep.equal(expectedSubMaterials);
+
+		});
+
+	});
+
+	describe('The Henriad (subsequent version) (material)', () => {
+
+		it('includes its sub-materials and sub-sub-materials with their corresponding original versions', () => {
+
+			const expectedSubMaterials = [
+				{
+					model: 'MATERIAL',
+					uuid: THE_FIRST_HENRIAD_SUBSEQUENT_VERSION_MATERIAL_UUID,
+					name: 'The First Henriad',
+					format: 'sub-group of plays',
+					year: 2009,
+					writingCredits: [
+						{
+							model: 'WRITING_CREDIT',
+							name: 'by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+									name: 'William Shakespeare'
+								},
+								{
+									model: 'COMPANY',
+									uuid: THE_KINGS_MEN_COMPANY_UUID,
+									name: 'The King\'s Men'
+								}
+							]
+						},
+						{
+							model: 'WRITING_CREDIT',
+							name: 'adapted for young people by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: CARL_HEAP_PERSON_UUID,
+									name: 'Carl Heap'
+								},
+								{
+									model: 'COMPANY',
+									uuid: BEGGARS_BELIEF_THEATRE_COMPANY_UUID,
+									name: 'Beggars Belief Theatre Company'
+								}
+							]
+						}
+					],
+					originalVersionMaterial: {
+						model: 'MATERIAL',
+						uuid: THE_FIRST_HENRIAD_ORIGINAL_VERSION_MATERIAL_UUID,
+						name: 'The First Henriad',
+						format: 'sub-group of plays',
+						year: 1599,
+						writingCredits: [
+							{
+								model: 'WRITING_CREDIT',
+								name: 'by',
+								entities: [
+									{
+										model: 'PERSON',
+										uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+										name: 'William Shakespeare'
+									},
+									{
+										model: 'COMPANY',
+										uuid: THE_KINGS_MEN_COMPANY_UUID,
+										name: 'The King\'s Men'
+									}
+								]
+							}
+						],
+						surMaterial: {
+							model: 'MATERIAL',
+							uuid: THE_HENRIAD_ORIGINAL_VERSION_MATERIAL_UUID,
+							name: 'The Henriad',
+							surMaterial: null
+						}
+					},
+					subMaterials: [
+						{
+							model: 'MATERIAL',
+							uuid: RICHARD_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
+							name: 'Richard II',
+							format: 'play',
+							year: 2009,
+							writingCredits: [
+								{
+									model: 'WRITING_CREDIT',
+									name: 'by',
+									entities: [
+										{
+											model: 'PERSON',
+											uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+											name: 'William Shakespeare'
+										},
+										{
+											model: 'COMPANY',
+											uuid: THE_KINGS_MEN_COMPANY_UUID,
+											name: 'The King\'s Men'
+										}
+									]
+								},
+								{
+									model: 'WRITING_CREDIT',
+									name: 'adapted for young people by',
+									entities: [
+										{
+											model: 'PERSON',
+											uuid: CARL_HEAP_PERSON_UUID,
+											name: 'Carl Heap'
+										},
+										{
+											model: 'COMPANY',
+											uuid: BEGGARS_BELIEF_THEATRE_COMPANY_UUID,
+											name: 'Beggars Belief Theatre Company'
+										}
+									]
+								}
+							],
+							originalVersionMaterial: {
+								model: 'MATERIAL',
+								uuid: RICHARD_II_ORIGINAL_VERSION_MATERIAL_UUID,
+								name: 'Richard II',
+								format: 'play',
+								year: 1595,
+								writingCredits: [
+									{
+										model: 'WRITING_CREDIT',
+										name: 'by',
+										entities: [
+											{
+												model: 'PERSON',
+												uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
+												name: 'William Shakespeare'
+											},
+											{
+												model: 'COMPANY',
+												uuid: THE_KINGS_MEN_COMPANY_UUID,
+												name: 'The King\'s Men'
+											}
+										]
+									}
+								],
+								surMaterial: {
+									model: 'MATERIAL',
+									uuid: THE_FIRST_HENRIAD_ORIGINAL_VERSION_MATERIAL_UUID,
+									name: 'The First Henriad',
+									surMaterial: {
+										model: 'MATERIAL',
+										uuid: THE_HENRIAD_ORIGINAL_VERSION_MATERIAL_UUID,
+										name: 'The Henriad'
+									}
+								}
+							},
+							characterGroups: []
+						}
+					],
+					characterGroups: []
+
+				}
+			];
+
+			const { subMaterials } = theHenriadSubsequentVersionMaterial.body;
+
+			expect(subMaterials).to.deep.equal(expectedSubMaterials);
 
 		});
 

--- a/test-e2e/model-interaction/mat-with-sub-sub-mats.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-sub-mats.test.js
@@ -507,6 +507,7 @@ describe('Material with sub-sub-materials', () => {
 					format: 'sub-collection of plays',
 					year: 2009,
 					writingCredits: [],
+					originalVersionMaterial: null,
 					subMaterials: [
 						{
 							model: 'MATERIAL',
@@ -531,6 +532,22 @@ describe('Material with sub-sub-materials', () => {
 										}
 									]
 								}
+							],
+							originalVersionMaterial: null,
+							characterGroups: [
+								{
+									model: 'CHARACTER_GROUP',
+									name: null,
+									position: null,
+									characters: [
+										{
+											model: 'CHARACTER',
+											uuid: BAR_CHARACTER_UUID,
+											name: 'Bar',
+											qualifier: null
+										}
+									]
+								}
 							]
 						},
 						{
@@ -551,7 +568,9 @@ describe('Material with sub-sub-materials', () => {
 										}
 									]
 								}
-							]
+							],
+							originalVersionMaterial: null,
+							characterGroups: []
 						},
 						{
 							model: 'MATERIAL',
@@ -571,9 +590,12 @@ describe('Material with sub-sub-materials', () => {
 										}
 									]
 								}
-							]
+							],
+							originalVersionMaterial: null,
+							characterGroups: []
 						}
-					]
+					],
+					characterGroups: []
 				},
 				{
 					model: 'MATERIAL',
@@ -582,6 +604,7 @@ describe('Material with sub-sub-materials', () => {
 					format: 'sub-collection of plays',
 					year: 2009,
 					writingCredits: [],
+					originalVersionMaterial: null,
 					subMaterials: [
 						{
 							model: 'MATERIAL',
@@ -601,7 +624,9 @@ describe('Material with sub-sub-materials', () => {
 										}
 									]
 								}
-							]
+							],
+							originalVersionMaterial: null,
+							characterGroups: []
 						},
 						{
 							model: 'MATERIAL',
@@ -621,7 +646,9 @@ describe('Material with sub-sub-materials', () => {
 										}
 									]
 								}
-							]
+							],
+							originalVersionMaterial: null,
+							characterGroups: []
 						},
 						{
 							model: 'MATERIAL',
@@ -646,9 +673,26 @@ describe('Material with sub-sub-materials', () => {
 										}
 									]
 								}
+							],
+							originalVersionMaterial: null,
+							characterGroups: [
+								{
+									model: 'CHARACTER_GROUP',
+									name: null,
+									position: null,
+									characters: [
+										{
+											model: 'CHARACTER',
+											uuid: BAR_CHARACTER_UUID,
+											name: 'Bar',
+											qualifier: null
+										}
+									]
+								}
 							]
 						}
-					]
+					],
+					characterGroups: []
 				},
 				{
 					model: 'MATERIAL',
@@ -657,6 +701,7 @@ describe('Material with sub-sub-materials', () => {
 					format: 'sub-collection of plays',
 					year: 2009,
 					writingCredits: [],
+					originalVersionMaterial: null,
 					subMaterials: [
 						{
 							model: 'MATERIAL',
@@ -676,7 +721,9 @@ describe('Material with sub-sub-materials', () => {
 										}
 									]
 								}
-							]
+							],
+							originalVersionMaterial: null,
+							characterGroups: []
 						},
 						{
 							model: 'MATERIAL',
@@ -701,6 +748,22 @@ describe('Material with sub-sub-materials', () => {
 										}
 									]
 								}
+							],
+							originalVersionMaterial: null,
+							characterGroups: [
+								{
+									model: 'CHARACTER_GROUP',
+									name: null,
+									position: null,
+									characters: [
+										{
+											model: 'CHARACTER',
+											uuid: BAR_CHARACTER_UUID,
+											name: 'Bar',
+											qualifier: null
+										}
+									]
+								}
 							]
 						},
 						{
@@ -721,9 +784,12 @@ describe('Material with sub-sub-materials', () => {
 										}
 									]
 								}
-							]
+							],
+							originalVersionMaterial: null,
+							characterGroups: []
 						}
-					]
+					],
+					characterGroups: []
 				}
 			];
 
@@ -745,8 +811,10 @@ describe('Material with sub-sub-materials', () => {
 				name: 'The Great Game: Afghanistan',
 				format: 'collection of plays',
 				year: 2009,
+				writingCredits: [],
+				originalVersionMaterial: null,
 				surMaterial: null,
-				writingCredits: []
+				characterGroups: []
 			};
 
 			const { surMaterial } = partOneInvasionsAndIndependenceMaterial.body;
@@ -782,7 +850,23 @@ describe('Material with sub-sub-materials', () => {
 							]
 						}
 					],
-					subMaterials: []
+					originalVersionMaterial: null,
+					subMaterials: [],
+					characterGroups: [
+						{
+							model: 'CHARACTER_GROUP',
+							name: null,
+							position: null,
+							characters: [
+								{
+									model: 'CHARACTER',
+									uuid: BAR_CHARACTER_UUID,
+									name: 'Bar',
+									qualifier: null
+								}
+							]
+						}
+					]
 				},
 				{
 					model: 'MATERIAL',
@@ -803,7 +887,9 @@ describe('Material with sub-sub-materials', () => {
 							]
 						}
 					],
-					subMaterials: []
+					originalVersionMaterial: null,
+					subMaterials: [],
+					characterGroups: []
 				},
 				{
 					model: 'MATERIAL',
@@ -824,7 +910,9 @@ describe('Material with sub-sub-materials', () => {
 							]
 						}
 					],
-					subMaterials: []
+					originalVersionMaterial: null,
+					subMaterials: [],
+					characterGroups: []
 				}
 			];
 
@@ -846,12 +934,19 @@ describe('Material with sub-sub-materials', () => {
 				name: 'Part One - Invasions and Independence 1842-1930',
 				format: 'sub-collection of plays',
 				year: 2009,
+				writingCredits: [],
+				originalVersionMaterial: null,
 				surMaterial: {
 					model: 'MATERIAL',
 					uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
-					name: 'The Great Game: Afghanistan'
+					name: 'The Great Game: Afghanistan',
+					format: 'collection of plays',
+					year: 2009,
+					writingCredits: [],
+					originalVersionMaterial: null,
+					characterGroups: []
 				},
-				writingCredits: []
+				characterGroups: []
 			};
 
 			const { surMaterial } = buglesAtTheGatesOfJalalabadMaterial.body;


### PR DESCRIPTION
This PR enables multi-tiered materials to derive their sur, sur-sur, sub, and sub-sub material credits so that they may be displayed on its instance page, i.e. basically does for material instances as was done for production instances in https://github.com/andygout/theatrebase-api/pull/533.

---

## Real-life examples

#### The Coast of Utopia (material) - before
![the-coast-of-utopia-material-before](https://user-images.githubusercontent.com/10484515/236805072-0153e58f-23f4-4aef-b948-52c7272f9bb9.png)

---

#### The Coast of Utopia (material) - after
![the-coast-of-utopia-material-after](https://user-images.githubusercontent.com/10484515/236805107-371a5691-f101-444c-adb2-83b97437a4fe.png)

---

#### Voyage (material) - before
![voyage-material-before](https://user-images.githubusercontent.com/10484515/236805130-2e3d6ba6-28b9-4a12-8c58-aef4cca78b41.png)

---

#### Voyage (material) - after
![voyage-material-after](https://user-images.githubusercontent.com/10484515/236805159-81c97bcd-e02a-415d-be1b-5f16ed603483.png)

---

#### The Bomb: A Partial History (material) - before
![the-bomb-a-partial-history-material-before](https://user-images.githubusercontent.com/10484515/236805180-3fa6c756-a22e-4806-ad27-5d0357c4ea4b.png)

---

#### The Bomb: A Partial History (material) - after
![the-bomb-a-partial-history-material-after](https://user-images.githubusercontent.com/10484515/236805190-bef56c5d-a07a-44e2-8730-c320c7ba7219.png)

---

#### First Blast: Proliferation (1940-1992) (material) - before
![first-blast-proliferation-1940-1992-material-before](https://user-images.githubusercontent.com/10484515/236805285-cf6f9474-b57b-4ddb-8ff0-534ee3d82bf6.png)

---

#### First Blast: Proliferation (1940-1992) (material) - after
![first-blast-proliferation-1940-1992-material-after](https://user-images.githubusercontent.com/10484515/236805477-5041f1c2-67bf-4725-b329-6f1341bcc121.png)

---

#### From Elsewhere: The Message… (material) - before
![from-elsewhere-the-message…-material-before](https://user-images.githubusercontent.com/10484515/236805509-6af1a5c3-afa5-4f85-8975-e6d04b59bba3.png)

---

#### From Elsewhere: The Message… (material) - after
![from-elsewhere-the-message…-material-after](https://user-images.githubusercontent.com/10484515/236805524-0e82086e-dfec-495a-9ac0-fc15573e914d.png)

---

## Test examples

### `mat-with-sub-mats-subsequent-versions.test.js`

#### Agamemnon (subsequent version) (material) - before
![agamemnon-subsequent-version-before](https://user-images.githubusercontent.com/10484515/236807849-fbc29c6e-3283-4c37-a0b5-9d025a24e8ce.png)

---

#### Agamemnon (subsequent version) (material) - after
![agamemnon-subsequent-version-after](https://user-images.githubusercontent.com/10484515/236807978-64536941-2bb4-48e3-9a0c-757bcab1d1e2.png)

---

#### The Oresteia (subsequent version) (material) - before
![the-oresteia-subsequent-version-before](https://user-images.githubusercontent.com/10484515/236807970-b191e5bb-2acd-4312-8eab-371c7e448021.png)

---

#### The Oresteia (subsequent version) (material) - after
![the-oresteia-subsequent-version-after](https://user-images.githubusercontent.com/10484515/236807890-440d588b-00c6-4a1c-b08f-360b87f16e1c.png)

---

### `mat-with-sub-mats.test.js`

#### Voyage (material) (material with sur-material) - before
![voyage-material-before](https://user-images.githubusercontent.com/10484515/236809110-0352aa3d-5ae7-4ce0-ae4b-7382ef6968a9.png)

---

#### Voyage (material) (material with sur-material) - after
![voyage-material-after](https://user-images.githubusercontent.com/10484515/236809125-5d9ba3e6-c368-4b01-9cc8-f2a60439a326.png)

---

#### The Coast of Utopia (material) (material with sub-materials) - before
![the-coast-of-utopia-material-before](https://user-images.githubusercontent.com/10484515/236809076-d2826079-349c-4b4e-a421-aa20475b531d.png)

---

#### The Coast of Utopia (material) (material with sub-materials) - after
![the-coast-of-utopia-material-after](https://user-images.githubusercontent.com/10484515/236809096-78fea575-7e67-4070-9ac2-dd4dc6999ebf.png)

---

### `mat-with-sub-sub-mats-source-mats.test.js`

#### Godblog (material) - before
![godblog-material-before](https://user-images.githubusercontent.com/10484515/236810194-41cbabdf-eb5f-4066-bb80-99da1ba733be.png)

---

#### Godblog (material) - after
![godblog-material-after](https://user-images.githubusercontent.com/10484515/236810205-02899e26-4f19-4966-8176-d0e513aa9296.png)

---

### `mat-with-sub-sub-mats-subsequent-versions.test.js`

#### Richard II (subsequent version) (material) - before
![richard-ii-subsequent-version-before](https://user-images.githubusercontent.com/10484515/236811407-4c328887-a22a-4908-bf98-431e31fc4108.png)

---

#### Richard II (subsequent version) (material) - after
![richard-ii-subsequent-version-after](https://user-images.githubusercontent.com/10484515/236811429-aadca048-fa87-4505-b30a-19a02610778f.png)

---

#### The First Henriad (subsequent version) (material) - before
![the-first-henriad-subsequent-version-before](https://user-images.githubusercontent.com/10484515/236811445-ed430435-096b-40b5-aa63-1d530790f274.png)

---

#### The First Henriad (subsequent version) (material) - after
![the-first-henriad-subsequent-version-after](https://user-images.githubusercontent.com/10484515/236811458-cd9ef2e5-6f6b-4f02-898f-07f22a4ab8d3.png)

---

#### The Henriad (subsequent version) (material) - before
![the-henriad-subsequent-version-before](https://user-images.githubusercontent.com/10484515/236811479-0b93b31e-e659-4905-8b16-5dcadb3119cc.png)

---

#### The Henriad (subsequent version) (material) - before
![the-henriad-subsequent-version-after](https://user-images.githubusercontent.com/10484515/236811492-b65adcd1-a978-4123-be0c-83bfc11b2d3d.png)

---

### `mat-with-sub-sub-mats.test.js`

#### Bugles at the Gates of Jalalabad (material) (material with sur-sur-material) - before
![bugles-at-the-gates-of-jalalabad-material-before](https://user-images.githubusercontent.com/10484515/236812884-6eadd664-ee6f-40c0-a9aa-708583369eb1.png)

---

#### Bugles at the Gates of Jalalabad (material) (material with sur-sur-material) - after
![bugles-at-the-gates-of-jalalabad-material-after](https://user-images.githubusercontent.com/10484515/236812573-1a61a209-7b75-4558-af12-2da83cb6a03e.png)

---

#### Part One - Invasions and Independence 1842-1930 (material) (material with sur-material and sub-materials) - before
![part-one-invasions-and-independence-1842-1930-material-before](https://user-images.githubusercontent.com/10484515/236812899-3bf1c8c5-d565-44b3-b6da-da406ba6fbc5.png)

---

#### Part One - Invasions and Independence 1842-1930 (material)  (material with sur-material and sub-materials)- after
![part-one-invasions-and-independence-1842-1930-material-after](https://user-images.githubusercontent.com/10484515/236812588-02d7a131-2651-48ed-97bf-b7bdc1ce6d84.png)

---

#### The Great Game: Afghanistan (material) (material with sub-sub-materials) - before
![the-great-game-afghanistan-material-before](https://user-images.githubusercontent.com/10484515/236812919-73133a01-7e46-4f22-acfa-48a6c50d3c35.png)

---

#### The Great Game: Afghanistan (material) (material with sub-sub-materials) - after
![the-great-game-afghanistan-material-after](https://user-images.githubusercontent.com/10484515/236812605-6885cbbf-a74b-4c81-b058-40727c9e0beb.png)