### PR TITLE
Add E2E CRUD tests for updating instance with existing data

### DIFF
--- a/src/neo4j/cypher-queries/validation/sub-material-checks.js
+++ b/src/neo4j/cypher-queries/validation/sub-material-checks.js
@@ -8,7 +8,10 @@ export default () => `
 
 	OPTIONAL MATCH (subjectMaterial:Material { uuid: $subjectMaterialUuid })
 
-	OPTIONAL MATCH (m)<-[surMaterialRel:HAS_SUB_MATERIAL]-(:Material)
+	OPTIONAL MATCH (m)<-[surMaterialRel:HAS_SUB_MATERIAL]-(surMaterial:Material)
+		WHERE
+			$subjectMaterialUuid IS NULL OR
+			$subjectMaterialUuid <> surMaterial.uuid
 
 	OPTIONAL MATCH (m)
 		-[:HAS_SUB_MATERIAL]->(:Material)

--- a/src/neo4j/cypher-queries/validation/sub-production-checks.js
+++ b/src/neo4j/cypher-queries/validation/sub-production-checks.js
@@ -3,7 +3,10 @@ export default () => `
 
 	OPTIONAL MATCH (subjectProduction:Production { uuid: $subjectProductionUuid })
 
-	OPTIONAL MATCH (p)<-[surProductionRel:HAS_SUB_PRODUCTION]-(:Production)
+	OPTIONAL MATCH (p)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
+		WHERE
+			$subjectProductionUuid IS NULL OR
+			$subjectProductionUuid <> surProduction.uuid
 
 	OPTIONAL MATCH (p)
 		-[:HAS_SUB_PRODUCTION]->(:Production)

--- a/test-e2e/crud/award-ceremonies-api.test.js
+++ b/test-e2e/crud/award-ceremonies-api.test.js
@@ -373,38 +373,38 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 		const A_DISAPPEARING_NUMBER_MATERIAL_UUID = '59';
 		const THE_REPORTER_MATERIAL_UUID = '60';
 		const VERNON_GOD_LITTLE_MATERIAL_UUID = '61';
-		const THE_CHALK_GARDEN_DONMAR_PRODUCTION_UUID = '62';
-		const PIAF_DONMAR_PRODUCTION_UUID = '65';
-		const PIAF_VAUDEVILLE_PRODUCTION_UUID = '68';
-		const VAUDEVILLE_THEATRE_VENUE_UUID = '70';
-		const IVANOV_WYNDHAMS_PRODUCTION_UUID = '71';
-		const WALDO_DORFMAN_PRODUCTION_UUID = '74';
-		const DORFMAN_THEATRE_VENUE_UUID = '76';
-		const WALDO_NOËL_COWARD_PRODUCTION_UUID = '77';
-		const NOËL_COWARD_THEATRE_VENUE_UUID = '79';
-		const FRED_OLD_VIC_PRODUCTION_UUID = '80';
-		const OLD_VIC_THEATRE_VENUE_UUID = '82';
-		const EVENING_STANDARD_THEATRE_AWARDS_AWARD_UUID = '104';
-		const PAULE_CONSTABLE_PERSON_UUID = '105';
-		const THE_CHALK_GARDEN_MATERIAL_UUID = '106';
-		const ILLUMINATIONS_LTD_COMPANY_UUID = '107';
-		const PIAF_MATERIAL_UUID = '108';
-		const NEIL_AUSTIN_PERSON_UUID = '109';
-		const MARK_HENDERSON_PERSON_UUID = '110';
-		const IVANOV_MATERIAL_UUID = '111';
-		const LIMELIGHT_LTD_COMPANY_UUID = '112';
-		const KEVIN_ADAMS_PERSON_UUID = '113';
-		const JON_CLARK_PERSON_UUID = '114';
-		const WALDO_MATERIAL_UUID = '115';
-		const STAGE_SUN_LTD_COMPANY_UUID = '116';
-		const HOWARD_HARRISON_PERSON_UUID = '117';
-		const RAFAEL_AMARGO_PERSON_UUID = '118';
-		const STEVEN_HOGGETT_PERSON_UUID = '119';
-		const LYNNE_PAGE_PERSON_UUID = '120';
-		const KATE_PRINCE_PERSON_UUID = '121';
-		const ENGLAND_PEOPLE_VERY_NICE_MATERIAL_UUID = '122';
-		const JERUSALEM_MATERIAL_UUID = '123';
-		const OUR_CLASS_MATERIAL_UUID = '124';
+		const THE_CHALK_GARDEN_DONMAR_PRODUCTION_UUID = '104';
+		const PIAF_DONMAR_PRODUCTION_UUID = '107';
+		const PIAF_VAUDEVILLE_PRODUCTION_UUID = '110';
+		const VAUDEVILLE_THEATRE_VENUE_UUID = '112';
+		const IVANOV_WYNDHAMS_PRODUCTION_UUID = '113';
+		const WALDO_DORFMAN_PRODUCTION_UUID = '116';
+		const DORFMAN_THEATRE_VENUE_UUID = '118';
+		const WALDO_NOËL_COWARD_PRODUCTION_UUID = '119';
+		const NOËL_COWARD_THEATRE_VENUE_UUID = '121';
+		const FRED_OLD_VIC_PRODUCTION_UUID = '122';
+		const OLD_VIC_THEATRE_VENUE_UUID = '124';
+		const EVENING_STANDARD_THEATRE_AWARDS_AWARD_UUID = '146';
+		const PAULE_CONSTABLE_PERSON_UUID = '147';
+		const THE_CHALK_GARDEN_MATERIAL_UUID = '148';
+		const ILLUMINATIONS_LTD_COMPANY_UUID = '149';
+		const PIAF_MATERIAL_UUID = '150';
+		const NEIL_AUSTIN_PERSON_UUID = '151';
+		const MARK_HENDERSON_PERSON_UUID = '152';
+		const IVANOV_MATERIAL_UUID = '153';
+		const LIMELIGHT_LTD_COMPANY_UUID = '154';
+		const KEVIN_ADAMS_PERSON_UUID = '155';
+		const JON_CLARK_PERSON_UUID = '156';
+		const WALDO_MATERIAL_UUID = '157';
+		const STAGE_SUN_LTD_COMPANY_UUID = '158';
+		const HOWARD_HARRISON_PERSON_UUID = '159';
+		const RAFAEL_AMARGO_PERSON_UUID = '160';
+		const STEVEN_HOGGETT_PERSON_UUID = '161';
+		const LYNNE_PAGE_PERSON_UUID = '162';
+		const KATE_PRINCE_PERSON_UUID = '163';
+		const ENGLAND_PEOPLE_VERY_NICE_MATERIAL_UUID = '164';
+		const JERUSALEM_MATERIAL_UUID = '165';
+		const OUR_CLASS_MATERIAL_UUID = '166';
 
 		before(async () => {
 
@@ -2938,7 +2938,1110 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 
 		});
 
-		it('updates award ceremony', async () => {
+		it('updates award ceremony (with existing data)', async () => {
+
+			expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
+
+			const response = await chai.request(app)
+				.put(`/award-ceremonies/${AWARD_CEREMONY_UUID}`)
+				.send({
+					name: '2008',
+					award: {
+						name: 'Laurence Olivier Awards',
+						differentiator: '1'
+					},
+					categories: [
+						{
+							name: 'Best Sound Design',
+							nominations: [
+								{
+									entities: [
+										{
+											name: 'Steve C Kennedy',
+											differentiator: '1'
+										}
+									],
+									productions: [
+										{
+											uuid: HAIRSPRAY_SHAFTESBURY_PRODUCTION_UUID
+										}
+									],
+									materials: [
+										{
+											name: 'Hairspray',
+											differentiator: '1'
+										}
+									]
+								},
+								{
+									entities: [
+										{
+											model: 'COMPANY',
+											name: 'Soundwaves Ltd',
+											differentiator: '1'
+										}
+									],
+									productions: [
+										{
+											uuid: GARPLY_LYTTELTON_PRODUCTION_UUID
+										},
+										{
+											uuid: GARPLY_WYNDHAMS_PRODUCTION_UUID
+										}
+									],
+									materials: [
+										{
+											name: 'Garply',
+											differentiator: '1'
+										}
+									]
+								},
+								{
+									isWinner: true,
+									entities: [
+										{
+											name: 'Paul Arditti',
+											differentiator: '1'
+										},
+										{
+											name: 'Jocelyn Pook',
+											differentiator: '1'
+										}
+									],
+									productions: [
+										{
+											uuid: SAINT_JOAN_OLIVIER_PRODUCTION_UUID
+										}
+									],
+									materials: [
+										{
+											name: 'Saint Joan',
+											differentiator: '1'
+										}
+									]
+								},
+								{
+									entities: [
+										{
+											model: 'COMPANY',
+											name: 'Autograph',
+											differentiator: '1',
+											members: [
+												{
+													name: 'Terry Jardine',
+													differentiator: '1'
+												},
+												{
+													name: 'Nick Lidster',
+													differentiator: '1'
+												}
+											]
+										}
+									],
+									productions: [
+										{
+											uuid: PARADE_DONMAR_PRODUCTION_UUID
+										}
+									],
+									materials: [
+										{
+											name: 'Parade',
+											differentiator: '1'
+										}
+									]
+								},
+								{
+									entities: [
+										{
+											model: 'COMPANY',
+											name: 'Audio Creative Ltd',
+											differentiator: '1',
+											members: [
+												{
+													name: 'Terry Jardine',
+													differentiator: '1'
+												}
+											]
+										},
+										{
+											name: 'Simon Baker',
+											differentiator: '1'
+										}
+									],
+									productions: [
+										{
+											uuid: GARPLY_LYTTELTON_PRODUCTION_UUID
+										},
+										{
+											uuid: GARPLY_WYNDHAMS_PRODUCTION_UUID
+										}
+									],
+									materials: [
+										{
+											name: 'Garply',
+											differentiator: '1'
+										}
+									]
+								}
+							]
+						},
+						{
+							name: 'Best Director',
+							nominations: [
+								{
+									entities: [
+										{
+											name: 'Rob Ashford',
+											differentiator: '1'
+										}
+									]
+								},
+								{
+									entities: [
+										{
+											name: 'Marianne Elliott',
+											differentiator: '1'
+										},
+										{
+											name: 'Tom Morris',
+											differentiator: '1'
+										}
+									]
+								},
+								{
+									isWinner: true,
+									entities: [
+										{
+											name: 'Rupert Goold',
+											differentiator: '1'
+										}
+									]
+								}
+							]
+						},
+						{
+							name: 'Best Revival',
+							nominations: [
+								{
+									productions: [
+										{
+											uuid: GARPLY_LYTTELTON_PRODUCTION_UUID
+										},
+										{
+											uuid: GARPLY_WYNDHAMS_PRODUCTION_UUID
+										}
+									]
+								},
+								{
+									isWinner: true,
+									productions: [
+										{
+											uuid: GRAULT_ALMEIDA_PRODUCTION_UUID
+										}
+									]
+								},
+								{
+									productions: [
+										{
+											uuid: SAINT_JOAN_OLIVIER_PRODUCTION_UUID
+										}
+									]
+								}
+							]
+						},
+						{
+							name: 'Best New Play',
+							nominations: [
+								{
+									isWinner: true,
+									materials: [
+										{
+											name: 'A Disappearing Number',
+											differentiator: '1'
+										}
+									]
+								},
+								{
+									customType: 'Special Commendation',
+									materials: [
+										{
+											name: 'The Reporter',
+											differentiator: '1'
+										}
+									]
+								},
+								{
+									customType: 'Finalist',
+									materials: [
+										{
+											name: 'Vernon God Little',
+											differentiator: '1'
+										}
+									]
+								}
+							]
+						},
+						{
+							name: 'Best New Dance Production'
+						}
+					]
+				});
+
+			const expectedResponseBody = {
+				model: 'AWARD_CEREMONY',
+				uuid: AWARD_CEREMONY_UUID,
+				name: '2008',
+				errors: {},
+				award: {
+					model: 'AWARD',
+					name: 'Laurence Olivier Awards',
+					differentiator: '1',
+					errors: {}
+				},
+				categories: [
+					{
+						model: 'AWARD_CEREMONY_CATEGORY',
+						name: 'Best Sound Design',
+						errors: {},
+						nominations: [
+							{
+								model: 'NOMINATION',
+								isWinner: false,
+								customType: '',
+								errors: {},
+								entities: [
+									{
+										model: 'PERSON',
+										name: 'Steve C Kennedy',
+										differentiator: '1',
+										errors: {}
+									},
+									{
+										model: 'PERSON',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								],
+								productions: [
+									{
+										model: 'PRODUCTION_IDENTIFIER',
+										uuid: HAIRSPRAY_SHAFTESBURY_PRODUCTION_UUID,
+										errors: {}
+									},
+									{
+										model: 'PRODUCTION_IDENTIFIER',
+										uuid: '',
+										errors: {}
+									}
+								],
+								materials: [
+									{
+										model: 'MATERIAL',
+										name: 'Hairspray',
+										differentiator: '1',
+										errors: {}
+									},
+									{
+										model: 'MATERIAL',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								]
+							},
+							{
+								model: 'NOMINATION',
+								isWinner: false,
+								customType: '',
+								errors: {},
+								entities: [
+									{
+										model: 'COMPANY',
+										name: 'Soundwaves Ltd',
+										differentiator: '1',
+										errors: {},
+										members: [
+											{
+												model: 'PERSON',
+												name: '',
+												differentiator: '',
+												errors: {}
+											}
+										]
+									},
+									{
+										model: 'PERSON',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								],
+								productions: [
+									{
+										model: 'PRODUCTION_IDENTIFIER',
+										uuid: GARPLY_LYTTELTON_PRODUCTION_UUID,
+										errors: {}
+									},
+									{
+										model: 'PRODUCTION_IDENTIFIER',
+										uuid: GARPLY_WYNDHAMS_PRODUCTION_UUID,
+										errors: {}
+									},
+									{
+										model: 'PRODUCTION_IDENTIFIER',
+										uuid: '',
+										errors: {}
+									}
+								],
+								materials: [
+									{
+										model: 'MATERIAL',
+										name: 'Garply',
+										differentiator: '1',
+										errors: {}
+									},
+									{
+										model: 'MATERIAL',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								]
+							},
+							{
+								model: 'NOMINATION',
+								isWinner: true,
+								customType: '',
+								errors: {},
+								entities: [
+									{
+										model: 'PERSON',
+										name: 'Paul Arditti',
+										differentiator: '1',
+										errors: {}
+									},
+									{
+										model: 'PERSON',
+										name: 'Jocelyn Pook',
+										differentiator: '1',
+										errors: {}
+									},
+									{
+										model: 'PERSON',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								],
+								productions: [
+									{
+										model: 'PRODUCTION_IDENTIFIER',
+										uuid: SAINT_JOAN_OLIVIER_PRODUCTION_UUID,
+										errors: {}
+									},
+									{
+										model: 'PRODUCTION_IDENTIFIER',
+										uuid: '',
+										errors: {}
+									}
+								],
+								materials: [
+									{
+										model: 'MATERIAL',
+										name: 'Saint Joan',
+										differentiator: '1',
+										errors: {}
+									},
+									{
+										model: 'MATERIAL',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								]
+							},
+							{
+								model: 'NOMINATION',
+								isWinner: false,
+								customType: '',
+								errors: {},
+								entities: [
+									{
+										model: 'COMPANY',
+										name: 'Autograph',
+										differentiator: '1',
+										errors: {},
+										members: [
+											{
+												model: 'PERSON',
+												name: 'Terry Jardine',
+												differentiator: '1',
+												errors: {}
+											},
+											{
+												model: 'PERSON',
+												name: 'Nick Lidster',
+												differentiator: '1',
+												errors: {}
+											},
+											{
+												model: 'PERSON',
+												name: '',
+												differentiator: '',
+												errors: {}
+											}
+										]
+									},
+									{
+										model: 'PERSON',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								],
+								productions: [
+									{
+										model: 'PRODUCTION_IDENTIFIER',
+										uuid: PARADE_DONMAR_PRODUCTION_UUID,
+										errors: {}
+									},
+									{
+										model: 'PRODUCTION_IDENTIFIER',
+										uuid: '',
+										errors: {}
+									}
+								],
+								materials: [
+									{
+										model: 'MATERIAL',
+										name: 'Parade',
+										differentiator: '1',
+										errors: {}
+									},
+									{
+										model: 'MATERIAL',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								]
+							},
+							{
+								model: 'NOMINATION',
+								isWinner: false,
+								customType: '',
+								errors: {},
+								entities: [
+									{
+										model: 'COMPANY',
+										name: 'Audio Creative Ltd',
+										differentiator: '1',
+										errors: {},
+										members: [
+											{
+												model: 'PERSON',
+												name: 'Terry Jardine',
+												differentiator: '1',
+												errors: {}
+											},
+											{
+												model: 'PERSON',
+												name: '',
+												differentiator: '',
+												errors: {}
+											}
+										]
+									},
+									{
+										model: 'PERSON',
+										name: 'Simon Baker',
+										differentiator: '1',
+										errors: {}
+									},
+									{
+										model: 'PERSON',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								],
+								productions: [
+									{
+										model: 'PRODUCTION_IDENTIFIER',
+										uuid: GARPLY_LYTTELTON_PRODUCTION_UUID,
+										errors: {}
+									},
+									{
+										model: 'PRODUCTION_IDENTIFIER',
+										uuid: GARPLY_WYNDHAMS_PRODUCTION_UUID,
+										errors: {}
+									},
+									{
+										model: 'PRODUCTION_IDENTIFIER',
+										uuid: '',
+										errors: {}
+									}
+								],
+								materials: [
+									{
+										model: 'MATERIAL',
+										name: 'Garply',
+										differentiator: '1',
+										errors: {}
+									},
+									{
+										model: 'MATERIAL',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								]
+							},
+							{
+								model: 'NOMINATION',
+								isWinner: false,
+								customType: '',
+								errors: {},
+								entities: [
+									{
+										model: 'PERSON',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								],
+								productions: [
+									{
+										model: 'PRODUCTION_IDENTIFIER',
+										uuid: '',
+										errors: {}
+									}
+								],
+								materials: [
+									{
+										model: 'MATERIAL',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD_CEREMONY_CATEGORY',
+						name: 'Best Director',
+						errors: {},
+						nominations: [
+							{
+								model: 'NOMINATION',
+								isWinner: false,
+								customType: '',
+								errors: {},
+								entities: [
+									{
+										model: 'PERSON',
+										name: 'Rob Ashford',
+										differentiator: '1',
+										errors: {}
+									},
+									{
+										model: 'PERSON',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								],
+								productions: [
+									{
+										model: 'PRODUCTION_IDENTIFIER',
+										uuid: '',
+										errors: {}
+									}
+								],
+								materials: [
+									{
+										model: 'MATERIAL',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								]
+							},
+							{
+								model: 'NOMINATION',
+								isWinner: false,
+								customType: '',
+								errors: {},
+								entities: [
+									{
+										model: 'PERSON',
+										name: 'Marianne Elliott',
+										differentiator: '1',
+										errors: {}
+									},
+									{
+										model: 'PERSON',
+										name: 'Tom Morris',
+										differentiator: '1',
+										errors: {}
+									},
+									{
+										model: 'PERSON',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								],
+								productions: [
+									{
+										model: 'PRODUCTION_IDENTIFIER',
+										uuid: '',
+										errors: {}
+									}
+								],
+								materials: [
+									{
+										model: 'MATERIAL',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								]
+							},
+							{
+								model: 'NOMINATION',
+								isWinner: true,
+								customType: '',
+								errors: {},
+								entities: [
+									{
+										model: 'PERSON',
+										name: 'Rupert Goold',
+										differentiator: '1',
+										errors: {}
+									},
+									{
+										model: 'PERSON',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								],
+								productions: [
+									{
+										model: 'PRODUCTION_IDENTIFIER',
+										uuid: '',
+										errors: {}
+									}
+								],
+								materials: [
+									{
+										model: 'MATERIAL',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								]
+							},
+							{
+								model: 'NOMINATION',
+								isWinner: false,
+								customType: '',
+								errors: {},
+								entities: [
+									{
+										model: 'PERSON',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								],
+								productions: [
+									{
+										model: 'PRODUCTION_IDENTIFIER',
+										uuid: '',
+										errors: {}
+									}
+								],
+								materials: [
+									{
+										model: 'MATERIAL',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD_CEREMONY_CATEGORY',
+						name: 'Best Revival',
+						errors: {},
+						nominations: [
+							{
+								model: 'NOMINATION',
+								isWinner: false,
+								customType: '',
+								errors: {},
+								entities: [
+									{
+										model: 'PERSON',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								],
+								productions: [
+									{
+										model: 'PRODUCTION_IDENTIFIER',
+										uuid: GARPLY_LYTTELTON_PRODUCTION_UUID,
+										errors: {}
+									},
+									{
+										model: 'PRODUCTION_IDENTIFIER',
+										uuid: GARPLY_WYNDHAMS_PRODUCTION_UUID,
+										errors: {}
+									},
+									{
+										model: 'PRODUCTION_IDENTIFIER',
+										uuid: '',
+										errors: {}
+									}
+								],
+								materials: [
+									{
+										model: 'MATERIAL',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								]
+							},
+							{
+								model: 'NOMINATION',
+								isWinner: true,
+								customType: '',
+								errors: {},
+								entities: [
+									{
+										model: 'PERSON',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								],
+								productions: [
+									{
+										model: 'PRODUCTION_IDENTIFIER',
+										uuid: GRAULT_ALMEIDA_PRODUCTION_UUID,
+										errors: {}
+									},
+									{
+										model: 'PRODUCTION_IDENTIFIER',
+										uuid: '',
+										errors: {}
+									}
+								],
+								materials: [
+									{
+										model: 'MATERIAL',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								]
+							},
+							{
+								model: 'NOMINATION',
+								isWinner: false,
+								customType: '',
+								errors: {},
+								entities: [
+									{
+										model: 'PERSON',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								],
+								productions: [
+									{
+										model: 'PRODUCTION_IDENTIFIER',
+										uuid: SAINT_JOAN_OLIVIER_PRODUCTION_UUID,
+										errors: {}
+									},
+									{
+										model: 'PRODUCTION_IDENTIFIER',
+										uuid: '',
+										errors: {}
+									}
+								],
+								materials: [
+									{
+										model: 'MATERIAL',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								]
+							},
+							{
+								model: 'NOMINATION',
+								isWinner: false,
+								customType: '',
+								errors: {},
+								entities: [
+									{
+										model: 'PERSON',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								],
+								productions: [
+									{
+										model: 'PRODUCTION_IDENTIFIER',
+										uuid: '',
+										errors: {}
+									}
+								],
+								materials: [
+									{
+										model: 'MATERIAL',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD_CEREMONY_CATEGORY',
+						name: 'Best New Play',
+						errors: {},
+						nominations: [
+							{
+								model: 'NOMINATION',
+								isWinner: true,
+								customType: '',
+								errors: {},
+								entities: [
+									{
+										model: 'PERSON',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								],
+								productions: [
+									{
+										model: 'PRODUCTION_IDENTIFIER',
+										uuid: '',
+										errors: {}
+									}
+								],
+								materials: [
+									{
+										model: 'MATERIAL',
+										name: 'A Disappearing Number',
+										differentiator: '1',
+										errors: {}
+									},
+									{
+										model: 'MATERIAL',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								]
+							},
+							{
+								model: 'NOMINATION',
+								isWinner: false,
+								customType: 'Special Commendation',
+								errors: {},
+								entities: [
+									{
+										model: 'PERSON',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								],
+								productions: [
+									{
+										model: 'PRODUCTION_IDENTIFIER',
+										uuid: '',
+										errors: {}
+									}
+								],
+								materials: [
+									{
+										model: 'MATERIAL',
+										name: 'The Reporter',
+										differentiator: '1',
+										errors: {}
+									},
+									{
+										model: 'MATERIAL',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								]
+							},
+							{
+								model: 'NOMINATION',
+								isWinner: false,
+								customType: 'Finalist',
+								errors: {},
+								entities: [
+									{
+										model: 'PERSON',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								],
+								productions: [
+									{
+										model: 'PRODUCTION_IDENTIFIER',
+										uuid: '',
+										errors: {}
+									}
+								],
+								materials: [
+									{
+										model: 'MATERIAL',
+										name: 'Vernon God Little',
+										differentiator: '1',
+										errors: {}
+									},
+									{
+										model: 'MATERIAL',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								]
+							},
+							{
+								model: 'NOMINATION',
+								isWinner: false,
+								customType: '',
+								errors: {},
+								entities: [
+									{
+										model: 'PERSON',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								],
+								productions: [
+									{
+										model: 'PRODUCTION_IDENTIFIER',
+										uuid: '',
+										errors: {}
+									}
+								],
+								materials: [
+									{
+										model: 'MATERIAL',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD_CEREMONY_CATEGORY',
+						name: 'Best New Dance Production',
+						errors: {},
+						nominations: [
+							{
+								model: 'NOMINATION',
+								isWinner: false,
+								customType: '',
+								errors: {},
+								entities: [
+									{
+										model: 'PERSON',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								],
+								productions: [
+									{
+										model: 'PRODUCTION_IDENTIFIER',
+										uuid: '',
+										errors: {}
+									}
+								],
+								materials: [
+									{
+										model: 'MATERIAL',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD_CEREMONY_CATEGORY',
+						name: '',
+						errors: {},
+						nominations: [
+							{
+								model: 'NOMINATION',
+								isWinner: false,
+								customType: '',
+								errors: {},
+								entities: [
+									{
+										model: 'PERSON',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								],
+								productions: [
+									{
+										model: 'PRODUCTION_IDENTIFIER',
+										uuid: '',
+										errors: {}
+									}
+								],
+								materials: [
+									{
+										model: 'MATERIAL',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								]
+							}
+						]
+					}
+				]
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
+
+		});
+
+		it('updates award ceremony (with new data)', async () => {
 
 			expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
 

--- a/test-e2e/crud/materials-api.test.js
+++ b/test-e2e/crud/materials-api.test.js
@@ -393,17 +393,17 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 		const JOHN_GABRIEL_BORKMAN_CHARACTER_UUID = '24';
 		const GUNHILD_BORKMAN_CHARACTER_UUID = '25';
 		const ERHART_BORKMAN_CHARACTER_UUID = '26';
-		const THREE_SISTERS_ORIGINAL_VERSION_MATERIAL_UUID = '41';
-		const ANTON_CHEKHOV_PERSON_UUID = '42';
-		const CHEKHOV_THEATRE_COMPANY_UUID = '43';
-		const BENEDICT_ANDREWS_PERSON_UUID = '44';
-		const THREE_SISTERS_SOURCE_MATERIAL_MATERIAL_UUID = '45';
-		const THREE_SISTERS_SUB_MATERIAL_1_MATERIAL_UUID = '46';
-		const THREE_SISTERS_SUB_MATERIAL_2_MATERIAL_UUID = '47';
-		const THREE_SISTERS_SUB_MATERIAL_3_MATERIAL_UUID = '48';
-		const OLGA_SERGEYEVNA_PROZOROVA_CHARACTER_UUID = '49';
-		const MARIA_SERGEYEVNA_KULYGINA_CHARACTER_UUID = '50';
-		const IRINA_SERGEYEVNA_PROZOROVA_CHARACTER_UUID = '51';
+		const THREE_SISTERS_ORIGINAL_VERSION_MATERIAL_UUID = '66';
+		const ANTON_CHEKHOV_PERSON_UUID = '67';
+		const CHEKHOV_THEATRE_COMPANY_UUID = '68';
+		const BENEDICT_ANDREWS_PERSON_UUID = '69';
+		const THREE_SISTERS_SOURCE_MATERIAL_MATERIAL_UUID = '70';
+		const THREE_SISTERS_SUB_MATERIAL_1_MATERIAL_UUID = '71';
+		const THREE_SISTERS_SUB_MATERIAL_2_MATERIAL_UUID = '72';
+		const THREE_SISTERS_SUB_MATERIAL_3_MATERIAL_UUID = '73';
+		const OLGA_SERGEYEVNA_PROZOROVA_CHARACTER_UUID = '74';
+		const MARIA_SERGEYEVNA_KULYGINA_CHARACTER_UUID = '75';
+		const IRINA_SERGEYEVNA_PROZOROVA_CHARACTER_UUID = '76';
 
 		before(async () => {
 
@@ -1030,7 +1030,284 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 
 		});
 
-		it('updates material', async () => {
+		it('updates material (with existing data)', async () => {
+
+			expect(await countNodesWithLabel('Material')).to.equal(6);
+
+			const response = await chai.request(app)
+				.put(`/materials/${MATERIAL_UUID}`)
+				.send({
+					name: 'John Gabriel Borkman',
+					differentiator: '2',
+					format: 'play',
+					year: 2007,
+					originalVersionMaterial: {
+						name: 'John Gabriel Borkman',
+						differentiator: '1'
+					},
+					writingCredits: [
+						{
+							name: '',
+							entities: [
+								{
+									name: 'Henrik Ibsen',
+									differentiator: '1'
+								},
+								{
+									model: 'COMPANY',
+									name: 'Ibsen Theatre Company',
+									differentiator: '1'
+								}
+							]
+						},
+						{
+							name: 'version by',
+							entities: [
+								{
+									name: 'David Eldridge',
+									differentiator: '1'
+								}
+							]
+						},
+						{
+							name: 'based on',
+							entities: [
+								{
+									model: 'MATERIAL',
+									name: 'John Gabriel Borkman',
+									differentiator: '3'
+								}
+							]
+						}
+					],
+					subMaterials: [
+						{
+							name: 'John Gabriel Borkman sub-material #1',
+							differentiator: '1'
+						},
+						{
+							name: 'John Gabriel Borkman sub-material #2',
+							differentiator: '1'
+						},
+						{
+							name: 'John Gabriel Borkman sub-material #3',
+							differentiator: '1'
+						}
+					],
+					characterGroups: [
+						{
+							name: 'The Borkmans',
+							characters: [
+								{
+									name: 'John Gabriel Borkman',
+									underlyingName: 'Mr John Gabriel Borkman',
+									differentiator: '1',
+									qualifier: 'foo'
+								},
+								{
+									name: 'Gunhild Borkman',
+									underlyingName: 'Mrs Gunhild Borkman',
+									differentiator: '1',
+									qualifier: 'bar'
+								},
+								{
+									name: 'Erhart Borkman',
+									underlyingName: 'Mr Erhart Borkman',
+									differentiator: '1',
+									qualifier: 'baz'
+								}
+							]
+						}
+					]
+				});
+
+			const expectedResponseBody = {
+				model: 'MATERIAL',
+				uuid: MATERIAL_UUID,
+				name: 'John Gabriel Borkman',
+				differentiator: '2',
+				format: 'play',
+				year: 2007,
+				errors: {},
+				originalVersionMaterial: {
+					model: 'MATERIAL',
+					name: 'John Gabriel Borkman',
+					differentiator: '1',
+					errors: {}
+				},
+				writingCredits: [
+					{
+						model: 'WRITING_CREDIT',
+						name: '',
+						creditType: null,
+						errors: {},
+						entities: [
+							{
+								model: 'PERSON',
+								name: 'Henrik Ibsen',
+								differentiator: '1',
+								errors: {}
+							},
+							{
+								model: 'COMPANY',
+								name: 'Ibsen Theatre Company',
+								differentiator: '1',
+								errors: {}
+							},
+							{
+								model: 'PERSON',
+								name: '',
+								differentiator: '',
+								errors: {}
+							}
+						]
+					},
+					{
+						model: 'WRITING_CREDIT',
+						name: 'version by',
+						creditType: null,
+						errors: {},
+						entities: [
+							{
+								model: 'PERSON',
+								name: 'David Eldridge',
+								differentiator: '1',
+								errors: {}
+							},
+							{
+								model: 'PERSON',
+								name: '',
+								differentiator: '',
+								errors: {}
+							}
+						]
+					},
+					{
+						model: 'WRITING_CREDIT',
+						name: 'based on',
+						creditType: null,
+						errors: {},
+						entities: [
+							{
+								model: 'MATERIAL',
+								name: 'John Gabriel Borkman',
+								differentiator: '3',
+								errors: {}
+							},
+							{
+								model: 'PERSON',
+								name: '',
+								differentiator: '',
+								errors: {}
+							}
+						]
+					},
+					{
+						model: 'WRITING_CREDIT',
+						name: '',
+						creditType: null,
+						errors: {},
+						entities: [
+							{
+								model: 'PERSON',
+								name: '',
+								differentiator: '',
+								errors: {}
+							}
+						]
+					}
+				],
+				subMaterials: [
+					{
+						model: 'MATERIAL',
+						name: 'John Gabriel Borkman sub-material #1',
+						differentiator: '1',
+						errors: {}
+					},
+					{
+						model: 'MATERIAL',
+						name: 'John Gabriel Borkman sub-material #2',
+						differentiator: '1',
+						errors: {}
+					},
+					{
+						model: 'MATERIAL',
+						name: 'John Gabriel Borkman sub-material #3',
+						differentiator: '1',
+						errors: {}
+					},
+					{
+						model: 'MATERIAL',
+						name: '',
+						differentiator: '',
+						errors: {}
+					}
+				],
+				characterGroups: [
+					{
+						model: 'CHARACTER_GROUP',
+						name: 'The Borkmans',
+						errors: {},
+						characters: [
+							{
+								model: 'CHARACTER',
+								name: 'John Gabriel Borkman',
+								underlyingName: 'Mr John Gabriel Borkman',
+								differentiator: '1',
+								qualifier: 'foo',
+								errors: {}
+							},
+							{
+								model: 'CHARACTER',
+								name: 'Gunhild Borkman',
+								underlyingName: 'Mrs Gunhild Borkman',
+								differentiator: '1',
+								qualifier: 'bar',
+								errors: {}
+							},
+							{
+								model: 'CHARACTER',
+								name: 'Erhart Borkman',
+								underlyingName: 'Mr Erhart Borkman',
+								differentiator: '1',
+								qualifier: 'baz',
+								errors: {}
+							},
+							{
+								model: 'CHARACTER',
+								name: '',
+								underlyingName: '',
+								differentiator: '',
+								qualifier: '',
+								errors: {}
+							}
+						]
+					},
+					{
+						model: 'CHARACTER_GROUP',
+						name: '',
+						errors: {},
+						characters: [
+							{
+								model: 'CHARACTER',
+								name: '',
+								underlyingName: '',
+								differentiator: '',
+								qualifier: '',
+								errors: {}
+							}
+						]
+					}
+				]
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Material')).to.equal(6);
+
+		});
+
+		it('updates material (with new data)', async () => {
 
 			expect(await countNodesWithLabel('Material')).to.equal(6);
 

--- a/test-e2e/crud/productions-api.test.js
+++ b/test-e2e/crud/productions-api.test.js
@@ -566,33 +566,33 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 		const CREW_ASSISTANTS_LTD_COMPANY_UUID = '43';
 		const MOLLY_EINCHCOMB_PERSON_UUID = '44';
 		const MATTHEW_HELLYER_PERSON_UUID = '45';
-		const THE_TRAGEDY_OF_KING_RICHARD_III_MATERIAL_UUID = '46';
-		const ALMEIDA_THEATRE_VENUE_UUID = '47';
-		const DENISE_WOOD_PERSON_UUID = '48';
-		const TIATA_FAHODZI_COMPANY_UUID = '49';
-		const REBECCA_FRECKNALL_PERSON_UUID = '50';
-		const SIMEON_BLAKE_HALL_PERSON_UUID = '51';
-		const ALMEIDA_THEATRE_COMPANY_UUID = '52';
-		const RUPERT_GOOLD_PERSON_UUID = '53';
-		const ROBERT_ICKE_PERSON_UUID = '54';
-		const HEADLONG_THEATRE_COMPANY_UUID = '55';
-		const RALPH_FIENNES_PERSON_UUID = '56';
-		const TOM_CANTON_PERSON_UUID = '57';
-		const MARK_HADFIELD_PERSON_UUID = '58';
-		const JOSH_COLLINS_PERSON_UUID = '59';
-		const RC_ANNIE_LTD_COMPANY_UUID = '60';
-		const HILDEGARD_BECHTLER_PERSON_UUID = '61';
-		const CHLOE_LAMFORD_PERSON_UUID = '62';
-		const AUTOGRAPH_COMPANY_UUID = '63';
-		const ANDREW_BRUCE_PERSON_UUID = '64';
-		const NICK_LIDSTER_PERSON_UUID = '65';
-		const ANNA_ANDERSON_PERSON_UUID = '66';
-		const DEPUTY_STAGE_MANAGERS_LTD_COMPANY_UUID = '67';
-		const CHERYL_FIRTH_PERSON_UUID = '68';
-		const TOM_LEGGAT_PERSON_UUID = '69';
-		const DESIGN_ASSISTANTS_LTD_COMPANY_UUID = '70';
-		const COLIN_FALCONER_PERSON_UUID = '71';
-		const ALEX_LOWDE_PERSON_UUID = '72';
+		const THE_TRAGEDY_OF_KING_RICHARD_III_MATERIAL_UUID = '73';
+		const ALMEIDA_THEATRE_VENUE_UUID = '74';
+		const DENISE_WOOD_PERSON_UUID = '75';
+		const TIATA_FAHODZI_COMPANY_UUID = '76';
+		const REBECCA_FRECKNALL_PERSON_UUID = '77';
+		const SIMEON_BLAKE_HALL_PERSON_UUID = '78';
+		const ALMEIDA_THEATRE_COMPANY_UUID = '79';
+		const RUPERT_GOOLD_PERSON_UUID = '80';
+		const ROBERT_ICKE_PERSON_UUID = '81';
+		const HEADLONG_THEATRE_COMPANY_UUID = '82';
+		const RALPH_FIENNES_PERSON_UUID = '83';
+		const TOM_CANTON_PERSON_UUID = '84';
+		const MARK_HADFIELD_PERSON_UUID = '85';
+		const JOSH_COLLINS_PERSON_UUID = '86';
+		const RC_ANNIE_LTD_COMPANY_UUID = '87';
+		const HILDEGARD_BECHTLER_PERSON_UUID = '88';
+		const CHLOE_LAMFORD_PERSON_UUID = '89';
+		const AUTOGRAPH_COMPANY_UUID = '90';
+		const ANDREW_BRUCE_PERSON_UUID = '91';
+		const NICK_LIDSTER_PERSON_UUID = '92';
+		const ANNA_ANDERSON_PERSON_UUID = '93';
+		const DEPUTY_STAGE_MANAGERS_LTD_COMPANY_UUID = '94';
+		const CHERYL_FIRTH_PERSON_UUID = '95';
+		const TOM_LEGGAT_PERSON_UUID = '96';
+		const DESIGN_ASSISTANTS_LTD_COMPANY_UUID = '97';
+		const COLIN_FALCONER_PERSON_UUID = '98';
+		const ALEX_LOWDE_PERSON_UUID = '99';
 
 		before(async () => {
 
@@ -2657,7 +2657,961 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 
 		});
 
-		it('updates production', async () => {
+		it('updates production (with existing data)', async () => {
+
+			expect(await countNodesWithLabel('Production')).to.equal(7);
+
+			const response = await chai.request(app)
+				.put(`/productions/${PRODUCTION_UUID}`)
+				.send({
+					name: 'Hamlet',
+					startDate: '2010-09-30',
+					pressDate: '2010-10-07',
+					endDate: '2011-01-26',
+					material: {
+						name: 'The Tragedy of Hamlet, Prince of Denmark',
+						differentiator: '1'
+					},
+					venue: {
+						name: 'National Theatre',
+						differentiator: '1'
+					},
+					subProductions: [
+						{
+							uuid: HAMLET_SUB_PRODUCTION_1_PRODUCTION_UUID
+						},
+						{
+							uuid: HAMLET_SUB_PRODUCTION_2_PRODUCTION_UUID
+						},
+						{
+							uuid: HAMLET_SUB_PRODUCTION_3_PRODUCTION_UUID
+						}
+					],
+					producerCredits: [
+						{
+							name: 'executive produced by',
+							entities: [
+								{
+									name: 'Lisa Burger',
+									differentiator: '1'
+								}
+							]
+						},
+						{
+							name: 'in association with',
+							entities: [
+								{
+									model: 'COMPANY',
+									name: 'Fuel Theatre',
+									differentiator: '1'
+								}
+							]
+						},
+						{
+							name: 'associate produced by',
+							entities: [
+								{
+									name: 'Simon Godwin',
+									differentiator: '1'
+								},
+								{
+									name: 'Tom Morris',
+									differentiator: '1'
+								}
+							]
+						},
+						{
+							name: 'produced by',
+							entities: [
+								{
+									model: 'COMPANY',
+									name: 'National Theatre Company',
+									differentiator: '1',
+									members: [
+										{
+											name: 'Nicholas Hytner',
+											differentiator: '1'
+										},
+										{
+											name: 'Nick Starr',
+											differentiator: '1'
+										}
+									]
+								}
+							]
+						},
+						{
+							name: 'co-produced by',
+							entities: [
+								{
+									model: 'COMPANY',
+									name: 'London Theatre Company',
+									differentiator: '1',
+									members: [
+										{
+											name: 'Nicholas Hytner',
+											differentiator: '1'
+										}
+									]
+								}
+							]
+						}
+					],
+					cast: [
+						{
+							name: 'Rory Kinnear',
+							differentiator: '1',
+							roles: [
+								{
+									name: 'Hamlet',
+									characterName: 'Hamlet, Prince of Denmark',
+									characterDifferentiator: '1',
+									qualifier: 'foo'
+								}
+							]
+						},
+						{
+							name: 'James Laurenson',
+							differentiator: '1',
+							roles: [
+								{
+									name: 'Ghost',
+									characterName: 'Ghost of King Hamlet',
+									characterDifferentiator: '1',
+									qualifier: 'bar'
+								},
+								{
+									name: 'First Player',
+									characterName: 'Player King',
+									characterDifferentiator: '1',
+									qualifier: 'baz'
+								}
+							]
+						},
+						{
+							name: 'Michael Sheldon',
+							differentiator: '1',
+							roles: [
+								{
+									name: 'Third Player',
+									characterName: 'Lucianus',
+									characterDifferentiator: '1',
+									qualifier: 'qux'
+								},
+								{
+									name: 'Ambassador of the English',
+									characterName: 'English Ambassador',
+									characterDifferentiator: '1',
+									qualifier: 'quux',
+									isAlternate: true
+								}
+							]
+						},
+						{
+							name: 'Leo Staar',
+							differentiator: '1',
+							roles: []
+						}
+					],
+					creativeCredits: [
+						{
+							name: 'Director',
+							entities: [
+								{
+									name: 'Nicholas Hytner',
+									differentiator: '1'
+								}
+							]
+						},
+						{
+							name: 'Designers',
+							entities: [
+								{
+									model: 'COMPANY',
+									name: 'Handspring Puppet Company',
+									differentiator: '1'
+								}
+							]
+						},
+						{
+							name: 'Sound Designers',
+							entities: [
+								{
+									name: 'Ben Ringham',
+									differentiator: '1'
+								},
+								{
+									name: 'Max Ringham',
+									differentiator: '1'
+								}
+							]
+						},
+						{
+							name: 'Lighting Designers',
+							entities: [
+								{
+									model: 'COMPANY',
+									name: '59 Productions',
+									differentiator: '1',
+									members: [
+										{
+											name: 'Leo Warner',
+											differentiator: '1'
+										},
+										{
+											name: 'Mark Grimmer',
+											differentiator: '1'
+										}
+									]
+								}
+							]
+						},
+						{
+							name: 'Video Designers',
+							entities: [
+								{
+									model: 'COMPANY',
+									name: '59 Productions',
+									differentiator: '1',
+									members: [
+										{
+											name: 'Leo Warner',
+											differentiator: '1'
+										}
+									]
+								}
+							]
+						}
+					],
+					crewCredits: [
+						{
+							name: 'Production Manager',
+							entities: [
+								{
+									name: 'Igor',
+									differentiator: '1'
+								}
+							]
+						},
+						{
+							name: 'Deputy Stage Managers',
+							entities: [
+								{
+									model: 'COMPANY',
+									name: 'Crew Deputies Ltd',
+									differentiator: '1'
+								}
+							]
+						},
+						{
+							name: 'Assistant Stage Managers',
+							entities: [
+								{
+									name: 'Sara Gunter',
+									differentiator: '1'
+								},
+								{
+									name: 'Julia Wickham',
+									differentiator: '1'
+								}
+							]
+						},
+						{
+							name: 'Design Assistants',
+							entities: [
+								{
+									model: 'COMPANY',
+									name: 'Crew Assistants Ltd',
+									differentiator: '1',
+									members: [
+										{
+											name: 'Molly Einchcomb',
+											differentiator: '1'
+										},
+										{
+											name: 'Matthew Hellyer',
+											differentiator: '1'
+										}
+									]
+								}
+							]
+						},
+						{
+							name: 'Sound Design Assistants',
+							entities: [
+								{
+									model: 'COMPANY',
+									name: 'Crew Assistants Ltd',
+									differentiator: '1',
+									members: [
+										{
+											name: 'Molly Einchcomb',
+											differentiator: '1'
+										}
+									]
+								}
+							]
+						}
+					]
+				});
+
+			const expectedResponseBody = {
+				model: 'PRODUCTION',
+				uuid: PRODUCTION_UUID,
+				name: 'Hamlet',
+				startDate: '2010-09-30',
+				pressDate: '2010-10-07',
+				endDate: '2011-01-26',
+				errors: {},
+				material: {
+					model: 'MATERIAL',
+					name: 'The Tragedy of Hamlet, Prince of Denmark',
+					differentiator: '1',
+					errors: {}
+				},
+				venue: {
+					model: 'VENUE',
+					name: 'National Theatre',
+					differentiator: '1',
+					errors: {}
+				},
+				subProductions: [
+					{
+						model: 'PRODUCTION_IDENTIFIER',
+						uuid: HAMLET_SUB_PRODUCTION_1_PRODUCTION_UUID,
+						errors: {}
+					},
+					{
+						model: 'PRODUCTION_IDENTIFIER',
+						uuid: HAMLET_SUB_PRODUCTION_2_PRODUCTION_UUID,
+						errors: {}
+					},
+					{
+						model: 'PRODUCTION_IDENTIFIER',
+						uuid: HAMLET_SUB_PRODUCTION_3_PRODUCTION_UUID,
+						errors: {}
+					},
+					{
+						model: 'PRODUCTION_IDENTIFIER',
+						uuid: '',
+						errors: {}
+					}
+				],
+				producerCredits: [
+					{
+						model: 'PRODUCER_CREDIT',
+						name: 'executive produced by',
+						errors: {},
+						entities: [
+							{
+								model: 'PERSON',
+								name: 'Lisa Burger',
+								differentiator: '1',
+								errors: {}
+							},
+							{
+								model: 'PERSON',
+								name: '',
+								differentiator: '',
+								errors: {}
+							}
+						]
+					},
+					{
+						model: 'PRODUCER_CREDIT',
+						name: 'in association with',
+						errors: {},
+						entities: [
+							{
+								model: 'COMPANY',
+								name: 'Fuel Theatre',
+								differentiator: '1',
+								errors: {},
+								members: [
+									{
+										model: 'PERSON',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								]
+							},
+							{
+								model: 'PERSON',
+								name: '',
+								differentiator: '',
+								errors: {}
+							}
+						]
+					},
+					{
+						model: 'PRODUCER_CREDIT',
+						name: 'associate produced by',
+						errors: {},
+						entities: [
+							{
+								model: 'PERSON',
+								name: 'Simon Godwin',
+								differentiator: '1',
+								errors: {}
+							},
+							{
+								model: 'PERSON',
+								name: 'Tom Morris',
+								differentiator: '1',
+								errors: {}
+							},
+							{
+								model: 'PERSON',
+								name: '',
+								differentiator: '',
+								errors: {}
+							}
+						]
+					},
+					{
+						model: 'PRODUCER_CREDIT',
+						name: 'produced by',
+						errors: {},
+						entities: [
+							{
+								model: 'COMPANY',
+								name: 'National Theatre Company',
+								differentiator: '1',
+								errors: {},
+								members: [
+									{
+										model: 'PERSON',
+										name: 'Nicholas Hytner',
+										differentiator: '1',
+										errors: {}
+									},
+									{
+										model: 'PERSON',
+										name: 'Nick Starr',
+										differentiator: '1',
+										errors: {}
+									},
+									{
+										model: 'PERSON',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								]
+							},
+							{
+								model: 'PERSON',
+								name: '',
+								differentiator: '',
+								errors: {}
+							}
+						]
+					},
+					{
+						model: 'PRODUCER_CREDIT',
+						name: 'co-produced by',
+						errors: {},
+						entities: [
+							{
+								model: 'COMPANY',
+								name: 'London Theatre Company',
+								differentiator: '1',
+								errors: {},
+								members: [
+									{
+										model: 'PERSON',
+										name: 'Nicholas Hytner',
+										differentiator: '1',
+										errors: {}
+									},
+									{
+										model: 'PERSON',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								]
+							},
+							{
+								model: 'PERSON',
+								name: '',
+								differentiator: '',
+								errors: {}
+							}
+						]
+					},
+					{
+						model: 'PRODUCER_CREDIT',
+						name: '',
+						errors: {},
+						entities: [
+							{
+								model: 'PERSON',
+								name: '',
+								differentiator: '',
+								errors: {}
+							}
+						]
+					}
+				],
+				cast: [
+					{
+						model: 'PERSON',
+						name: 'Rory Kinnear',
+						differentiator: '1',
+						errors: {},
+						roles: [
+							{
+								model: 'ROLE',
+								name: 'Hamlet',
+								characterName: 'Hamlet, Prince of Denmark',
+								characterDifferentiator: '1',
+								qualifier: 'foo',
+								isAlternate: false,
+								errors: {}
+							},
+							{
+								model: 'ROLE',
+								name: '',
+								characterName: '',
+								characterDifferentiator: '',
+								qualifier: '',
+								isAlternate: false,
+								errors: {}
+							}
+						]
+					},
+					{
+						model: 'PERSON',
+						name: 'James Laurenson',
+						differentiator: '1',
+						errors: {},
+						roles: [
+							{
+								model: 'ROLE',
+								name: 'Ghost',
+								characterName: 'Ghost of King Hamlet',
+								characterDifferentiator: '1',
+								qualifier: 'bar',
+								isAlternate: false,
+								errors: {}
+							},
+							{
+								model: 'ROLE',
+								name: 'First Player',
+								characterName: 'Player King',
+								characterDifferentiator: '1',
+								qualifier: 'baz',
+								isAlternate: false,
+								errors: {}
+							},
+							{
+								model: 'ROLE',
+								name: '',
+								characterName: '',
+								characterDifferentiator: '',
+								qualifier: '',
+								isAlternate: false,
+								errors: {}
+							}
+						]
+					},
+					{
+						model: 'PERSON',
+						name: 'Michael Sheldon',
+						differentiator: '1',
+						errors: {},
+						roles: [
+							{
+								model: 'ROLE',
+								name: 'Third Player',
+								characterName: 'Lucianus',
+								characterDifferentiator: '1',
+								qualifier: 'qux',
+								isAlternate: false,
+								errors: {}
+							},
+							{
+								model: 'ROLE',
+								name: 'Ambassador of the English',
+								characterName: 'English Ambassador',
+								characterDifferentiator: '1',
+								qualifier: 'quux',
+								isAlternate: true,
+								errors: {}
+							},
+							{
+								model: 'ROLE',
+								name: '',
+								characterName: '',
+								characterDifferentiator: '',
+								qualifier: '',
+								isAlternate: false,
+								errors: {}
+							}
+						]
+					},
+					{
+						model: 'PERSON',
+						name: 'Leo Staar',
+						differentiator: '1',
+						errors: {},
+						roles: [
+							{
+								model: 'ROLE',
+								name: '',
+								characterName: '',
+								characterDifferentiator: '',
+								qualifier: '',
+								isAlternate: false,
+								errors: {}
+							}
+						]
+					},
+					{
+						model: 'PERSON',
+						name: '',
+						differentiator: '',
+						errors: {},
+						roles: [
+							{
+								model: 'ROLE',
+								name: '',
+								characterName: '',
+								characterDifferentiator: '',
+								qualifier: '',
+								isAlternate: false,
+								errors: {}
+							}
+						]
+					}
+				],
+				creativeCredits: [
+					{
+						model: 'CREATIVE_CREDIT',
+						name: 'Director',
+						errors: {},
+						entities: [
+							{
+								model: 'PERSON',
+								name: 'Nicholas Hytner',
+								differentiator: '1',
+								errors: {}
+							},
+							{
+								model: 'PERSON',
+								name: '',
+								differentiator: '',
+								errors: {}
+							}
+						]
+					},
+					{
+						model: 'CREATIVE_CREDIT',
+						name: 'Designers',
+						errors: {},
+						entities: [
+							{
+								model: 'COMPANY',
+								name: 'Handspring Puppet Company',
+								differentiator: '1',
+								errors: {},
+								members: [
+									{
+										model: 'PERSON',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								]
+							},
+							{
+								model: 'PERSON',
+								name: '',
+								differentiator: '',
+								errors: {}
+							}
+						]
+					},
+					{
+						model: 'CREATIVE_CREDIT',
+						name: 'Sound Designers',
+						errors: {},
+						entities: [
+							{
+								model: 'PERSON',
+								name: 'Ben Ringham',
+								differentiator: '1',
+								errors: {}
+							},
+							{
+								model: 'PERSON',
+								name: 'Max Ringham',
+								differentiator: '1',
+								errors: {}
+							},
+							{
+								model: 'PERSON',
+								name: '',
+								differentiator: '',
+								errors: {}
+							}
+						]
+					},
+					{
+						model: 'CREATIVE_CREDIT',
+						name: 'Lighting Designers',
+						errors: {},
+						entities: [
+							{
+								model: 'COMPANY',
+								name: '59 Productions',
+								differentiator: '1',
+								errors: {},
+								members: [
+									{
+										model: 'PERSON',
+										name: 'Leo Warner',
+										differentiator: '1',
+										errors: {}
+									},
+									{
+										model: 'PERSON',
+										name: 'Mark Grimmer',
+										differentiator: '1',
+										errors: {}
+									},
+									{
+										model: 'PERSON',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								]
+							},
+							{
+								model: 'PERSON',
+								name: '',
+								differentiator: '',
+								errors: {}
+							}
+						]
+					},
+					{
+						model: 'CREATIVE_CREDIT',
+						name: 'Video Designers',
+						errors: {},
+						entities: [
+							{
+								model: 'COMPANY',
+								name: '59 Productions',
+								differentiator: '1',
+								errors: {},
+								members: [
+									{
+										model: 'PERSON',
+										name: 'Leo Warner',
+										differentiator: '1',
+										errors: {}
+									},
+									{
+										model: 'PERSON',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								]
+							},
+							{
+								model: 'PERSON',
+								name: '',
+								differentiator: '',
+								errors: {}
+							}
+						]
+					},
+					{
+						model: 'CREATIVE_CREDIT',
+						name: '',
+						errors: {},
+						entities: [
+							{
+								model: 'PERSON',
+								name: '',
+								differentiator: '',
+								errors: {}
+							}
+						]
+					}
+				],
+				crewCredits: [
+					{
+						model: 'CREW_CREDIT',
+						name: 'Production Manager',
+						errors: {},
+						entities: [
+							{
+								model: 'PERSON',
+								name: 'Igor',
+								differentiator: '1',
+								errors: {}
+							},
+							{
+								model: 'PERSON',
+								name: '',
+								differentiator: '',
+								errors: {}
+							}
+						]
+					},
+					{
+						model: 'CREW_CREDIT',
+						name: 'Deputy Stage Managers',
+						errors: {},
+						entities: [
+							{
+								model: 'COMPANY',
+								name: 'Crew Deputies Ltd',
+								differentiator: '1',
+								errors: {},
+								members: [
+									{
+										model: 'PERSON',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								]
+							},
+							{
+								model: 'PERSON',
+								name: '',
+								differentiator: '',
+								errors: {}
+							}
+						]
+					},
+					{
+						model: 'CREW_CREDIT',
+						name: 'Assistant Stage Managers',
+						errors: {},
+						entities: [
+							{
+								model: 'PERSON',
+								name: 'Sara Gunter',
+								differentiator: '1',
+								errors: {}
+							},
+							{
+								model: 'PERSON',
+								name: 'Julia Wickham',
+								differentiator: '1',
+								errors: {}
+							},
+							{
+								model: 'PERSON',
+								name: '',
+								differentiator: '',
+								errors: {}
+							}
+						]
+					},
+					{
+						model: 'CREW_CREDIT',
+						name: 'Design Assistants',
+						errors: {},
+						entities: [
+							{
+								model: 'COMPANY',
+								name: 'Crew Assistants Ltd',
+								differentiator: '1',
+								errors: {},
+								members: [
+									{
+										model: 'PERSON',
+										name: 'Molly Einchcomb',
+										differentiator: '1',
+										errors: {}
+									},
+									{
+										model: 'PERSON',
+										name: 'Matthew Hellyer',
+										differentiator: '1',
+										errors: {}
+									},
+									{
+										model: 'PERSON',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								]
+							},
+							{
+								model: 'PERSON',
+								name: '',
+								differentiator: '',
+								errors: {}
+							}
+						]
+					},
+					{
+						model: 'CREW_CREDIT',
+						name: 'Sound Design Assistants',
+						errors: {},
+						entities: [
+							{
+								model: 'COMPANY',
+								name: 'Crew Assistants Ltd',
+								differentiator: '1',
+								errors: {},
+								members: [
+									{
+										model: 'PERSON',
+										name: 'Molly Einchcomb',
+										differentiator: '1',
+										errors: {}
+									},
+									{
+										model: 'PERSON',
+										name: '',
+										differentiator: '',
+										errors: {}
+									}
+								]
+							},
+							{
+								model: 'PERSON',
+								name: '',
+								differentiator: '',
+								errors: {}
+							}
+						]
+					},
+					{
+						model: 'CREW_CREDIT',
+						name: '',
+						errors: {},
+						entities: [
+							{
+								model: 'PERSON',
+								name: '',
+								differentiator: '',
+								errors: {}
+							}
+						]
+					}
+				]
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Production')).to.equal(7);
+
+		});
+
+		it('updates production (with new data)', async () => {
 
 			expect(await countNodesWithLabel('Production')).to.equal(7);
 

--- a/test-unit/src/neo4j/cypher-queries/validation.test.js
+++ b/test-unit/src/neo4j/cypher-queries/validation.test.js
@@ -59,7 +59,10 @@ describe('Cypher Queries Validation module', () => {
 
 				OPTIONAL MATCH (subjectMaterial:Material { uuid: $subjectMaterialUuid })
 
-				OPTIONAL MATCH (m)<-[surMaterialRel:HAS_SUB_MATERIAL]-(:Material)
+				OPTIONAL MATCH (m)<-[surMaterialRel:HAS_SUB_MATERIAL]-(surMaterial:Material)
+					WHERE
+						$subjectMaterialUuid IS NULL OR
+						$subjectMaterialUuid <> surMaterial.uuid
 
 				OPTIONAL MATCH (m)
 					-[:HAS_SUB_MATERIAL]->(:Material)
@@ -92,7 +95,10 @@ describe('Cypher Queries Validation module', () => {
 
 				OPTIONAL MATCH (subjectProduction:Production { uuid: $subjectProductionUuid })
 
-				OPTIONAL MATCH (p)<-[surProductionRel:HAS_SUB_PRODUCTION]-(:Production)
+				OPTIONAL MATCH (p)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
+					WHERE
+						$subjectProductionUuid IS NULL OR
+						$subjectProductionUuid <> surProduction.uuid
 
 				OPTIONAL MATCH (p)
 					-[:HAS_SUB_PRODUCTION]->(:Production)


### PR DESCRIPTION
It was discovered in PR https://github.com/andygout/theatrebase-api/pull/546 that the sub-instance validation check Cypher queries required a condition when performing the `MATCH` to identify if the sub-instance was already associated with another sur-instance - the condition being that the sur-instance with which the sub-instance is associated is not the subject instance.

This issue surfaces when updating an instance with sub-instances that were present pre-update: validation fails owing to e.g.
> Material with these attributes is already assigned to another sur-material

This was a blind spot in the tests so this PR adds end-to-end CRUD tests (as were added for venues in the above mentioned PR) for award ceremonies, materials, and productions to check what happens when updating respective instances of those classes (with the full range of attributes assigned values) with their existing data, with the expectation being that they successfully update with experiencing any validation errors.

To get these tests passing required some changes to the sub-material and sub-production validation check Cypher queries.