### PR TITLE
Fix Base class constructor unit tests

### DIFF
--- a/test-unit/src/models/Base.test.js
+++ b/test-unit/src/models/Base.test.js
@@ -81,10 +81,10 @@ describe('Base model', () => {
 
 				context('model is Nomination', () => {
 
-					it('does not assign differentiator property', () => {
+					it('does not assign name property', () => {
 
-						const instance = new Nomination({ differentiator: '1' });
-						expect(instance).to.not.have.property('differentiator');
+						const instance = new Nomination({ name: '1' });
+						expect(instance).to.not.have.property('name');
 
 					});
 
@@ -92,13 +92,13 @@ describe('Base model', () => {
 
 				context('model is ProductionIdentifier', () => {
 
-					it('does not assign differentiator property', () => {
+					it('does not assign name property', () => {
 
 						const instance = new ProductionIdentifier({
 							uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
-							differentiator: '1'
+							name: '1'
 						});
-						expect(instance).to.not.have.property('differentiator');
+						expect(instance).to.not.have.property('name');
 
 					});
 


### PR DESCRIPTION
This PR corrects Base class constructor unit tests because they were not testing the right thing: the Base class constructor contains a conditional that exempts specified models from having a `name` property - not a `differentiator` property, which is what is currently being tested.

The `differentiator` property is assigned by the Entity class constructor and tested in its unit tests.