### PR TITLE
Revise import/export of validation queries in cypher-queries index

### DIFF
--- a/src/neo4j/cypher-queries/index.js
+++ b/src/neo4j/cypher-queries/index.js
@@ -32,11 +32,11 @@ import {
 	getListQuery as getSharedListQuery
 } from './shared';
 import {
-	getDuplicateRecordCountQuery as getSharedDuplicateRecordCountQuery,
-	getExistenceQuery as getSharedExistenceQuery,
-	getSubMaterialChecksQuery as getSharedSubMaterialChecksQuery,
-	getSubProductionChecksQuery as getSharedSubProductionChecksQuery,
-	getSubVenueChecksQuery as getSubVenueValidationChecksQuery
+	getDuplicateRecordCountQuery,
+	getExistenceQuery,
+	getSubMaterialChecksQuery,
+	getSubProductionChecksQuery,
+	getSubVenueChecksQuery
 } from './validation';
 import {
 	getCreateQuery as getVenueCreateQuery,
@@ -95,11 +95,11 @@ const sharedQueries = {
 };
 
 const validationQueries = {
-	getDuplicateRecordCountQuery: getSharedDuplicateRecordCountQuery,
-	getExistenceQuery: getSharedExistenceQuery,
-	getSubMaterialChecksQuery: getSharedSubMaterialChecksQuery,
-	getSubProductionChecksQuery: getSharedSubProductionChecksQuery,
-	getSubVenueChecksQuery: getSubVenueValidationChecksQuery
+	getDuplicateRecordCountQuery,
+	getExistenceQuery,
+	getSubMaterialChecksQuery,
+	getSubProductionChecksQuery,
+	getSubVenueChecksQuery
 };
 
 export {


### PR DESCRIPTION
This PR revises the import/export of validation queries in the cypher-queries index.

Their names currently incorrectly include `Shared`, which applies to another directory of queries.

Because their names are unique (i.e. won't be repeated by different models, such as the likes of e.g. `getEditQuery`, which require differentiation because multiple models each have their own instance of this query) there is no need to import them with an alias and before reverting to the original name at export stage: we can use the same names at both stages.