### PR TITLE
Revise existence Cypher validation query

### DIFF
--- a/src/models/Entity.js
+++ b/src/models/Entity.js
@@ -117,10 +117,12 @@ export default class Entity extends Base {
 
 		const { getExistenceQuery } = validationQueries;
 
-		await neo4jQuery({
+		const { isExistent } = await neo4jQuery({
 			query: getExistenceQuery(opts.model || this.model),
 			params: { uuid: this.uuid }
 		});
+
+		return isExistent;
 
 	}
 
@@ -166,7 +168,9 @@ export default class Entity extends Base {
 
 	async update () {
 
-		await this.confirmExistenceInDatabase();
+		const isExistent = await this.confirmExistenceInDatabase();
+
+		if (!isExistent) throw new Error('Not Found');
 
 		const { getUpdateQuery } = sharedQueries;
 

--- a/src/models/NominatedProductionIdentifier.js
+++ b/src/models/NominatedProductionIdentifier.js
@@ -13,22 +13,10 @@ export default class NominatedProductionIdentifier extends ProductionIdentifier 
 
 		if (this.uuid) {
 
-			try {
+			const isExistent = await this.confirmExistenceInDatabase({ model: MODELS.PRODUCTION });
 
-				await this.confirmExistenceInDatabase({ model: MODELS.PRODUCTION });
-
-			} catch (error) {
-
-				if (error.message === 'Not Found') {
-
-					this.addPropertyError('uuid', 'Production with this UUID does not exist');
-
-				} else {
-
-					throw error;
-
-				}
-
+			if (!isExistent) {
+				this.addPropertyError('uuid', 'Production with this UUID does not exist');
 			}
 
 		}

--- a/src/neo4j/cypher-queries/validation/existence.js
+++ b/src/neo4j/cypher-queries/validation/existence.js
@@ -3,5 +3,5 @@ import { MODEL_TO_NODE_LABEL_MAP } from '../../../utils/constants';
 export default model => `
 	MATCH (n:${MODEL_TO_NODE_LABEL_MAP[model]} { uuid: $uuid })
 
-	RETURN n
+	RETURN TOBOOLEAN(COUNT(n)) AS isExistent
 `;

--- a/test-int/input-validation-failures/award-ceremony.test.js
+++ b/test-int/input-validation-failures/award-ceremony.test.js
@@ -18,7 +18,9 @@ describe('Input validation failures: AwardCeremony instance', () => {
 
 	beforeEach(() => {
 
-		sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ duplicateRecordCount: 0 });
+		// Stub with a contrived resolution that ensures various
+		// neo4jQuery function calls all pass database validation.
+		sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ isExistent: true, duplicateRecordCount: 0 });
 
 	});
 

--- a/test-int/input-validation-failures/award.test.js
+++ b/test-int/input-validation-failures/award.test.js
@@ -18,7 +18,9 @@ describe('Input validation failures: Award instance', () => {
 
 	beforeEach(() => {
 
-		sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ duplicateRecordCount: 0 });
+		// Stub with a contrived resolution that ensures various
+		// neo4jQuery function calls all pass database validation.
+		sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ isExistent: true, duplicateRecordCount: 0 });
 
 	});
 

--- a/test-int/input-validation-failures/character.test.js
+++ b/test-int/input-validation-failures/character.test.js
@@ -18,7 +18,9 @@ describe('Input validation failures: Character instance', () => {
 
 	beforeEach(() => {
 
-		sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ duplicateRecordCount: 0 });
+		// Stub with a contrived resolution that ensures various
+		// neo4jQuery function calls all pass database validation.
+		sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ isExistent: true, duplicateRecordCount: 0 });
 
 	});
 

--- a/test-int/input-validation-failures/company.test.js
+++ b/test-int/input-validation-failures/company.test.js
@@ -18,7 +18,9 @@ describe('Input validation failures: Company instance', () => {
 
 	beforeEach(() => {
 
-		sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ duplicateRecordCount: 0 });
+		// Stub with a contrived resolution that ensures various
+		// neo4jQuery function calls all pass database validation.
+		sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ isExistent: true, duplicateRecordCount: 0 });
 
 	});
 

--- a/test-int/input-validation-failures/material.test.js
+++ b/test-int/input-validation-failures/material.test.js
@@ -24,6 +24,7 @@ describe('Input validation failures: Material instance', () => {
 		sandbox
 			.stub(neo4jQueryModule, 'neo4jQuery')
 			.resolves({
+				isExistent: true,
 				duplicateRecordCount: 0,
 				isAssignedToSurMaterial: false,
 				isSurSurMaterial: false,

--- a/test-int/input-validation-failures/person.test.js
+++ b/test-int/input-validation-failures/person.test.js
@@ -18,7 +18,9 @@ describe('Input validation failures: Person instance', () => {
 
 	beforeEach(() => {
 
-		sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ duplicateRecordCount: 0 });
+		// Stub with a contrived resolution that ensures various
+		// neo4jQuery function calls all pass database validation.
+		sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ isExistent: true, duplicateRecordCount: 0 });
 
 	});
 

--- a/test-int/input-validation-failures/production.test.js
+++ b/test-int/input-validation-failures/production.test.js
@@ -23,6 +23,7 @@ describe('Input validation failures: Production instance', () => {
 		sandbox
 			.stub(neo4jQueryModule, 'neo4jQuery')
 			.resolves({
+				isExistent: true,
 				duplicateRecordCount: 0,
 				exists: true,
 				isAssignedToSurProduction: false,

--- a/test-int/input-validation-failures/venue.test.js
+++ b/test-int/input-validation-failures/venue.test.js
@@ -23,6 +23,7 @@ describe('Input validation failures: Venue instance', () => {
 		sandbox
 			.stub(neo4jQueryModule, 'neo4jQuery')
 			.resolves({
+				isExistent: true,
 				duplicateRecordCount: 0,
 				isAssignedToSurVenue: false,
 				isSurVenue: false,

--- a/test-unit/src/models/NominatedProductionIdentifier.test.js
+++ b/test-unit/src/models/NominatedProductionIdentifier.test.js
@@ -6,12 +6,12 @@ describe('NominatedProductionIdentifier model', () => {
 
 	describe('runDatabaseValidations method', () => {
 
-		context('confirmExistenceInDatabase method resolves (i.e. production uuid exists in database)', () => {
+		context('confirmExistenceInDatabase method resolves with true (i.e. production uuid exists in database)', () => {
 
 			it('will not call addPropertyError method', async () => {
 
 				const instance = new NominatedProductionIdentifier({ uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' });
-				stub(instance, 'confirmExistenceInDatabase').resolves();
+				stub(instance, 'confirmExistenceInDatabase').resolves(true);
 				spy(instance, 'addPropertyError');
 				await instance.runDatabaseValidations();
 				assert.calledOnce(instance.confirmExistenceInDatabase);
@@ -22,12 +22,12 @@ describe('NominatedProductionIdentifier model', () => {
 
 		});
 
-		context('confirmExistenceInDatabase method throws a \'Not Found\' error (i.e. production uuid does not exist in database)', () => {
+		context('confirmExistenceInDatabase method resolves with false (i.e. production uuid does not exist in database)', () => {
 
 			it('will call addPropertyError method', async () => {
 
 				const instance = new NominatedProductionIdentifier({ uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' });
-				stub(instance, 'confirmExistenceInDatabase').rejects(new Error('Not Found'));
+				stub(instance, 'confirmExistenceInDatabase').resolves(false);
 				spy(instance, 'addPropertyError');
 				await instance.runDatabaseValidations();
 				assert.calledOnce(instance.confirmExistenceInDatabase);

--- a/test-unit/src/neo4j/cypher-queries/validation.test.js
+++ b/test-unit/src/neo4j/cypher-queries/validation.test.js
@@ -37,7 +37,7 @@ describe('Cypher Queries Validation module', () => {
 			expect(removeExcessWhitespace(result)).to.equal(removeExcessWhitespace(`
 				MATCH (n:Venue { uuid: $uuid })
 
-				RETURN n
+				RETURN TOBOOLEAN(COUNT(n)) AS isExistent
 			`));
 
 		});


### PR DESCRIPTION
This PR revises the existence Cypher validation query.

Currently the query tries to find a node and return it, and because of the way the `neo4jQuery` model works, will throw an error if it is not found.

The query should be providing a response as to the existence of the node rather than failing in the event of its non-existence, and this PR applies those changes so that it now returns an object with a `isExistent` property which returns a boolean value.