### PR TITLE
Rename 'exists' property in sub-production checks Cypher query

### DIFF
--- a/src/models/SubProductionIdentifier.js
+++ b/src/models/SubProductionIdentifier.js
@@ -17,7 +17,7 @@ export default class SubProductionIdentifier extends ProductionIdentifier {
 			const { getSubProductionChecksQuery } = validationQueries;
 
 			const {
-				exists,
+				isExistent,
 				isAssignedToSurProduction,
 				isSurSurProduction,
 				isSurProductionOfSubjectProduction,
@@ -27,7 +27,7 @@ export default class SubProductionIdentifier extends ProductionIdentifier {
 				params: { uuid: this.uuid, subjectProductionUuid }
 			});
 
-			if (!exists) {
+			if (!isExistent) {
 				this.addPropertyError('uuid', 'Production with this UUID does not exist');
 			}
 

--- a/src/neo4j/cypher-queries/validation/sub-production-checks.js
+++ b/src/neo4j/cypher-queries/validation/sub-production-checks.js
@@ -19,7 +19,7 @@ export default () => `
 		<-[subjectProductionSurSurProductionRel:HAS_SUB_PRODUCTION]-(:Production)
 
 	RETURN
-		TOBOOLEAN(COUNT(p)) AS exists,
+		TOBOOLEAN(COUNT(p)) AS isExistent,
 		TOBOOLEAN(COUNT(surProductionRel)) AS isAssignedToSurProduction,
 		TOBOOLEAN(COUNT(subSubProductionRel)) AS isSurSurProduction,
 		TOBOOLEAN(COUNT(subProductionRelWithSubjectProduction)) AS isSurProductionOfSubjectProduction,

--- a/test-int/input-validation-failures/production.test.js
+++ b/test-int/input-validation-failures/production.test.js
@@ -25,7 +25,6 @@ describe('Input validation failures: Production instance', () => {
 			.resolves({
 				isExistent: true,
 				duplicateRecordCount: 0,
-				exists: true,
 				isAssignedToSurProduction: false,
 				isSurSurProduction: false,
 				isSurProductionOfSubjectProduction: false,

--- a/test-unit/src/models/SubProductionIdentifier.test.js
+++ b/test-unit/src/models/SubProductionIdentifier.test.js
@@ -41,7 +41,7 @@ describe('SubProductionIdentifier model', () => {
 			it('will not call addPropertyError method', async () => {
 
 				stubs.neo4jQuery.resolves({
-					exists: true,
+					isExistent: true,
 					isAssignedToSurProduction: false,
 					isSurSurProduction: false,
 					isSurProductionOfSubjectProduction: false,
@@ -79,7 +79,7 @@ describe('SubProductionIdentifier model', () => {
 			it('will call addPropertyError method', async () => {
 
 				stubs.neo4jQuery.resolves({
-					exists: false,
+					isExistent: false,
 					isAssignedToSurProduction: false,
 					isSurSurProduction: false,
 					isSurProductionOfSubjectProduction: false,
@@ -122,7 +122,7 @@ describe('SubProductionIdentifier model', () => {
 			it('will call addPropertyError method', async () => {
 
 				stubs.neo4jQuery.resolves({
-					exists: true,
+					isExistent: true,
 					isAssignedToSurProduction: true,
 					isSurSurProduction: false,
 					isSurProductionOfSubjectProduction: false,
@@ -165,7 +165,7 @@ describe('SubProductionIdentifier model', () => {
 			it('will call addPropertyError method', async () => {
 
 				stubs.neo4jQuery.resolves({
-					exists: true,
+					isExistent: true,
 					isAssignedToSurProduction: false,
 					isSurSurProduction: true,
 					isSurProductionOfSubjectProduction: false,
@@ -208,7 +208,7 @@ describe('SubProductionIdentifier model', () => {
 			it('will call addPropertyError method', async () => {
 
 				stubs.neo4jQuery.resolves({
-					exists: true,
+					isExistent: true,
 					isAssignedToSurProduction: false,
 					isSurSurProduction: false,
 					isSurProductionOfSubjectProduction: true,
@@ -251,7 +251,7 @@ describe('SubProductionIdentifier model', () => {
 			it('will call addPropertyError method', async () => {
 
 				stubs.neo4jQuery.resolves({
-					exists: true,
+					isExistent: true,
 					isAssignedToSurProduction: false,
 					isSurSurProduction: false,
 					isSurProductionOfSubjectProduction: false,

--- a/test-unit/src/neo4j/cypher-queries/validation.test.js
+++ b/test-unit/src/neo4j/cypher-queries/validation.test.js
@@ -111,7 +111,7 @@ describe('Cypher Queries Validation module', () => {
 					<-[subjectProductionSurSurProductionRel:HAS_SUB_PRODUCTION]-(:Production)
 
 				RETURN
-					TOBOOLEAN(COUNT(p)) AS exists,
+					TOBOOLEAN(COUNT(p)) AS isExistent,
 					TOBOOLEAN(COUNT(surProductionRel)) AS isAssignedToSurProduction,
 					TOBOOLEAN(COUNT(subSubProductionRel)) AS isSurSurProduction,
 					TOBOOLEAN(COUNT(subProductionRelWithSubjectProduction)) AS isSurProductionOfSubjectProduction,


### PR DESCRIPTION
This PR renames the `exists` property in the sub-production checks Cypher query so that it a) is consistent with equivalent checks elsewhere and b) uses the naming convention of beginning with `is` to express that it is a boolean value.