### PR TITLE
Rename queryOpts -> opts in neo4jQuery function

### DIFF
--- a/src/neo4j/query.js
+++ b/src/neo4j/query.js
@@ -3,12 +3,12 @@ import { getDriver } from './get-driver';
 
 const driver = getDriver();
 
-export const neo4jQuery = async (queryData, queryOpts = {}) => {
+export const neo4jQuery = async (queryData, opts = {}) => {
 
 	const { query, params } = queryData;
 
-	const isOptionalResult = Boolean(queryOpts.isOptionalResult);
-	const isArrayResult = Boolean(queryOpts.isArrayResult);
+	const isOptionalResult = Boolean(opts.isOptionalResult);
+	const isArrayResult = Boolean(opts.isArrayResult);
 
 	const session = driver.session();
 


### PR DESCRIPTION
This PR renames the neo4jQuery function's `queryOpts` parameter to `opts` because they don't relate specifically to the query itself but rather how the query response is handled.