### PR TITLE
Identify parse error line of invalid database seed JSONs

### DIFF
--- a/db-seeding/seed-db.js
+++ b/db-seeding/seed-db.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 
 const directly = require('directly');
+const jsonlint = require('jsonlint');
 
 const BASE_URL = 'http://localhost:3000';
 
@@ -51,7 +52,9 @@ async function seedInstances (pluralisedModel) {
 
 					const rawData = fs.readFileSync(`${directoryPath}/${filename}`);
 
-					const instance = JSON.parse(rawData);
+					// Parse with jsonlint rather than JSON.parse() because
+					// its errors specify the line of parse errors.
+					const instance = jsonlint.parse(rawData.toString());
 
 					const url = `${BASE_URL}/${modelUrlRoute}`;
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "chai-http": "4.3.0",
     "eslint": "8.24.0",
     "eslint-plugin-no-only-tests": "3.0.0",
+    "jsonlint": "^1.6.3",
     "lintspaces-cli": "0.7.1",
     "mocha": "10.0.0",
     "node-mocks-http": "1.11.0",


### PR DESCRIPTION
This PR modifies the error messaging when a database seed is an invalid JSON by exposing the line of the parse error.

#### Before

Only the position is given, which is not very helpful for locating the cause of the parse error.

```
/{path}/theatrebase-api/db-seeding/seed-db.js:72
                    throw new Error(`${filenamePathSlug}: ${error.message}`);
                          ^

Error: materials/coriolanus.json: Unexpected token { in JSON at position 1026
    at /{path}/theatrebase-api/db-seeding/seed-db.js:72:12
    at Directly.executeOne (/{path}/theatrebase-api/node_modules/directly/directly.js:64:37)
    at Directly.rejoinRace (/{path}/theatrebase-api/node_modules/directly/directly.js:105:10)
    at /{path}/theatrebase-api/node_modules/directly/directly.js:77:10
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

---

#### After

The line number of the parse error is now given, making it far easier to identify the cause.

```
/{path}/theatrebase-api/db-seeding/seed-db.js:72
                    throw new Error(`${filenamePathSlug}: ${error.message}`);
                          ^

Error: materials/coriolanus.json: Parse error on line 76:
... "Adrian"                }               {                   "name": "A Ci
---------------------^
Expecting 'EOF', '}', ',', ']', got '{'
    at /{path}/theatrebase-api/db-seeding/seed-db.js:72:12
    at Directly.executeOne (/{path}/theatrebase-api/node_modules/directly/directly.js:64:37)
    at Directly.rejoinRace (/{path}/theatrebase-api/node_modules/directly/directly.js:105:10)
    at /{path}/theatrebase-api/node_modules/directly/directly.js:77:10
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

### New dev dependencies:
- [jsonlint](https://www.npmjs.com/package/jsonlint)