### PR TITLE
Accommodate material characters with duplicate underlying names

### DIFF
--- a/db-seeding/seeds/materials/charged-5-that-almost-unnameable-lust.json
+++ b/db-seeding/seeds/materials/charged-5-that-almost-unnameable-lust.json
@@ -19,8 +19,7 @@
 					"differentiator": "That Almost Unnameable Lust"
 				},
 				{
-					"name": "Liz",
-					"differentiator": "That Almost Unnameable Lust"
+					"name": "Liz"
 				},
 				{
 					"name": "Writer",

--- a/db-seeding/seeds/materials/women-power-and-politics-03-handbagged.json
+++ b/db-seeding/seeds/materials/women-power-and-politics-03-handbagged.json
@@ -15,23 +15,32 @@
 		{
 			"characters": [
 				{
-					"name": "T"
+					"name": "T",
+					"underlyingName": "Margaret Thatcher",
+					"qualifier": "older"
 				},
 				{
-					"name": "Q"
+					"name": "Q",
+					"underlyingName": "Queen Elizabeth II",
+					"qualifier": "older"
 				},
 				{
-					"name": "Mags"
+					"name": "Mags",
+					"underlyingName": "Margaret Thatcher",
+					"qualifier": "younger"
 				},
 				{
 					"name": "Liz",
-					"differentiator": "Handbagged"
+					"underlyingName": "Queen Elizabeth II",
+					"qualifier": "younger"
 				},
 				{
-					"name": "Ron"
+					"name": "Ron",
+					"underlyingName": "Ronald Reagan"
 				},
 				{
-					"name": "Shea"
+					"name": "Shea",
+					"underlyingName": "Michael Shea"
 				}
 			]
 		}

--- a/src/lib/prepare-as-params.js
+++ b/src/lib/prepare-as-params.js
@@ -103,11 +103,17 @@ export const prepareAsParams = instance => {
 
 				if (requiresUuidValue) {
 
-					const instanceWithShareableUuid = recordedInstances.find(recordedInstance =>
-						instance.model === recordedInstance.model &&
-						instance.name === recordedInstance.name &&
-						instance.differentiator === recordedInstance.differentiator
-					);
+					const instanceWithShareableUuid = recordedInstances.find(recordedInstance => {
+						const instanceNameForComparison = instance.underlyingName || instance.name;
+						const recordedInstanceNameForComparison = recordedInstance.underlyingName || recordedInstance.name;
+
+						const isInstanceWithShareableUuid =
+							instance.model === recordedInstance.model &&
+							instanceNameForComparison === recordedInstanceNameForComparison &&
+							instance.differentiator === recordedInstance.differentiator;
+
+						return isInstanceWithShareableUuid;
+					});
 
 					accumulator[key] = instanceWithShareableUuid?.uuid || randomUUID({ disableEntropyCache: true });
 
@@ -117,6 +123,7 @@ export const prepareAsParams = instance => {
 							model: instance.model,
 							uuid: accumulator[key],
 							name: instance.name,
+							underlyingName: instance.underlyingName,
 							differentiator: instance.differentiator
 						});
 

--- a/test-e2e/model-interaction/char-multi-appearances-same-mat.test.js
+++ b/test-e2e/model-interaction/char-multi-appearances-same-mat.test.js
@@ -21,6 +21,17 @@ describe('Character with multiple appearances in the same material under differe
 	const ALICE_EVE_PERSON_UUID = '15';
 	const BRIAN_COX_PERSON_UUID = '16';
 	const SINEAD_CUSACK_PERSON_UUID = '17';
+	const HANDBAGGED_MATERIAL_UUID = '23';
+	const MARGARET_THATCHER_CHARACTER_UUID = '25';
+	const QUEEN_ELIZABETH_II_CHARACTER_UUID = '26';
+	const RONALD_REAGAN_CHARACTER_UUID = '27';
+	const HANDBAGGED_TRICYCLE_PRODUCTION_UUID = '28';
+	const TRICYCLE_THEATRE_VENUE_UUID = '30';
+	const STELLA_GONET_PERSON_UUID = '31';
+	const KIKA_MARKHAM_PERSON_UUID = '32';
+	const HEATHER_CRANEY_PERSON_UUID = '33';
+	const CLAIRE_COX_PERSON_UUID = '34';
+	const TOM_MANNION_PERSON_UUID = '35';
 
 	let esmeCharacter;
 	let aliceCharacter;
@@ -29,6 +40,11 @@ describe('Character with multiple appearances in the same material under differe
 	let rockNRollRoyalCourtProduction;
 	let aliceEvePerson;
 	let sineadCusackPerson;
+	let queenElizabethIICharacter;
+	let handbaggedMaterial;
+	let handbaggedTricycleProduction;
+	let kikaMarkhamPerson;
+	let claireCoxPerson;
 
 	const sandbox = createSandbox();
 
@@ -126,6 +142,101 @@ describe('Character with multiple appearances in the same material under differe
 				]
 			});
 
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Handbagged',
+				format: 'play',
+				year: '2010',
+				characterGroups: [
+					{
+						characters: [
+							{
+								name: 'T',
+								underlyingName: 'Margaret Thatcher',
+								qualifier: 'older'
+							},
+							{
+								name: 'Q',
+								underlyingName: 'Queen Elizabeth II',
+								qualifier: 'older'
+							},
+							{
+								name: 'Mags',
+								underlyingName: 'Margaret Thatcher',
+								qualifier: 'younger'
+							},
+							{
+								name: 'Liz',
+								underlyingName: 'Queen Elizabeth II',
+								qualifier: 'younger'
+							},
+							{
+								name: 'Ron',
+								underlyingName: 'Ronald Reagan'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Handbagged',
+				startDate: '2010-06-04',
+				pressDate: '2010-06-11',
+				endDate: '2010-07-17',
+				material: {
+					name: 'Handbagged'
+				},
+				venue: {
+					name: 'Tricycle Theatre'
+				},
+				cast: [
+					{
+						name: 'Stella Gonet',
+						roles: [
+							{
+								name: 'T'
+							}
+						]
+					},
+					{
+						name: 'Kika Markham',
+						roles: [
+							{
+								name: 'Q'
+							}
+						]
+					},
+					{
+						name: 'Heather Craney',
+						roles: [
+							{
+								name: 'Mags'
+							}
+						]
+					},
+					{
+						name: 'Claire Cox',
+						roles: [
+							{
+								name: 'Liz'
+							}
+						]
+					},
+					{
+						name: 'Tom Mannion',
+						roles: [
+							{
+								name: 'Ron'
+							}
+						]
+					}
+				]
+			});
+
 		esmeCharacter = await chai.request(app)
 			.get(`/characters/${ESME_CHARACTER_UUID}`);
 
@@ -146,6 +257,21 @@ describe('Character with multiple appearances in the same material under differe
 
 		sineadCusackPerson = await chai.request(app)
 			.get(`/people/${SINEAD_CUSACK_PERSON_UUID}`);
+
+		queenElizabethIICharacter = await chai.request(app)
+			.get(`/characters/${QUEEN_ELIZABETH_II_CHARACTER_UUID}`);
+
+		handbaggedMaterial = await chai.request(app)
+			.get(`/materials/${HANDBAGGED_MATERIAL_UUID}`);
+
+		handbaggedTricycleProduction = await chai.request(app)
+			.get(`/productions/${HANDBAGGED_TRICYCLE_PRODUCTION_UUID}`);
+
+		kikaMarkhamPerson = await chai.request(app)
+			.get(`/people/${KIKA_MARKHAM_PERSON_UUID}`);
+
+		claireCoxPerson = await chai.request(app)
+			.get(`/people/${CLAIRE_COX_PERSON_UUID}`);
 
 	});
 
@@ -547,6 +673,293 @@ describe('Character with multiple appearances in the same material under differe
 			];
 
 			const { castMemberProductions } = sineadCusackPerson.body;
+
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
+
+		});
+
+	});
+
+	describe('Queen Elizabeth II (character)', () => {
+
+		it('includes materials in which character is depicted, including the qualifiers used', () => {
+
+			const expectedMaterials = [
+				{
+					model: 'MATERIAL',
+					uuid: HANDBAGGED_MATERIAL_UUID,
+					name: 'Handbagged',
+					format: 'play',
+					year: 2010,
+					surMaterial: null,
+					writingCredits: [],
+					depictions: [
+						{
+							displayName: 'Q',
+							qualifier: 'older',
+							group: null
+						},
+						{
+							displayName: 'Liz',
+							qualifier: 'younger',
+							group: null
+						}
+					]
+				}
+			];
+
+			const { materials } = queenElizabethIICharacter.body;
+
+			expect(materials).to.deep.equal(expectedMaterials);
+
+		});
+
+		it('includes productions in which character was portrayed, including by which performer', () => {
+
+			const expectedProductions = [
+				{
+					model: 'PRODUCTION',
+					uuid: HANDBAGGED_TRICYCLE_PRODUCTION_UUID,
+					name: 'Handbagged',
+					startDate: '2010-06-04',
+					endDate: '2010-07-17',
+					venue: {
+						model: 'VENUE',
+						uuid: TRICYCLE_THEATRE_VENUE_UUID,
+						name: 'Tricycle Theatre',
+						surVenue: null
+					},
+					surProduction: null,
+					performers: [
+						{
+							model: 'PERSON',
+							uuid: KIKA_MARKHAM_PERSON_UUID,
+							name: 'Kika Markham',
+							roleName: 'Q',
+							qualifier: null,
+							isAlternate: false,
+							otherRoles: []
+						},
+						{
+							model: 'PERSON',
+							uuid: CLAIRE_COX_PERSON_UUID,
+							name: 'Claire Cox',
+							roleName: 'Liz',
+							qualifier: null,
+							isAlternate: false,
+							otherRoles: []
+						}
+					]
+				}
+			];
+
+			const { productions } = queenElizabethIICharacter.body;
+
+			expect(productions).to.deep.equal(expectedProductions);
+
+		});
+
+	});
+
+	describe('Handbagged (material)', () => {
+
+		it('includes Queen Elizabeth II in its characters with an entry for each qualifier', () => {
+
+			const expectedCharacters = [
+				{
+					model: 'CHARACTER',
+					uuid: MARGARET_THATCHER_CHARACTER_UUID,
+					name: 'T',
+					qualifier: 'older'
+				},
+				{
+					model: 'CHARACTER',
+					uuid: QUEEN_ELIZABETH_II_CHARACTER_UUID,
+					name: 'Q',
+					qualifier: 'older'
+				},
+				{
+					model: 'CHARACTER',
+					uuid: MARGARET_THATCHER_CHARACTER_UUID,
+					name: 'Mags',
+					qualifier: 'younger'
+				},
+				{
+					model: 'CHARACTER',
+					uuid: QUEEN_ELIZABETH_II_CHARACTER_UUID,
+					name: 'Liz',
+					qualifier: 'younger'
+				},
+				{
+					model: 'CHARACTER',
+					uuid: RONALD_REAGAN_CHARACTER_UUID,
+					name: 'Ron',
+					qualifier: null
+				}
+			];
+
+			const { characterGroups: [{ characters }] } = handbaggedMaterial.body;
+
+			expect(characters).to.deep.equal(expectedCharacters);
+
+		});
+
+	});
+
+	describe('Handbagged at Tricycle Theatre (production)', () => {
+
+		it('includes the portrayers of Queen Elizabeth II in its cast with their corresponding display names', () => {
+
+			const expectedCast = [
+				{
+					model: 'PERSON',
+					uuid: STELLA_GONET_PERSON_UUID,
+					name: 'Stella Gonet',
+					roles: [
+						{
+							model: 'CHARACTER',
+							uuid: MARGARET_THATCHER_CHARACTER_UUID,
+							name: 'T',
+							qualifier: null,
+							isAlternate: false
+						}
+					]
+				},
+				{
+					model: 'PERSON',
+					uuid: KIKA_MARKHAM_PERSON_UUID,
+					name: 'Kika Markham',
+					roles: [
+						{
+							model: 'CHARACTER',
+							uuid: QUEEN_ELIZABETH_II_CHARACTER_UUID,
+							name: 'Q',
+							qualifier: null,
+							isAlternate: false
+						}
+					]
+				},
+				{
+					model: 'PERSON',
+					uuid: HEATHER_CRANEY_PERSON_UUID,
+					name: 'Heather Craney',
+					roles: [
+						{
+							model: 'CHARACTER',
+							uuid: MARGARET_THATCHER_CHARACTER_UUID,
+							name: 'Mags',
+							qualifier: null,
+							isAlternate: false
+						}
+					]
+				},
+				{
+					model: 'PERSON',
+					uuid: CLAIRE_COX_PERSON_UUID,
+					name: 'Claire Cox',
+					roles: [
+						{
+							model: 'CHARACTER',
+							uuid: QUEEN_ELIZABETH_II_CHARACTER_UUID,
+							name: 'Liz',
+							qualifier: null,
+							isAlternate: false
+						}
+					]
+				},
+				{
+					model: 'PERSON',
+					uuid: TOM_MANNION_PERSON_UUID,
+					name: 'Tom Mannion',
+					roles: [
+						{
+							model: 'CHARACTER',
+							uuid: RONALD_REAGAN_CHARACTER_UUID,
+							name: 'Ron',
+							qualifier: null,
+							isAlternate: false
+						}
+					]
+				}
+			];
+
+			const { cast } = handbaggedTricycleProduction.body;
+
+			expect(cast).to.deep.equal(expectedCast);
+
+		});
+
+	});
+
+	describe('Kika Markham (person)', () => {
+
+		it('includes in their production credits their portrayal of Queen Elizabeth II with its corresponding display name (i.e. Q)', () => {
+
+			const expectedCastMemberProductions = [
+				{
+					model: 'PRODUCTION',
+					uuid: HANDBAGGED_TRICYCLE_PRODUCTION_UUID,
+					name: 'Handbagged',
+					startDate: '2010-06-04',
+					endDate: '2010-07-17',
+					venue: {
+						model: 'VENUE',
+						uuid: TRICYCLE_THEATRE_VENUE_UUID,
+						name: 'Tricycle Theatre',
+						surVenue: null
+					},
+					surProduction: null,
+					roles: [
+						{
+							model: 'CHARACTER',
+							uuid: QUEEN_ELIZABETH_II_CHARACTER_UUID,
+							name: 'Q',
+							qualifier: null,
+							isAlternate: false
+						}
+					]
+				}
+			];
+
+			const { castMemberProductions } = kikaMarkhamPerson.body;
+
+			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
+
+		});
+
+	});
+
+	describe('Claire Cox (person)', () => {
+
+		it('includes in their production credits their portrayal of Queen Elizabeth II with its corresponding display name (i.e. Liz)', () => {
+
+			const expectedCastMemberProductions = [
+				{
+					model: 'PRODUCTION',
+					uuid: HANDBAGGED_TRICYCLE_PRODUCTION_UUID,
+					name: 'Handbagged',
+					startDate: '2010-06-04',
+					endDate: '2010-07-17',
+					venue: {
+						model: 'VENUE',
+						uuid: TRICYCLE_THEATRE_VENUE_UUID,
+						name: 'Tricycle Theatre',
+						surVenue: null
+					},
+					surProduction: null,
+					roles: [
+						{
+							model: 'CHARACTER',
+							uuid: QUEEN_ELIZABETH_II_CHARACTER_UUID,
+							name: 'Liz',
+							qualifier: null,
+							isAlternate: false
+						}
+					]
+				}
+			];
+
+			const { castMemberProductions } = claireCoxPerson.body;
 
 			expect(castMemberProductions).to.deep.equal(expectedCastMemberProductions);
 

--- a/test-unit/src/lib/prepare-as-params.test.js
+++ b/test-unit/src/lib/prepare-as-params.test.js
@@ -563,23 +563,31 @@ describe('Prepare As Params module', () => {
 				.onFirstCall().returns('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
 				.onSecondCall().returns('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb')
 				.onThirdCall().returns('cccccccc-cccc-cccc-cccc-cccccccccccc')
-				.onCall(3).returns('dddddddd-dddd-dddd-dddd-dddddddddddd');
+				.onCall(3).returns('dddddddd-dddd-dddd-dddd-dddddddddddd')
+				.onCall(4).returns('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee')
+				.onCall(5).returns('ffffffff-ffff-ffff-ffff-ffffffffffff');
 			const instance = {
 				characters: [
-					applyModelGetter({ uuid: '', name: 'Foo', underlyingName: '', differentiator: '', qualifier: 'younger' }),
-					applyModelGetter({ uuid: '', name: 'Bar', underlyingName: '', differentiator: '1', qualifier: 'younger' }),
-					applyModelGetter({ uuid: '', name: 'Baz', underlyingName: '', differentiator: '', qualifier: '' }),
-					applyModelGetter({ uuid: '', name: 'Foo', underlyingName: '', differentiator: '', qualifier: 'older' }),
-					applyModelGetter({ uuid: '', name: 'Bar', underlyingName: '', differentiator: '1', qualifier: 'older' }),
-					applyModelGetter({ uuid: '', name: 'Baz', underlyingName: '', differentiator: '1', qualifier: '' })
+					applyModelGetter({ uuid: '', name: 'Ferdinand Foo', underlyingName: '', differentiator: '', qualifier: 'younger' }),
+					applyModelGetter({ uuid: '', name: 'Bar', underlyingName: 'Beatrice Bar', differentiator: '1', qualifier: 'younger' }),
+					applyModelGetter({ uuid: '', name: 'Brandon Baz', underlyingName: '', differentiator: '', qualifier: '' }),
+					applyModelGetter({ uuid: '', name: 'Qux', underlyingName: 'Quincy Qux', differentiator: '', qualifier: '' }),
+					applyModelGetter({ uuid: '', name: 'Quux', underlyingName: 'Clara Qux', differentiator: '', qualifier: '' }),
+					applyModelGetter({ uuid: '', name: 'Ferdinand Foo', underlyingName: '', differentiator: '', qualifier: 'older' }),
+					applyModelGetter({ uuid: '', name: 'Beatrice', underlyingName: 'Beatrice Bar', differentiator: '1', qualifier: 'older' }),
+					applyModelGetter({ uuid: '', name: 'Baz', underlyingName: 'Brandon Baz', differentiator: '', qualifier: '' }),
+					applyModelGetter({ uuid: '', name: 'Quincy Qux', underlyingName: '', differentiator: '', qualifier: '' }),
+					applyModelGetter({ uuid: '', name: 'Clara Quux', underlyingName: '', differentiator: '1', qualifier: '' })
 				]
 			};
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.callCount).to.equal(4);
-			expect(stubs.neo4jInt.callCount).to.equal(6);
-			expect(result.characters[0].uuid).to.equal(result.characters[3].uuid);
-			expect(result.characters[1].uuid).to.equal(result.characters[4].uuid);
-			expect(result.characters[2].uuid).not.to.equal(result.characters[5].uuid);
+			expect(stubs.cryptoRandomUUID.callCount).to.equal(6);
+			expect(stubs.neo4jInt.callCount).to.equal(10);
+			expect(result.characters[0].uuid).to.equal(result.characters[5].uuid);
+			expect(result.characters[1].uuid).to.equal(result.characters[6].uuid);
+			expect(result.characters[2].uuid).to.equal(result.characters[7].uuid);
+			expect(result.characters[3].uuid).to.equal(result.characters[8].uuid);
+			expect(result.characters[4].uuid).to.not.equal(result.characters[9].uuid);
 
 		});
 
@@ -937,25 +945,33 @@ describe('Prepare As Params module', () => {
 				.onFirstCall().returns('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
 				.onSecondCall().returns('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb')
 				.onThirdCall().returns('cccccccc-cccc-cccc-cccc-cccccccccccc')
-				.onCall(3).returns('dddddddd-dddd-dddd-dddd-dddddddddddd');
+				.onCall(3).returns('dddddddd-dddd-dddd-dddd-dddddddddddd')
+				.onCall(4).returns('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee')
+				.onCall(5).returns('ffffffff-ffff-ffff-ffff-ffffffffffff');
 			const instance = {
 				production: {
 					cast: [
-						applyModelGetter({ uuid: '', name: 'Foo', differentiator: '' }),
-						applyModelGetter({ uuid: '', name: 'Bar', differentiator: '1' }),
-						applyModelGetter({ uuid: '', name: 'Baz', differentiator: '' }),
-						applyModelGetter({ uuid: '', name: 'Foo', differentiator: '' }),
-						applyModelGetter({ uuid: '', name: 'Bar', differentiator: '1' }),
-						applyModelGetter({ uuid: '', name: 'Baz', differentiator: '1' })
+						applyModelGetter({ uuid: '', name: 'Ferdinand Foo', underlyingName: '', differentiator: '', qualifier: 'younger' }),
+						applyModelGetter({ uuid: '', name: 'Bar', underlyingName: 'Beatrice Bar', differentiator: '1', qualifier: 'younger' }),
+						applyModelGetter({ uuid: '', name: 'Brandon Baz', underlyingName: '', differentiator: '', qualifier: '' }),
+						applyModelGetter({ uuid: '', name: 'Qux', underlyingName: 'Quincy Qux', differentiator: '', qualifier: '' }),
+						applyModelGetter({ uuid: '', name: 'Quux', underlyingName: 'Clara Qux', differentiator: '', qualifier: '' }),
+						applyModelGetter({ uuid: '', name: 'Ferdinand Foo', underlyingName: '', differentiator: '', qualifier: 'older' }),
+						applyModelGetter({ uuid: '', name: 'Beatrice', underlyingName: 'Beatrice Bar', differentiator: '1', qualifier: 'older' }),
+						applyModelGetter({ uuid: '', name: 'Baz', underlyingName: 'Brandon Baz', differentiator: '', qualifier: '' }),
+						applyModelGetter({ uuid: '', name: 'Quincy Qux', underlyingName: '', differentiator: '', qualifier: '' }),
+						applyModelGetter({ uuid: '', name: 'Clara Quux', underlyingName: '', differentiator: '1', qualifier: '' })
 					]
 				}
 			};
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.callCount).to.equal(4);
-			expect(stubs.neo4jInt.callCount).to.equal(6);
-			expect(result.production.cast[0].uuid).to.equal(result.production.cast[3].uuid);
-			expect(result.production.cast[1].uuid).to.equal(result.production.cast[4].uuid);
-			expect(result.production.cast[2].uuid).not.to.equal(result.production.cast[5].uuid);
+			expect(stubs.cryptoRandomUUID.callCount).to.equal(6);
+			expect(stubs.neo4jInt.callCount).to.equal(10);
+			expect(result.production.cast[0].uuid).to.equal(result.production.cast[5].uuid);
+			expect(result.production.cast[1].uuid).to.equal(result.production.cast[6].uuid);
+			expect(result.production.cast[2].uuid).to.equal(result.production.cast[7].uuid);
+			expect(result.production.cast[3].uuid).to.equal(result.production.cast[8].uuid);
+			expect(result.production.cast[4].uuid).to.not.equal(result.production.cast[9].uuid);
 
 		});
 
@@ -1361,28 +1377,36 @@ describe('Prepare As Params module', () => {
 				.onFirstCall().returns('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
 				.onSecondCall().returns('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb')
 				.onThirdCall().returns('cccccccc-cccc-cccc-cccc-cccccccccccc')
-				.onCall(3).returns('dddddddd-dddd-dddd-dddd-dddddddddddd');
+				.onCall(3).returns('dddddddd-dddd-dddd-dddd-dddddddddddd')
+				.onCall(4).returns('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee')
+				.onCall(5).returns('ffffffff-ffff-ffff-ffff-ffffffffffff');
 			const instance = {
 				characterGroups: [
 					{
 						characters: [
-							applyModelGetter({ uuid: '', name: 'Foo', underlyingName: '', differentiator: '', qualifier: 'younger' }),
-							applyModelGetter({ uuid: '', name: 'Bar', underlyingName: '', differentiator: '1', qualifier: 'younger' }),
-							applyModelGetter({ uuid: '', name: 'Baz', underlyingName: '', differentiator: '', qualifier: '' }),
-							applyModelGetter({ uuid: '', name: 'Foo', underlyingName: '', differentiator: '', qualifier: 'older' }),
-							applyModelGetter({ uuid: '', name: 'Bar', underlyingName: '', differentiator: '1', qualifier: 'older' }),
-							applyModelGetter({ uuid: '', name: 'Baz', underlyingName: '', differentiator: '1', qualifier: '' })
+							applyModelGetter({ uuid: '', name: 'Ferdinand Foo', underlyingName: '', differentiator: '', qualifier: 'younger' }),
+							applyModelGetter({ uuid: '', name: 'Bar', underlyingName: 'Beatrice Bar', differentiator: '1', qualifier: 'younger' }),
+							applyModelGetter({ uuid: '', name: 'Brandon Baz', underlyingName: '', differentiator: '', qualifier: '' }),
+							applyModelGetter({ uuid: '', name: 'Qux', underlyingName: 'Quincy Qux', differentiator: '', qualifier: '' }),
+							applyModelGetter({ uuid: '', name: 'Quux', underlyingName: 'Clara Qux', differentiator: '', qualifier: '' }),
+							applyModelGetter({ uuid: '', name: 'Ferdinand Foo', underlyingName: '', differentiator: '', qualifier: 'older' }),
+							applyModelGetter({ uuid: '', name: 'Beatrice', underlyingName: 'Beatrice Bar', differentiator: '1', qualifier: 'older' }),
+							applyModelGetter({ uuid: '', name: 'Baz', underlyingName: 'Brandon Baz', differentiator: '', qualifier: '' }),
+							applyModelGetter({ uuid: '', name: 'Quincy Qux', underlyingName: '', differentiator: '', qualifier: '' }),
+							applyModelGetter({ uuid: '', name: 'Clara Quux', underlyingName: '', differentiator: '1', qualifier: '' })
 						]
 					}
 				]
 			};
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.callCount).to.equal(4);
-			expect(stubs.neo4jInt.callCount).to.equal(6);
-			expect(result.characterGroups[0].characters[0].uuid).to.equal(result.characterGroups[0].characters[3].uuid);
-			expect(result.characterGroups[0].characters[1].uuid).to.equal(result.characterGroups[0].characters[4].uuid);
-			expect(result.characterGroups[0].characters[2].uuid).not.to.equal(
-				result.characterGroups[0].characters[5].uuid
+			expect(stubs.cryptoRandomUUID.callCount).to.equal(6);
+			expect(stubs.neo4jInt.callCount).to.equal(10);
+			expect(result.characterGroups[0].characters[0].uuid).to.equal(result.characterGroups[0].characters[5].uuid);
+			expect(result.characterGroups[0].characters[1].uuid).to.equal(result.characterGroups[0].characters[6].uuid);
+			expect(result.characterGroups[0].characters[2].uuid).to.equal(result.characterGroups[0].characters[7].uuid);
+			expect(result.characterGroups[0].characters[3].uuid).to.equal(result.characterGroups[0].characters[8].uuid);
+			expect(result.characterGroups[0].characters[4].uuid).not.to.equal(
+				result.characterGroups[0].characters[9].uuid
 			);
 
 		});
@@ -1393,33 +1417,41 @@ describe('Prepare As Params module', () => {
 				.onFirstCall().returns('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
 				.onSecondCall().returns('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb')
 				.onThirdCall().returns('cccccccc-cccc-cccc-cccc-cccccccccccc')
-				.onCall(3).returns('dddddddd-dddd-dddd-dddd-dddddddddddd');
+				.onCall(3).returns('dddddddd-dddd-dddd-dddd-dddddddddddd')
+				.onCall(4).returns('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee')
+				.onCall(5).returns('ffffffff-ffff-ffff-ffff-ffffffffffff');
 			const instance = {
 				characterGroups: [
 					{
 						name: 'Montagues',
 						characters: [
-							applyModelGetter({ uuid: '', name: 'Foo', underlyingName: '', differentiator: '', qualifier: '' }),
-							applyModelGetter({ uuid: '', name: 'Bar', underlyingName: '', differentiator: '', qualifier: '' }),
-							applyModelGetter({ uuid: '', name: 'Baz', underlyingName: '', differentiator: '', qualifier: '' })
+							applyModelGetter({ uuid: '', name: 'Ferdinand Foo', underlyingName: '', differentiator: '', qualifier: 'younger' }),
+							applyModelGetter({ uuid: '', name: 'Bar', underlyingName: 'Beatrice Bar', differentiator: '1', qualifier: 'younger' }),
+							applyModelGetter({ uuid: '', name: 'Brandon Baz', underlyingName: '', differentiator: '', qualifier: '' }),
+							applyModelGetter({ uuid: '', name: 'Qux', underlyingName: 'Quincy Qux', differentiator: '', qualifier: '' }),
+							applyModelGetter({ uuid: '', name: 'Quux', underlyingName: 'Clara Qux', differentiator: '', qualifier: '' })
 						]
 					},
 					{
 						name: 'Capulets',
 						characters: [
-							applyModelGetter({ uuid: '', name: 'Foo', underlyingName: '', differentiator: '', qualifier: '' }),
-							applyModelGetter({ uuid: '', name: 'Bar', underlyingName: '', differentiator: '', qualifier: '' }),
-							applyModelGetter({ uuid: '', name: 'Baz', underlyingName: '', differentiator: '1', qualifier: '' })
+							applyModelGetter({ uuid: '', name: 'Ferdinand Foo', underlyingName: '', differentiator: '', qualifier: 'older' }),
+							applyModelGetter({ uuid: '', name: 'Beatrice', underlyingName: 'Beatrice Bar', differentiator: '1', qualifier: 'older' }),
+							applyModelGetter({ uuid: '', name: 'Baz', underlyingName: 'Brandon Baz', differentiator: '', qualifier: '' }),
+							applyModelGetter({ uuid: '', name: 'Quincy Qux', underlyingName: '', differentiator: '', qualifier: '' }),
+							applyModelGetter({ uuid: '', name: 'Clara Quux', underlyingName: '', differentiator: '1', qualifier: '' })
 						]
 					}
 				]
 			};
 			const result = prepareAsParams(instance);
-			expect(stubs.cryptoRandomUUID.callCount).to.equal(4);
-			expect(stubs.neo4jInt.callCount).to.equal(8);
+			expect(stubs.cryptoRandomUUID.callCount).to.equal(6);
+			expect(stubs.neo4jInt.callCount).to.equal(12);
 			expect(result.characterGroups[0].characters[0].uuid).to.equal(result.characterGroups[1].characters[0].uuid);
 			expect(result.characterGroups[0].characters[1].uuid).to.equal(result.characterGroups[1].characters[1].uuid);
-			expect(result.characterGroups[0].characters[2].uuid).not.to.equal(result.characterGroups[1].characters[2].uuid);
+			expect(result.characterGroups[0].characters[2].uuid).to.equal(result.characterGroups[1].characters[2].uuid);
+			expect(result.characterGroups[0].characters[3].uuid).to.equal(result.characterGroups[1].characters[3].uuid);
+			expect(result.characterGroups[0].characters[4].uuid).not.to.equal(result.characterGroups[1].characters[4].uuid);
 
 		});
 


### PR DESCRIPTION
This PR applies changes so that if the first introduction of a character to the database is in a material where they appear twice with the same `underlyingName` value (and with different `qualifier` values) then it is treated as the same character.

Currently the code will create two separate characters because at time of entry neither can be found as an existing entry; even though one instance of the character is `MERGE`d before the other, the Cypher query is presumably run in such an order which means that it is not yet available to be found as the `existingCharacter` by the second instance, and consequently the `uuid: COALESCE(existingCharacter.uuid, characterParam.uuid)` statement will choose the `characterParam.uuid` over the null `existingCharacter.uuid` value.

This PR modifies the `prepareAsParams` function so that they instance will share the same UUID if they share the same value that will be used as the `:Character` node's `name` value (i.e. the depiction's `underlyingName` if present, else the `name`).

This issue was identified in adding an `underlyingName` value for characters in the material, Handbagged by Moira Buffini when it became apparent that the characters were older and younger incarnations of famous figures:
- T -> Margaret Thatcher (older)
- Q -> Queen Elizabeth II (younger)
- Mags -> Margaret Thatcher (younger)
- Liz -> Queen Elizabeth II (older)
- Ron -> Ronald Reagan

T and Mags needed to be assigned to the same underlying (and yet-to-be-created) character of Margaret Thatcher.

Q and Liz needed to be assigned to the same underlying (and yet-to-be-created) character of Queen Elizabeth II.

### Before

Separate characters created for T and Mags, and Q and Liz respectively

#### Margaret Thatcher (T)
<img width="809" alt="margaret-thatcher-t-before" src="https://github.com/andygout/theatrebase-api/assets/10484515/fbd32f8f-99fa-4383-acb7-4a76b9f859ca">

---

#### Margaret Thatcher (Mags)
<img width="840" alt="margaret-thatcher-mags-before" src="https://github.com/andygout/theatrebase-api/assets/10484515/cba89b40-57a5-42c7-9f3e-d23c99b2e667">

---

#### Queen Elizabeth II (Q)
<img width="821" alt="queen-elizabeth-q-before" src="https://github.com/andygout/theatrebase-api/assets/10484515/65dcdddd-69f4-433a-a3f7-71aa554dd1c8">

---

#### Queen Elizabeth II (Liz)
<img width="800" alt="queen-elizabeth-liz-before" src="https://github.com/andygout/theatrebase-api/assets/10484515/a34cff22-277b-40eb-af28-46ef47aef343">

---

### After

Consolidated character created for T and Mags, and Q and Liz respectively

#### Margaret Thatcher
<img width="914" alt="margaret-thatcher-after" src="https://github.com/andygout/theatrebase-api/assets/10484515/3314a97f-caad-4347-acd5-22a563406e17">

---

#### Queen Elizabeth II
<img width="931" alt="queen-elizabeth-ii-after" src="https://github.com/andygout/theatrebase-api/assets/10484515/23f13420-764e-4db3-b989-42e2f17ec973">