### PR TITLE
Fix character production credits characters also performed by performer

### DIFF
--- a/src/neo4j/cypher-queries/character/show/show-productions.js
+++ b/src/neo4j/cypher-queries/character/show/show-productions.js
@@ -35,8 +35,7 @@ export default () => `
 				otherRole.characterName <> characterDepiction.displayName
 			)
 
-	OPTIONAL MATCH (person)<-[otherRole]-(production)-[productionRel]->
-		(materialForProduction)-[otherCharacterDepiction:DEPICTS]->(otherCharacter:Character)
+	OPTIONAL MATCH (materialForProduction)-[otherCharacterDepiction:DEPICTS]->(otherCharacter:Character)
 		WHERE
 			(
 				otherCharacter.name IN [otherRole.roleName, otherRole.characterName] OR


### PR DESCRIPTION
This PR fixes the Cypher query to show character productions: currently part of the query is broken resulting in some of the character's portrayers' other roles they performed missing from the credits.

Presumably this is an issue caused by re-`MATCH`ing the same pattern with the existing identifiers which in any case is unnecessary: each row is handled individually so starting the `MATCH` pattern with the `materialForProduction` identifier and joining to a character will still be linked to the role associated with that starting `materialForProduction` identifier, allowing the `MATCH` clause's role-to-character `WHERE` conditions to work.

### Before

Does not include that Alice Eve also performed a character called Alice

<img width="926" alt="esme-before" src="https://github.com/andygout/theatrebase-api/assets/10484515/b4ed2c02-9534-401f-b3dc-b91b7138b2ca">

---

### After

Now includes that Alice Eve also performed a character called Alice

<img width="910" alt="esme-after" src="https://github.com/andygout/theatrebase-api/assets/10484515/b31b84e0-d6ec-4f85-bec6-bd24ed26262c">