### PR TITLE
Upgrade Neo4j v4.4.2 -> v5.9.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     docker:
       - image: cimg/node:18.7.0
-      - image: neo4j:4.4.2
+      - image: neo4j:5.9.0
         environment:
           NEO4J_AUTH: none
     steps:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     neo4j:
         container_name: neo4j-test
-        image: neo4j:4.4.2
+        image: neo4j:5.9.0
         environment:
             - NEO4J_AUTH=none
         ports:

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "dotenv": "16.0.3",
     "express": "4.18.1",
     "morgan": "1.10.0",
-    "neo4j-driver": "5.0.1",
+    "neo4j-driver": "5.10.0",
     "source-map-support": "0.5.21"
   },
   "devDependencies": {

--- a/src/neo4j/create-constraints.js
+++ b/src/neo4j/create-constraints.js
@@ -16,7 +16,7 @@ const CONSTRAINABLE_MODELS = new Set([
 
 const createConstraint = async model => {
 
-	const createConstraintQuery = `CREATE CONSTRAINT ON (node:${model}) ASSERT node.uuid IS UNIQUE`;
+	const createConstraintQuery = `CREATE CONSTRAINT FOR (node:${model}) REQUIRE node.uuid IS UNIQUE`;
 
 	try {
 

--- a/src/neo4j/create-indexes.js
+++ b/src/neo4j/create-indexes.js
@@ -15,7 +15,7 @@ const INDEXABLE_MODELS = new Set([
 
 const createIndex = async model => {
 
-	const createIndexQuery = `CREATE INDEX ON :${model}(name)`;
+	const createIndexQuery = `CREATE INDEX FOR (n:${model}) ON (n.name)`;
 
 	try {
 

--- a/src/neo4j/cypher-queries/award-ceremony/create-update.js
+++ b/src/neo4j/cypher-queries/award-ceremony/create-update.js
@@ -36,7 +36,7 @@ const getCreateUpdateQuery = action => {
 				($award.differentiator IS NULL AND existingAward.differentiator IS NULL) OR
 				$award.differentiator = existingAward.differentiator
 
-		FOREACH (item IN CASE $award.name WHEN NULL THEN [] ELSE [1] END |
+		FOREACH (item IN CASE WHEN $award.name IS NULL THEN [] ELSE [1] END |
 			MERGE (award:Award {
 				uuid: COALESCE(existingAward.uuid, $award.uuid),
 				name: $award.name
@@ -50,7 +50,7 @@ const getCreateUpdateQuery = action => {
 
 		UNWIND (CASE $categories WHEN [] THEN [{ nominations: [] }] ELSE $categories END) AS categoryParam
 
-			FOREACH (item IN CASE categoryParam.name WHEN NULL THEN [] ELSE [1] END |
+			FOREACH (item IN CASE WHEN categoryParam.name IS NULL THEN [] ELSE [1] END |
 				CREATE (:AwardCeremonyCategory { name: categoryParam.name })
 					<-[:PRESENTS_CATEGORY { position: categoryParam.position }]-(ceremony)
 			)
@@ -79,7 +79,7 @@ const getCreateUpdateQuery = action => {
 							) OR
 							nomineePersonParam.differentiator = existingNomineePerson.differentiator
 
-					FOREACH (item IN CASE nomineePersonParam WHEN NULL THEN [] ELSE [1] END |
+					FOREACH (item IN CASE WHEN nomineePersonParam IS NULL THEN [] ELSE [1] END |
 						MERGE (nomineePerson:Person {
 							uuid: COALESCE(existingNomineePerson.uuid, nomineePersonParam.uuid),
 							name: nomineePersonParam.name
@@ -111,7 +111,7 @@ const getCreateUpdateQuery = action => {
 							) OR
 							nomineeCompanyParam.differentiator = existingNomineeCompany.differentiator
 
-					FOREACH (item IN CASE nomineeCompanyParam WHEN NULL THEN [] ELSE [1] END |
+					FOREACH (item IN CASE WHEN nomineeCompanyParam IS NULL THEN [] ELSE [1] END |
 						MERGE (nomineeCompany:Company {
 							uuid: COALESCE(existingNomineeCompany.uuid, nomineeCompanyParam.uuid),
 							name: nomineeCompanyParam.name
@@ -161,7 +161,7 @@ const getCreateUpdateQuery = action => {
 							ELSE []
 						END | SET nominatedCompanyRel.nominatedMemberUuids = [])
 
-						FOREACH (item IN CASE nominatedMemberParam WHEN NULL THEN [] ELSE [1] END |
+						FOREACH (item IN CASE WHEN nominatedMemberParam IS NULL THEN [] ELSE [1] END |
 							MERGE (nominatedMember:Person {
 								uuid: COALESCE(existingPerson.uuid, nominatedMemberParam.uuid),
 								name: nominatedMemberParam.name
@@ -189,7 +189,7 @@ const getCreateUpdateQuery = action => {
 
 					OPTIONAL MATCH (existingNomineeProduction:Production { uuid: nomineeProductionParam.uuid })
 
-					FOREACH (item IN CASE existingNomineeProduction WHEN NULL THEN [] ELSE [1] END |
+					FOREACH (item IN CASE WHEN existingNomineeProduction IS NULL THEN [] ELSE [1] END |
 						CREATE (category)-
 							[:HAS_NOMINEE {
 								nominationPosition: nomination.position,
@@ -215,7 +215,7 @@ const getCreateUpdateQuery = action => {
 							) OR
 							nomineeMaterialParam.differentiator = existingNomineeMaterial.differentiator
 
-					FOREACH (item IN CASE nomineeMaterialParam WHEN NULL THEN [] ELSE [1] END |
+					FOREACH (item IN CASE WHEN nomineeMaterialParam IS NULL THEN [] ELSE [1] END |
 						MERGE (nomineeMaterial:Material {
 							uuid: COALESCE(existingNomineeMaterial.uuid, nomineeMaterialParam.uuid),
 							name: nomineeMaterialParam.name

--- a/src/neo4j/cypher-queries/award-ceremony/edit.js
+++ b/src/neo4j/cypher-queries/award-ceremony/edit.js
@@ -53,7 +53,7 @@ export default () => `
 		nomineeRel.isWinner AS isWinner,
 		nomineeRel.customType AS customType,
 		COLLECT(
-			CASE nominee WHEN NULL
+			CASE WHEN nominee IS NULL
 				THEN null
 				ELSE nominee { .model, .uuid, .name, .differentiator, members: nominatedMembers }
 			END
@@ -105,7 +105,7 @@ export default () => `
 		ceremony.name AS name,
 		{ name: COALESCE(award.name, ''), differentiator: COALESCE(award.differentiator, '') } AS award,
 		COLLECT(
-			CASE category WHEN NULL
+			CASE WHEN category IS NULL
 				THEN null
 				ELSE category { .name, nominations }
 			END

--- a/src/neo4j/cypher-queries/award-ceremony/list.js
+++ b/src/neo4j/cypher-queries/award-ceremony/list.js
@@ -7,7 +7,7 @@ export default () => `
 		'AWARD_CEREMONY' AS model,
 		ceremony.uuid AS uuid,
 		ceremony.name AS name,
-		CASE award WHEN NULL THEN null ELSE award { model: 'AWARD', .uuid, .name } END AS award
+		CASE WHEN award IS NULL THEN null ELSE award { model: 'AWARD', .uuid, .name } END AS award
 
 	ORDER BY ceremony.name DESC, award.name
 

--- a/src/neo4j/cypher-queries/award-ceremony/show.js
+++ b/src/neo4j/cypher-queries/award-ceremony/show.js
@@ -38,7 +38,7 @@ export default () => [`
 		entity,
 		sourceMaterialWriterRel.credit AS sourceMaterialWritingCreditName,
 		COLLECT(
-			CASE sourceMaterialWriter WHEN NULL
+			CASE WHEN sourceMaterialWriter IS NULL
 				THEN null
 				ELSE sourceMaterialWriter { model: TOUPPER(HEAD(LABELS(sourceMaterialWriter))), .uuid, .name }
 			END
@@ -69,7 +69,7 @@ export default () => [`
 		nominee,
 		entityRel.credit AS writingCreditName,
 		COLLECT(
-			CASE entity WHEN NULL
+			CASE WHEN entity IS NULL
 				THEN null
 				ELSE entity {
 					model: TOUPPER(HEAD(LABELS(entity))),
@@ -77,13 +77,13 @@ export default () => [`
 					.name,
 					.format,
 					.year,
-					surMaterial: CASE entitySurMaterial WHEN NULL
+					surMaterial: CASE WHEN entitySurMaterial IS NULL
 						THEN null
 						ELSE entitySurMaterial {
 							model: 'MATERIAL',
 							.uuid,
 							.name,
-							surMaterial: CASE entitySurSurMaterial WHEN NULL
+							surMaterial: CASE WHEN entitySurSurMaterial IS NULL
 								THEN null
 								ELSE entitySurSurMaterial { model: 'MATERIAL', .uuid, .name }
 							END
@@ -110,13 +110,13 @@ export default () => [`
 		category,
 		nomineeRel,
 		nominee,
-		CASE surMaterial WHEN NULL
+		CASE WHEN surMaterial IS NULL
 			THEN null
 			ELSE surMaterial {
 				model: 'MATERIAL',
 				.uuid,
 				.name,
-				surMaterial: CASE surSurMaterial WHEN NULL
+				surMaterial: CASE WHEN surSurMaterial IS NULL
 					THEN null
 					ELSE surSurMaterial { model: 'MATERIAL', .uuid, .name }
 				END
@@ -149,25 +149,25 @@ export default () => [`
 			.startDate,
 			.endDate,
 			nominatedMemberUuids: nomineeRel.nominatedMemberUuids,
-			venue: CASE venue WHEN NULL
+			venue: CASE WHEN venue IS NULL
 				THEN null
 				ELSE venue {
 					model: 'VENUE',
 					.uuid,
 					.name,
-					surVenue: CASE surVenue WHEN NULL
+					surVenue: CASE WHEN surVenue IS NULL
 						THEN null
 						ELSE surVenue { model: 'VENUE', .uuid, .name }
 					END
 				}
 			END,
-			surProduction: CASE surProduction WHEN NULL
+			surProduction: CASE WHEN surProduction IS NULL
 				THEN null
 				ELSE surProduction {
 					model: 'PRODUCTION',
 					.uuid,
 					.name,
-					surProduction: CASE surSurProduction WHEN NULL
+					surProduction: CASE WHEN surSurProduction IS NULL
 						THEN null
 						ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
 					END
@@ -210,7 +210,7 @@ export default () => [`
 		nomineeRel.isWinner AS isWinner,
 		nomineeRel.customType AS customType,
 		COLLECT(
-			CASE nominee WHEN NULL
+			CASE WHEN nominee IS NULL
 				THEN null
 				ELSE nominee {
 					.model,
@@ -275,9 +275,9 @@ export default () => [`
 		'AWARD_CEREMONY' AS model,
 		ceremony.uuid AS uuid,
 		ceremony.name AS name,
-		CASE award WHEN NULL THEN null ELSE award { model: 'AWARD', .uuid, .name } END AS award,
+		CASE WHEN award IS NULL THEN null ELSE award { model: 'AWARD', .uuid, .name } END AS award,
 		COLLECT(
-			CASE category WHEN NULL
+			CASE WHEN category IS NULL
 				THEN null
 				ELSE category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }
 			END

--- a/src/neo4j/cypher-queries/award/show.js
+++ b/src/neo4j/cypher-queries/award/show.js
@@ -12,7 +12,7 @@ export default () => [`
 		award.name AS name,
 		award.differentiator AS differentiator,
 		COLLECT(
-			CASE ceremony WHEN NULL
+			CASE WHEN ceremony IS NULL
 				THEN null
 				ELSE ceremony { model: 'AWARD_CEREMONY', .uuid, .name }
 			END

--- a/src/neo4j/cypher-queries/character/show/show-materials.js
+++ b/src/neo4j/cypher-queries/character/show/show-materials.js
@@ -35,7 +35,7 @@ export default () => `
 		entitySurSurMaterial,
 		sourceMaterialWriterRel.credit AS sourceMaterialWritingCreditName,
 		COLLECT(
-			CASE sourceMaterialWriter WHEN NULL
+			CASE WHEN sourceMaterialWriter IS NULL
 				THEN null
 				ELSE sourceMaterialWriter { model: TOUPPER(HEAD(LABELS(sourceMaterialWriter))), .uuid, .name }
 			END
@@ -56,7 +56,7 @@ export default () => `
 
 	WITH character, materialRel, material, entityRel.credit AS writingCreditName,
 		COLLECT(
-			CASE entity WHEN NULL
+			CASE WHEN entity IS NULL
 				THEN null
 				ELSE entity {
 					model: TOUPPER(HEAD(LABELS(entity))),
@@ -64,13 +64,13 @@ export default () => `
 					.name,
 					.format,
 					.year,
-					surMaterial: CASE entitySurMaterial WHEN NULL
+					surMaterial: CASE WHEN entitySurMaterial IS NULL
 						THEN null
 						ELSE entitySurMaterial {
 							model: 'MATERIAL',
 							.uuid,
 							.name,
-							surMaterial: CASE entitySurSurMaterial WHEN NULL
+							surMaterial: CASE WHEN entitySurSurMaterial IS NULL
 								THEN null
 								ELSE entitySurSurMaterial { model: 'MATERIAL', .uuid, .name }
 							END
@@ -122,7 +122,7 @@ export default () => `
 
 	WITH character,
 		COLLECT(
-			CASE material WHEN NULL
+			CASE WHEN material IS NULL
 				THEN null
 				ELSE material {
 					model: 'MATERIAL',
@@ -130,13 +130,13 @@ export default () => `
 					.name,
 					.format,
 					.year,
-					surMaterial: CASE surMaterial WHEN NULL
+					surMaterial: CASE WHEN surMaterial IS NULL
 						THEN null
 						ELSE surMaterial {
 							model: 'MATERIAL',
 							.uuid,
 							.name,
-							surMaterial: CASE surSurMaterial WHEN NULL
+							surMaterial: CASE WHEN surSurMaterial IS NULL
 								THEN null
 								ELSE surSurMaterial { model: 'MATERIAL', .uuid, .name }
 							END

--- a/src/neo4j/cypher-queries/character/show/show-productions.js
+++ b/src/neo4j/cypher-queries/character/show/show-productions.js
@@ -51,7 +51,7 @@ export default () => `
 
 	WITH variantNamedPortrayals, production, person, role,
 		COLLECT(DISTINCT(
-			CASE otherRole WHEN NULL
+			CASE WHEN otherRole IS NULL
 				THEN null
 				ELSE {
 					model: 'CHARACTER',
@@ -101,7 +101,7 @@ export default () => `
 	RETURN
 		variantNamedPortrayals,
 		COLLECT(
-			CASE production WHEN NULL
+			CASE WHEN production IS NULL
 				THEN null
 				ELSE production {
 					model: 'PRODUCTION',
@@ -109,25 +109,25 @@ export default () => `
 					.name,
 					.startDate,
 					.endDate,
-					venue: CASE venue WHEN NULL
+					venue: CASE WHEN venue IS NULL
 						THEN null
 						ELSE venue {
 							model: 'VENUE',
 							.uuid,
 							.name,
-							surVenue: CASE surVenue WHEN NULL
+							surVenue: CASE WHEN surVenue IS NULL
 								THEN null
 								ELSE surVenue { model: 'VENUE', .uuid, .name }
 							END
 						}
 					END,
-					surProduction: CASE surProduction WHEN NULL
+					surProduction: CASE WHEN surProduction IS NULL
 						THEN null
 						ELSE surProduction {
 							model: 'PRODUCTION',
 							.uuid,
 							.name,
-							surProduction: CASE surSurProduction WHEN NULL
+							surProduction: CASE WHEN surSurProduction IS NULL
 								THEN null
 								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
 							END

--- a/src/neo4j/cypher-queries/company/show/show-awards-rights-grantor-material.js
+++ b/src/neo4j/cypher-queries/company/show/show-awards-rights-grantor-material.js
@@ -70,7 +70,7 @@ export default () => `
 
 	WITH nominatedRightsGrantorMaterial, nomineeRel, category, categoryRel, ceremony,
 		COLLECT(
-			CASE nominatedEntity WHEN NULL
+			CASE WHEN nominatedEntity IS NULL
 				THEN null
 				ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
 			END
@@ -114,7 +114,7 @@ export default () => `
 
 	WITH nominatedRightsGrantorMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
 		COLLECT(
-			CASE nominatedProduction WHEN NULL
+			CASE WHEN nominatedProduction IS NULL
 				THEN null
 				ELSE nominatedProduction {
 					model: 'PRODUCTION',
@@ -122,25 +122,25 @@ export default () => `
 					.name,
 					.startDate,
 					.endDate,
-					venue: CASE venue WHEN NULL
+					venue: CASE WHEN venue IS NULL
 						THEN null
 						ELSE venue {
 							model: 'VENUE',
 							.uuid,
 							.name,
-							surVenue: CASE surVenue WHEN NULL
+							surVenue: CASE WHEN surVenue IS NULL
 								THEN null
 								ELSE surVenue { model: 'VENUE', .uuid, .name }
 							END
 						}
 					END,
-					surProduction: CASE surProduction WHEN NULL
+					surProduction: CASE WHEN surProduction IS NULL
 						THEN null
 						ELSE surProduction {
 							model: 'PRODUCTION',
 							.uuid,
 							.name,
-							surProduction: CASE surSurProduction WHEN NULL
+							surProduction: CASE WHEN surSurProduction IS NULL
 								THEN null
 								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
 							END
@@ -182,7 +182,7 @@ export default () => `
 		nominatedEntities,
 		nominatedProductions,
 		COLLECT(
-			CASE nominatedMaterial WHEN NULL
+			CASE WHEN nominatedMaterial IS NULL
 				THEN null
 				ELSE nominatedMaterial {
 					model: 'MATERIAL',
@@ -190,7 +190,7 @@ export default () => `
 					.name,
 					.format,
 					.year,
-					surMaterial: CASE nominatedSurMaterial WHEN NULL
+					surMaterial: CASE WHEN nominatedSurMaterial IS NULL
 						THEN null
 						ELSE nominatedSurMaterial { model: 'MATERIAL', .uuid, .name }
 					END
@@ -214,7 +214,7 @@ export default () => `
 		nominatedProductions,
 		nominatedMaterials,
 		COLLECT(
-			CASE nominatedRightsGrantorMaterial WHEN NULL
+			CASE WHEN nominatedRightsGrantorMaterial IS NULL
 				THEN null
 				ELSE nominatedRightsGrantorMaterial {
 					model: 'MATERIAL',
@@ -222,13 +222,13 @@ export default () => `
 					.name,
 					.format,
 					.year,
-					surMaterial: CASE nominatedRightsGrantorSurMaterial WHEN NULL
+					surMaterial: CASE WHEN nominatedRightsGrantorSurMaterial IS NULL
 						THEN null
 						ELSE nominatedRightsGrantorSurMaterial {
 							model: 'MATERIAL',
 							.uuid,
 							.name,
-							surMaterial: CASE nominatedRightsGrantorSurSurMaterial WHEN NULL
+							surMaterial: CASE WHEN nominatedRightsGrantorSurSurMaterial IS NULL
 								THEN null
 								ELSE nominatedRightsGrantorSurSurMaterial { model: 'MATERIAL', .uuid, .name }
 							END

--- a/src/neo4j/cypher-queries/company/show/show-awards-sourcing-material.js
+++ b/src/neo4j/cypher-queries/company/show/show-awards-sourcing-material.js
@@ -73,7 +73,7 @@ export default () => `
 
 	WITH nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony,
 		COLLECT(
-			CASE nominatedEntity WHEN NULL
+			CASE WHEN nominatedEntity IS NULL
 				THEN null
 				ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
 			END
@@ -117,7 +117,7 @@ export default () => `
 
 	WITH nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
 		COLLECT(
-			CASE nominatedProduction WHEN NULL
+			CASE WHEN nominatedProduction IS NULL
 				THEN null
 				ELSE nominatedProduction {
 					model: 'PRODUCTION',
@@ -125,25 +125,25 @@ export default () => `
 					.name,
 					.startDate,
 					.endDate,
-					venue: CASE venue WHEN NULL
+					venue: CASE WHEN venue IS NULL
 						THEN null
 						ELSE venue {
 							model: 'VENUE',
 							.uuid,
 							.name,
-							surVenue: CASE surVenue WHEN NULL
+							surVenue: CASE WHEN surVenue IS NULL
 								THEN null
 								ELSE surVenue { model: 'VENUE', .uuid, .name }
 							END
 						}
 					END,
-					surProduction: CASE surProduction WHEN NULL
+					surProduction: CASE WHEN surProduction IS NULL
 						THEN null
 						ELSE surProduction {
 							model: 'PRODUCTION',
 							.uuid,
 							.name,
-							surProduction: CASE surSurProduction WHEN NULL
+							surProduction: CASE WHEN surSurProduction IS NULL
 								THEN null
 								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
 							END
@@ -185,7 +185,7 @@ export default () => `
 		nominatedEntities,
 		nominatedProductions,
 		COLLECT(
-			CASE nominatedMaterial WHEN NULL
+			CASE WHEN nominatedMaterial IS NULL
 				THEN null
 				ELSE nominatedMaterial {
 					model: 'MATERIAL',
@@ -193,7 +193,7 @@ export default () => `
 					.name,
 					.format,
 					.year,
-					surMaterial: CASE nominatedSurMaterial WHEN NULL
+					surMaterial: CASE WHEN nominatedSurMaterial IS NULL
 						THEN null
 						ELSE nominatedSurMaterial { model: 'MATERIAL', .uuid, .name }
 					END
@@ -216,7 +216,7 @@ export default () => `
 		nominatedProductions,
 		nominatedMaterials,
 		COLLECT(
-			CASE nominatedSourcingMaterial WHEN NULL
+			CASE WHEN nominatedSourcingMaterial IS NULL
 				THEN null
 				ELSE nominatedSourcingMaterial {
 					model: 'MATERIAL',
@@ -224,13 +224,13 @@ export default () => `
 					.name,
 					.format,
 					.year,
-					surMaterial: CASE nominatedSourcingSurMaterial WHEN NULL
+					surMaterial: CASE WHEN nominatedSourcingSurMaterial IS NULL
 						THEN null
 						ELSE nominatedSourcingSurMaterial {
 							model: 'MATERIAL',
 							.uuid,
 							.name,
-							surMaterial: CASE nominatedSourcingSurSurMaterial WHEN NULL
+							surMaterial: CASE WHEN nominatedSourcingSurSurMaterial IS NULL
 								THEN null
 								ELSE nominatedSourcingSurSurMaterial { model: 'MATERIAL', .uuid, .name }
 							END

--- a/src/neo4j/cypher-queries/company/show/show-awards-subsequent-version-material.js
+++ b/src/neo4j/cypher-queries/company/show/show-awards-subsequent-version-material.js
@@ -70,7 +70,7 @@ export default () => `
 
 	WITH nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony,
 		COLLECT(
-			CASE nominatedEntity WHEN NULL
+			CASE WHEN nominatedEntity IS NULL
 				THEN null
 				ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
 			END
@@ -114,7 +114,7 @@ export default () => `
 
 	WITH nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
 		COLLECT(
-			CASE nominatedProduction WHEN NULL
+			CASE WHEN nominatedProduction IS NULL
 				THEN null
 				ELSE nominatedProduction {
 					model: 'PRODUCTION',
@@ -122,25 +122,25 @@ export default () => `
 					.name,
 					.startDate,
 					.endDate,
-					venue: CASE venue WHEN NULL
+					venue: CASE WHEN venue IS NULL
 						THEN null
 						ELSE venue {
 							model: 'VENUE',
 							.uuid,
 							.name,
-							surVenue: CASE surVenue WHEN NULL
+							surVenue: CASE WHEN surVenue IS NULL
 								THEN null
 								ELSE surVenue { model: 'VENUE', .uuid, .name }
 							END
 						}
 					END,
-					surProduction: CASE surProduction WHEN NULL
+					surProduction: CASE WHEN surProduction IS NULL
 						THEN null
 						ELSE surProduction {
 							model: 'PRODUCTION',
 							.uuid,
 							.name,
-							surProduction: CASE surSurProduction WHEN NULL
+							surProduction: CASE WHEN surSurProduction IS NULL
 								THEN null
 								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
 							END
@@ -182,7 +182,7 @@ export default () => `
 		nominatedEntities,
 		nominatedProductions,
 		COLLECT(
-			CASE nominatedMaterial WHEN NULL
+			CASE WHEN nominatedMaterial IS NULL
 				THEN null
 				ELSE nominatedMaterial {
 					model: 'MATERIAL',
@@ -190,7 +190,7 @@ export default () => `
 					.name,
 					.format,
 					.year,
-					surMaterial: CASE nominatedSurMaterial WHEN NULL
+					surMaterial: CASE WHEN nominatedSurMaterial IS NULL
 						THEN null
 						ELSE nominatedSurMaterial { model: 'MATERIAL', .uuid, .name }
 					END
@@ -216,7 +216,7 @@ export default () => `
 		nominatedProductions,
 		nominatedMaterials,
 		COLLECT(
-			CASE nominatedSubsequentVersionMaterial WHEN NULL
+			CASE WHEN nominatedSubsequentVersionMaterial IS NULL
 				THEN null
 				ELSE nominatedSubsequentVersionMaterial {
 					model: 'MATERIAL',
@@ -224,13 +224,13 @@ export default () => `
 					.name,
 					.format,
 					.year,
-					surMaterial: CASE nominatedSubsequentVersionSurMaterial WHEN NULL
+					surMaterial: CASE WHEN nominatedSubsequentVersionSurMaterial IS NULL
 						THEN null
 						ELSE nominatedSubsequentVersionSurMaterial {
 							model: 'MATERIAL',
 							.uuid,
 							.name,
-							surMaterial: CASE nominatedSubsequentVersionSurSurMaterial WHEN NULL
+							surMaterial: CASE WHEN nominatedSubsequentVersionSurSurMaterial IS NULL
 								THEN null
 								ELSE nominatedSubsequentVersionSurSurMaterial { model: 'MATERIAL', .uuid, .name }
 							END

--- a/src/neo4j/cypher-queries/company/show/show-awards.js
+++ b/src/neo4j/cypher-queries/company/show/show-awards.js
@@ -75,7 +75,7 @@ export default () => `
 
 	WITH nominatedMembers, nomineeRel, category, categoryRel, ceremony,
 		COLLECT(
-			CASE coNominatedEntity WHEN NULL
+			CASE WHEN coNominatedEntity IS NULL
 				THEN null
 				ELSE coNominatedEntity {
 					model: TOUPPER(HEAD(LABELS(coNominatedEntity))),
@@ -124,7 +124,7 @@ export default () => `
 
 	WITH nomineeRel, category, categoryRel, ceremony, nominatedMembers, coNominatedEntities,
 		COLLECT(
-			CASE nominatedProduction WHEN NULL
+			CASE WHEN nominatedProduction IS NULL
 				THEN null
 				ELSE nominatedProduction {
 					model: 'PRODUCTION',
@@ -132,25 +132,25 @@ export default () => `
 					.name,
 					.startDate,
 					.endDate,
-					venue: CASE venue WHEN NULL
+					venue: CASE WHEN venue IS NULL
 						THEN null
 						ELSE venue {
 							model: 'VENUE',
 							.uuid,
 							.name,
-							surVenue: CASE surVenue WHEN NULL
+							surVenue: CASE WHEN surVenue IS NULL
 								THEN null
 								ELSE surVenue { model: 'VENUE', .uuid, .name }
 							END
 						}
 					END,
-					surProduction: CASE surProduction WHEN NULL
+					surProduction: CASE WHEN surProduction IS NULL
 						THEN null
 						ELSE surProduction {
 							model: 'PRODUCTION',
 							.uuid,
 							.name,
-							surProduction: CASE surSurProduction WHEN NULL
+							surProduction: CASE WHEN surSurProduction IS NULL
 								THEN null
 								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
 							END
@@ -185,7 +185,7 @@ export default () => `
 
 	WITH nomineeRel, category, categoryRel, ceremony, nominatedMembers, coNominatedEntities, nominatedProductions,
 		COLLECT(
-			CASE nominatedMaterial WHEN NULL
+			CASE WHEN nominatedMaterial IS NULL
 				THEN null
 				ELSE nominatedMaterial {
 					model: 'MATERIAL',
@@ -193,13 +193,13 @@ export default () => `
 					.name,
 					.format,
 					.year,
-					surMaterial: CASE nominatedSurMaterial WHEN NULL
+					surMaterial: CASE WHEN nominatedSurMaterial IS NULL
 						THEN null
 						ELSE nominatedSurMaterial {
 							model: 'MATERIAL',
 							.uuid,
 							.name,
-							surMaterial: CASE nominatedSurSurMaterial WHEN NULL
+							surMaterial: CASE WHEN nominatedSurSurMaterial IS NULL
 								THEN null
 								ELSE nominatedSurSurMaterial { model: 'MATERIAL', .uuid, .name }
 							END

--- a/src/neo4j/cypher-queries/company/show/show-materials.js
+++ b/src/neo4j/cypher-queries/company/show/show-materials.js
@@ -33,9 +33,9 @@ export default () => `
 			company,
 			material,
 			writerRel.creditType AS creditType,
-			CASE writerRel WHEN NULL THEN false ELSE true END AS hasDirectCredit,
-			CASE subsequentVersionRel WHEN NULL THEN false ELSE true END AS isSubsequentVersion,
-			CASE sourcingMaterialRel WHEN NULL THEN false ELSE true END AS isSourcingMaterial,
+			CASE WHEN writerRel IS NULL THEN false ELSE true END AS hasDirectCredit,
+			CASE WHEN subsequentVersionRel IS NULL THEN false ELSE true END AS isSubsequentVersion,
+			CASE WHEN sourcingMaterialRel IS NULL THEN false ELSE true END AS isSourcingMaterial,
 			entityRel,
 			entity,
 			entitySurMaterial,
@@ -57,7 +57,7 @@ export default () => `
 			entitySurSurMaterial,
 			sourceMaterialWriterRel.credit AS sourceMaterialWritingCreditName,
 			COLLECT(
-				CASE sourceMaterialWriter WHEN NULL
+				CASE WHEN sourceMaterialWriter IS NULL
 					THEN null
 					ELSE sourceMaterialWriter { model: TOUPPER(HEAD(LABELS(sourceMaterialWriter))), .uuid, .name }
 				END
@@ -95,7 +95,7 @@ export default () => `
 			isSourcingMaterial,
 			entityRel.credit AS writingCreditName,
 			COLLECT(
-				CASE entity WHEN NULL
+				CASE WHEN entity IS NULL
 					THEN null
 					ELSE entity {
 						model: TOUPPER(HEAD(LABELS(entity))),
@@ -103,13 +103,13 @@ export default () => `
 						.name,
 						.format,
 						.year,
-						surMaterial: CASE entitySurMaterial WHEN NULL
+						surMaterial: CASE WHEN entitySurMaterial IS NULL
 							THEN null
 							ELSE entitySurMaterial {
 								model: 'MATERIAL',
 								.uuid,
 								.name,
-								surMaterial: CASE entitySurSurMaterial WHEN NULL
+								surMaterial: CASE WHEN entitySurSurMaterial IS NULL
 									THEN null
 									ELSE entitySurSurMaterial { model: 'MATERIAL', .uuid, .name }
 								END
@@ -166,7 +166,7 @@ export default () => `
 
 		WITH company,
 			COLLECT(
-				CASE material WHEN NULL
+				CASE WHEN material IS NULL
 					THEN null
 					ELSE material {
 						model: 'MATERIAL',
@@ -174,13 +174,13 @@ export default () => `
 						.name,
 						.format,
 						.year,
-						surMaterial: CASE surMaterial WHEN NULL
+						surMaterial: CASE WHEN surMaterial IS NULL
 							THEN null
 							ELSE surMaterial {
 								model: 'MATERIAL',
 								.uuid,
 								.name,
-								surMaterial: CASE surSurMaterial WHEN NULL
+								surMaterial: CASE WHEN surSurMaterial IS NULL
 									THEN null
 									ELSE surSurMaterial { model: 'MATERIAL', .uuid, .name }
 								END

--- a/src/neo4j/cypher-queries/company/show/show-productions.js
+++ b/src/neo4j/cypher-queries/company/show/show-productions.js
@@ -32,7 +32,7 @@ export default () => `
 
 	WITH company, production, entityRel.credit AS producerCreditName,
 		COLLECT(
-			CASE entity WHEN NULL
+			CASE WHEN entity IS NULL
 				THEN null
 				ELSE entity { model: TOUPPER(HEAD(LABELS(entity))), .uuid, .name, members: creditedMembers }
 			END
@@ -84,7 +84,7 @@ export default () => `
 
 	WITH company,
 		COLLECT(
-			CASE production WHEN NULL
+			CASE WHEN production IS NULL
 				THEN null
 				ELSE production {
 					model: 'PRODUCTION',
@@ -92,25 +92,25 @@ export default () => `
 					.name,
 					.startDate,
 					.endDate,
-					venue: CASE venue WHEN NULL
+					venue: CASE WHEN venue IS NULL
 						THEN null
 						ELSE venue {
 							model: 'VENUE',
 							.uuid,
 							.name,
-							surVenue: CASE surVenue WHEN NULL
+							surVenue: CASE WHEN surVenue IS NULL
 								THEN null
 								ELSE surVenue { model: 'VENUE', .uuid, .name }
 							END
 						}
 					END,
-					surProduction: CASE surProduction WHEN NULL
+					surProduction: CASE WHEN surProduction IS NULL
 						THEN null
 						ELSE surProduction {
 							model: 'PRODUCTION',
 							.uuid,
 							.name,
-							surProduction: CASE surSurProduction WHEN NULL
+							surProduction: CASE WHEN surSurProduction IS NULL
 								THEN null
 								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
 							END
@@ -184,7 +184,7 @@ export default () => `
 
 	WITH company, producerProductions, creativeRel, production, creditedMembers,
 		COLLECT(
-			CASE coCreditedEntity WHEN NULL
+			CASE WHEN coCreditedEntity IS NULL
 				THEN null
 				ELSE coCreditedEntity {
 					model: TOUPPER(HEAD(LABELS(coCreditedEntity))),
@@ -236,7 +236,7 @@ export default () => `
 
 	WITH company, producerProductions,
 		COLLECT(
-			CASE production WHEN NULL
+			CASE WHEN production IS NULL
 				THEN null
 				ELSE production {
 					model: 'PRODUCTION',
@@ -244,25 +244,25 @@ export default () => `
 					.name,
 					.startDate,
 					.endDate,
-					venue: CASE venue WHEN NULL
+					venue: CASE WHEN venue IS NULL
 						THEN null
 						ELSE venue {
 							model: 'VENUE',
 							.uuid,
 							.name,
-							surVenue: CASE surVenue WHEN NULL
+							surVenue: CASE WHEN surVenue IS NULL
 								THEN null
 								ELSE surVenue { model: 'VENUE', .uuid, .name }
 							END
 						}
 					END,
-					surProduction: CASE surProduction WHEN NULL
+					surProduction: CASE WHEN surProduction IS NULL
 						THEN null
 						ELSE surProduction {
 							model: 'PRODUCTION',
 							.uuid,
 							.name,
-							surProduction: CASE surSurProduction WHEN NULL
+							surProduction: CASE WHEN surSurProduction IS NULL
 								THEN null
 								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
 							END
@@ -336,7 +336,7 @@ export default () => `
 
 	WITH producerProductions, creativeProductions, crewRel, production, creditedMembers,
 		COLLECT(
-			CASE coCreditedEntity WHEN NULL
+			CASE WHEN coCreditedEntity IS NULL
 				THEN null
 				ELSE coCreditedEntity {
 					model: TOUPPER(HEAD(LABELS(coCreditedEntity))),
@@ -390,7 +390,7 @@ export default () => `
 		producerProductions,
 		creativeProductions,
 		COLLECT(
-			CASE production WHEN NULL
+			CASE WHEN production IS NULL
 				THEN null
 				ELSE production {
 					model: 'PRODUCTION',
@@ -398,25 +398,25 @@ export default () => `
 					.name,
 					.startDate,
 					.endDate,
-					venue: CASE venue WHEN NULL
+					venue: CASE WHEN venue IS NULL
 						THEN null
 						ELSE venue {
 							model: 'VENUE',
 							.uuid,
 							.name,
-							surVenue: CASE surVenue WHEN NULL
+							surVenue: CASE WHEN surVenue IS NULL
 								THEN null
 								ELSE surVenue { model: 'VENUE', .uuid, .name }
 							END
 						}
 					END,
-					surProduction: CASE surProduction WHEN NULL
+					surProduction: CASE WHEN surProduction IS NULL
 						THEN null
 						ELSE surProduction {
 							model: 'PRODUCTION',
 							.uuid,
 							.name,
-							surProduction: CASE surSurProduction WHEN NULL
+							surProduction: CASE WHEN surSurProduction IS NULL
 								THEN null
 								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
 							END

--- a/src/neo4j/cypher-queries/material/create-update.js
+++ b/src/neo4j/cypher-queries/material/create-update.js
@@ -68,7 +68,7 @@ const getCreateUpdateQuery = action => {
 				) OR
 				$originalVersionMaterial.differentiator = existingOriginalVersionMaterial.differentiator
 
-		FOREACH (item IN CASE $originalVersionMaterial.name WHEN NULL THEN [] ELSE [1] END |
+		FOREACH (item IN CASE WHEN $originalVersionMaterial.name IS NULL THEN [] ELSE [1] END |
 			MERGE (originalVersionMaterial:Material {
 				uuid: COALESCE(existingOriginalVersionMaterial.uuid, $originalVersionMaterial.uuid),
 				name: $originalVersionMaterial.name
@@ -93,7 +93,7 @@ const getCreateUpdateQuery = action => {
 						(writingPersonParam.differentiator IS NULL AND existingWritingPerson.differentiator IS NULL) OR
 						writingPersonParam.differentiator = existingWritingPerson.differentiator
 
-				FOREACH (item IN CASE writingPersonParam WHEN NULL THEN [] ELSE [1] END |
+				FOREACH (item IN CASE WHEN writingPersonParam IS NULL THEN [] ELSE [1] END |
 					MERGE (writingPerson:Person {
 						uuid: COALESCE(existingWritingPerson.uuid, writingPersonParam.uuid),
 						name: writingPersonParam.name
@@ -125,7 +125,7 @@ const getCreateUpdateQuery = action => {
 						) OR
 						writingCompanyParam.differentiator = existingWritingCompany.differentiator
 
-				FOREACH (item IN CASE writingCompanyParam WHEN NULL THEN [] ELSE [1] END |
+				FOREACH (item IN CASE WHEN writingCompanyParam IS NULL THEN [] ELSE [1] END |
 					MERGE (writingCompany:Company {
 						uuid: COALESCE(existingWritingCompany.uuid, writingCompanyParam.uuid),
 						name: writingCompanyParam.name
@@ -157,7 +157,7 @@ const getCreateUpdateQuery = action => {
 						) OR
 						sourceMaterialParam.differentiator = existingSourceMaterial.differentiator
 
-				FOREACH (item IN CASE sourceMaterialParam WHEN NULL THEN [] ELSE [1] END |
+				FOREACH (item IN CASE WHEN sourceMaterialParam IS NULL THEN [] ELSE [1] END |
 					MERGE (sourceMaterial:Material {
 						uuid: COALESCE(existingSourceMaterial.uuid, sourceMaterialParam.uuid),
 						name: sourceMaterialParam.name
@@ -181,7 +181,7 @@ const getCreateUpdateQuery = action => {
 						(subMaterialParam.differentiator IS NULL AND existingSubMaterial.differentiator IS NULL) OR
 						subMaterialParam.differentiator = existingSubMaterial.differentiator
 
-				FOREACH (item IN CASE subMaterialParam WHEN NULL THEN [] ELSE [1] END |
+				FOREACH (item IN CASE WHEN subMaterialParam IS NULL THEN [] ELSE [1] END |
 					MERGE (subMaterial:Material {
 						uuid: COALESCE(existingSubMaterial.uuid, subMaterialParam.uuid),
 						name: subMaterialParam.name
@@ -210,7 +210,7 @@ const getCreateUpdateQuery = action => {
 						(characterParam.differentiator IS NULL AND existingCharacter.differentiator IS NULL) OR
 						characterParam.differentiator = existingCharacter.differentiator
 
-				FOREACH (item IN CASE characterParam WHEN NULL THEN [] ELSE [1] END |
+				FOREACH (item IN CASE WHEN characterParam IS NULL THEN [] ELSE [1] END |
 					MERGE (character:Character {
 						uuid: COALESCE(existingCharacter.uuid, characterParam.uuid),
 						name: COALESCE(characterParam.underlyingName, characterParam.name)
@@ -221,7 +221,7 @@ const getCreateUpdateQuery = action => {
 						[:DEPICTS {
 							groupPosition: characterGroup.position,
 							characterPosition: characterParam.position,
-							displayName: CASE characterParam.underlyingName WHEN NULL
+							displayName: CASE WHEN characterParam.underlyingName IS NULL
 								THEN null
 								ELSE characterParam.name
 							END,

--- a/src/neo4j/cypher-queries/material/edit.js
+++ b/src/neo4j/cypher-queries/material/edit.js
@@ -15,7 +15,7 @@ export default () => `
 		entityRel.credit AS writingCreditName,
 		entityRel.creditType AS writingCreditType,
 		COLLECT(
-			CASE entity WHEN NULL
+			CASE WHEN entity IS NULL
 				THEN null
 				ELSE entity { model: TOUPPER(HEAD(LABELS(entity))), .name, .differentiator }
 			END
@@ -40,7 +40,7 @@ export default () => `
 
 	WITH material, originalVersionMaterial, writingCredits,
 		COLLECT(
-			CASE subMaterial WHEN NULL
+			CASE WHEN subMaterial IS NULL
 				THEN null
 				ELSE subMaterial { .name, .differentiator, .format, .year }
 			END
@@ -53,11 +53,11 @@ export default () => `
 
 	WITH material, originalVersionMaterial, writingCredits, subMaterials, characterRel.group AS characterGroupName,
 		COLLECT(
-			CASE character WHEN NULL
+			CASE WHEN character IS NULL
 				THEN null
 				ELSE character {
 					name: COALESCE(characterRel.displayName, character.name),
-					underlyingName: CASE characterRel.displayName WHEN NULL THEN null ELSE character.name END,
+					underlyingName: CASE WHEN characterRel.displayName IS NULL THEN null ELSE character.name END,
 					.differentiator,
 					qualifier: characterRel.qualifier,
 					group: characterRel.group

--- a/src/neo4j/cypher-queries/material/list.js
+++ b/src/neo4j/cypher-queries/material/list.js
@@ -30,7 +30,7 @@ export default () => `
 		entitySurSurMaterial,
 		sourceMaterialWriterRel.credit AS sourceMaterialWritingCreditName,
 		COLLECT(
-			CASE sourceMaterialWriter WHEN NULL
+			CASE WHEN sourceMaterialWriter IS NULL
 				THEN null
 				ELSE sourceMaterialWriter { model: TOUPPER(HEAD(LABELS(sourceMaterialWriter))), .uuid, .name }
 			END
@@ -51,7 +51,7 @@ export default () => `
 
 	WITH material, entityRel.credit AS writingCreditName,
 		COLLECT(
-			CASE entity WHEN NULL
+			CASE WHEN entity IS NULL
 				THEN null
 				ELSE entity {
 					model: TOUPPER(HEAD(LABELS(entity))),
@@ -59,13 +59,13 @@ export default () => `
 					.name,
 					.format,
 					.year,
-					surMaterial: CASE entitySurMaterial WHEN NULL
+					surMaterial: CASE WHEN entitySurMaterial IS NULL
 						THEN null
 						ELSE entitySurMaterial {
 							model: 'MATERIAL',
 							.uuid,
 							.name,
-							surMaterial: CASE entitySurSurMaterial WHEN NULL
+							surMaterial: CASE WHEN entitySurSurMaterial IS NULL
 								THEN null
 								ELSE entitySurSurMaterial { model: 'MATERIAL', .uuid, .name }
 							END
@@ -104,13 +104,13 @@ export default () => `
 		material.name AS name,
 		material.format AS format,
 		material.year AS year,
-		CASE surMaterial WHEN NULL
+		CASE WHEN surMaterial IS NULL
 			THEN null
 			ELSE surMaterial {
 				model: 'MATERIAL',
 				.uuid,
 				.name,
-				surMaterial: CASE surSurMaterial WHEN NULL
+				surMaterial: CASE WHEN surSurMaterial IS NULL
 					THEN null
 					ELSE surSurMaterial { model: 'MATERIAL', .uuid, .name }
 				END

--- a/src/neo4j/cypher-queries/material/show/show-awards-sourcing-material.js
+++ b/src/neo4j/cypher-queries/material/show/show-awards-sourcing-material.js
@@ -72,7 +72,7 @@ export default () => `
 
 	WITH material, nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony,
 		COLLECT(
-			CASE nominatedEntity WHEN NULL
+			CASE WHEN nominatedEntity IS NULL
 				THEN null
 				ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
 			END
@@ -117,7 +117,7 @@ export default () => `
 
 	WITH material, nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
 		COLLECT(
-			CASE nominatedProduction WHEN NULL
+			CASE WHEN nominatedProduction IS NULL
 				THEN null
 				ELSE nominatedProduction {
 					model: 'PRODUCTION',
@@ -125,25 +125,25 @@ export default () => `
 					.name,
 					.startDate,
 					.endDate,
-					venue: CASE venue WHEN NULL
+					venue: CASE WHEN venue IS NULL
 						THEN null
 						ELSE venue {
 							model: 'VENUE',
 							.uuid,
 							.name,
-							surVenue: CASE surVenue WHEN NULL
+							surVenue: CASE WHEN surVenue IS NULL
 								THEN null
 								ELSE surVenue { model: 'VENUE', .uuid, .name }
 							END
 						}
 					END,
-					surProduction: CASE surProduction WHEN NULL
+					surProduction: CASE WHEN surProduction IS NULL
 						THEN null
 						ELSE surProduction {
 							model: 'PRODUCTION',
 							.uuid,
 							.name,
-							surProduction: CASE surSurProduction WHEN NULL
+							surProduction: CASE WHEN surSurProduction IS NULL
 								THEN null
 								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
 							END
@@ -183,7 +183,7 @@ export default () => `
 		nominatedEntities,
 		nominatedProductions,
 		COLLECT(
-			CASE nominatedMaterial WHEN NULL
+			CASE WHEN nominatedMaterial IS NULL
 				THEN null
 				ELSE nominatedMaterial { model: 'MATERIAL', .uuid, .name, .format, .year }
 			END
@@ -204,7 +204,7 @@ export default () => `
 		nominatedProductions,
 		nominatedMaterials,
 		COLLECT(
-			CASE nominatedSourcingMaterial WHEN NULL
+			CASE WHEN nominatedSourcingMaterial IS NULL
 				THEN null
 				ELSE nominatedSourcingMaterial {
 					model: 'MATERIAL',
@@ -212,13 +212,13 @@ export default () => `
 					.name,
 					.format,
 					.year,
-					surMaterial: CASE nominatedSourcingSurMaterial WHEN NULL
+					surMaterial: CASE WHEN nominatedSourcingSurMaterial IS NULL
 						THEN null
 						ELSE nominatedSourcingSurMaterial {
 							model: 'MATERIAL',
 							.uuid,
 							.name,
-							surMaterial: CASE nominatedSourcingSurSurMaterial WHEN NULL
+							surMaterial: CASE WHEN nominatedSourcingSurSurMaterial IS NULL
 								THEN null
 								ELSE nominatedSourcingSurSurMaterial { model: 'MATERIAL', .uuid, .name }
 							END

--- a/src/neo4j/cypher-queries/material/show/show-awards-subsequent-version-material.js
+++ b/src/neo4j/cypher-queries/material/show/show-awards-subsequent-version-material.js
@@ -72,7 +72,7 @@ export default () => `
 
 	WITH material, nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony,
 		COLLECT(
-			CASE nominatedEntity WHEN NULL
+			CASE WHEN nominatedEntity IS NULL
 				THEN null
 				ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
 			END
@@ -117,7 +117,7 @@ export default () => `
 
 	WITH material, nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
 		COLLECT(
-			CASE nominatedProduction WHEN NULL
+			CASE WHEN nominatedProduction IS NULL
 				THEN null
 				ELSE nominatedProduction {
 					model: 'PRODUCTION',
@@ -125,25 +125,25 @@ export default () => `
 					.name,
 					.startDate,
 					.endDate,
-					venue: CASE venue WHEN NULL
+					venue: CASE WHEN venue IS NULL
 						THEN null
 						ELSE venue {
 							model: 'VENUE',
 							.uuid,
 							.name,
-							surVenue: CASE surVenue WHEN NULL
+							surVenue: CASE WHEN surVenue IS NULL
 								THEN null
 								ELSE surVenue { model: 'VENUE', .uuid, .name }
 							END
 						}
 					END,
-					surProduction: CASE surProduction WHEN NULL
+					surProduction: CASE WHEN surProduction IS NULL
 						THEN null
 						ELSE surProduction {
 							model: 'PRODUCTION',
 							.uuid,
 							.name,
-							surProduction: CASE surSurProduction WHEN NULL
+							surProduction: CASE WHEN surSurProduction IS NULL
 								THEN null
 								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
 							END
@@ -183,7 +183,7 @@ export default () => `
 		nominatedEntities,
 		nominatedProductions,
 		COLLECT(
-			CASE nominatedMaterial WHEN NULL
+			CASE WHEN nominatedMaterial IS NULL
 				THEN null
 				ELSE nominatedMaterial { model: 'MATERIAL', .uuid, .name, .format, .year }
 			END
@@ -206,7 +206,7 @@ export default () => `
 		nominatedProductions,
 		nominatedMaterials,
 		COLLECT(
-			CASE nominatedSubsequentVersionMaterial WHEN NULL
+			CASE WHEN nominatedSubsequentVersionMaterial IS NULL
 				THEN null
 				ELSE nominatedSubsequentVersionMaterial {
 					model: 'MATERIAL',
@@ -214,13 +214,13 @@ export default () => `
 					.name,
 					.format,
 					.year,
-					surMaterial: CASE nominatedSubsequentVersionSurMaterial WHEN NULL
+					surMaterial: CASE WHEN nominatedSubsequentVersionSurMaterial IS NULL
 						THEN null
 						ELSE nominatedSubsequentVersionSurMaterial {
 							model: 'MATERIAL',
 							.uuid,
 							.name,
-							surMaterial: CASE nominatedSubsequentVersionSurSurMaterial WHEN NULL
+							surMaterial: CASE WHEN nominatedSubsequentVersionSurSurMaterial IS NULL
 								THEN null
 								ELSE nominatedSubsequentVersionSurSurMaterial { model: 'MATERIAL', .uuid, .name }
 							END

--- a/src/neo4j/cypher-queries/material/show/show-awards.js
+++ b/src/neo4j/cypher-queries/material/show/show-awards.js
@@ -81,7 +81,7 @@ export default () => `
 
 	WITH material, recipientMaterial, nomineeRel, category, categoryRel, ceremony,
 		COLLECT(
-			CASE nominatedEntity WHEN NULL
+			CASE WHEN nominatedEntity IS NULL
 				THEN null
 				ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
 			END
@@ -126,7 +126,7 @@ export default () => `
 
 	WITH material, recipientMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
 		COLLECT(
-			CASE nominatedProduction WHEN NULL
+			CASE WHEN nominatedProduction IS NULL
 				THEN null
 				ELSE nominatedProduction {
 					model: 'PRODUCTION',
@@ -134,25 +134,25 @@ export default () => `
 					.name,
 					.startDate,
 					.endDate,
-					venue: CASE venue WHEN NULL
+					venue: CASE WHEN venue IS NULL
 						THEN null
 						ELSE venue {
 							model: 'VENUE',
 							.uuid,
 							.name,
-							surVenue: CASE surVenue WHEN NULL
+							surVenue: CASE WHEN surVenue IS NULL
 								THEN null
 								ELSE surVenue { model: 'VENUE', .uuid, .name }
 							END
 						}
 					END,
-					surProduction: CASE surProduction WHEN NULL
+					surProduction: CASE WHEN surProduction IS NULL
 						THEN null
 						ELSE surProduction {
 							model: 'PRODUCTION',
 							.uuid,
 							.name,
-							surProduction: CASE surSurProduction WHEN NULL
+							surProduction: CASE WHEN surSurProduction IS NULL
 								THEN null
 								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
 							END
@@ -189,7 +189,7 @@ export default () => `
 
 	WITH recipientMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities, nominatedProductions,
 		COLLECT(
-			CASE coNominatedMaterial WHEN NULL
+			CASE WHEN coNominatedMaterial IS NULL
 				THEN null
 				ELSE coNominatedMaterial {
 					model: 'MATERIAL',
@@ -197,13 +197,13 @@ export default () => `
 					.name,
 					.format,
 					.year,
-					surMaterial: CASE coNominatedMaterialSurMaterial WHEN NULL
+					surMaterial: CASE WHEN coNominatedMaterialSurMaterial IS NULL
 						THEN null
 						ELSE coNominatedMaterialSurMaterial {
 							model: 'MATERIAL',
 							.uuid,
 							.name,
-							surMaterial: CASE coNominatedMaterialSurSurMaterial WHEN NULL
+							surMaterial: CASE WHEN coNominatedMaterialSurSurMaterial IS NULL
 								THEN null
 								ELSE coNominatedMaterialSurSurMaterial { model: 'MATERIAL', .uuid, .name }
 							END
@@ -219,7 +219,7 @@ export default () => `
 			model: 'NOMINATION',
 			isWinner: COALESCE(nomineeRel.isWinner, false),
 			type: COALESCE(nomineeRel.customType, CASE WHEN nomineeRel.isWinner THEN 'Winner' ELSE 'Nomination' END),
-			recipientMaterial: CASE recipientMaterial WHEN NULL
+			recipientMaterial: CASE WHEN recipientMaterial IS NULL
 				THEN null
 				ELSE recipientMaterial { model: 'MATERIAL', .uuid, .name, .format, .year }
 			END,

--- a/src/neo4j/cypher-queries/material/show/show-materials.js
+++ b/src/neo4j/cypher-queries/material/show/show-materials.js
@@ -3,18 +3,16 @@ export default () => `
 
 	OPTIONAL MATCH (material)<-[:SUBSEQUENT_VERSION_OF]-(subsequentVersionMaterial)
 
-	WITH
-		material,
-		COLLECT(subsequentVersionMaterial) AS subsequentVersionMaterials
-
 	OPTIONAL MATCH (material)<-[:USES_SOURCE_MATERIAL]-(sourcingMaterial:Material)
 
 	WITH
 		material,
-		[material] +
-		subsequentVersionMaterials +
-		COLLECT(sourcingMaterial)
-			AS relatedMaterials
+		COLLECT(subsequentVersionMaterial) AS subsequentVersionMaterials,
+		COLLECT(sourcingMaterial) AS sourcingMaterials
+
+	WITH
+		material,
+		[material] + subsequentVersionMaterials + sourcingMaterials AS relatedMaterials
 
 	UNWIND (CASE relatedMaterials WHEN [] THEN [null] ELSE relatedMaterials END) AS relatedMaterial
 
@@ -37,13 +35,13 @@ export default () => `
 		WITH
 			material,
 			relatedMaterial,
-			CASE subsequentVersionRel WHEN NULL THEN false ELSE true END AS isSubsequentVersion,
-			CASE sourcingMaterialRel WHEN NULL THEN false ELSE true END AS isSourcingMaterial,
+			CASE WHEN subsequentVersionRel IS NULL THEN false ELSE true END AS isSubsequentVersion,
+			CASE WHEN sourcingMaterialRel IS NULL THEN false ELSE true END AS isSourcingMaterial,
 			entityRel,
 			entity,
 			entitySurMaterial,
 			entitySurSurMaterial,
-			CASE originalVersionWritingEntityRel WHEN NULL THEN false ELSE true END AS isOriginalVersionWritingEntity,
+			CASE WHEN originalVersionWritingEntityRel IS NULL THEN false ELSE true END AS isOriginalVersionWritingEntity,
 			sourceMaterialWriterRel,
 			sourceMaterialWriter
 			ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriterRel.entityPosition
@@ -60,7 +58,7 @@ export default () => `
 			isOriginalVersionWritingEntity,
 			sourceMaterialWriterRel.credit AS sourceMaterialWritingCreditName,
 			COLLECT(
-				CASE sourceMaterialWriter WHEN NULL
+				CASE WHEN sourceMaterialWriter IS NULL
 					THEN null
 					ELSE sourceMaterialWriter { model: TOUPPER(HEAD(LABELS(sourceMaterialWriter))), .uuid, .name }
 				END
@@ -103,13 +101,13 @@ export default () => `
 						.name,
 						.format,
 						.year,
-						surMaterial: CASE entitySurMaterial WHEN NULL
+						surMaterial: CASE WHEN entitySurMaterial IS NULL
 							THEN null
 							ELSE entitySurMaterial {
 								model: 'MATERIAL',
 								.uuid,
 								.name,
-								surMaterial: CASE entitySurSurMaterial WHEN NULL
+								surMaterial: CASE WHEN entitySurSurMaterial IS NULL
 									THEN null
 									ELSE entitySurSurMaterial { model: 'MATERIAL', .uuid, .name }
 								END
@@ -154,7 +152,7 @@ export default () => `
 
 		WITH material,
 			COLLECT(
-				CASE relatedMaterial WHEN NULL
+				CASE WHEN relatedMaterial IS NULL
 					THEN null
 					ELSE relatedMaterial {
 						model: 'MATERIAL',
@@ -162,13 +160,13 @@ export default () => `
 						.name,
 						.format,
 						.year,
-						surMaterial: CASE surMaterial WHEN NULL
+						surMaterial: CASE WHEN surMaterial IS NULL
 							THEN null
 							ELSE surMaterial {
 								model: 'MATERIAL',
 								.uuid,
 								.name,
-								surMaterial: CASE surSurMaterial WHEN NULL
+								surMaterial: CASE WHEN surSurMaterial IS NULL
 									THEN null
 									ELSE surSurMaterial { model: 'MATERIAL', .uuid, .name }
 								END

--- a/src/neo4j/cypher-queries/material/show/show-productions.js
+++ b/src/neo4j/cypher-queries/material/show/show-productions.js
@@ -25,7 +25,7 @@ export default () => `
 			surProductionRel,
 			surSurProduction,
 			surSurProductionRel,
-			CASE sourcingMaterialRel WHEN NULL THEN false ELSE true END AS usesSourcingMaterial
+			CASE WHEN sourcingMaterialRel IS NULL THEN false ELSE true END AS usesSourcingMaterial
 			ORDER BY
 				production.startDate DESC,
 				COALESCE(surSurProduction.name, surProduction.name, production.name),
@@ -36,7 +36,7 @@ export default () => `
 
 		WITH
 			COLLECT(
-				CASE production WHEN NULL
+				CASE WHEN production IS NULL
 					THEN null
 					ELSE production {
 						model: 'PRODUCTION',
@@ -45,25 +45,25 @@ export default () => `
 						.startDate,
 						.endDate,
 						usesSourcingMaterial,
-						venue: CASE venue WHEN NULL
+						venue: CASE WHEN venue IS NULL
 							THEN null
 							ELSE venue {
 								model: 'VENUE',
 								.uuid,
 								.name,
-								surVenue: CASE surVenue WHEN NULL
+								surVenue: CASE WHEN surVenue IS NULL
 									THEN null
 									ELSE surVenue { model: 'VENUE', .uuid, .name }
 								END
 							}
 						END,
-						surProduction: CASE surProduction WHEN NULL
+						surProduction: CASE WHEN surProduction IS NULL
 							THEN null
 							ELSE surProduction {
 								model: 'PRODUCTION',
 								.uuid,
 								.name,
-								surProduction: CASE surSurProduction WHEN NULL
+								surProduction: CASE WHEN surSurProduction IS NULL
 									THEN null
 									ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
 								END

--- a/src/neo4j/cypher-queries/material/show/show.js
+++ b/src/neo4j/cypher-queries/material/show/show.js
@@ -7,7 +7,12 @@ export default () => `
 
 	WITH
 		material,
-		[material] + COLLECT(surMaterial) + COLLECT(subMaterial) AS collectionMaterials
+		COLLECT(surMaterial) AS surMaterials,
+		COLLECT(subMaterial) AS subMaterials
+
+	WITH
+		material,
+		[material] + surMaterials + subMaterials AS collectionMaterials
 
 	UNWIND (CASE collectionMaterials WHEN [] THEN [null] ELSE collectionMaterials END) AS collectionMaterial
 
@@ -25,11 +30,11 @@ export default () => `
 			material,
 			collectionMaterial,
 			CASE WHEN material = collectionMaterial THEN true ELSE false END AS isSubjectMaterial,
-			CASE surMaterialRel WHEN NULL THEN false ELSE true END AS isSurMaterial,
-			CASE surSurMaterialRel WHEN NULL THEN false ELSE true END AS isSurSurMaterial,
-			CASE subMaterialRel WHEN NULL THEN false ELSE true END AS isSubMaterial,
+			CASE WHEN surMaterialRel IS NULL THEN false ELSE true END AS isSurMaterial,
+			CASE WHEN surSurMaterialRel IS NULL THEN false ELSE true END AS isSurSurMaterial,
+			CASE WHEN subMaterialRel IS NULL THEN false ELSE true END AS isSubMaterial,
 			subMaterialRel.position AS subMaterialPosition,
-			CASE subSubMaterialRel WHEN NULL THEN false ELSE true END AS isSubSubMaterial,
+			CASE WHEN subSubMaterialRel IS NULL THEN false ELSE true END AS isSubSubMaterial,
 			subSubMaterialRel.position AS subSubMaterialPosition,
 			subSubMaterialSurMaterial.uuid AS subSubMaterialSurMaterialUuid
 
@@ -74,7 +79,7 @@ export default () => `
 				subSubMaterialPosition,
 				subSubMaterialSurMaterialUuid,
 				relatedMaterial,
-				CASE originalVersionRel WHEN NULL THEN false ELSE true END AS isOriginalVersion,
+				CASE WHEN originalVersionRel IS NULL THEN false ELSE true END AS isOriginalVersion,
 				entityRel,
 				entity,
 				entitySurMaterial,
@@ -102,7 +107,7 @@ export default () => `
 				entitySurSurMaterial,
 				sourceMaterialWriterRel.credit AS sourceMaterialWritingCreditName,
 				COLLECT(
-					CASE sourceMaterialWriter WHEN NULL
+					CASE WHEN sourceMaterialWriter IS NULL
 						THEN null
 						ELSE sourceMaterialWriter { model: TOUPPER(HEAD(LABELS(sourceMaterialWriter))), .uuid, .name }
 					END
@@ -160,13 +165,13 @@ export default () => `
 							.name,
 							.format,
 							.year,
-							surMaterial: CASE entitySurMaterial WHEN NULL
+							surMaterial: CASE WHEN entitySurMaterial IS NULL
 								THEN null
 								ELSE entitySurMaterial {
 									model: 'MATERIAL',
 									.uuid,
 									.name,
-									surMaterial: CASE entitySurSurMaterial WHEN NULL
+									surMaterial: CASE WHEN entitySurSurMaterial IS NULL
 										THEN null
 										ELSE entitySurSurMaterial { model: 'MATERIAL', .uuid, .name }
 									END
@@ -237,7 +242,7 @@ export default () => `
 				subSubMaterialPosition,
 				subSubMaterialSurMaterialUuid,
 				COLLECT(
-					CASE relatedMaterial WHEN NULL
+					CASE WHEN relatedMaterial IS NULL
 						THEN null
 						ELSE relatedMaterial {
 							model: 'MATERIAL',
@@ -245,13 +250,13 @@ export default () => `
 							.name,
 							.format,
 							.year,
-							surMaterial: CASE surMaterial WHEN NULL
+							surMaterial: CASE WHEN surMaterial IS NULL
 								THEN null
 								ELSE surMaterial {
 									model: 'MATERIAL',
 									.uuid,
 									.name,
-									surMaterial: CASE surSurMaterial WHEN NULL
+									surMaterial: CASE WHEN surSurMaterial IS NULL
 										THEN null
 										ELSE surSurMaterial { model: 'MATERIAL', .uuid, .name }
 									END
@@ -318,7 +323,7 @@ export default () => `
 			characterRel.group AS characterGroupName,
 			characterRel.groupPosition AS characterGroupPosition,
 			COLLECT(
-				CASE character WHEN NULL
+				CASE WHEN character IS NULL
 					THEN null
 					ELSE character {
 						model: 'CHARACTER',

--- a/src/neo4j/cypher-queries/person/show/show-awards-rights-grantor-material.js
+++ b/src/neo4j/cypher-queries/person/show/show-awards-rights-grantor-material.js
@@ -70,7 +70,7 @@ export default () => `
 
 	WITH nominatedRightsGrantorMaterial, nomineeRel, category, categoryRel, ceremony,
 		COLLECT(
-			CASE nominatedEntity WHEN NULL
+			CASE WHEN nominatedEntity IS NULL
 				THEN null
 				ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
 			END
@@ -114,7 +114,7 @@ export default () => `
 
 	WITH nominatedRightsGrantorMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
 		COLLECT(
-			CASE nominatedProduction WHEN NULL
+			CASE WHEN nominatedProduction IS NULL
 				THEN null
 				ELSE nominatedProduction {
 					model: 'PRODUCTION',
@@ -122,25 +122,25 @@ export default () => `
 					.name,
 					.startDate,
 					.endDate,
-					venue: CASE venue WHEN NULL
+					venue: CASE WHEN venue IS NULL
 						THEN null
 						ELSE venue {
 							model: 'VENUE',
 							.uuid,
 							.name,
-							surVenue: CASE surVenue WHEN NULL
+							surVenue: CASE WHEN surVenue IS NULL
 								THEN null
 								ELSE surVenue { model: 'VENUE', .uuid, .name }
 							END
 						}
 					END,
-					surProduction: CASE surProduction WHEN NULL
+					surProduction: CASE WHEN surProduction IS NULL
 						THEN null
 						ELSE surProduction {
 							model: 'PRODUCTION',
 							.uuid,
 							.name,
-							surProduction: CASE surSurProduction WHEN NULL
+							surProduction: CASE WHEN surSurProduction IS NULL
 								THEN null
 								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
 							END
@@ -182,7 +182,7 @@ export default () => `
 		nominatedEntities,
 		nominatedProductions,
 		COLLECT(
-			CASE nominatedMaterial WHEN NULL
+			CASE WHEN nominatedMaterial IS NULL
 				THEN null
 				ELSE nominatedMaterial {
 					model: 'MATERIAL',
@@ -190,7 +190,7 @@ export default () => `
 					.name,
 					.format,
 					.year,
-					surMaterial: CASE nominatedSurMaterial WHEN NULL
+					surMaterial: CASE WHEN nominatedSurMaterial IS NULL
 						THEN null
 						ELSE nominatedSurMaterial { model: 'MATERIAL', .uuid, .name }
 					END
@@ -214,7 +214,7 @@ export default () => `
 		nominatedProductions,
 		nominatedMaterials,
 		COLLECT(
-			CASE nominatedRightsGrantorMaterial WHEN NULL
+			CASE WHEN nominatedRightsGrantorMaterial IS NULL
 				THEN null
 				ELSE nominatedRightsGrantorMaterial {
 					model: 'MATERIAL',
@@ -222,13 +222,13 @@ export default () => `
 					.name,
 					.format,
 					.year,
-					surMaterial: CASE nominatedRightsGrantorSurMaterial WHEN NULL
+					surMaterial: CASE WHEN nominatedRightsGrantorSurMaterial IS NULL
 						THEN null
 						ELSE nominatedRightsGrantorSurMaterial {
 							model: 'MATERIAL',
 							.uuid,
 							.name,
-							surMaterial: CASE nominatedRightsGrantorSurSurMaterial WHEN NULL
+							surMaterial: CASE WHEN nominatedRightsGrantorSurSurMaterial IS NULL
 								THEN null
 								ELSE nominatedRightsGrantorSurSurMaterial { model: 'MATERIAL', .uuid, .name }
 							END

--- a/src/neo4j/cypher-queries/person/show/show-awards-sourcing-material.js
+++ b/src/neo4j/cypher-queries/person/show/show-awards-sourcing-material.js
@@ -73,7 +73,7 @@ export default () => `
 
 	WITH nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony,
 		COLLECT(
-			CASE nominatedEntity WHEN NULL
+			CASE WHEN nominatedEntity IS NULL
 				THEN null
 				ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
 			END
@@ -117,7 +117,7 @@ export default () => `
 
 	WITH nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
 		COLLECT(
-			CASE nominatedProduction WHEN NULL
+			CASE WHEN nominatedProduction IS NULL
 				THEN null
 				ELSE nominatedProduction {
 					model: 'PRODUCTION',
@@ -125,25 +125,25 @@ export default () => `
 					.name,
 					.startDate,
 					.endDate,
-					venue: CASE venue WHEN NULL
+					venue: CASE WHEN venue IS NULL
 						THEN null
 						ELSE venue {
 							model: 'VENUE',
 							.uuid,
 							.name,
-							surVenue: CASE surVenue WHEN NULL
+							surVenue: CASE WHEN surVenue IS NULL
 								THEN null
 								ELSE surVenue { model: 'VENUE', .uuid, .name }
 							END
 						}
 					END,
-					surProduction: CASE surProduction WHEN NULL
+					surProduction: CASE WHEN surProduction IS NULL
 						THEN null
 						ELSE surProduction {
 							model: 'PRODUCTION',
 							.uuid,
 							.name,
-							surProduction: CASE surSurProduction WHEN NULL
+							surProduction: CASE WHEN surSurProduction IS NULL
 								THEN null
 								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
 							END
@@ -185,7 +185,7 @@ export default () => `
 		nominatedEntities,
 		nominatedProductions,
 		COLLECT(
-			CASE nominatedMaterial WHEN NULL
+			CASE WHEN nominatedMaterial IS NULL
 				THEN null
 				ELSE nominatedMaterial {
 					model: 'MATERIAL',
@@ -193,7 +193,7 @@ export default () => `
 					.name,
 					.format,
 					.year,
-					surMaterial: CASE nominatedSurMaterial WHEN NULL
+					surMaterial: CASE WHEN nominatedSurMaterial IS NULL
 						THEN null
 						ELSE nominatedSurMaterial { model: 'MATERIAL', .uuid, .name }
 					END
@@ -216,7 +216,7 @@ export default () => `
 		nominatedProductions,
 		nominatedMaterials,
 		COLLECT(
-			CASE nominatedSourcingMaterial WHEN NULL
+			CASE WHEN nominatedSourcingMaterial IS NULL
 				THEN null
 				ELSE nominatedSourcingMaterial {
 					model: 'MATERIAL',
@@ -224,13 +224,13 @@ export default () => `
 					.name,
 					.format,
 					.year,
-					surMaterial: CASE nominatedSourcingSurMaterial WHEN NULL
+					surMaterial: CASE WHEN nominatedSourcingSurMaterial IS NULL
 						THEN null
 						ELSE nominatedSourcingSurMaterial {
 							model: 'MATERIAL',
 							.uuid,
 							.name,
-							surMaterial: CASE nominatedSourcingSurSurMaterial WHEN NULL
+							surMaterial: CASE WHEN nominatedSourcingSurSurMaterial IS NULL
 								THEN null
 								ELSE nominatedSourcingSurSurMaterial { model: 'MATERIAL', .uuid, .name }
 							END

--- a/src/neo4j/cypher-queries/person/show/show-awards-subsequent-version-material.js
+++ b/src/neo4j/cypher-queries/person/show/show-awards-subsequent-version-material.js
@@ -70,7 +70,7 @@ export default () => `
 
 	WITH nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony,
 		COLLECT(
-			CASE nominatedEntity WHEN NULL
+			CASE WHEN nominatedEntity IS NULL
 				THEN null
 				ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
 			END
@@ -114,7 +114,7 @@ export default () => `
 
 	WITH nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
 		COLLECT(
-			CASE nominatedProduction WHEN NULL
+			CASE WHEN nominatedProduction IS NULL
 				THEN null
 				ELSE nominatedProduction {
 					model: 'PRODUCTION',
@@ -122,25 +122,25 @@ export default () => `
 					.name,
 					.startDate,
 					.endDate,
-					venue: CASE venue WHEN NULL
+					venue: CASE WHEN venue IS NULL
 						THEN null
 						ELSE venue {
 							model: 'VENUE',
 							.uuid,
 							.name,
-							surVenue: CASE surVenue WHEN NULL
+							surVenue: CASE WHEN surVenue IS NULL
 								THEN null
 								ELSE surVenue { model: 'VENUE', .uuid, .name }
 							END
 						}
 					END,
-					surProduction: CASE surProduction WHEN NULL
+					surProduction: CASE WHEN surProduction IS NULL
 						THEN null
 						ELSE surProduction {
 							model: 'PRODUCTION',
 							.uuid,
 							.name,
-							surProduction: CASE surSurProduction WHEN NULL
+							surProduction: CASE WHEN surSurProduction IS NULL
 								THEN null
 								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
 							END
@@ -182,7 +182,7 @@ export default () => `
 		nominatedEntities,
 		nominatedProductions,
 		COLLECT(
-			CASE nominatedMaterial WHEN NULL
+			CASE WHEN nominatedMaterial IS NULL
 				THEN null
 				ELSE nominatedMaterial {
 					model: 'MATERIAL',
@@ -190,7 +190,7 @@ export default () => `
 					.name,
 					.format,
 					.year,
-					surMaterial: CASE nominatedSurMaterial WHEN NULL
+					surMaterial: CASE WHEN nominatedSurMaterial IS NULL
 						THEN null
 						ELSE nominatedSurMaterial { model: 'MATERIAL', .uuid, .name }
 					END
@@ -215,7 +215,7 @@ export default () => `
 		nominatedProductions,
 		nominatedMaterials,
 		COLLECT(
-			CASE nominatedSubsequentVersionMaterial WHEN NULL
+			CASE WHEN nominatedSubsequentVersionMaterial IS NULL
 				THEN null
 				ELSE nominatedSubsequentVersionMaterial {
 					model: 'MATERIAL',
@@ -223,13 +223,13 @@ export default () => `
 					.name,
 					.format,
 					.year,
-					surMaterial: CASE nominatedSubsequentVersionSurMaterial WHEN NULL
+					surMaterial: CASE WHEN nominatedSubsequentVersionSurMaterial IS NULL
 						THEN null
 						ELSE nominatedSubsequentVersionSurMaterial {
 							model: 'MATERIAL',
 							.uuid,
 							.name,
-							surMaterial: CASE nominatedSubsequentVersionSurSurMaterial WHEN NULL
+							surMaterial: CASE WHEN nominatedSubsequentVersionSurSurMaterial IS NULL
 								THEN null
 								ELSE nominatedSubsequentVersionSurSurMaterial { model: 'MATERIAL', .uuid, .name }
 							END

--- a/src/neo4j/cypher-queries/person/show/show-awards.js
+++ b/src/neo4j/cypher-queries/person/show/show-awards.js
@@ -57,7 +57,7 @@ export default () => `
 		category,
 		categoryRel,
 		ceremony,
-		CASE nominatedEmployerCompany WHEN NULL
+		CASE WHEN nominatedEmployerCompany IS NULL
 			THEN null
 			ELSE nominatedEmployerCompany { model: 'COMPANY', .uuid, .name, coMembers: coNominatedMembers }
 		END AS nominatedEmployerCompany,
@@ -111,7 +111,7 @@ export default () => `
 
 	WITH entityRel, nominatedEmployerCompany, category, categoryRel, ceremony,
 		COLLECT(
-			CASE coNominatedEntity WHEN NULL
+			CASE WHEN coNominatedEntity IS NULL
 				THEN null
 				ELSE coNominatedEntity {
 					model: TOUPPER(HEAD(LABELS(coNominatedEntity))),
@@ -160,7 +160,7 @@ export default () => `
 
 	WITH entityRel, nominatedEmployerCompany, category, categoryRel, ceremony, coNominatedEntities,
 		COLLECT(
-			CASE nominatedProduction WHEN NULL
+			CASE WHEN nominatedProduction IS NULL
 				THEN null
 				ELSE nominatedProduction {
 					model: 'PRODUCTION',
@@ -168,25 +168,25 @@ export default () => `
 					.name,
 					.startDate,
 					.endDate,
-					venue: CASE venue WHEN NULL
+					venue: CASE WHEN venue IS NULL
 						THEN null
 						ELSE venue {
 							model: 'VENUE',
 							.uuid,
 							.name,
-							surVenue: CASE surVenue WHEN NULL
+							surVenue: CASE WHEN surVenue IS NULL
 								THEN null
 								ELSE surVenue { model: 'VENUE', .uuid, .name }
 							END
 						}
 					END,
-					surProduction: CASE surProduction WHEN NULL
+					surProduction: CASE WHEN surProduction IS NULL
 						THEN null
 						ELSE surProduction {
 							model: 'PRODUCTION',
 							.uuid,
 							.name,
-							surProduction: CASE surSurProduction WHEN NULL
+							surProduction: CASE WHEN surSurProduction IS NULL
 								THEN null
 								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
 							END
@@ -228,7 +228,7 @@ export default () => `
 		coNominatedEntities,
 		nominatedProductions,
 		COLLECT(
-			CASE nominatedMaterial WHEN NULL
+			CASE WHEN nominatedMaterial IS NULL
 				THEN null
 				ELSE nominatedMaterial {
 					model: 'MATERIAL',
@@ -236,13 +236,13 @@ export default () => `
 					.name,
 					.format,
 					.year,
-					surMaterial: CASE nominatedSurMaterial WHEN NULL
+					surMaterial: CASE WHEN nominatedSurMaterial IS NULL
 						THEN null
 						ELSE nominatedSurMaterial {
 							model: 'MATERIAL',
 							.uuid,
 							.name,
-							surMaterial: CASE nominatedSurSurMaterial WHEN NULL
+							surMaterial: CASE WHEN nominatedSurSurMaterial IS NULL
 								THEN null
 								ELSE nominatedSurSurMaterial { model: 'MATERIAL', .uuid, .name }
 							END

--- a/src/neo4j/cypher-queries/person/show/show-materials.js
+++ b/src/neo4j/cypher-queries/person/show/show-materials.js
@@ -33,9 +33,9 @@ export default () => `
 			person,
 			material,
 			writerRel.creditType AS creditType,
-			CASE writerRel WHEN NULL THEN false ELSE true END AS hasDirectCredit,
-			CASE subsequentVersionRel WHEN NULL THEN false ELSE true END AS isSubsequentVersion,
-			CASE sourcingMaterialRel WHEN NULL THEN false ELSE true END AS isSourcingMaterial,
+			CASE WHEN writerRel IS NULL THEN false ELSE true END AS hasDirectCredit,
+			CASE WHEN subsequentVersionRel IS NULL THEN false ELSE true END AS isSubsequentVersion,
+			CASE WHEN sourcingMaterialRel IS NULL THEN false ELSE true END AS isSourcingMaterial,
 			entityRel,
 			entity,
 			entitySurMaterial,
@@ -57,7 +57,7 @@ export default () => `
 			entitySurSurMaterial,
 			sourceMaterialWriterRel.credit AS sourceMaterialWritingCreditName,
 			COLLECT(
-				CASE sourceMaterialWriter WHEN NULL
+				CASE WHEN sourceMaterialWriter IS NULL
 					THEN null
 					ELSE sourceMaterialWriter { model: TOUPPER(HEAD(LABELS(sourceMaterialWriter))), .uuid, .name }
 				END
@@ -95,7 +95,7 @@ export default () => `
 			isSourcingMaterial,
 			entityRel.credit AS writingCreditName,
 			COLLECT(
-				CASE entity WHEN NULL
+				CASE WHEN entity IS NULL
 					THEN null
 					ELSE entity {
 						model: TOUPPER(HEAD(LABELS(entity))),
@@ -103,13 +103,13 @@ export default () => `
 						.name,
 						.format,
 						.year,
-						surMaterial: CASE entitySurMaterial WHEN NULL
+						surMaterial: CASE WHEN entitySurMaterial IS NULL
 							THEN null
 							ELSE entitySurMaterial {
 								model: 'MATERIAL',
 								.uuid,
 								.name,
-								surMaterial: CASE entitySurSurMaterial WHEN NULL
+								surMaterial: CASE WHEN entitySurSurMaterial IS NULL
 									THEN null
 									ELSE entitySurSurMaterial { model: 'MATERIAL', .uuid, .name }
 								END
@@ -166,7 +166,7 @@ export default () => `
 
 		WITH person,
 			COLLECT(
-				CASE material WHEN NULL
+				CASE WHEN material IS NULL
 					THEN null
 					ELSE material {
 						model: 'MATERIAL',
@@ -174,13 +174,13 @@ export default () => `
 						.name,
 						.format,
 						.year,
-						surMaterial: CASE surMaterial WHEN NULL
+						surMaterial: CASE WHEN surMaterial IS NULL
 							THEN null
 							ELSE surMaterial {
 								model: 'MATERIAL',
 								.uuid,
 								.name,
-								surMaterial: CASE surSurMaterial WHEN NULL
+								surMaterial: CASE WHEN surSurMaterial IS NULL
 									THEN null
 									ELSE surSurMaterial { model: 'MATERIAL', .uuid, .name }
 								END

--- a/src/neo4j/cypher-queries/person/show/show-productions.js
+++ b/src/neo4j/cypher-queries/person/show/show-productions.js
@@ -28,7 +28,7 @@ export default () => `
 
 	WITH person, production, entityRel.credit AS producerCreditName,
 		COLLECT(
-			CASE entity WHEN NULL
+			CASE WHEN entity IS NULL
 				THEN null
 				ELSE entity { model: TOUPPER(HEAD(LABELS(entity))), .uuid, .name, members: creditedMembers }
 			END
@@ -80,7 +80,7 @@ export default () => `
 
 	WITH person,
 		COLLECT(
-			CASE production WHEN NULL
+			CASE WHEN production IS NULL
 				THEN null
 				ELSE production {
 					model: 'PRODUCTION',
@@ -88,25 +88,25 @@ export default () => `
 					.name,
 					.startDate,
 					.endDate,
-					venue: CASE venue WHEN NULL
+					venue: CASE WHEN venue IS NULL
 						THEN null
 						ELSE venue {
 							model: 'VENUE',
 							.uuid,
 							.name,
-							surVenue: CASE surVenue WHEN NULL
+							surVenue: CASE WHEN surVenue IS NULL
 								THEN null
 								ELSE surVenue { model: 'VENUE', .uuid, .name }
 							END
 						}
 					END,
-					surProduction: CASE surProduction WHEN NULL
+					surProduction: CASE WHEN surProduction IS NULL
 						THEN null
 						ELSE surProduction {
 							model: 'PRODUCTION',
 							.uuid,
 							.name,
-							surProduction: CASE surSurProduction WHEN NULL
+							surProduction: CASE WHEN surSurProduction IS NULL
 								THEN null
 								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
 							END
@@ -149,7 +149,7 @@ export default () => `
 		surSurProduction,
 		surSurProductionRel,
 		COLLECT(
-			CASE role.roleName WHEN NULL
+			CASE WHEN role.roleName IS NULL
 				THEN { name: 'Performer' }
 				ELSE role {
 					model: 'CHARACTER',
@@ -170,7 +170,7 @@ export default () => `
 
 	WITH person, producerProductions,
 		COLLECT(
-			CASE production WHEN NULL
+			CASE WHEN production IS NULL
 				THEN null
 				ELSE production {
 					model: 'PRODUCTION',
@@ -178,25 +178,25 @@ export default () => `
 					.name,
 					.startDate,
 					.endDate,
-					venue: CASE venue WHEN NULL
+					venue: CASE WHEN venue IS NULL
 						THEN null
 						ELSE venue {
 							model: 'VENUE',
 							.uuid,
 							.name,
-							surVenue: CASE surVenue WHEN NULL
+							surVenue: CASE WHEN surVenue IS NULL
 								THEN null
 								ELSE surVenue { model: 'VENUE', .uuid, .name }
 							END
 						}
 					END,
-					surProduction: CASE surProduction WHEN NULL
+					surProduction: CASE WHEN surProduction IS NULL
 						THEN null
 						ELSE surProduction {
 							model: 'PRODUCTION',
 							.uuid,
 							.name,
-							surProduction: CASE surSurProduction WHEN NULL
+							surProduction: CASE WHEN surSurProduction IS NULL
 								THEN null
 								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
 							END
@@ -255,7 +255,7 @@ export default () => `
 		producerProductions,
 		castMemberProductions,
 		production,
-		CASE creditedEmployerCompany WHEN NULL
+		CASE WHEN creditedEmployerCompany IS NULL
 			THEN null
 			ELSE creditedEmployerCompany { model: 'COMPANY', .uuid, .name, coMembers: coCreditedMembers }
 		END AS creditedEmployerCompany,
@@ -319,7 +319,7 @@ export default () => `
 		entityRel,
 		creditedEmployerCompany,
 		COLLECT(
-			CASE coCreditedEntity WHEN NULL
+			CASE WHEN coCreditedEntity IS NULL
 				THEN null
 				ELSE coCreditedEntity {
 					model: TOUPPER(HEAD(LABELS(coCreditedEntity))),
@@ -378,7 +378,7 @@ export default () => `
 
 	WITH person, producerProductions, castMemberProductions,
 		COLLECT(
-			CASE production WHEN NULL
+			CASE WHEN production IS NULL
 				THEN null
 				ELSE production {
 					model: 'PRODUCTION',
@@ -386,25 +386,25 @@ export default () => `
 					.name,
 					.startDate,
 					.endDate,
-					venue: CASE venue WHEN NULL
+					venue: CASE WHEN venue IS NULL
 						THEN null
 						ELSE venue {
 							model: 'VENUE',
 							.uuid,
 							.name,
-							surVenue: CASE surVenue WHEN NULL
+							surVenue: CASE WHEN surVenue IS NULL
 								THEN null
 								ELSE surVenue { model: 'VENUE', .uuid, .name }
 							END
 						}
 					END,
-					surProduction: CASE surProduction WHEN NULL
+					surProduction: CASE WHEN surProduction IS NULL
 						THEN null
 						ELSE surProduction {
 							model: 'PRODUCTION',
 							.uuid,
 							.name,
-							surProduction: CASE surSurProduction WHEN NULL
+							surProduction: CASE WHEN surSurProduction IS NULL
 								THEN null
 								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
 							END
@@ -466,7 +466,7 @@ export default () => `
 		castMemberProductions,
 		creativeProductions,
 		production,
-		CASE creditedEmployerCompany WHEN NULL
+		CASE WHEN creditedEmployerCompany IS NULL
 			THEN null
 			ELSE creditedEmployerCompany { model: 'COMPANY', .uuid, .name, coMembers: coCreditedMembers }
 		END AS creditedEmployerCompany,
@@ -530,7 +530,7 @@ export default () => `
 		entityRel,
 		creditedEmployerCompany,
 		COLLECT(
-			CASE coCreditedEntity WHEN NULL
+			CASE WHEN coCreditedEntity IS NULL
 				THEN null
 				ELSE coCreditedEntity {
 					model: TOUPPER(HEAD(LABELS(coCreditedEntity))),
@@ -592,7 +592,7 @@ export default () => `
 		castMemberProductions,
 		creativeProductions,
 		COLLECT(
-			CASE production WHEN NULL
+			CASE WHEN production IS NULL
 				THEN null
 				ELSE production {
 					model: 'PRODUCTION',
@@ -600,25 +600,25 @@ export default () => `
 					.name,
 					.startDate,
 					.endDate,
-					venue: CASE venue WHEN NULL
+					venue: CASE WHEN venue IS NULL
 						THEN null
 						ELSE venue {
 							model: 'VENUE',
 							.uuid,
 							.name,
-							surVenue: CASE surVenue WHEN NULL
+							surVenue: CASE WHEN surVenue IS NULL
 								THEN null
 								ELSE surVenue { model: 'VENUE', .uuid, .name }
 							END
 						}
 					END,
-					surProduction: CASE surProduction WHEN NULL
+					surProduction: CASE WHEN surProduction IS NULL
 						THEN null
 						ELSE surProduction {
 							model: 'PRODUCTION',
 							.uuid,
 							.name,
-							surProduction: CASE surSurProduction WHEN NULL
+							surProduction: CASE WHEN surSurProduction IS NULL
 								THEN null
 								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
 							END

--- a/src/neo4j/cypher-queries/production/create-update.js
+++ b/src/neo4j/cypher-queries/production/create-update.js
@@ -41,7 +41,7 @@ const getCreateUpdateQuery = action => {
 				($material.differentiator IS NULL AND existingMaterial.differentiator IS NULL) OR
 				$material.differentiator = existingMaterial.differentiator
 
-		FOREACH (item IN CASE $material.name WHEN NULL THEN [] ELSE [1] END |
+		FOREACH (item IN CASE WHEN $material.name IS NULL THEN [] ELSE [1] END |
 			MERGE (material:Material {
 				uuid: COALESCE(existingMaterial.uuid, $material.uuid),
 				name: $material.name
@@ -58,7 +58,7 @@ const getCreateUpdateQuery = action => {
 				($venue.differentiator IS NULL AND existingVenue.differentiator IS NULL) OR
 				$venue.differentiator = existingVenue.differentiator
 
-		FOREACH (item IN CASE $venue.name WHEN NULL THEN [] ELSE [1] END |
+		FOREACH (item IN CASE WHEN $venue.name IS NULL THEN [] ELSE [1] END |
 			MERGE (venue:Venue {
 				uuid: COALESCE(existingVenue.uuid, $venue.uuid),
 				name: $venue.name
@@ -74,7 +74,7 @@ const getCreateUpdateQuery = action => {
 
 				OPTIONAL MATCH (existingSubProduction:Production { uuid: subProductionParam.uuid })
 
-				FOREACH (item IN CASE existingSubProduction WHEN NULL THEN [] ELSE [1] END |
+				FOREACH (item IN CASE WHEN existingSubProduction IS NULL THEN [] ELSE [1] END |
 					CREATE (production)-[:HAS_SUB_PRODUCTION { position: subProductionParam.position }]->
 						(existingSubProduction)
 				)
@@ -97,7 +97,7 @@ const getCreateUpdateQuery = action => {
 						) OR
 						producerPersonParam.differentiator = existingProducerPerson.differentiator
 
-				FOREACH (item IN CASE producerPersonParam WHEN NULL THEN [] ELSE [1] END |
+				FOREACH (item IN CASE WHEN producerPersonParam IS NULL THEN [] ELSE [1] END |
 					MERGE (producerPerson:Person {
 						uuid: COALESCE(existingProducerPerson.uuid, producerPersonParam.uuid),
 						name: producerPersonParam.name
@@ -128,7 +128,7 @@ const getCreateUpdateQuery = action => {
 						) OR
 						producerCompanyParam.differentiator = existingProducerCompany.differentiator
 
-				FOREACH (item IN CASE producerCompanyParam WHEN NULL THEN [] ELSE [1] END |
+				FOREACH (item IN CASE WHEN producerCompanyParam IS NULL THEN [] ELSE [1] END |
 					MERGE (producerCompany:Company {
 						uuid: COALESCE(existingProducerCompany.uuid, producerCompanyParam.uuid),
 						name: producerCompanyParam.name
@@ -170,7 +170,7 @@ const getCreateUpdateQuery = action => {
 						SET producerCompanyRel.creditedMemberUuids = []
 					)
 
-					FOREACH (item IN CASE creditedMemberParam WHEN NULL THEN [] ELSE [1] END |
+					FOREACH (item IN CASE WHEN creditedMemberParam IS NULL THEN [] ELSE [1] END |
 						MERGE (creditedMember:Person {
 							uuid: COALESCE(existingPerson.uuid, creditedMemberParam.uuid),
 							name: creditedMemberParam.name
@@ -197,7 +197,7 @@ const getCreateUpdateQuery = action => {
 					(castMemberParam.differentiator IS NULL AND existingPerson.differentiator IS NULL) OR
 					castMemberParam.differentiator = existingPerson.differentiator
 
-			FOREACH (item IN CASE castMemberParam WHEN NULL THEN [] ELSE [1] END |
+			FOREACH (item IN CASE WHEN castMemberParam IS NULL THEN [] ELSE [1] END |
 				MERGE (castMember:Person {
 					uuid: COALESCE(existingPerson.uuid, castMemberParam.uuid),
 					name: castMemberParam.name
@@ -236,7 +236,7 @@ const getCreateUpdateQuery = action => {
 						) OR
 						creativePersonParam.differentiator = existingCreativePerson.differentiator
 
-				FOREACH (item IN CASE creativePersonParam WHEN NULL THEN [] ELSE [1] END |
+				FOREACH (item IN CASE WHEN creativePersonParam IS NULL THEN [] ELSE [1] END |
 					MERGE (creativePerson:Person {
 						uuid: COALESCE(existingCreativePerson.uuid, creativePersonParam.uuid),
 						name: creativePersonParam.name
@@ -267,7 +267,7 @@ const getCreateUpdateQuery = action => {
 						) OR
 						creativeCompanyParam.differentiator = existingCreativeCompany.differentiator
 
-				FOREACH (item IN CASE creativeCompanyParam WHEN NULL THEN [] ELSE [1] END |
+				FOREACH (item IN CASE WHEN creativeCompanyParam IS NULL THEN [] ELSE [1] END |
 					MERGE (creativeCompany:Company {
 						uuid: COALESCE(existingCreativeCompany.uuid, creativeCompanyParam.uuid),
 						name: creativeCompanyParam.name
@@ -309,7 +309,7 @@ const getCreateUpdateQuery = action => {
 						SET creativeCompanyRel.creditedMemberUuids = []
 					)
 
-					FOREACH (item IN CASE creditedMemberParam WHEN NULL THEN [] ELSE [1] END |
+					FOREACH (item IN CASE WHEN creditedMemberParam IS NULL THEN [] ELSE [1] END |
 						MERGE (creditedMember:Person {
 							uuid: COALESCE(existingPerson.uuid, creditedMemberParam.uuid),
 							name: creditedMemberParam.name
@@ -345,7 +345,7 @@ const getCreateUpdateQuery = action => {
 						) OR
 						crewPersonParam.differentiator = existingCrewPerson.differentiator
 
-				FOREACH (item IN CASE crewPersonParam WHEN NULL THEN [] ELSE [1] END |
+				FOREACH (item IN CASE WHEN crewPersonParam IS NULL THEN [] ELSE [1] END |
 					MERGE (crewPerson:Person {
 						uuid: COALESCE(existingCrewPerson.uuid, crewPersonParam.uuid),
 						name: crewPersonParam.name
@@ -376,7 +376,7 @@ const getCreateUpdateQuery = action => {
 						) OR
 						crewCompanyParam.differentiator = existingCrewCompany.differentiator
 
-				FOREACH (item IN CASE crewCompanyParam WHEN NULL THEN [] ELSE [1] END |
+				FOREACH (item IN CASE WHEN crewCompanyParam IS NULL THEN [] ELSE [1] END |
 					MERGE (crewCompany:Company {
 						uuid: COALESCE(existingCrewCompany.uuid, crewCompanyParam.uuid),
 						name: crewCompanyParam.name
@@ -418,7 +418,7 @@ const getCreateUpdateQuery = action => {
 						SET crewCompanyRel.creditedMemberUuids = []
 					)
 
-					FOREACH (item IN CASE creditedMemberParam WHEN NULL THEN [] ELSE [1] END |
+					FOREACH (item IN CASE WHEN creditedMemberParam IS NULL THEN [] ELSE [1] END |
 						MERGE (creditedMember:Person {
 							uuid: COALESCE(existingPerson.uuid, creditedMemberParam.uuid),
 							name: creditedMemberParam.name

--- a/src/neo4j/cypher-queries/production/edit.js
+++ b/src/neo4j/cypher-queries/production/edit.js
@@ -11,7 +11,7 @@ export default () => `
 		ORDER BY subProductionRel.position
 
 	WITH production, material, venue,
-		COLLECT(CASE subProduction WHEN NULL THEN null ELSE subProduction { .uuid } END) + [{}] AS subProductions
+		COLLECT(CASE WHEN subProduction IS NULL THEN null ELSE subProduction { .uuid } END) + [{}] AS subProductions
 
 	OPTIONAL MATCH (production)-[producerEntityRel:HAS_PRODUCER_ENTITY]->(producerEntity)
 		WHERE
@@ -47,7 +47,7 @@ export default () => `
 
 	WITH production, material, venue, subProductions, producerEntityRel.credit AS producerCreditName,
 		COLLECT(
-			CASE producerEntity WHEN NULL
+			CASE WHEN producerEntity IS NULL
 				THEN null
 				ELSE producerEntity { .model, .name, .differentiator, members: creditedMembers }
 			END
@@ -74,7 +74,7 @@ export default () => `
 
 	WITH production, material, venue, subProductions, producerCredits, castMember,
 		COLLECT(
-			CASE role.roleName WHEN NULL
+			CASE WHEN role.roleName IS NULL
 				THEN null
 				ELSE {
 					name: role.roleName,
@@ -88,7 +88,7 @@ export default () => `
 
 	WITH production, material, venue, subProductions, producerCredits,
 		COLLECT(
-			CASE castMember WHEN NULL
+			CASE WHEN castMember IS NULL
 				THEN null
 				ELSE castMember { .name, .differentiator, roles: roles }
 			END
@@ -153,7 +153,7 @@ export default () => `
 		cast,
 		creativeEntityRel.credit AS creativeCreditName,
 		COLLECT(
-			CASE creativeEntity WHEN NULL
+			CASE WHEN creativeEntity IS NULL
 				THEN null
 				ELSE creativeEntity { .model, .name, .differentiator, members: creditedMembers }
 			END
@@ -251,7 +251,7 @@ export default () => `
 		creativeCredits,
 		crewEntityRel.credit AS crewCreditName,
 		COLLECT(
-			CASE crewEntity WHEN NULL
+			CASE WHEN crewEntity IS NULL
 				THEN null
 				ELSE crewEntity { .model, .name, .differentiator, members: creditedMembers }
 			END

--- a/src/neo4j/cypher-queries/production/list.js
+++ b/src/neo4j/cypher-queries/production/list.js
@@ -16,25 +16,25 @@ export default () => `
 		production.name AS name,
 		production.startDate AS startDate,
 		production.endDate AS endDate,
-		CASE venue WHEN NULL
+		CASE WHEN venue IS NULL
 			THEN null
 			ELSE venue {
 				model: 'VENUE',
 				.uuid,
 				.name,
-				surVenue: CASE surVenue WHEN NULL
+				surVenue: CASE WHEN surVenue IS NULL
 					THEN null
 					ELSE surVenue { model: 'VENUE', .uuid, .name }
 				END
 			}
 		END AS venue,
-		CASE surProduction WHEN NULL
+		CASE WHEN surProduction IS NULL
 			THEN null
 			ELSE surProduction {
 				model: 'PRODUCTION',
 				.uuid,
 				.name,
-				surProduction: CASE surSurProduction WHEN NULL
+				surProduction: CASE WHEN surSurProduction IS NULL
 					THEN null
 					ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
 				END

--- a/src/neo4j/cypher-queries/production/show/show-awards.js
+++ b/src/neo4j/cypher-queries/production/show/show-awards.js
@@ -28,13 +28,13 @@ export default () => `
 				.name,
 				.startDate,
 				.endDate,
-				venue: CASE productionLinkedToCategoryVenue WHEN NULL
+				venue: CASE WHEN productionLinkedToCategoryVenue IS NULL
 					THEN null
 					ELSE productionLinkedToCategoryVenue {
 						model: 'VENUE',
 						.uuid,
 						.name,
-						surVenue: CASE productionLinkedToCategorySurVenue WHEN NULL
+						surVenue: CASE WHEN productionLinkedToCategorySurVenue IS NULL
 							THEN null
 							ELSE productionLinkedToCategorySurVenue { model: 'VENUE', .uuid, .name }
 						END
@@ -97,7 +97,7 @@ export default () => `
 
 	WITH production, recipientProduction, nomineeRel, category, categoryRel, ceremony,
 		COLLECT(
-			CASE nominatedEntity WHEN NULL
+			CASE WHEN nominatedEntity IS NULL
 				THEN null
 				ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
 			END
@@ -144,7 +144,7 @@ export default () => `
 
 	WITH recipientProduction, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
 		COLLECT(
-			CASE coNominatedProduction WHEN NULL
+			CASE WHEN coNominatedProduction IS NULL
 				THEN null
 				ELSE coNominatedProduction {
 					model: 'PRODUCTION',
@@ -152,25 +152,25 @@ export default () => `
 					.name,
 					.startDate,
 					.endDate,
-					venue: CASE coNominatedProductionVenue WHEN NULL
+					venue: CASE WHEN coNominatedProductionVenue IS NULL
 						THEN null
 						ELSE coNominatedProductionVenue {
 							model: 'VENUE',
 							.uuid,
 							.name,
-							surVenue: CASE coNominatedProductionSurVenue WHEN NULL
+							surVenue: CASE WHEN coNominatedProductionSurVenue IS NULL
 								THEN null
 								ELSE coNominatedProductionSurVenue { model: 'VENUE', .uuid, .name }
 							END
 						}
 					END,
-					surProduction: CASE coNominatedProductionSurProduction WHEN NULL
+					surProduction: CASE WHEN coNominatedProductionSurProduction IS NULL
 						THEN null
 						ELSE coNominatedProductionSurProduction {
 							model: 'PRODUCTION',
 							.uuid,
 							.name,
-							surProduction: CASE coNominatedProductionSurSurProduction WHEN NULL
+							surProduction: CASE WHEN coNominatedProductionSurSurProduction IS NULL
 								THEN null
 								ELSE coNominatedProductionSurSurProduction{ model: 'PRODUCTION', .uuid, .name }
 							END
@@ -207,7 +207,7 @@ export default () => `
 
 	WITH recipientProduction, nomineeRel, category, categoryRel, ceremony, nominatedEntities, coNominatedProductions,
 		COLLECT(
-			CASE nominatedMaterial WHEN NULL
+			CASE WHEN nominatedMaterial IS NULL
 				THEN null
 				ELSE nominatedMaterial {
 					model: 'MATERIAL',
@@ -215,13 +215,13 @@ export default () => `
 					.name,
 					.format,
 					.year,
-					surMaterial: CASE nominatedSurMaterial WHEN NULL
+					surMaterial: CASE WHEN nominatedSurMaterial IS NULL
 						THEN null
 						ELSE nominatedSurMaterial {
 							model: 'MATERIAL',
 							.uuid,
 							.name,
-							surMaterial: CASE nominatedSurSurMaterial WHEN NULL
+							surMaterial: CASE WHEN nominatedSurSurMaterial IS NULL
 								THEN null
 								ELSE nominatedSurSurMaterial { model: 'MATERIAL', .uuid, .name }
 							END
@@ -237,7 +237,7 @@ export default () => `
 			model: 'NOMINATION',
 			isWinner: COALESCE(nomineeRel.isWinner, false),
 			type: COALESCE(nomineeRel.customType, CASE WHEN nomineeRel.isWinner THEN 'Winner' ELSE 'Nomination' END),
-			recipientProduction: CASE recipientProduction WHEN NULL THEN null ELSE recipientProduction END,
+			recipientProduction: CASE WHEN recipientProduction IS NULL THEN null ELSE recipientProduction END,
 			entities: nominatedEntities,
 			coProductions: coNominatedProductions,
 			materials: nominatedMaterials

--- a/src/neo4j/cypher-queries/production/show/show.js
+++ b/src/neo4j/cypher-queries/production/show/show.js
@@ -7,7 +7,12 @@ export default () => `
 
 	WITH
 		production,
-		[production] + COLLECT(surProduction) + COLLECT(subProduction) AS collectionProductions
+		COLLECT(surProduction) AS surProductions,
+		COLLECT(subProduction) AS subProductions
+
+	WITH
+		production,
+		[production] + surProductions + subProductions AS collectionProductions
 
 	UNWIND (CASE collectionProductions WHEN [] THEN [null] ELSE collectionProductions END) AS collectionProduction
 
@@ -25,11 +30,11 @@ export default () => `
 			production,
 			collectionProduction,
 			CASE WHEN production = collectionProduction THEN true ELSE false END AS isSubjectProduction,
-			CASE surProductionRel WHEN NULL THEN false ELSE true END AS isSurProduction,
-			CASE surSurProductionRel WHEN NULL THEN false ELSE true END AS isSurSurProduction,
-			CASE subProductionRel WHEN NULL THEN false ELSE true END AS isSubProduction,
+			CASE WHEN surProductionRel IS NULL THEN false ELSE true END AS isSurProduction,
+			CASE WHEN surSurProductionRel IS NULL THEN false ELSE true END AS isSurSurProduction,
+			CASE WHEN subProductionRel IS NULL THEN false ELSE true END AS isSubProduction,
 			subProductionRel.position AS subProductionPosition,
-			CASE subSubProductionRel WHEN NULL THEN false ELSE true END AS isSubSubProduction,
+			CASE WHEN subSubProductionRel IS NULL THEN false ELSE true END AS isSubSubProduction,
 			subSubProductionRel.position AS subSubProductionPosition,
 			subSubProductionSurProduction.uuid AS subSubProductionSurProductionUuid
 
@@ -91,7 +96,7 @@ export default () => `
 			entitySurSurMaterial,
 			sourceMaterialWriterRel.credit AS sourceMaterialWritingCreditName,
 			COLLECT(
-				CASE sourceMaterialWriter WHEN NULL
+				CASE WHEN sourceMaterialWriter IS NULL
 					THEN null
 					ELSE sourceMaterialWriter { model: TOUPPER(HEAD(LABELS(sourceMaterialWriter))), .uuid, .name }
 				END
@@ -143,7 +148,7 @@ export default () => `
 			surSurMaterial,
 			entityRel.credit AS writingCreditName,
 			COLLECT(
-				CASE entity WHEN NULL
+				CASE WHEN entity IS NULL
 					THEN null
 					ELSE entity {
 						model: TOUPPER(HEAD(LABELS(entity))),
@@ -151,13 +156,13 @@ export default () => `
 						.name,
 						.format,
 						.year,
-						surMaterial: CASE entitySurMaterial WHEN NULL
+						surMaterial: CASE WHEN entitySurMaterial IS NULL
 							THEN null
 							ELSE entitySurMaterial {
 								model: 'MATERIAL',
 								.uuid,
 								.name,
-								surMaterial: CASE entitySurSurMaterial WHEN NULL
+								surMaterial: CASE WHEN entitySurSurMaterial IS NULL
 									THEN null
 									ELSE entitySurSurMaterial { model: 'MATERIAL', .uuid, .name }
 								END
@@ -224,7 +229,7 @@ export default () => `
 			isSubSubProduction,
 			subSubProductionPosition,
 			subSubProductionSurProductionUuid,
-			CASE material WHEN NULL
+			CASE WHEN material IS NULL
 				THEN null
 				ELSE material {
 					model: 'MATERIAL',
@@ -232,13 +237,13 @@ export default () => `
 					.name,
 					.format,
 					.year,
-					surMaterial: CASE surMaterial WHEN NULL
+					surMaterial: CASE WHEN surMaterial IS NULL
 						THEN null
 						ELSE surMaterial {
 							model: 'MATERIAL',
 							.uuid,
 							.name,
-							surMaterial: CASE surSurMaterial WHEN NULL
+							surMaterial: CASE WHEN surSurMaterial IS NULL
 								THEN null
 								ELSE surSurMaterial { model: 'MATERIAL', .uuid, .name }
 							END
@@ -264,13 +269,13 @@ export default () => `
 			subSubProductionPosition,
 			subSubProductionSurProductionUuid,
 			material,
-			CASE venue WHEN NULL
+			CASE WHEN venue IS NULL
 				THEN null
 				ELSE venue {
 					model: 'VENUE',
 					.uuid,
 					.name,
-					surVenue: CASE surVenue WHEN NULL
+					surVenue: CASE WHEN surVenue IS NULL
 						THEN null
 						ELSE surVenue { model: 'VENUE', .uuid, .name }
 					END
@@ -381,7 +386,7 @@ export default () => `
 			venue,
 			producerEntityRel.credit AS producerCreditName,
 			COLLECT(
-				CASE producerEntity WHEN NULL
+				CASE WHEN producerEntity IS NULL
 					THEN null
 					ELSE producerEntity { .model, .uuid, .name, members: creditedMembers }
 				END
@@ -476,7 +481,7 @@ export default () => `
 			producerCredits,
 			castMember,
 				COLLECT(
-					CASE role.roleName WHEN NULL
+					CASE WHEN role.roleName IS NULL
 						THEN { name: 'Performer' }
 						ELSE role {
 							model: 'CHARACTER',
@@ -503,7 +508,7 @@ export default () => `
 			venue,
 			producerCredits,
 				COLLECT(
-					CASE castMember WHEN NULL
+					CASE WHEN castMember IS NULL
 						THEN null
 						ELSE castMember { model: 'PERSON', .uuid, .name, roles }
 					END
@@ -623,7 +628,7 @@ export default () => `
 			cast,
 			creativeEntityRel.credit AS creativeCreditName,
 			COLLECT(
-				CASE creativeEntity WHEN NULL
+				CASE WHEN creativeEntity IS NULL
 					THEN null
 					ELSE creativeEntity { .model, .uuid, .name, members: creditedMembers }
 				END
@@ -795,7 +800,7 @@ export default () => `
 			creativeCredits,
 			crewEntityRel.credit AS crewCreditName,
 			COLLECT(
-				CASE crewEntity WHEN NULL
+				CASE WHEN crewEntity IS NULL
 					THEN null
 					ELSE crewEntity { .model, .uuid, .name, members: creditedMembers }
 				END

--- a/src/neo4j/cypher-queries/shared/delete.js
+++ b/src/neo4j/cypher-queries/shared/delete.js
@@ -14,7 +14,7 @@ export default model => {
 			-[]-(undeleteableInstanceAssociate)
 
 		UNWIND
-			CASE undeleteableInstanceAssociate WHEN NULL
+			CASE WHEN undeleteableInstanceAssociate IS NULL
 				THEN [null]
 				ELSE LABELS(undeleteableInstanceAssociate)
 			END AS associateLabel

--- a/src/neo4j/cypher-queries/venue/create-update.js
+++ b/src/neo4j/cypher-queries/venue/create-update.js
@@ -32,7 +32,7 @@ const getCreateUpdateQuery = action => {
 					(subVenueParam.differentiator IS NULL AND existingVenue.differentiator IS NULL) OR
 					subVenueParam.differentiator = existingVenue.differentiator
 
-			FOREACH (item IN CASE subVenueParam WHEN NULL THEN [] ELSE [1] END |
+			FOREACH (item IN CASE WHEN subVenueParam IS NULL THEN [] ELSE [1] END |
 				MERGE (subVenue:Venue {
 					uuid: COALESCE(existingVenue.uuid, subVenueParam.uuid),
 					name: subVenueParam.name

--- a/src/neo4j/cypher-queries/venue/edit.js
+++ b/src/neo4j/cypher-queries/venue/edit.js
@@ -11,7 +11,7 @@ export default () => `
 		venue.name AS name,
 		venue.differentiator AS differentiator,
 		COLLECT(
-			CASE subVenue WHEN NULL
+			CASE WHEN subVenue IS NULL
 				THEN null
 				ELSE subVenue { .name, .differentiator }
 			END

--- a/src/neo4j/cypher-queries/venue/list.js
+++ b/src/neo4j/cypher-queries/venue/list.js
@@ -12,7 +12,7 @@ export default () => `
 		venue.uuid AS uuid,
 		venue.name AS name,
 		COLLECT(
-			CASE subVenue WHEN NULL
+			CASE WHEN subVenue IS NULL
 				THEN null
 				ELSE subVenue { model: 'VENUE', .uuid, .name }
 			END

--- a/src/neo4j/cypher-queries/venue/show.js
+++ b/src/neo4j/cypher-queries/venue/show.js
@@ -4,7 +4,7 @@ export default () => [`
 	OPTIONAL MATCH (surVenue:Venue)-[:HAS_SUB_VENUE]->(venue)
 
 	WITH venue,
-		CASE surVenue WHEN NULL
+		CASE WHEN surVenue IS NULL
 			THEN null
 			ELSE surVenue { model: 'VENUE', .uuid, .name }
 		END AS surVenue
@@ -16,7 +16,7 @@ export default () => [`
 
 	WITH venue, surVenue,
 		COLLECT(
-			CASE subVenue WHEN NULL
+			CASE WHEN subVenue IS NULL
 				THEN null
 				ELSE subVenue { model: 'VENUE', .uuid, .name }
 			END
@@ -56,7 +56,7 @@ export default () => [`
 		surVenue,
 		subVenues,
 		COLLECT(
-			CASE production WHEN NULL
+			CASE WHEN production IS NULL
 				THEN null
 				ELSE production {
 					model: 'PRODUCTION',
@@ -68,13 +68,13 @@ export default () => [`
 						THEN venueLinkedToProduction { model: 'VENUE', .uuid, .name }
 						ELSE null
 					END,
-					surProduction: CASE surProduction WHEN NULL
+					surProduction: CASE WHEN surProduction IS NULL
 						THEN null
 						ELSE surProduction {
 							model: 'PRODUCTION',
 							.uuid,
 							.name,
-							surProduction: CASE surSurProduction WHEN NULL
+							surProduction: CASE WHEN surSurProduction IS NULL
 								THEN null
 								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
 							END

--- a/test-unit/src/neo4j/cypher-queries/award-ceremony.test.js
+++ b/test-unit/src/neo4j/cypher-queries/award-ceremony.test.js
@@ -27,7 +27,7 @@ describe('Cypher Queries Award Ceremony module', () => {
 					ceremony.name AS name,
 					{ name: COALESCE(award.name, ''), differentiator: COALESCE(award.differentiator, '') } AS award,
 					COLLECT(
-						CASE category WHEN NULL
+						CASE WHEN category IS NULL
 							THEN null
 							ELSE category { .name, nominations }
 						END
@@ -84,7 +84,7 @@ describe('Cypher Queries Award Ceremony module', () => {
 					ceremony.name AS name,
 					{ name: COALESCE(award.name, ''), differentiator: COALESCE(award.differentiator, '') } AS award,
 					COLLECT(
-						CASE category WHEN NULL
+						CASE WHEN category IS NULL
 							THEN null
 							ELSE category { .name, nominations }
 						END

--- a/test-unit/src/neo4j/cypher-queries/shared.test.js
+++ b/test-unit/src/neo4j/cypher-queries/shared.test.js
@@ -85,7 +85,7 @@ describe('Cypher Queries Shared module', () => {
 					-[]-(undeleteableInstanceAssociate)
 
 				UNWIND
-					CASE undeleteableInstanceAssociate WHEN NULL
+					CASE WHEN undeleteableInstanceAssociate IS NULL
 						THEN [null]
 						ELSE LABELS(undeleteableInstanceAssociate)
 					END AS associateLabel

--- a/test-unit/src/neo4j/cypher-queries/venue.test.js
+++ b/test-unit/src/neo4j/cypher-queries/venue.test.js
@@ -27,7 +27,7 @@ describe('Cypher Queries Venue module', () => {
 					venue.name AS name,
 					venue.differentiator AS differentiator,
 					COLLECT(
-						CASE subVenue WHEN NULL
+						CASE WHEN subVenue IS NULL
 							THEN null
 							ELSE subVenue { .name, .differentiator }
 						END
@@ -74,7 +74,7 @@ describe('Cypher Queries Venue module', () => {
 					venue.name AS name,
 					venue.differentiator AS differentiator,
 					COLLECT(
-						CASE subVenue WHEN NULL
+						CASE WHEN subVenue IS NULL
 							THEN null
 							ELSE subVenue { .name, .differentiator }
 						END


### PR DESCRIPTION
This PR upgrades the Neo4j version from v4.4.2 to v5.9.0 (current latest) by updating the Docker Neo4j image as well as applying modifications to the Cypher queries to accommodate the major breaking changes so that it can use this version of the Neo4j Desktop app.

|Release|Release Date|Hotfixes until|Compatible Driver Versions|
|---|---|---|---|
|5.9|Jun 15, 2023|Release of 5.10|5.x, 4.4|

Even though the current `neo4j-driver` version was v5.0.1 and according to the above should have been compatible, I had issues with the app connecting to the database which were fixed by upgrading to the current latest version (v5.10.0).

Ref. [Neo4j Knowledge Base: Neo4j Supported Versions](https://neo4j.com/developer/kb/neo4j-supported-versions)

---

Some changes to the Cypher queries for creating indexes and constraints were required as per the feedback when running the current queries and as outlined in [Neo4j Docs: Cypher Manual / Indexes for search performance](https://neo4j.com/docs/cypher-manual/5/indexes-for-search-performance) and [Neo4j Docs: Cypher Manual / Deprecations, additions, and compatibility](https://neo4j.com/docs/cypher-manual/5/deprecations-additions-removals-compatibility).

These changes have been applied in:
- `src/neo4j/create-constraints.js`
- `src/neo4j/create-indexes.js`

---

The Cypher query breaking changes are documented in [Neo4j Docs: Cypher Manual / Deprecations, additions, and compatibility](https://neo4j.com/docs/cypher-manual/5/deprecations-additions-removals-compatibility) and a couple of those changes (listed under **Version 4.4 - Deprecated features**) needed to be made:

> ### Feature
> [**Functionality**] [**Deprecated**]
>
> ```cypher
> MATCH (n) RETURN n.propertyName_1, n.propertyName_2 + count(*)
> ```
>
> ### Details
> Implied grouping keys are deprecated. Only expressions that do not contain aggregations are still considered grouping keys. In expressions that contain aggregations, the leaves must be either:
> - An aggregation
> - A literal
> - A parameter
> - A variable, **ONLY IF** it is either:
>    1) A projection expression on its own (e.g. the `n` in `RETURN n AS myNode, n.value + count(*))`
>    2) A local variable in the expression (e.g the `x` in `RETURN n, n.prop + size([ x IN range(1, 10) | x ]`)
> - Property access, **ONLY IF** it is also a projection expression on its own (e.g. the `n.prop` in `RETURN n.prop, n.prop + count(*)`)
> - Map access, **ONLY IF** it is also a projection expression on its own (e.g. the `map.prop` in `WITH {prop: 2} AS map RETURN map.prop, map.prop + count(*)`)

This change was applied to the following files (they are the first changes in each of these files):
- `src/neo4j/cypher-queries/material/show/show-materials.js`
- `src/neo4j/cypher-queries/material/show/show.js`
- `src/neo4j/cypher-queries/production/show/show.js`

---

> ### Feature
> [**Functionality**] [**Deprecated**]
>
> ```cypher
> MATCH (n)
> RETURN
> CASE n.prop
>    WHEN null THEN 'one'
>    ELSE 'two'
> END
> ```
>
> ### Details
> Currently, if `n.prop` is `null`, `'one'` would be returned. Since `null = null` returns `false` in Cypher, a `WHEN` expression will no longer match in future versions.
>
> Please use `IS NULL` instead:
>
> ```cypher
> MATCH (n)
> RETURN
> CASE
>    WHEN n.prop IS NULL THEN 'one'
>    ELSE 'two'
> END
> ```

---

The previous Neo4j upgrade was done on 10 Jan 2022 in this PR: https://github.com/andygout/theatrebase-api/pull/468.

### References:
- [Neo4j Knowledge Base: Neo4j Supported Versions](https://neo4j.com/developer/kb/neo4j-supported-versions)
- [Neo4j Docs: Cypher Manual / Indexes for search performance](https://neo4j.com/docs/cypher-manual/5/indexes-for-search-performance)
- [Neo4j Docs: Cypher Manual / Deprecations, additions, and compatibility](https://neo4j.com/docs/cypher-manual/5/deprecations-additions-removals-compatibility)