### PR TITLE
Rename Docker Neo4j container name

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
     neo4j:
-        container_name: neo4j-test
+        container_name: neo4j
         image: neo4j:5.9.0
         environment:
             - NEO4J_AUTH=none


### PR DESCRIPTION
This PR renames the Docker Neo4j container name.

Admittedly it is used exclusively for end-to-end tests, but its only real purpose is to differentiate itself from other containers that may appear in the future, which will be for other services, so the name of the service alone (i.e. with the `-test` suffix removed, as this would be shared by all of them) is sufficient.