### PR TITLE
Revise Cypher syntax

### DIFF
--- a/src/neo4j/cypher-queries/award-ceremony/show.js
+++ b/src/neo4j/cypher-queries/award-ceremony/show.js
@@ -10,11 +10,10 @@ export default () => [`
 			nominee:Production OR
 			nominee:Material
 
-	OPTIONAL MATCH (nominee:Material)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity)
-		WHERE entity:Person OR entity:Company OR entity:Material
+	OPTIONAL MATCH (nominee:Material)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->
+		(entity:Person|Company|Material)
 
-	OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->(sourceMaterialWriter)
-		WHERE sourceMaterialWriter:Person OR sourceMaterialWriter:Company
+	OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->(sourceMaterialWriter:Person|Company)
 
 	WITH
 		ceremony,

--- a/src/neo4j/cypher-queries/character/show/show-materials.js
+++ b/src/neo4j/cypher-queries/character/show/show-materials.js
@@ -3,11 +3,9 @@ export default () => `
 
 	OPTIONAL MATCH (character)<-[materialRel:DEPICTS]-(material:Material)
 
-	OPTIONAL MATCH (material)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity)
-		WHERE entity:Person OR entity:Company OR entity:Material
+	OPTIONAL MATCH (material)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity:Person|Company|Material)
 
-	OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->(sourceMaterialWriter)
-		WHERE sourceMaterialWriter:Person OR sourceMaterialWriter:Company
+	OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->(sourceMaterialWriter:Person|Company)
 
 	OPTIONAL MATCH (entity:Material)<-[:HAS_SUB_MATERIAL]-(entitySurMaterial:Material)
 
@@ -148,8 +146,8 @@ export default () => `
 			END
 		) AS materials
 
-	OPTIONAL MATCH (character)<-[variantNamedDepiction:DEPICTS]-(:Material)
-		WHERE variantNamedDepiction.displayName IS NOT NULL
+	OPTIONAL MATCH (character)
+		<-[variantNamedDepiction:DEPICTS WHERE variantNamedDepiction.displayName IS NOT NULL]-(:Material)
 
 	WITH character, materials, variantNamedDepiction
 		ORDER BY variantNamedDepiction.displayName

--- a/src/neo4j/cypher-queries/company/show/show-awards.js
+++ b/src/neo4j/cypher-queries/company/show/show-awards.js
@@ -35,9 +35,8 @@ export default () => `
 		WITH company, nomineeRel, category, categoryRel, ceremony,
 			COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
 
-	OPTIONAL MATCH (category)-[coNominatedEntityRel:HAS_NOMINEE]->(coNominatedEntity)
+	OPTIONAL MATCH (category)-[coNominatedEntityRel:HAS_NOMINEE]->(coNominatedEntity:Person|Company)
 		WHERE
-			(coNominatedEntity:Person OR coNominatedEntity:Company) AND
 			coNominatedEntityRel.nominatedCompanyUuid IS NULL AND
 			(
 				nomineeRel.nominationPosition IS NULL OR

--- a/src/neo4j/cypher-queries/company/show/show-materials.js
+++ b/src/neo4j/cypher-queries/company/show/show-materials.js
@@ -19,15 +19,14 @@ export default () => `
 		OPTIONAL MATCH (company)<-[:HAS_WRITING_ENTITY]-(:Material)
 			<-[sourcingMaterialRel:USES_SOURCE_MATERIAL]-(material)
 
-		OPTIONAL MATCH (material)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity)
-			WHERE entity:Person OR entity:Company OR entity:Material
+		OPTIONAL MATCH (material)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity:Person|Company|Material)
 
 		OPTIONAL MATCH (entity:Material)<-[:HAS_SUB_MATERIAL]-(entitySurMaterial:Material)
 
 		OPTIONAL MATCH (entitySurMaterial)<-[:HAS_SUB_MATERIAL]-(entitySurSurMaterial:Material)
 
-		OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->(sourceMaterialWriter)
-			WHERE sourceMaterialWriter:Person OR sourceMaterialWriter:Company
+		OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->
+			(sourceMaterialWriter:Person|Company)
 
 		WITH
 			company,

--- a/src/neo4j/cypher-queries/company/show/show-productions.js
+++ b/src/neo4j/cypher-queries/company/show/show-productions.js
@@ -3,10 +3,8 @@ export default () => `
 
 	OPTIONAL MATCH (company)<-[:HAS_PRODUCER_ENTITY]-(production:Production)
 
-	OPTIONAL MATCH (production)-[entityRel:HAS_PRODUCER_ENTITY]->(entity)
-		WHERE
-			(entity:Person OR entity:Company) AND
-			entityRel.creditedCompanyUuid IS NULL
+	OPTIONAL MATCH (production)-[entityRel:HAS_PRODUCER_ENTITY WHERE entityRel.creditedCompanyUuid IS NULL]->
+		(entity:Person|Company)
 
 	UNWIND (CASE WHEN entityRel IS NOT NULL AND entityRel.creditedMemberUuids IS NOT NULL
 		THEN [uuid IN entityRel.creditedMemberUuids]
@@ -138,9 +136,8 @@ export default () => `
 		WITH company, producerProductions, creativeRel, production,
 			COLLECT(creditedMember { model: 'PERSON', .uuid, .name }) AS creditedMembers
 
-	OPTIONAL MATCH (production)-[coCreditedEntityRel:HAS_CREATIVE_ENTITY]->(coCreditedEntity)
+	OPTIONAL MATCH (production)-[coCreditedEntityRel:HAS_CREATIVE_ENTITY]->(coCreditedEntity:Person|Company)
 		WHERE
-			(coCreditedEntity:Person OR coCreditedEntity:Company) AND
 			coCreditedEntityRel.creditedCompanyUuid IS NULL AND
 			(creativeRel.creditPosition IS NULL OR creativeRel.creditPosition = coCreditedEntityRel.creditPosition) AND
 			coCreditedEntity.uuid <> company.uuid
@@ -290,9 +287,8 @@ export default () => `
 		WITH company, producerProductions, creativeProductions, crewRel, production,
 			COLLECT(creditedMember { model: 'PERSON', .uuid, .name }) AS creditedMembers
 
-	OPTIONAL MATCH (production)-[coCreditedEntityRel:HAS_CREW_ENTITY]->(coCreditedEntity)
+	OPTIONAL MATCH (production)-[coCreditedEntityRel:HAS_CREW_ENTITY]->(coCreditedEntity:Person|Company)
 		WHERE
-			(coCreditedEntity:Person OR coCreditedEntity:Company) AND
 			coCreditedEntityRel.creditedCompanyUuid IS NULL AND
 			(crewRel.creditPosition IS NULL OR crewRel.creditPosition = coCreditedEntityRel.creditPosition) AND
 			coCreditedEntity.uuid <> company.uuid

--- a/src/neo4j/cypher-queries/material/create-update.js
+++ b/src/neo4j/cypher-queries/material/create-update.js
@@ -22,8 +22,7 @@ const getCreateUpdateQuery = action => {
 
 			WITH DISTINCT material
 
-			OPTIONAL MATCH (material)-[writerRel:HAS_WRITING_ENTITY]->(entity)
-				WHERE entity:Person OR entity:Company
+			OPTIONAL MATCH (material)-[writerRel:HAS_WRITING_ENTITY]->(entity:Person|Company)
 
 			DELETE writerRel
 

--- a/src/neo4j/cypher-queries/material/edit.js
+++ b/src/neo4j/cypher-queries/material/edit.js
@@ -3,8 +3,7 @@ export default () => `
 
 	OPTIONAL MATCH (material)-[:SUBSEQUENT_VERSION_OF]->(originalVersionMaterial:Material)
 
-	OPTIONAL MATCH (material)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity)
-		WHERE entity:Person OR entity:Company OR entity:Material
+	OPTIONAL MATCH (material)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity:Person|Company|Material)
 
 	WITH material, originalVersionMaterial, entityRel, entity
 		ORDER BY entityRel.creditPosition, entityRel.entityPosition

--- a/src/neo4j/cypher-queries/material/list.js
+++ b/src/neo4j/cypher-queries/material/list.js
@@ -2,11 +2,9 @@ export default () => `
 	MATCH (material:Material)
 		WHERE NOT EXISTS((material)-[:HAS_SUB_MATERIAL]->(:Material))
 
-	OPTIONAL MATCH (material)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity)
-		WHERE entity:Person OR entity:Company OR entity:Material
+	OPTIONAL MATCH (material)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity:Person|Company|Material)
 
-	OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->(sourceMaterialWriter)
-		WHERE sourceMaterialWriter:Person OR sourceMaterialWriter:Company
+	OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->(sourceMaterialWriter:Person|Company)
 
 	OPTIONAL MATCH (entity:Material)<-[:HAS_SUB_MATERIAL]-(entitySurMaterial:Material)
 

--- a/src/neo4j/cypher-queries/material/show/show-materials.js
+++ b/src/neo4j/cypher-queries/material/show/show-materials.js
@@ -20,13 +20,13 @@ export default () => `
 
 		OPTIONAL MATCH (relatedMaterial)-[sourcingMaterialRel:USES_SOURCE_MATERIAL]->(material)
 
-		OPTIONAL MATCH (relatedMaterial)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity)
-			WHERE entity:Person OR entity:Company OR entity:Material
+		OPTIONAL MATCH (relatedMaterial)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->
+			(entity:Person|Company|Material)
 
 		OPTIONAL MATCH (entity)<-[originalVersionWritingEntityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]-(material)
 
-		OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->(sourceMaterialWriter)
-			WHERE sourceMaterialWriter:Person OR sourceMaterialWriter:Company
+		OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->
+			(sourceMaterialWriter:Person|Company)
 
 		OPTIONAL MATCH (entity:Material)<-[:HAS_SUB_MATERIAL]-(entitySurMaterial:Material)
 

--- a/src/neo4j/cypher-queries/material/show/show.js
+++ b/src/neo4j/cypher-queries/material/show/show.js
@@ -57,11 +57,11 @@ export default () => `
 
 			OPTIONAL MATCH (relatedMaterial)<-[originalVersionRel:SUBSEQUENT_VERSION_OF]-(collectionMaterial)
 
-			OPTIONAL MATCH (relatedMaterial)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity)
-				WHERE entity:Person OR entity:Company OR entity:Material
+			OPTIONAL MATCH (relatedMaterial)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->
+				(entity:Person|Company|Material)
 
-			OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->(sourceMaterialWriter)
-				WHERE sourceMaterialWriter:Person OR sourceMaterialWriter:Company
+			OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->
+				(sourceMaterialWriter:Person|Company)
 
 			OPTIONAL MATCH (entity:Material)<-[:HAS_SUB_MATERIAL]-(entitySurMaterial:Material)
 

--- a/src/neo4j/cypher-queries/person/show/show-awards.js
+++ b/src/neo4j/cypher-queries/person/show/show-awards.js
@@ -64,9 +64,8 @@ export default () => `
 		COALESCE(nominatedEmployerCompany, person) AS entity,
 		COALESCE(nominatedCompanyRel, nomineeRel) AS entityRel
 
-	OPTIONAL MATCH (category)-[coNominatedEntityRel:HAS_NOMINEE]->(coNominatedEntity)
+	OPTIONAL MATCH (category)-[coNominatedEntityRel:HAS_NOMINEE]->(coNominatedEntity:Person|Company)
 		WHERE
-			(coNominatedEntity:Person OR coNominatedEntity:Company) AND
 			coNominatedEntityRel.nominatedCompanyUuid IS NULL AND
 			(
 				entityRel.nominationPosition IS NULL OR

--- a/src/neo4j/cypher-queries/person/show/show-materials.js
+++ b/src/neo4j/cypher-queries/person/show/show-materials.js
@@ -19,15 +19,14 @@ export default () => `
 		OPTIONAL MATCH (person)<-[:HAS_WRITING_ENTITY]-(:Material)
 			<-[sourcingMaterialRel:USES_SOURCE_MATERIAL]-(material)
 
-		OPTIONAL MATCH (material)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity)
-			WHERE entity:Person OR entity:Company OR entity:Material
+		OPTIONAL MATCH (material)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity:Person|Company|Material)
 
 		OPTIONAL MATCH (entity:Material)<-[:HAS_SUB_MATERIAL]-(entitySurMaterial:Material)
 
 		OPTIONAL MATCH (entitySurMaterial)<-[:HAS_SUB_MATERIAL]-(entitySurSurMaterial:Material)
 
-		OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->(sourceMaterialWriter)
-			WHERE sourceMaterialWriter:Person OR sourceMaterialWriter:Company
+		OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->
+			(sourceMaterialWriter:Person|Company)
 
 		WITH
 			person,

--- a/src/neo4j/cypher-queries/person/show/show-productions.js
+++ b/src/neo4j/cypher-queries/person/show/show-productions.js
@@ -3,10 +3,8 @@ export default () => `
 
 	OPTIONAL MATCH (person)<-[:HAS_PRODUCER_ENTITY]-(production:Production)
 
-	OPTIONAL MATCH (production)-[entityRel:HAS_PRODUCER_ENTITY]->(entity)
-		WHERE
-			(entity:Person OR entity:Company) AND
-			entityRel.creditedCompanyUuid IS NULL
+	OPTIONAL MATCH (production)-[entityRel:HAS_PRODUCER_ENTITY WHERE entityRel.creditedCompanyUuid IS NULL]->
+		(entity:Person|Company)
 
 	UNWIND (CASE WHEN entityRel IS NOT NULL AND entityRel.creditedMemberUuids IS NOT NULL
 		THEN [uuid IN entityRel.creditedMemberUuids]
@@ -262,9 +260,8 @@ export default () => `
 		COALESCE(creditedEmployerCompany, person) AS entity,
 		COALESCE(creativeCompanyRel, creativeRel) AS entityRel
 
-	OPTIONAL MATCH (production)-[coCreditedEntityRel:HAS_CREATIVE_ENTITY]->(coCreditedEntity)
+	OPTIONAL MATCH (production)-[coCreditedEntityRel:HAS_CREATIVE_ENTITY]->(coCreditedEntity:Person|Company)
 		WHERE
-			(coCreditedEntity:Person OR coCreditedEntity:Company) AND
 			coCreditedEntityRel.creditedCompanyUuid IS NULL AND
 			(
 				entityRel.creditPosition IS NULL OR
@@ -473,9 +470,8 @@ export default () => `
 		COALESCE(creditedEmployerCompany, person) AS entity,
 		COALESCE(crewCompanyRel, crewRel) AS entityRel
 
-	OPTIONAL MATCH (production)-[coCreditedEntityRel:HAS_CREW_ENTITY]->(coCreditedEntity)
+	OPTIONAL MATCH (production)-[coCreditedEntityRel:HAS_CREW_ENTITY]->(coCreditedEntity:Person|Company)
 		WHERE
-			(coCreditedEntity:Person OR coCreditedEntity:Company) AND
 			coCreditedEntityRel.creditedCompanyUuid IS NULL AND
 			(
 				entityRel.creditPosition IS NULL OR

--- a/src/neo4j/cypher-queries/production/show/show.js
+++ b/src/neo4j/cypher-queries/production/show/show.js
@@ -44,15 +44,14 @@ export default () => `
 
 		OPTIONAL MATCH (surMaterial)<-[:HAS_SUB_MATERIAL]-(surSurMaterial:Material)
 
-		OPTIONAL MATCH (material)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity)
-			WHERE entity:Person OR entity:Company OR entity:Material
+		OPTIONAL MATCH (material)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity:Person|Company|Material)
 
 		OPTIONAL MATCH (entity:Material)<-[:HAS_SUB_MATERIAL]-(entitySurMaterial:Material)
 
 		OPTIONAL MATCH (entitySurMaterial)<-[:HAS_SUB_MATERIAL]-(entitySurSurMaterial:Material)
 
-		OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->(sourceMaterialWriter)
-			WHERE sourceMaterialWriter:Person OR sourceMaterialWriter:Company
+		OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->
+			(sourceMaterialWriter:Person|Company)
 
 		WITH
 			production,

--- a/test-e2e/test-helpers/neo4j/count-nodes-with-label.js
+++ b/test-e2e/test-helpers/neo4j/count-nodes-with-label.js
@@ -3,9 +3,7 @@ import { neo4jQuery } from '../../../src/neo4j/query';
 export default async label => {
 
 	const query = `
-		MATCH (n:${label})
-
-		RETURN COUNT(n) AS count
+		RETURN COUNT { (n:${label}) } AS count
 	`;
 
 	const { count } = await neo4jQuery({ query, params: {} });

--- a/test-unit/src/neo4j/cypher-queries/material.test.js
+++ b/test-unit/src/neo4j/cypher-queries/material.test.js
@@ -73,8 +73,7 @@ describe('Cypher Queries Material module', () => {
 
 				WITH DISTINCT material
 
-				OPTIONAL MATCH (material)-[writerRel:HAS_WRITING_ENTITY]->(entity)
-					WHERE entity:Person OR entity:Company
+				OPTIONAL MATCH (material)-[writerRel:HAS_WRITING_ENTITY]->(entity:Person|Company)
 
 				DELETE writerRel
 


### PR DESCRIPTION
Some revised Cypher syntax was introduced in Neo4j version 5.0, as documented here: [Neo4j Docs: Cypher Manual / Deprecations, additions, and compatibility](https://neo4j.com/docs/cypher-manual/5/deprecations-additions-removals-compatibility).

Following this the PR [Upgrade Neo4j v4.4.2 -> v5.9.0](https://github.com/andygout/theatrebase-api/pull/563), some of this revised syntax can now be applied, as is done in this PR:

> ### Feature
> [**Functionality**] [**Added**]
>
> ```cypher
> COUNT { (n) WHERE n.foo = "bar" }
> ```
>
> ### Details
> New expression which returns the number of results of a subquery.

---

> ### Feature
> [**Functionality**] [**Deprecated**]
>
> ```cypher
> ()-[:A|:B]->()
> ```
>
> ### Details
> Replaced by:
> ```cypher
> ()-[:A|B]->()
> ```

N.B. I was not using this multiple label feature at all before now, but now that it has been adopted we are naturally using the current syntax.

---

> ### Feature
> [**Syntax**] [**News**]
>
> ```cypher
> MATCH ()-[r:R {prop1: 42} WHERE r.prop2 > 42]->()
> ```
>
> ### Details
> New syntax that enables inlining of WHERE clauses inside relationship patterns.

---

### References:
- [Neo4j Docs: Cypher Manual / Deprecations, additions, and compatibility](https://neo4j.com/docs/cypher-manual/5/deprecations-additions-removals-compatibility)