### PR TITLE
Replace Cypher SIGN() with TOBOOLEAN()

### DIFF
--- a/src/models/AwardCeremony.js
+++ b/src/models/AwardCeremony.js
@@ -2,7 +2,7 @@ import { getDuplicateBaseInstanceIndices } from '../lib/get-duplicate-indices';
 import { prepareAsParams } from '../lib/prepare-as-params';
 import Entity from './Entity';
 import { Award, AwardCeremonyCategory } from '.';
-import { getAwardContextualDuplicateRecordCountQuery } from '../neo4j/cypher-queries';
+import { getAwardContextualDuplicateRecordCheckQuery } from '../neo4j/cypher-queries';
 import { neo4jQuery } from '../neo4j/query';
 import { MODELS } from '../utils/constants';
 
@@ -56,8 +56,8 @@ export default class AwardCeremony extends Entity {
 
 		const preparedParams = prepareAsParams(this);
 
-		const { duplicateRecordCount } = await neo4jQuery({
-			query: getAwardContextualDuplicateRecordCountQuery(),
+		const { isDuplicateRecord } = await neo4jQuery({
+			query: getAwardContextualDuplicateRecordCheckQuery(),
 			params: {
 				uuid: preparedParams.uuid,
 				name: preparedParams.name,
@@ -68,7 +68,7 @@ export default class AwardCeremony extends Entity {
 			}
 		});
 
-		if (duplicateRecordCount > 0) {
+		if (isDuplicateRecord) {
 
 			const uniquenessErrorMessage = 'Award ceremony already exists for given award';
 

--- a/src/models/Entity.js
+++ b/src/models/Entity.js
@@ -83,12 +83,12 @@ export default class Entity extends Base {
 
 	async validateUniquenessInDatabase () {
 
-		const { getDuplicateRecordCountQuery } = validationQueries;
+		const { getDuplicateRecordCheckQuery } = validationQueries;
 
 		const preparedParams = prepareAsParams(this);
 
-		const { duplicateRecordCount } = await neo4jQuery({
-			query: getDuplicateRecordCountQuery(this.model),
+		const { isDuplicateRecord } = await neo4jQuery({
+			query: getDuplicateRecordCheckQuery(this.model),
 			params: {
 				uuid: preparedParams.uuid,
 				name: preparedParams.name,
@@ -96,7 +96,7 @@ export default class Entity extends Base {
 			}
 		});
 
-		if (duplicateRecordCount > 0) {
+		if (isDuplicateRecord) {
 
 			const uniquenessErrorMessage = 'Name and differentiator combination already exists';
 

--- a/src/neo4j/cypher-queries/award-ceremony/award-contextual-duplicate-record-check.js
+++ b/src/neo4j/cypher-queries/award-ceremony/award-contextual-duplicate-record-check.js
@@ -10,5 +10,5 @@ export default () => `
 				$award.differentiator = award.differentiator
 			)
 
-	RETURN SIGN(COUNT(ceremony)) AS duplicateRecordCount
+	RETURN TOBOOLEAN(COUNT(ceremony)) AS isDuplicateRecord
 `;

--- a/src/neo4j/cypher-queries/award-ceremony/index.js
+++ b/src/neo4j/cypher-queries/award-ceremony/index.js
@@ -1,11 +1,11 @@
-import getAwardContextualDuplicateRecordCountQuery from './award-contextual-duplicate-record-count';
+import getAwardContextualDuplicateRecordCheckQuery from './award-contextual-duplicate-record-check';
 import { getCreateQuery, getUpdateQuery } from './create-update';
 import getEditQuery from './edit';
 import getListQuery from './list';
 import getShowQueries from './show';
 
 export {
-	getAwardContextualDuplicateRecordCountQuery,
+	getAwardContextualDuplicateRecordCheckQuery,
 	getCreateQuery,
 	getEditQuery,
 	getUpdateQuery,

--- a/src/neo4j/cypher-queries/index.js
+++ b/src/neo4j/cypher-queries/index.js
@@ -1,6 +1,6 @@
 import { getShowQueries as getAwardShowQueries } from './award';
 import {
-	getAwardContextualDuplicateRecordCountQuery,
+	getAwardContextualDuplicateRecordCheckQuery,
 	getCreateQuery as getAwardCeremonyCreateQuery,
 	getEditQuery as getAwardCeremonyEditQuery,
 	getUpdateQuery as getAwardCeremonyUpdateQuery,
@@ -32,7 +32,7 @@ import {
 	getListQuery as getSharedListQuery
 } from './shared';
 import {
-	getDuplicateRecordCountQuery,
+	getDuplicateRecordCheckQuery,
 	getExistenceQuery,
 	getSubMaterialChecksQuery,
 	getSubProductionChecksQuery,
@@ -95,7 +95,7 @@ const sharedQueries = {
 };
 
 const validationQueries = {
-	getDuplicateRecordCountQuery,
+	getDuplicateRecordCheckQuery,
 	getExistenceQuery,
 	getSubMaterialChecksQuery,
 	getSubProductionChecksQuery,
@@ -103,7 +103,7 @@ const validationQueries = {
 };
 
 export {
-	getAwardContextualDuplicateRecordCountQuery,
+	getAwardContextualDuplicateRecordCheckQuery,
 	getCreateQueries,
 	getEditQueries,
 	getUpdateQueries,

--- a/src/neo4j/cypher-queries/validation/duplicate-record-check.js
+++ b/src/neo4j/cypher-queries/validation/duplicate-record-check.js
@@ -12,5 +12,5 @@ export default model => `
 				$uuid <> n.uuid
 			)
 
-	RETURN SIGN(COUNT(n)) AS duplicateRecordCount
+	RETURN TOBOOLEAN(COUNT(n)) AS isDuplicateRecord
 `;

--- a/src/neo4j/cypher-queries/validation/index.js
+++ b/src/neo4j/cypher-queries/validation/index.js
@@ -1,11 +1,11 @@
-import getDuplicateRecordCountQuery from './duplicate-record-count';
+import getDuplicateRecordCheckQuery from './duplicate-record-check';
 import getExistenceQuery from './existence';
 import getSubMaterialChecksQuery from './sub-material-checks';
 import getSubProductionChecksQuery from './sub-production-checks';
 import getSubVenueChecksQuery from './sub-venue-checks';
 
 export {
-	getDuplicateRecordCountQuery,
+	getDuplicateRecordCheckQuery,
 	getExistenceQuery,
 	getSubMaterialChecksQuery,
 	getSubProductionChecksQuery,

--- a/test-int/input-validation-failures/award-ceremony.test.js
+++ b/test-int/input-validation-failures/award-ceremony.test.js
@@ -20,7 +20,7 @@ describe('Input validation failures: AwardCeremony instance', () => {
 
 		// Stub with a contrived resolution that ensures various
 		// neo4jQuery function calls all pass database validation.
-		sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ isExistent: true, duplicateRecordCount: 0 });
+		sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ isExistent: true, isDuplicateRecord: false });
 
 	});
 

--- a/test-int/input-validation-failures/award.test.js
+++ b/test-int/input-validation-failures/award.test.js
@@ -20,7 +20,7 @@ describe('Input validation failures: Award instance', () => {
 
 		// Stub with a contrived resolution that ensures various
 		// neo4jQuery function calls all pass database validation.
-		sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ isExistent: true, duplicateRecordCount: 0 });
+		sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ isExistent: true, isDuplicateRecord: false });
 
 	});
 

--- a/test-int/input-validation-failures/character.test.js
+++ b/test-int/input-validation-failures/character.test.js
@@ -20,7 +20,7 @@ describe('Input validation failures: Character instance', () => {
 
 		// Stub with a contrived resolution that ensures various
 		// neo4jQuery function calls all pass database validation.
-		sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ isExistent: true, duplicateRecordCount: 0 });
+		sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ isExistent: true, isDuplicateRecord: false });
 
 	});
 

--- a/test-int/input-validation-failures/company.test.js
+++ b/test-int/input-validation-failures/company.test.js
@@ -20,7 +20,7 @@ describe('Input validation failures: Company instance', () => {
 
 		// Stub with a contrived resolution that ensures various
 		// neo4jQuery function calls all pass database validation.
-		sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ isExistent: true, duplicateRecordCount: 0 });
+		sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ isExistent: true, isDuplicateRecord: false });
 
 	});
 

--- a/test-int/input-validation-failures/material.test.js
+++ b/test-int/input-validation-failures/material.test.js
@@ -25,7 +25,7 @@ describe('Input validation failures: Material instance', () => {
 			.stub(neo4jQueryModule, 'neo4jQuery')
 			.resolves({
 				isExistent: true,
-				duplicateRecordCount: 0,
+				isDuplicate: false,
 				isAssignedToSurMaterial: false,
 				isSurSurMaterial: false,
 				isSurMaterialOfSubjectMaterial: false,

--- a/test-int/input-validation-failures/person.test.js
+++ b/test-int/input-validation-failures/person.test.js
@@ -20,7 +20,7 @@ describe('Input validation failures: Person instance', () => {
 
 		// Stub with a contrived resolution that ensures various
 		// neo4jQuery function calls all pass database validation.
-		sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ isExistent: true, duplicateRecordCount: 0 });
+		sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves({ isExistent: true, isDuplicateRecord: false });
 
 	});
 

--- a/test-int/input-validation-failures/production.test.js
+++ b/test-int/input-validation-failures/production.test.js
@@ -24,7 +24,7 @@ describe('Input validation failures: Production instance', () => {
 			.stub(neo4jQueryModule, 'neo4jQuery')
 			.resolves({
 				isExistent: true,
-				duplicateRecordCount: 0,
+				isDuplicateRecord: false,
 				isAssignedToSurProduction: false,
 				isSurSurProduction: false,
 				isSurProductionOfSubjectProduction: false,

--- a/test-int/input-validation-failures/venue.test.js
+++ b/test-int/input-validation-failures/venue.test.js
@@ -24,7 +24,7 @@ describe('Input validation failures: Venue instance', () => {
 			.stub(neo4jQueryModule, 'neo4jQuery')
 			.resolves({
 				isExistent: true,
-				duplicateRecordCount: 0,
+				isDuplicateRecord: false,
 				isAssignedToSurVenue: false,
 				isSurVenue: false,
 				isSubjectVenueASubVenue: false

--- a/test-unit/src/models/AwardCeremony.test.js
+++ b/test-unit/src/models/AwardCeremony.test.js
@@ -41,8 +41,8 @@ describe('AwardCeremony model', () => {
 				AwardCeremonyCategory: AwardCeremonyCategoryStub
 			},
 			cypherQueriesModule: {
-				getAwardContextualDuplicateRecordCountQuery: stub()
-					.returns('getAwardContextualDuplicateRecordCountQuery response')
+				getAwardContextualDuplicateRecordCheckQuery: stub()
+					.returns('getAwardContextualDuplicateRecordCheckQuery response')
 			},
 			neo4jQueryModule: {
 				neo4jQuery: stub().resolves({ neo4jQueryMockResponseProperty: 'neo4jQueryMockResponseValue' })
@@ -201,23 +201,23 @@ describe('AwardCeremony model', () => {
 			it('will not call addPropertyError method', async () => {
 
 				const instance = createInstance();
-				stubs.neo4jQueryModule.neo4jQuery.resolves({ duplicateRecordCount: 0 });
+				stubs.neo4jQueryModule.neo4jQuery.resolves({ isDuplicateRecord: false });
 				spy(instance, 'addPropertyError');
 				await instance.validateAwardContextualUniquenessInDatabase();
 				assert.callOrder(
 					stubs.prepareAsParamsModule.prepareAsParams,
-					stubs.cypherQueriesModule.getAwardContextualDuplicateRecordCountQuery,
+					stubs.cypherQueriesModule.getAwardContextualDuplicateRecordCheckQuery,
 					stubs.neo4jQueryModule.neo4jQuery
 				);
 				assert.calledOnce(stubs.prepareAsParamsModule.prepareAsParams);
 				assert.calledWithExactly(stubs.prepareAsParamsModule.prepareAsParams, instance);
-				assert.calledOnce(stubs.cypherQueriesModule.getAwardContextualDuplicateRecordCountQuery);
-				assert.calledWithExactly(stubs.cypherQueriesModule.getAwardContextualDuplicateRecordCountQuery);
+				assert.calledOnce(stubs.cypherQueriesModule.getAwardContextualDuplicateRecordCheckQuery);
+				assert.calledWithExactly(stubs.cypherQueriesModule.getAwardContextualDuplicateRecordCheckQuery);
 				assert.calledOnce(stubs.neo4jQueryModule.neo4jQuery);
 				assert.calledWithExactly(
 					stubs.neo4jQueryModule.neo4jQuery,
 					{
-						query: 'getAwardContextualDuplicateRecordCountQuery response',
+						query: 'getAwardContextualDuplicateRecordCheckQuery response',
 						params: {
 							uuid: 'UUID_VALUE',
 							name: 'NAME_VALUE',
@@ -240,24 +240,24 @@ describe('AwardCeremony model', () => {
 			it('will call addPropertyError method', async () => {
 
 				const instance = createInstance();
-				stubs.neo4jQueryModule.neo4jQuery.resolves({ duplicateRecordCount: 1 });
+				stubs.neo4jQueryModule.neo4jQuery.resolves({ isDuplicateRecord: true });
 				spy(instance, 'addPropertyError');
 				await instance.validateAwardContextualUniquenessInDatabase();
 				assert.callOrder(
 					stubs.prepareAsParamsModule.prepareAsParams,
-					stubs.cypherQueriesModule.getAwardContextualDuplicateRecordCountQuery,
+					stubs.cypherQueriesModule.getAwardContextualDuplicateRecordCheckQuery,
 					stubs.neo4jQueryModule.neo4jQuery,
 					instance.addPropertyError
 				);
 				assert.calledOnce(stubs.prepareAsParamsModule.prepareAsParams);
 				assert.calledWithExactly(stubs.prepareAsParamsModule.prepareAsParams, instance);
-				assert.calledOnce(stubs.cypherQueriesModule.getAwardContextualDuplicateRecordCountQuery);
-				assert.calledWithExactly(stubs.cypherQueriesModule.getAwardContextualDuplicateRecordCountQuery);
+				assert.calledOnce(stubs.cypherQueriesModule.getAwardContextualDuplicateRecordCheckQuery);
+				assert.calledWithExactly(stubs.cypherQueriesModule.getAwardContextualDuplicateRecordCheckQuery);
 				assert.calledOnce(stubs.neo4jQueryModule.neo4jQuery);
 				assert.calledWithExactly(
 					stubs.neo4jQueryModule.neo4jQuery,
 					{
-						query: 'getAwardContextualDuplicateRecordCountQuery response',
+						query: 'getAwardContextualDuplicateRecordCheckQuery response',
 						params: {
 							uuid: 'UUID_VALUE',
 							name: 'NAME_VALUE',

--- a/test-unit/src/models/Entity.test.js
+++ b/test-unit/src/models/Entity.test.js
@@ -58,9 +58,9 @@ describe('Entity model', () => {
 				getExistenceQuery:
 					sandbox.stub(cypherQueries.validationQueries, 'getExistenceQuery')
 						.returns('getExistenceQuery response'),
-				getDuplicateRecordCountQuery:
-					sandbox.stub(cypherQueries.validationQueries, 'getDuplicateRecordCountQuery')
-						.returns('getDuplicateRecordCountQuery response')
+				getDuplicateRecordCheckQuery:
+					sandbox.stub(cypherQueries.validationQueries, 'getDuplicateRecordCheckQuery')
+						.returns('getDuplicateRecordCheckQuery response')
 			},
 			neo4jQuery: sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves(neo4jQueryMockResponse)
 		};
@@ -415,23 +415,23 @@ describe('Entity model', () => {
 					name: 'NAME_VALUE',
 					differentiator: 'DIFFERENTIATOR_VALUE'
 				});
-				stubs.neo4jQuery.resolves({ duplicateRecordCount: 0 });
+				stubs.neo4jQuery.resolves({ isDuplicateRecord: false });
 				spy(instance, 'addPropertyError');
 				await instance.validateUniquenessInDatabase();
 				assert.callOrder(
 					stubs.prepareAsParams,
-					stubs.validationQueries.getDuplicateRecordCountQuery,
+					stubs.validationQueries.getDuplicateRecordCheckQuery,
 					stubs.neo4jQuery
 				);
 				assert.calledOnce(stubs.prepareAsParams);
 				assert.calledWithExactly(stubs.prepareAsParams, instance);
-				assert.calledOnce(stubs.validationQueries.getDuplicateRecordCountQuery);
-				assert.calledWithExactly(stubs.validationQueries.getDuplicateRecordCountQuery, instance.model);
+				assert.calledOnce(stubs.validationQueries.getDuplicateRecordCheckQuery);
+				assert.calledWithExactly(stubs.validationQueries.getDuplicateRecordCheckQuery, instance.model);
 				assert.calledOnce(stubs.neo4jQuery);
 				assert.calledWithExactly(
 					stubs.neo4jQuery,
 					{
-						query: 'getDuplicateRecordCountQuery response',
+						query: 'getDuplicateRecordCheckQuery response',
 						params: {
 							uuid: 'UUID_VALUE',
 							name: 'NAME_VALUE',
@@ -454,24 +454,24 @@ describe('Entity model', () => {
 					name: 'NAME_VALUE',
 					differentiator: 'DIFFERENTIATOR_VALUE'
 				});
-				stubs.neo4jQuery.resolves({ duplicateRecordCount: 1 });
+				stubs.neo4jQuery.resolves({ isDuplicateRecord: true });
 				spy(instance, 'addPropertyError');
 				await instance.validateUniquenessInDatabase();
 				assert.callOrder(
 					stubs.prepareAsParams,
-					stubs.validationQueries.getDuplicateRecordCountQuery,
+					stubs.validationQueries.getDuplicateRecordCheckQuery,
 					stubs.neo4jQuery,
 					instance.addPropertyError
 				);
 				assert.calledOnce(stubs.prepareAsParams);
 				assert.calledWithExactly(stubs.prepareAsParams, instance);
-				assert.calledOnce(stubs.validationQueries.getDuplicateRecordCountQuery);
-				assert.calledWithExactly(stubs.validationQueries.getDuplicateRecordCountQuery, instance.model);
+				assert.calledOnce(stubs.validationQueries.getDuplicateRecordCheckQuery);
+				assert.calledWithExactly(stubs.validationQueries.getDuplicateRecordCheckQuery, instance.model);
 				assert.calledOnce(stubs.neo4jQuery);
 				assert.calledWithExactly(
 					stubs.neo4jQuery,
 					{
-						query: 'getDuplicateRecordCountQuery response',
+						query: 'getDuplicateRecordCheckQuery response',
 						params: {
 							uuid: 'UUID_VALUE',
 							name: 'NAME_VALUE',
@@ -625,7 +625,7 @@ describe('Entity model', () => {
 				assert.calledWithExactly(
 					stubs.neo4jQuery.firstCall,
 					{
-						query: 'getDuplicateRecordCountQuery response',
+						query: 'getDuplicateRecordCheckQuery response',
 						params: {
 							uuid: 'UUID_VALUE',
 							name: 'NAME_VALUE',
@@ -680,7 +680,7 @@ describe('Entity model', () => {
 				assert.calledWithExactly(
 					stubs.neo4jQuery.firstCall,
 					{
-						query: 'getDuplicateRecordCountQuery response',
+						query: 'getDuplicateRecordCheckQuery response',
 						params: {
 							uuid: 'UUID_VALUE',
 							name: 'NAME_VALUE',
@@ -736,7 +736,7 @@ describe('Entity model', () => {
 				assert.calledWithExactly(
 					stubs.neo4jQuery,
 					{
-						query: 'getDuplicateRecordCountQuery response',
+						query: 'getDuplicateRecordCheckQuery response',
 						params: {
 							uuid: 'UUID_VALUE',
 							name: 'NAME_VALUE',

--- a/test-unit/src/neo4j/cypher-queries/validation.test.js
+++ b/test-unit/src/neo4j/cypher-queries/validation.test.js
@@ -5,11 +5,11 @@ import removeExcessWhitespace from '../../../test-helpers/remove-excess-whitespa
 
 describe('Cypher Queries Validation module', () => {
 
-	describe('getDuplicateRecordCountQuery function', () => {
+	describe('getDuplicateRecordCheckQuery function', () => {
 
 		it('returns requisite query', () => {
 
-			const result = cypherQueriesValidation.getDuplicateRecordCountQuery('VENUE', undefined);
+			const result = cypherQueriesValidation.getDuplicateRecordCheckQuery('VENUE', undefined);
 			expect(removeExcessWhitespace(result)).to.equal(removeExcessWhitespace(`
 				MATCH (n:Venue { name: $name })
 					WHERE
@@ -22,7 +22,7 @@ describe('Cypher Queries Validation module', () => {
 							$uuid <> n.uuid
 						)
 
-				RETURN SIGN(COUNT(n)) AS duplicateRecordCount
+				RETURN TOBOOLEAN(COUNT(n)) AS isDuplicateRecord
 			`));
 
 		});


### PR DESCRIPTION
This PR changes the usage of the Cypher function `SIGN()` — used for determining if a submitted instance already has a duplicate record in the Neo4j database — to `TOBOOLEAN()`.

The return value from `SIGN()` does not help answer the question any more than simply returning the integer returned by the `COUNT(n)` (which is its input value).

The other validation checks use a boolean value, so given that Cypher provides the means to return the necessary boolean value, it makes sense to do so, as it also creates more consistency and readable code in any case.

> ```cypher
> RETURN sign($number) AS sign
> ```
>
> `0` if zero, `-1` if negative, `1` if positive.

---

> ```cypher
> toBoolean(expr)
> ```
>
> The [`toBoolean`](https://neo4j.com/docs/cypher-manual/5/functions/scalar/#functions-toboolean) returns a boolean if possible, for the given expression; otherwise it returns `null`. The function returns an error if provided with an expression that is not a string, integer, boolean, or null.

---

### References:
- [Neo4j: Cypher Cheat Sheet](https://neo4j.com/docs/cypher-cheat-sheet/5/auradb-enterprise)
