### PR TITLE
Use Cypher subqueries

### DIFF
--- a/src/neo4j/cypher-queries/award-ceremony/show.js
+++ b/src/neo4j/cypher-queries/award-ceremony/show.js
@@ -1,284 +1,296 @@
 export default () => [`
 	MATCH (ceremony:AwardCeremony { uuid: $uuid })
 
-	OPTIONAL MATCH (ceremony)-[categoryRel:PRESENTS_CATEGORY]->(category:AwardCeremonyCategory)
+	CALL {
+		WITH ceremony
 
-	OPTIONAL MATCH (category)-[nomineeRel:HAS_NOMINEE]->(nominee)
-		WHERE
-			(nominee:Person AND nomineeRel.nominatedCompanyUuid IS NULL) OR
-			nominee:Company OR
-			nominee:Production OR
-			nominee:Material
+		OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
 
-	OPTIONAL MATCH (nominee:Material)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->
-		(entity:Person|Company|Material)
-
-	OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->(sourceMaterialWriter:Person|Company)
-
-	WITH
-		ceremony,
-		categoryRel,
-		category,
-		nomineeRel,
-		nominee,
-		entityRel,
-		entity,
-		sourceMaterialWriterRel,
-		sourceMaterialWriter
-		ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriterRel.entityPosition
-
-	WITH
-		ceremony,
-		categoryRel,
-		category,
-		nomineeRel,
-		nominee,
-		entityRel,
-		entity,
-		sourceMaterialWriterRel.credit AS sourceMaterialWritingCreditName,
-		COLLECT(
-			CASE WHEN sourceMaterialWriter IS NULL
+		RETURN
+			CASE WHEN award IS NULL
 				THEN null
-				ELSE sourceMaterialWriter { model: TOUPPER(HEAD(LABELS(sourceMaterialWriter))), .uuid, .name }
-			END
-		) AS sourceMaterialWriters
+				ELSE award { model: 'AWARD', .uuid, .name }
+			END AS award
+	}
 
-	WITH ceremony, categoryRel, category, nomineeRel, nominee, entityRel, entity,
-		COLLECT(
-			CASE SIZE(sourceMaterialWriters) WHEN 0
+	CALL {
+		WITH ceremony
+
+		OPTIONAL MATCH (ceremony)-[categoryRel:PRESENTS_CATEGORY]->(category:AwardCeremonyCategory)
+
+		OPTIONAL MATCH (category)-[nomineeRel:HAS_NOMINEE]->(nominee)
+			WHERE
+				(nominee:Person AND nomineeRel.nominatedCompanyUuid IS NULL) OR
+				nominee:Company OR
+				nominee:Production OR
+				nominee:Material
+
+		OPTIONAL MATCH (nominee:Material)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->
+			(entity:Person|Company|Material)
+
+		OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->
+			(sourceMaterialWriter:Person|Company)
+
+		WITH
+			categoryRel,
+			category,
+			nomineeRel,
+			nominee,
+			entityRel,
+			entity,
+			sourceMaterialWriterRel,
+			sourceMaterialWriter
+			ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriterRel.entityPosition
+
+		WITH
+			categoryRel,
+			category,
+			nomineeRel,
+			nominee,
+			entityRel,
+			entity,
+			sourceMaterialWriterRel.credit AS sourceMaterialWritingCreditName,
+			COLLECT(
+				CASE WHEN sourceMaterialWriter IS NULL
+					THEN null
+					ELSE sourceMaterialWriter { model: TOUPPER(HEAD(LABELS(sourceMaterialWriter))), .uuid, .name }
+				END
+			) AS sourceMaterialWriters
+
+		WITH categoryRel, category, nomineeRel, nominee, entityRel, entity,
+			COLLECT(
+				CASE SIZE(sourceMaterialWriters) WHEN 0
+					THEN null
+					ELSE {
+						model: 'WRITING_CREDIT',
+						name: COALESCE(sourceMaterialWritingCreditName, 'by'),
+						entities: sourceMaterialWriters
+					}
+				END
+			) AS sourceMaterialWritingCredits
+			ORDER BY entityRel.creditPosition, entityRel.entityPosition
+
+		OPTIONAL MATCH (entity:Material)<-[:HAS_SUB_MATERIAL]-(entitySurMaterial:Material)
+
+		OPTIONAL MATCH (entitySurMaterial)<-[:HAS_SUB_MATERIAL]-(entitySurSurMaterial:Material)
+
+		WITH
+			categoryRel,
+			category,
+			nomineeRel,
+			nominee,
+			entityRel.credit AS writingCreditName,
+			COLLECT(
+				CASE WHEN entity IS NULL
+					THEN null
+					ELSE entity {
+						model: TOUPPER(HEAD(LABELS(entity))),
+						.uuid,
+						.name,
+						.format,
+						.year,
+						surMaterial: CASE WHEN entitySurMaterial IS NULL
+							THEN null
+							ELSE entitySurMaterial {
+								model: 'MATERIAL',
+								.uuid,
+								.name,
+								surMaterial: CASE WHEN entitySurSurMaterial IS NULL
+									THEN null
+									ELSE entitySurSurMaterial { model: 'MATERIAL', .uuid, .name }
+								END
+							}
+						END,
+						writingCredits: sourceMaterialWritingCredits
+					}
+				END
+			) AS entities
+
+		WITH categoryRel, category, nomineeRel, nominee, writingCreditName,
+			[entity IN entities | CASE entity.model WHEN 'MATERIAL'
+				THEN entity
+				ELSE entity { .model, .uuid, .name }
+			END] AS entities
+
+		OPTIONAL MATCH (nominee:Material)<-[:HAS_SUB_MATERIAL]-(surMaterial:Material)
+
+		OPTIONAL MATCH (surMaterial)<-[:HAS_SUB_MATERIAL]-(surSurMaterial:Material)
+
+		WITH
+			categoryRel,
+			category,
+			nomineeRel,
+			nominee,
+			CASE WHEN surMaterial IS NULL
 				THEN null
-				ELSE {
-					model: 'WRITING_CREDIT',
-					name: COALESCE(sourceMaterialWritingCreditName, 'by'),
-					entities: sourceMaterialWriters
-				}
-			END
-		) AS sourceMaterialWritingCredits
-		ORDER BY entityRel.creditPosition, entityRel.entityPosition
-
-	OPTIONAL MATCH (entity:Material)<-[:HAS_SUB_MATERIAL]-(entitySurMaterial:Material)
-
-	OPTIONAL MATCH (entitySurMaterial)<-[:HAS_SUB_MATERIAL]-(entitySurSurMaterial:Material)
-
-	WITH
-		ceremony,
-		categoryRel,
-		category,
-		nomineeRel,
-		nominee,
-		entityRel.credit AS writingCreditName,
-		COLLECT(
-			CASE WHEN entity IS NULL
-				THEN null
-				ELSE entity {
-					model: TOUPPER(HEAD(LABELS(entity))),
+				ELSE surMaterial {
+					model: 'MATERIAL',
 					.uuid,
 					.name,
-					.format,
-					.year,
-					surMaterial: CASE WHEN entitySurMaterial IS NULL
+					surMaterial: CASE WHEN surSurMaterial IS NULL
 						THEN null
-						ELSE entitySurMaterial {
-							model: 'MATERIAL',
-							.uuid,
-							.name,
-							surMaterial: CASE WHEN entitySurSurMaterial IS NULL
-								THEN null
-								ELSE entitySurSurMaterial { model: 'MATERIAL', .uuid, .name }
-							END
-						}
-					END,
-					writingCredits: sourceMaterialWritingCredits
+						ELSE surSurMaterial { model: 'MATERIAL', .uuid, .name }
+					END
 				}
-			END
-		) AS entities
+			END AS surMaterial,
+			COLLECT(
+				CASE SIZE(entities) WHEN 0
+					THEN null
+					ELSE {
+						model: 'WRITING_CREDIT',
+						name: COALESCE(writingCreditName, 'by'),
+						entities: entities
+					}
+				END
+			) AS writingCredits
 
-	WITH ceremony, categoryRel, category, nomineeRel, nominee, writingCreditName,
-		[entity IN entities | CASE entity.model WHEN 'MATERIAL'
-			THEN entity
-			ELSE entity { .model, .uuid, .name }
-		END] AS entities
+		OPTIONAL MATCH (nominee:Production)-[:PLAYS_AT]->(venue:Venue)
 
-	OPTIONAL MATCH (nominee:Material)<-[:HAS_SUB_MATERIAL]-(surMaterial:Material)
+		OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
 
-	OPTIONAL MATCH (surMaterial)<-[:HAS_SUB_MATERIAL]-(surSurMaterial:Material)
+		OPTIONAL MATCH (nominee:Production)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
-	WITH
-		ceremony,
-		categoryRel,
-		category,
-		nomineeRel,
-		nominee,
-		CASE WHEN surMaterial IS NULL
-			THEN null
-			ELSE surMaterial {
-				model: 'MATERIAL',
+		OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+
+		WITH categoryRel, category, nomineeRel,
+			COLLECT(nominee {
+				model: TOUPPER(HEAD(LABELS(nominee))),
 				.uuid,
 				.name,
-				surMaterial: CASE WHEN surSurMaterial IS NULL
+				.startDate,
+				.endDate,
+				nominatedMemberUuids: nomineeRel.nominatedMemberUuids,
+				venue: CASE WHEN venue IS NULL
 					THEN null
-					ELSE surSurMaterial { model: 'MATERIAL', .uuid, .name }
+					ELSE venue {
+						model: 'VENUE',
+						.uuid,
+						.name,
+						surVenue: CASE WHEN surVenue IS NULL
+							THEN null
+							ELSE surVenue { model: 'VENUE', .uuid, .name }
+						END
+					}
+				END,
+				surProduction: CASE WHEN surProduction IS NULL
+					THEN null
+					ELSE surProduction {
+						model: 'PRODUCTION',
+						.uuid,
+						.name,
+						surProduction: CASE WHEN surSurProduction IS NULL
+							THEN null
+							ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+						END
+					}
+				END,
+				.format,
+				.year,
+				surMaterial,
+				writingCredits
+			}) AS nominees
+
+		UNWIND (CASE nominees WHEN [] THEN [null] ELSE nominees END) AS nominee
+
+			UNWIND (COALESCE(nominee.nominatedMemberUuids, [null])) AS nominatedMemberUuid
+
+				OPTIONAL MATCH (category)-[nominatedMemberRel:HAS_NOMINEE]->
+					(nominatedMember:Person { uuid: nominatedMemberUuid })
+					WHERE
+						nomineeRel.nominationPosition IS NULL OR
+						nomineeRel.nominationPosition = nominatedMemberRel.nominationPosition
+
+				WITH categoryRel, category, nomineeRel, nominee, nominatedMember
+					ORDER BY nominatedMemberRel.memberPosition
+
+				WITH categoryRel, category, nomineeRel, nominee,
+					COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
+
+		WITH categoryRel, category, nomineeRel, nominee, nominatedMembers
+			ORDER BY
+				nomineeRel.nominationPosition,
+				nomineeRel.entityPosition,
+				nomineeRel.productionPosition,
+				nomineeRel.materialPosition
+
+		WITH
+			categoryRel,
+			category,
+			nomineeRel.nominationPosition AS nominationPosition,
+			nomineeRel.isWinner AS isWinner,
+			nomineeRel.customType AS customType,
+			COLLECT(
+				CASE WHEN nominee IS NULL
+					THEN null
+					ELSE nominee {
+						.model,
+						.uuid,
+						.name,
+						members: nominatedMembers,
+						.startDate,
+						.endDate,
+						.venue,
+						.surProduction,
+						.format,
+						.year,
+						.surMaterial,
+						.writingCredits
+					}
 				END
-			}
-		END AS surMaterial,
-		COLLECT(
-			CASE SIZE(entities) WHEN 0
-				THEN null
-				ELSE {
-					model: 'WRITING_CREDIT',
-					name: COALESCE(writingCreditName, 'by'),
-					entities: entities
-				}
-			END
-		) AS writingCredits
+			) AS nominees
 
-	OPTIONAL MATCH (nominee:Production)-[:PLAYS_AT]->(venue:Venue)
+		WITH
+			categoryRel,
+			category,
+			nominationPosition,
+			isWinner,
+			customType,
+			[nominee IN nominees | CASE nominee.model
+				WHEN 'COMPANY' THEN nominee { .model, .uuid, .name, .members }
+				WHEN 'PERSON' THEN nominee { .model, .uuid, .name }
+				WHEN 'PRODUCTION' THEN nominee { .model, .uuid, .name, .startDate, .endDate, .venue, .surProduction }
+				WHEN 'MATERIAL' THEN nominee { .model, .uuid, .name, .format, .year, .surMaterial, .writingCredits }
+			END] AS nominees
 
-	OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
+		WITH
+			categoryRel,
+			category,
+			isWinner,
+			customType,
+			[nominee IN nominees WHERE nominee.model = 'PERSON' OR nominee.model = 'COMPANY'] AS nomineeEntities,
+			[nominee IN nominees WHERE nominee.model = 'PRODUCTION'] AS nomineeProductions,
+			[nominee IN nominees WHERE nominee.model = 'MATERIAL'] AS nomineeMaterials
 
-	OPTIONAL MATCH (nominee:Production)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
+		WITH categoryRel, category,
+			COLLECT(
+				CASE WHEN SIZE(nomineeEntities) = 0 AND SIZE(nomineeProductions) = 0 AND SIZE(nomineeMaterials) = 0
+					THEN null
+					ELSE {
+						model: 'NOMINATION',
+						isWinner: COALESCE(isWinner, false),
+						type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
+						entities: nomineeEntities,
+						productions: nomineeProductions,
+						materials: nomineeMaterials
+					}
+				END
+			) AS nominations
+			ORDER BY categoryRel.position
 
-	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+		RETURN
+			COLLECT(
+				CASE WHEN category IS NULL
+					THEN null
+					ELSE category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }
+				END
+			) AS categories
+	}
 
-	WITH ceremony, categoryRel, category, nomineeRel,
-		COLLECT(nominee {
-			model: TOUPPER(HEAD(LABELS(nominee))),
-			.uuid,
-			.name,
-			.startDate,
-			.endDate,
-			nominatedMemberUuids: nomineeRel.nominatedMemberUuids,
-			venue: CASE WHEN venue IS NULL
-				THEN null
-				ELSE venue {
-					model: 'VENUE',
-					.uuid,
-					.name,
-					surVenue: CASE WHEN surVenue IS NULL
-						THEN null
-						ELSE surVenue { model: 'VENUE', .uuid, .name }
-					END
-				}
-			END,
-			surProduction: CASE WHEN surProduction IS NULL
-				THEN null
-				ELSE surProduction {
-					model: 'PRODUCTION',
-					.uuid,
-					.name,
-					surProduction: CASE WHEN surSurProduction IS NULL
-						THEN null
-						ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
-					END
-				}
-			END,
-			.format,
-			.year,
-			surMaterial,
-			writingCredits
-		}) AS nominees
-
-	UNWIND (CASE nominees WHEN [] THEN [null] ELSE nominees END) AS nominee
-
-		UNWIND (COALESCE(nominee.nominatedMemberUuids, [null])) AS nominatedMemberUuid
-
-			OPTIONAL MATCH (category)-[nominatedMemberRel:HAS_NOMINEE]->
-				(nominatedMember:Person { uuid: nominatedMemberUuid })
-				WHERE
-					nomineeRel.nominationPosition IS NULL OR
-					nomineeRel.nominationPosition = nominatedMemberRel.nominationPosition
-
-			WITH ceremony, categoryRel, category, nomineeRel, nominee, nominatedMember
-				ORDER BY nominatedMemberRel.memberPosition
-
-			WITH ceremony, categoryRel, category, nomineeRel, nominee,
-				COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
-
-	WITH ceremony, categoryRel, category, nomineeRel, nominee, nominatedMembers
-		ORDER BY
-			nomineeRel.nominationPosition,
-			nomineeRel.entityPosition,
-			nomineeRel.productionPosition,
-			nomineeRel.materialPosition
-
-	WITH
-		ceremony,
-		categoryRel,
-		category,
-		nomineeRel.nominationPosition AS nominationPosition,
-		nomineeRel.isWinner AS isWinner,
-		nomineeRel.customType AS customType,
-		COLLECT(
-			CASE WHEN nominee IS NULL
-				THEN null
-				ELSE nominee {
-					.model,
-					.uuid,
-					.name,
-					members: nominatedMembers,
-					.startDate,
-					.endDate,
-					.venue,
-					.surProduction,
-					.format,
-					.year,
-					.surMaterial,
-					.writingCredits
-				}
-			END
-		) AS nominees
-
-	WITH
-		ceremony,
-		categoryRel,
-		category,
-		nominationPosition,
-		isWinner,
-		customType,
-		[nominee IN nominees | CASE nominee.model
-			WHEN 'COMPANY' THEN nominee { .model, .uuid, .name, .members }
-			WHEN 'PERSON' THEN nominee { .model, .uuid, .name }
-			WHEN 'PRODUCTION' THEN nominee { .model, .uuid, .name, .startDate, .endDate, .venue, .surProduction }
-			WHEN 'MATERIAL' THEN nominee { .model, .uuid, .name, .format, .year, .surMaterial, .writingCredits }
-		END] AS nominees
-
-	WITH
-		ceremony,
-		categoryRel,
-		category,
-		isWinner,
-		customType,
-		[nominee IN nominees WHERE nominee.model = 'PERSON' OR nominee.model = 'COMPANY'] AS nomineeEntities,
-		[nominee IN nominees WHERE nominee.model = 'PRODUCTION'] AS nomineeProductions,
-		[nominee IN nominees WHERE nominee.model = 'MATERIAL'] AS nomineeMaterials
-
-	WITH ceremony, categoryRel, category,
-		COLLECT(
-			CASE WHEN SIZE(nomineeEntities) = 0 AND SIZE(nomineeProductions) = 0 AND SIZE(nomineeMaterials) = 0
-				THEN null
-				ELSE {
-					model: 'NOMINATION',
-					isWinner: COALESCE(isWinner, false),
-					type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
-					entities: nomineeEntities,
-					productions: nomineeProductions,
-					materials: nomineeMaterials
-				}
-			END
-		) AS nominations
-		ORDER BY categoryRel.position
-
-	OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
 
 	RETURN
 		'AWARD_CEREMONY' AS model,
 		ceremony.uuid AS uuid,
 		ceremony.name AS name,
-		CASE WHEN award IS NULL THEN null ELSE award { model: 'AWARD', .uuid, .name } END AS award,
-		COLLECT(
-			CASE WHEN category IS NULL
-				THEN null
-				ELSE category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }
-			END
-		) AS categories
+		award,
+		categories
 `];

--- a/src/neo4j/cypher-queries/character/show/show-productions.js
+++ b/src/neo4j/cypher-queries/character/show/show-productions.js
@@ -1,140 +1,150 @@
 export default () => `
 	MATCH (character:Character { uuid: $uuid })
 
-	OPTIONAL MATCH (character)<-[depictionForVariantNamedPortrayal:DEPICTS]-(:Material)
-		<-[:PRODUCTION_OF]-(:Production)-[variantNamedPortrayal:HAS_CAST_MEMBER]->(:Person)
-		WHERE
-			character.name <> variantNamedPortrayal.roleName AND
-			(
-				character.name = variantNamedPortrayal.characterName OR
-				depictionForVariantNamedPortrayal.displayName = variantNamedPortrayal.characterName
-			)
+	CALL {
+		WITH character
 
-	WITH character, variantNamedPortrayal
-		ORDER BY variantNamedPortrayal.roleName
+		OPTIONAL MATCH (character)<-[depictionForVariantNamedPortrayal:DEPICTS]-(:Material)
+			<-[:PRODUCTION_OF]-(:Production)-[variantNamedPortrayal:HAS_CAST_MEMBER]->(:Person)
+			WHERE
+				character.name <> variantNamedPortrayal.roleName AND
+				(
+					character.name = variantNamedPortrayal.characterName OR
+					depictionForVariantNamedPortrayal.displayName = variantNamedPortrayal.characterName
+				)
 
-	WITH character,
-		COLLECT(DISTINCT(variantNamedPortrayal.roleName)) AS variantNamedPortrayals
+		WITH variantNamedPortrayal
+			ORDER BY variantNamedPortrayal.roleName
 
-	OPTIONAL MATCH (character)<-[characterDepiction:DEPICTS]-(materialForProduction:Material)
-		<-[productionRel:PRODUCTION_OF]-(production:Production)-[role:HAS_CAST_MEMBER]->(person:Person)
-		WHERE
-			(
-				character.name IN [role.roleName, role.characterName] OR
-				characterDepiction.displayName IN [role.roleName, role.characterName]
-			) AND
-			(role.characterDifferentiator IS NULL OR role.characterDifferentiator = character.differentiator)
+		RETURN
+			COLLECT(DISTINCT(variantNamedPortrayal.roleName)) AS variantNamedPortrayals
+	}
 
-	OPTIONAL MATCH (production)-[otherRole:HAS_CAST_MEMBER]->(person)
-		WHERE
-			otherRole.roleName <> character.name AND
-			(otherRole.characterName IS NULL OR otherRole.characterName <> character.name) AND
-			(characterDepiction.displayName IS NULL OR characterDepiction.displayName <> otherRole.roleName) AND
-			(
-				(otherRole.characterName IS NULL OR characterDepiction.displayName IS NULL) OR
-				otherRole.characterName <> characterDepiction.displayName
-			)
+	CALL {
+		WITH character
 
-	OPTIONAL MATCH (materialForProduction)-[otherCharacterDepiction:DEPICTS]->(otherCharacter:Character)
-		WHERE
-			(
-				otherCharacter.name IN [otherRole.roleName, otherRole.characterName] OR
-				otherCharacterDepiction.displayName IN [otherRole.roleName, otherRole.characterName]
-			) AND
-			(
-				otherRole.characterDifferentiator IS NULL OR
-				otherRole.characterDifferentiator = otherCharacter.differentiator
-			)
+		OPTIONAL MATCH (character)<-[characterDepiction:DEPICTS]-(materialForProduction:Material)
+			<-[productionRel:PRODUCTION_OF]-(production:Production)-[role:HAS_CAST_MEMBER]->(person:Person)
+			WHERE
+				(
+					character.name IN [role.roleName, role.characterName] OR
+					characterDepiction.displayName IN [role.roleName, role.characterName]
+				) AND
+				(role.characterDifferentiator IS NULL OR role.characterDifferentiator = character.differentiator)
 
-	WITH variantNamedPortrayals, production, person, role, otherRole, otherCharacter
-		ORDER BY otherRole.rolePosition
+		OPTIONAL MATCH (production)-[otherRole:HAS_CAST_MEMBER]->(person)
+			WHERE
+				otherRole.roleName <> character.name AND
+				(otherRole.characterName IS NULL OR otherRole.characterName <> character.name) AND
+				(characterDepiction.displayName IS NULL OR characterDepiction.displayName <> otherRole.roleName) AND
+				(
+					(otherRole.characterName IS NULL OR characterDepiction.displayName IS NULL) OR
+					otherRole.characterName <> characterDepiction.displayName
+				)
 
-	WITH variantNamedPortrayals, production, person, role,
-		COLLECT(DISTINCT(
-			CASE WHEN otherRole IS NULL
-				THEN null
-				ELSE {
-					model: 'CHARACTER',
-					uuid: otherCharacter.uuid,
-					name: otherRole.roleName,
-					qualifier: otherRole.qualifier,
-					isAlternate: COALESCE(otherRole.isAlternate, false)
-				}
-			END
-		)) AS otherRoles
-		ORDER BY role.castMemberPosition
+		OPTIONAL MATCH (materialForProduction)-[otherCharacterDepiction:DEPICTS]->(otherCharacter:Character)
+			WHERE
+				(
+					otherCharacter.name IN [otherRole.roleName, otherRole.characterName] OR
+					otherCharacterDepiction.displayName IN [otherRole.roleName, otherRole.characterName]
+				) AND
+				(
+					otherRole.characterDifferentiator IS NULL OR
+					otherRole.characterDifferentiator = otherCharacter.differentiator
+				)
 
-	OPTIONAL MATCH (production)-[:PLAYS_AT]->(venue:Venue)
+		WITH production, person, role, otherRole, otherCharacter
+			ORDER BY otherRole.rolePosition
 
-	OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
+		WITH production, person, role,
+			COLLECT(DISTINCT(
+				CASE WHEN otherRole IS NULL
+					THEN null
+					ELSE {
+						model: 'CHARACTER',
+						uuid: otherCharacter.uuid,
+						name: otherRole.roleName,
+						qualifier: otherRole.qualifier,
+						isAlternate: COALESCE(otherRole.isAlternate, false)
+					}
+				END
+			)) AS otherRoles
+			ORDER BY role.castMemberPosition
 
-	OPTIONAL MATCH (production)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
+		OPTIONAL MATCH (production)-[:PLAYS_AT]->(venue:Venue)
 
-	OPTIONAL MATCH (surProduction)<-[surSurProductionRel:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+		OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
 
-	WITH
-		variantNamedPortrayals,
-		production,
-		venue,
-		surVenue,
-		surProduction,
-		surProductionRel,
-		surSurProduction,
-		surSurProductionRel,
-		COLLECT(person {
-			model: 'PERSON',
-			.uuid,
-			.name,
-			roleName: role.roleName,
-			qualifier: role.qualifier,
-			isAlternate: COALESCE(role.isAlternate, false),
-			otherRoles
-		}) AS performers
-		ORDER BY
-			production.startDate DESC,
-			COALESCE(surSurProduction.name, surProduction.name, production.name),
-			COALESCE(surSurProductionRel.position, surProductionRel.position, -1) DESC,
-			COALESCE(surSurProductionRel.position, -1) DESC,
-			COALESCE(surProductionRel.position, -1) DESC,
-			venue.name
+		OPTIONAL MATCH (production)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
+
+		OPTIONAL MATCH (surProduction)<-[surSurProductionRel:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+
+		WITH
+			production,
+			venue,
+			surVenue,
+			surProduction,
+			surProductionRel,
+			surSurProduction,
+			surSurProductionRel,
+			COLLECT(person {
+				model: 'PERSON',
+				.uuid,
+				.name,
+				roleName: role.roleName,
+				qualifier: role.qualifier,
+				isAlternate: COALESCE(role.isAlternate, false),
+				otherRoles
+			}) AS performers
+			ORDER BY
+				production.startDate DESC,
+				COALESCE(surSurProduction.name, surProduction.name, production.name),
+				COALESCE(surSurProductionRel.position, surProductionRel.position, -1) DESC,
+				COALESCE(surSurProductionRel.position, -1) DESC,
+				COALESCE(surProductionRel.position, -1) DESC,
+				venue.name
+
+		RETURN
+			COLLECT(
+				CASE WHEN production IS NULL
+					THEN null
+					ELSE production {
+						model: 'PRODUCTION',
+						.uuid,
+						.name,
+						.startDate,
+						.endDate,
+						venue: CASE WHEN venue IS NULL
+							THEN null
+							ELSE venue {
+								model: 'VENUE',
+								.uuid,
+								.name,
+								surVenue: CASE WHEN surVenue IS NULL
+									THEN null
+									ELSE surVenue { model: 'VENUE', .uuid, .name }
+								END
+							}
+						END,
+						surProduction: CASE WHEN surProduction IS NULL
+							THEN null
+							ELSE surProduction {
+								model: 'PRODUCTION',
+								.uuid,
+								.name,
+								surProduction: CASE WHEN surSurProduction IS NULL
+									THEN null
+									ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+								END
+							}
+						END,
+						performers
+					}
+				END
+			) AS productions
+	}
 
 	RETURN
 		variantNamedPortrayals,
-		COLLECT(
-			CASE WHEN production IS NULL
-				THEN null
-				ELSE production {
-					model: 'PRODUCTION',
-					.uuid,
-					.name,
-					.startDate,
-					.endDate,
-					venue: CASE WHEN venue IS NULL
-						THEN null
-						ELSE venue {
-							model: 'VENUE',
-							.uuid,
-							.name,
-							surVenue: CASE WHEN surVenue IS NULL
-								THEN null
-								ELSE surVenue { model: 'VENUE', .uuid, .name }
-							END
-						}
-					END,
-					surProduction: CASE WHEN surProduction IS NULL
-						THEN null
-						ELSE surProduction {
-							model: 'PRODUCTION',
-							.uuid,
-							.name,
-							surProduction: CASE WHEN surSurProduction IS NULL
-								THEN null
-								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
-							END
-						}
-					END,
-					performers
-				}
-			END
-		) AS productions
+		productions
 `;

--- a/src/neo4j/cypher-queries/company/show/show-productions.js
+++ b/src/neo4j/cypher-queries/company/show/show-productions.js
@@ -1,425 +1,432 @@
 export default () => `
 	MATCH (company:Company { uuid: $uuid })
 
-	OPTIONAL MATCH (company)<-[:HAS_PRODUCER_ENTITY]-(production:Production)
+	CALL {
+		WITH company
 
-	OPTIONAL MATCH (production)-[entityRel:HAS_PRODUCER_ENTITY WHERE entityRel.creditedCompanyUuid IS NULL]->
-		(entity:Person|Company)
+		OPTIONAL MATCH (company)<-[:HAS_PRODUCER_ENTITY]-(production:Production)
 
-	UNWIND (CASE WHEN entityRel IS NOT NULL AND entityRel.creditedMemberUuids IS NOT NULL
-		THEN [uuid IN entityRel.creditedMemberUuids]
-		ELSE [null]
-	END) AS creditedMemberUuid
+		OPTIONAL MATCH (production)-[entityRel:HAS_PRODUCER_ENTITY WHERE entityRel.creditedCompanyUuid IS NULL]->
+			(entity:Person|Company)
 
-		OPTIONAL MATCH (production)-[creditedMemberRel:HAS_PRODUCER_ENTITY]->
-			(creditedMember:Person { uuid: creditedMemberUuid })
+		UNWIND (CASE WHEN entityRel IS NOT NULL AND entityRel.creditedMemberUuids IS NOT NULL
+			THEN [uuid IN entityRel.creditedMemberUuids]
+			ELSE [null]
+		END) AS creditedMemberUuid
+
+			OPTIONAL MATCH (production)-[creditedMemberRel:HAS_PRODUCER_ENTITY]->
+				(creditedMember:Person { uuid: creditedMemberUuid })
+				WHERE
+					entityRel.creditPosition IS NULL OR
+					entityRel.creditPosition = creditedMemberRel.creditPosition
+
+			WITH production, entityRel, entity, creditedMember
+				ORDER BY creditedMember.memberPosition
+
+			WITH production, entityRel, entity,
+				COLLECT(DISTINCT(creditedMember {
+					model: 'PERSON',
+					.uuid,
+					.name
+				})) AS creditedMembers
+			ORDER BY entityRel.creditPosition, entityRel.entityPosition
+
+		WITH production, entityRel.credit AS producerCreditName,
+			COLLECT(
+				CASE WHEN entity IS NULL
+					THEN null
+					ELSE entity { model: TOUPPER(HEAD(LABELS(entity))), .uuid, .name, members: creditedMembers }
+				END
+			) AS entities
+
+		WITH production, producerCreditName,
+			[entity IN entities | CASE entity.model WHEN 'COMPANY'
+				THEN entity
+				ELSE entity { .model, .uuid, .name }
+			END] AS entities
+
+		WITH production,
+			COLLECT(
+				CASE SIZE(entities) WHEN 0
+					THEN null
+					ELSE {
+						model: 'PRODUCER_CREDIT',
+						name: COALESCE(producerCreditName, 'produced by'),
+						entities: entities
+					}
+				END
+			) AS producerCredits
+
+		OPTIONAL MATCH (production)-[:PLAYS_AT]->(venue:Venue)
+
+		OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
+
+		OPTIONAL MATCH (production)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
+
+		OPTIONAL MATCH (surProduction)<-[surSurProductionRel:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+
+		WITH
+			production,
+			producerCredits,
+			venue,
+			surVenue,
+			surProduction,
+			surProductionRel,
+			surSurProduction,
+			surSurProductionRel
+			ORDER BY
+				production.startDate DESC,
+				COALESCE(surSurProduction.name, surProduction.name, production.name),
+				COALESCE(surSurProductionRel.position, surProductionRel.position, -1) DESC,
+				COALESCE(surSurProductionRel.position, -1) DESC,
+				COALESCE(surProductionRel.position, -1) DESC,
+				venue.name
+
+		RETURN
+			COLLECT(
+				CASE WHEN production IS NULL
+					THEN null
+					ELSE production {
+						model: 'PRODUCTION',
+						.uuid,
+						.name,
+						.startDate,
+						.endDate,
+						venue: CASE WHEN venue IS NULL
+							THEN null
+							ELSE venue {
+								model: 'VENUE',
+								.uuid,
+								.name,
+								surVenue: CASE WHEN surVenue IS NULL
+									THEN null
+									ELSE surVenue { model: 'VENUE', .uuid, .name }
+								END
+							}
+						END,
+						surProduction: CASE WHEN surProduction IS NULL
+							THEN null
+							ELSE surProduction {
+								model: 'PRODUCTION',
+								.uuid,
+								.name,
+								surProduction: CASE WHEN surSurProduction IS NULL
+									THEN null
+									ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+								END
+							}
+						END,
+						producerCredits
+					}
+				END
+			) AS producerProductions
+	}
+
+	CALL {
+		WITH company
+
+		OPTIONAL MATCH (company)<-[creativeRel:HAS_CREATIVE_ENTITY]-(production:Production)
+
+		UNWIND (CASE WHEN creativeRel IS NOT NULL AND creativeRel.creditedMemberUuids IS NOT NULL
+			THEN creativeRel.creditedMemberUuids
+			ELSE [null]
+		END) AS creditedMemberUuid
+
+			OPTIONAL MATCH (production)-[creditedMemberRel:HAS_CREATIVE_ENTITY]->
+				(creditedMember:Person { uuid: creditedMemberUuid })
+				WHERE
+					creativeRel.creditPosition IS NULL OR
+					creativeRel.creditPosition = creditedMemberRel.creditPosition
+
+			WITH company, creativeRel, production, creditedMember
+				ORDER BY creditedMemberRel.memberPosition
+
+			WITH company, creativeRel, production,
+				COLLECT(creditedMember { model: 'PERSON', .uuid, .name }) AS creditedMembers
+
+		OPTIONAL MATCH (production)-[coCreditedEntityRel:HAS_CREATIVE_ENTITY]->(coCreditedEntity:Person|Company)
 			WHERE
-				entityRel.creditPosition IS NULL OR
-				entityRel.creditPosition = creditedMemberRel.creditPosition
+				coCreditedEntityRel.creditedCompanyUuid IS NULL AND
+				(
+					creativeRel.creditPosition IS NULL OR
+					creativeRel.creditPosition = coCreditedEntityRel.creditPosition
+				) AND
+				coCreditedEntity.uuid <> company.uuid
 
-		WITH company, production, entityRel, entity, creditedMember
-			ORDER BY creditedMember.memberPosition
+		UNWIND (CASE WHEN coCreditedEntityRel IS NOT NULL AND coCreditedEntityRel.creditedMemberUuids IS NOT NULL
+			THEN [uuid IN coCreditedEntityRel.creditedMemberUuids]
+			ELSE [null]
+		END) AS coCreditedCompanyCreditedMemberUuid
 
-		WITH company, production, entityRel, entity,
-			COLLECT(DISTINCT(creditedMember {
-				model: 'PERSON',
-				.uuid,
-				.name
-			})) AS creditedMembers
-		ORDER BY entityRel.creditPosition, entityRel.entityPosition
+			OPTIONAL MATCH (production)-[coCreditedCompanyCreditedMemberRel:HAS_CREATIVE_ENTITY]->
+				(coCreditedCompanyCreditedMember:Person { uuid: coCreditedCompanyCreditedMemberUuid })
+				WHERE
+					coCreditedEntityRel.creditPosition IS NULL OR
+					coCreditedEntityRel.creditPosition = coCreditedCompanyCreditedMemberRel.creditPosition
 
-	WITH company, production, entityRel.credit AS producerCreditName,
-		COLLECT(
-			CASE WHEN entity IS NULL
-				THEN null
-				ELSE entity { model: TOUPPER(HEAD(LABELS(entity))), .uuid, .name, members: creditedMembers }
-			END
-		) AS entities
+			WITH
+				creativeRel,
+				production,
+				creditedMembers,
+				coCreditedEntityRel,
+				coCreditedEntity,
+				coCreditedCompanyCreditedMember
+				ORDER BY coCreditedCompanyCreditedMemberRel.memberPosition
 
-	WITH company, production, producerCreditName,
-		[entity IN entities | CASE entity.model WHEN 'COMPANY'
-			THEN entity
-			ELSE entity { .model, .uuid, .name }
-		END] AS entities
-
-	WITH company, production,
-		COLLECT(
-			CASE SIZE(entities) WHEN 0
-				THEN null
-				ELSE {
-					model: 'PRODUCER_CREDIT',
-					name: COALESCE(producerCreditName, 'produced by'),
-					entities: entities
-				}
-			END
-		) AS producerCredits
-
-	OPTIONAL MATCH (production)-[:PLAYS_AT]->(venue:Venue)
-
-	OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
-
-	OPTIONAL MATCH (production)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
-
-	OPTIONAL MATCH (surProduction)<-[surSurProductionRel:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
-
-	WITH
-		company,
-		production,
-		producerCredits,
-		venue,
-		surVenue,
-		surProduction,
-		surProductionRel,
-		surSurProduction,
-		surSurProductionRel
-		ORDER BY
-			production.startDate DESC,
-			COALESCE(surSurProduction.name, surProduction.name, production.name),
-			COALESCE(surSurProductionRel.position, surProductionRel.position, -1) DESC,
-			COALESCE(surSurProductionRel.position, -1) DESC,
-			COALESCE(surProductionRel.position, -1) DESC,
-			venue.name
-
-	WITH company,
-		COLLECT(
-			CASE WHEN production IS NULL
-				THEN null
-				ELSE production {
-					model: 'PRODUCTION',
+			WITH
+				creativeRel,
+				production,
+				creditedMembers,
+				coCreditedEntityRel,
+				coCreditedEntity,
+				COLLECT(coCreditedCompanyCreditedMember {
+					model: 'PERSON',
 					.uuid,
-					.name,
-					.startDate,
-					.endDate,
-					venue: CASE WHEN venue IS NULL
-						THEN null
-						ELSE venue {
-							model: 'VENUE',
-							.uuid,
-							.name,
-							surVenue: CASE WHEN surVenue IS NULL
-								THEN null
-								ELSE surVenue { model: 'VENUE', .uuid, .name }
-							END
-						}
-					END,
-					surProduction: CASE WHEN surProduction IS NULL
-						THEN null
-						ELSE surProduction {
-							model: 'PRODUCTION',
-							.uuid,
-							.name,
-							surProduction: CASE WHEN surSurProduction IS NULL
-								THEN null
-								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
-							END
-						}
-					END,
-					producerCredits
-				}
-			END
-		) AS producerProductions
+					.name
+				}) AS coCreditedCompanyCreditedMembers
+				ORDER BY coCreditedEntityRel.entityPosition
 
-	OPTIONAL MATCH (company)<-[creativeRel:HAS_CREATIVE_ENTITY]-(production:Production)
+		WITH creativeRel, production, creditedMembers,
+			COLLECT(
+				CASE WHEN coCreditedEntity IS NULL
+					THEN null
+					ELSE coCreditedEntity {
+						model: TOUPPER(HEAD(LABELS(coCreditedEntity))),
+						.uuid,
+						.name,
+						members: coCreditedCompanyCreditedMembers
+					}
+				END
+			) AS coCreditedEntities
+			ORDER BY creativeRel.creditPosition
 
-	UNWIND (CASE WHEN creativeRel IS NOT NULL AND creativeRel.creditedMemberUuids IS NOT NULL
-		THEN creativeRel.creditedMemberUuids
-		ELSE [null]
-	END) AS creditedMemberUuid
+		WITH creativeRel, production, creditedMembers,
+			[coCreditedEntity IN coCreditedEntities | CASE coCreditedEntity.model WHEN 'COMPANY'
+				THEN coCreditedEntity
+				ELSE coCreditedEntity { .model, .uuid, .name }
+			END] AS coCreditedEntities
 
-		OPTIONAL MATCH (production)-[creditedMemberRel:HAS_CREATIVE_ENTITY]->
-			(creditedMember:Person { uuid: creditedMemberUuid })
-			WHERE creativeRel.creditPosition IS NULL OR creativeRel.creditPosition = creditedMemberRel.creditPosition
+		OPTIONAL MATCH (production)-[:PLAYS_AT]->(venue:Venue)
 
-		WITH company, producerProductions, creativeRel, production, creditedMember
-			ORDER BY creditedMemberRel.memberPosition
+		OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
 
-		WITH company, producerProductions, creativeRel, production,
-			COLLECT(creditedMember { model: 'PERSON', .uuid, .name }) AS creditedMembers
+		OPTIONAL MATCH (production)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
-	OPTIONAL MATCH (production)-[coCreditedEntityRel:HAS_CREATIVE_ENTITY]->(coCreditedEntity:Person|Company)
-		WHERE
-			coCreditedEntityRel.creditedCompanyUuid IS NULL AND
-			(creativeRel.creditPosition IS NULL OR creativeRel.creditPosition = coCreditedEntityRel.creditPosition) AND
-			coCreditedEntity.uuid <> company.uuid
+		OPTIONAL MATCH (surProduction)<-[surSurProductionRel:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
 
-	UNWIND (CASE WHEN coCreditedEntityRel IS NOT NULL AND coCreditedEntityRel.creditedMemberUuids IS NOT NULL
-		THEN [uuid IN coCreditedEntityRel.creditedMemberUuids]
-		ELSE [null]
-	END) AS coCreditedCompanyCreditedMemberUuid
+		WITH
+			production,
+			venue,
+			surVenue,
+			surProduction,
+			surProductionRel,
+			surSurProduction,
+			surSurProductionRel,
+			COLLECT({
+				model: 'CREATIVE_CREDIT',
+				name: creativeRel.credit,
+				members: creditedMembers,
+				coEntities: coCreditedEntities
+			}) AS creativeCredits
+			ORDER BY
+				production.startDate DESC,
+				COALESCE(surSurProduction.name, surProduction.name, production.name),
+				COALESCE(surSurProductionRel.position, surProductionRel.position, -1) DESC,
+				COALESCE(surSurProductionRel.position, -1) DESC,
+				COALESCE(surProductionRel.position, -1) DESC,
+				venue.name
 
-		OPTIONAL MATCH (production)-[coCreditedCompanyCreditedMemberRel:HAS_CREATIVE_ENTITY]->
-			(coCreditedCompanyCreditedMember:Person { uuid: coCreditedCompanyCreditedMemberUuid })
+		RETURN
+			COLLECT(
+				CASE WHEN production IS NULL
+					THEN null
+					ELSE production {
+						model: 'PRODUCTION',
+						.uuid,
+						.name,
+						.startDate,
+						.endDate,
+						venue: CASE WHEN venue IS NULL
+							THEN null
+							ELSE venue {
+								model: 'VENUE',
+								.uuid,
+								.name,
+								surVenue: CASE WHEN surVenue IS NULL
+									THEN null
+									ELSE surVenue { model: 'VENUE', .uuid, .name }
+								END
+							}
+						END,
+						surProduction: CASE WHEN surProduction IS NULL
+							THEN null
+							ELSE surProduction {
+								model: 'PRODUCTION',
+								.uuid,
+								.name,
+								surProduction: CASE WHEN surSurProduction IS NULL
+									THEN null
+									ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+								END
+							}
+						END,
+						creativeCredits
+					}
+				END
+			) AS creativeProductions
+	}
+
+	CALL {
+		WITH company
+
+		OPTIONAL MATCH (company)<-[crewRel:HAS_CREW_ENTITY]-(production:Production)
+
+		UNWIND (CASE WHEN crewRel IS NOT NULL AND crewRel.creditedMemberUuids IS NOT NULL
+			THEN crewRel.creditedMemberUuids
+			ELSE [null]
+		END) AS creditedMemberUuid
+
+			OPTIONAL MATCH (production)-[creditedMemberRel:HAS_CREW_ENTITY]->
+				(creditedMember:Person { uuid: creditedMemberUuid })
+				WHERE crewRel.creditPosition IS NULL OR crewRel.creditPosition = creditedMemberRel.creditPosition
+
+			WITH company, crewRel, production, creditedMember
+				ORDER BY creditedMemberRel.memberPosition
+
+			WITH company, crewRel, production,
+				COLLECT(creditedMember { model: 'PERSON', .uuid, .name }) AS creditedMembers
+
+		OPTIONAL MATCH (production)-[coCreditedEntityRel:HAS_CREW_ENTITY]->(coCreditedEntity:Person|Company)
 			WHERE
-				coCreditedEntityRel.creditPosition IS NULL OR
-				coCreditedEntityRel.creditPosition = coCreditedCompanyCreditedMemberRel.creditPosition
+				coCreditedEntityRel.creditedCompanyUuid IS NULL AND
+				(crewRel.creditPosition IS NULL OR crewRel.creditPosition = coCreditedEntityRel.creditPosition) AND
+				coCreditedEntity.uuid <> company.uuid
 
-		WITH
-			company,
-			producerProductions,
-			creativeRel,
-			production,
-			creditedMembers,
-			coCreditedEntityRel,
-			coCreditedEntity,
-			coCreditedCompanyCreditedMember
-			ORDER BY coCreditedCompanyCreditedMemberRel.memberPosition
+		UNWIND (CASE WHEN coCreditedEntityRel IS NOT NULL AND coCreditedEntityRel.creditedMemberUuids IS NOT NULL
+			THEN [uuid IN coCreditedEntityRel.creditedMemberUuids]
+			ELSE [null]
+		END) AS coCreditedCompanyCreditedMemberUuid
 
-		WITH
-			company,
-			producerProductions,
-			creativeRel,
-			production,
-			creditedMembers,
-			coCreditedEntityRel,
-			coCreditedEntity,
-			COLLECT(coCreditedCompanyCreditedMember {
-				model: 'PERSON',
-				.uuid,
-				.name
-			}) AS coCreditedCompanyCreditedMembers
-			ORDER BY coCreditedEntityRel.entityPosition
+			OPTIONAL MATCH (production)-[coCreditedCompanyCreditedMemberRel:HAS_CREW_ENTITY]->
+				(coCreditedCompanyCreditedMember:Person { uuid: coCreditedCompanyCreditedMemberUuid })
+				WHERE
+					coCreditedEntityRel.creditPosition IS NULL OR
+					coCreditedEntityRel.creditPosition = coCreditedCompanyCreditedMemberRel.creditPosition
 
-	WITH company, producerProductions, creativeRel, production, creditedMembers,
-		COLLECT(
-			CASE WHEN coCreditedEntity IS NULL
-				THEN null
-				ELSE coCreditedEntity {
-					model: TOUPPER(HEAD(LABELS(coCreditedEntity))),
+			WITH
+				crewRel,
+				production,
+				creditedMembers,
+				coCreditedEntityRel,
+				coCreditedEntity,
+				coCreditedCompanyCreditedMember
+				ORDER BY coCreditedCompanyCreditedMemberRel.memberPosition
+
+			WITH
+				crewRel,
+				production,
+				creditedMembers,
+				coCreditedEntityRel,
+				coCreditedEntity,
+				COLLECT(coCreditedCompanyCreditedMember {
+					model: 'PERSON',
 					.uuid,
-					.name,
-					members: coCreditedCompanyCreditedMembers
-				}
-			END
-		) AS coCreditedEntities
-		ORDER BY creativeRel.creditPosition
+					.name
+				}) AS coCreditedCompanyCreditedMembers
+				ORDER BY coCreditedEntityRel.entityPosition
 
-	WITH company, producerProductions, creativeRel, production, creditedMembers,
-		[coCreditedEntity IN coCreditedEntities | CASE coCreditedEntity.model WHEN 'COMPANY'
-			THEN coCreditedEntity
-			ELSE coCreditedEntity { .model, .uuid, .name }
-		END] AS coCreditedEntities
+		WITH crewRel, production, creditedMembers,
+			COLLECT(
+				CASE WHEN coCreditedEntity IS NULL
+					THEN null
+					ELSE coCreditedEntity {
+						model: TOUPPER(HEAD(LABELS(coCreditedEntity))),
+						.uuid,
+						.name,
+						members: coCreditedCompanyCreditedMembers
+					}
+				END
+			) AS coCreditedEntities
+			ORDER BY crewRel.creditPosition
 
-	OPTIONAL MATCH (production)-[:PLAYS_AT]->(venue:Venue)
+		WITH crewRel, production, creditedMembers,
+			[coCreditedEntity IN coCreditedEntities | CASE coCreditedEntity.model WHEN 'COMPANY'
+				THEN coCreditedEntity
+				ELSE coCreditedEntity { .model, .uuid, .name }
+			END] AS coCreditedEntities
 
-	OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
+		OPTIONAL MATCH (production)-[:PLAYS_AT]->(venue:Venue)
 
-	OPTIONAL MATCH (production)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
+		OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
 
-	OPTIONAL MATCH (surProduction)<-[surSurProductionRel:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+		OPTIONAL MATCH (production)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
-	WITH
-		company,
-		producerProductions,
-		production,
-		venue,
-		surVenue,
-		surProduction,
-		surProductionRel,
-		surSurProduction,
-		surSurProductionRel,
-		COLLECT({
-			model: 'CREATIVE_CREDIT',
-			name: creativeRel.credit,
-			members: creditedMembers,
-			coEntities: coCreditedEntities
-		}) AS creativeCredits
-		ORDER BY
-			production.startDate DESC,
-			COALESCE(surSurProduction.name, surProduction.name, production.name),
-			COALESCE(surSurProductionRel.position, surProductionRel.position, -1) DESC,
-			COALESCE(surSurProductionRel.position, -1) DESC,
-			COALESCE(surProductionRel.position, -1) DESC,
-			venue.name
-
-	WITH company, producerProductions,
-		COLLECT(
-			CASE WHEN production IS NULL
-				THEN null
-				ELSE production {
-					model: 'PRODUCTION',
-					.uuid,
-					.name,
-					.startDate,
-					.endDate,
-					venue: CASE WHEN venue IS NULL
-						THEN null
-						ELSE venue {
-							model: 'VENUE',
-							.uuid,
-							.name,
-							surVenue: CASE WHEN surVenue IS NULL
-								THEN null
-								ELSE surVenue { model: 'VENUE', .uuid, .name }
-							END
-						}
-					END,
-					surProduction: CASE WHEN surProduction IS NULL
-						THEN null
-						ELSE surProduction {
-							model: 'PRODUCTION',
-							.uuid,
-							.name,
-							surProduction: CASE WHEN surSurProduction IS NULL
-								THEN null
-								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
-							END
-						}
-					END,
-					creativeCredits
-				}
-			END
-		) AS creativeProductions
-
-	OPTIONAL MATCH (company)<-[crewRel:HAS_CREW_ENTITY]-(production:Production)
-
-	UNWIND (CASE WHEN crewRel IS NOT NULL AND crewRel.creditedMemberUuids IS NOT NULL
-		THEN crewRel.creditedMemberUuids
-		ELSE [null]
-	END) AS creditedMemberUuid
-
-		OPTIONAL MATCH (production)-[creditedMemberRel:HAS_CREW_ENTITY]->
-			(creditedMember:Person { uuid: creditedMemberUuid })
-			WHERE crewRel.creditPosition IS NULL OR crewRel.creditPosition = creditedMemberRel.creditPosition
-
-		WITH company, producerProductions, creativeProductions, crewRel, production, creditedMember
-			ORDER BY creditedMemberRel.memberPosition
-
-		WITH company, producerProductions, creativeProductions, crewRel, production,
-			COLLECT(creditedMember { model: 'PERSON', .uuid, .name }) AS creditedMembers
-
-	OPTIONAL MATCH (production)-[coCreditedEntityRel:HAS_CREW_ENTITY]->(coCreditedEntity:Person|Company)
-		WHERE
-			coCreditedEntityRel.creditedCompanyUuid IS NULL AND
-			(crewRel.creditPosition IS NULL OR crewRel.creditPosition = coCreditedEntityRel.creditPosition) AND
-			coCreditedEntity.uuid <> company.uuid
-
-	UNWIND (CASE WHEN coCreditedEntityRel IS NOT NULL AND coCreditedEntityRel.creditedMemberUuids IS NOT NULL
-		THEN [uuid IN coCreditedEntityRel.creditedMemberUuids]
-		ELSE [null]
-	END) AS coCreditedCompanyCreditedMemberUuid
-
-		OPTIONAL MATCH (production)-[coCreditedCompanyCreditedMemberRel:HAS_CREW_ENTITY]->
-			(coCreditedCompanyCreditedMember:Person { uuid: coCreditedCompanyCreditedMemberUuid })
-			WHERE
-				coCreditedEntityRel.creditPosition IS NULL OR
-				coCreditedEntityRel.creditPosition = coCreditedCompanyCreditedMemberRel.creditPosition
+		OPTIONAL MATCH (surProduction)<-[surSurProductionRel:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
 
 		WITH
-			producerProductions,
-			creativeProductions,
-			crewRel,
 			production,
-			creditedMembers,
-			coCreditedEntityRel,
-			coCreditedEntity,
-			coCreditedCompanyCreditedMember
-			ORDER BY coCreditedCompanyCreditedMemberRel.memberPosition
+			venue,
+			surVenue,
+			surProduction,
+			surProductionRel,
+			surSurProduction,
+			surSurProductionRel,
+			COLLECT({
+				model: 'CREW_CREDIT',
+				name: crewRel.credit,
+				members: creditedMembers,
+				coEntities: coCreditedEntities
+			}) AS crewCredits
+			ORDER BY
+				production.startDate DESC,
+				COALESCE(surSurProduction.name, surProduction.name, production.name),
+				COALESCE(surSurProductionRel.position, surProductionRel.position, -1) DESC,
+				COALESCE(surSurProductionRel.position, -1) DESC,
+				COALESCE(surProductionRel.position, -1) DESC,
+				venue.name
 
-		WITH
-			producerProductions,
-			creativeProductions,
-			crewRel,
-			production,
-			creditedMembers,
-			coCreditedEntityRel,
-			coCreditedEntity,
-			COLLECT(coCreditedCompanyCreditedMember {
-				model: 'PERSON',
-				.uuid,
-				.name
-			}) AS coCreditedCompanyCreditedMembers
-			ORDER BY coCreditedEntityRel.entityPosition
-
-	WITH producerProductions, creativeProductions, crewRel, production, creditedMembers,
-		COLLECT(
-			CASE WHEN coCreditedEntity IS NULL
-				THEN null
-				ELSE coCreditedEntity {
-					model: TOUPPER(HEAD(LABELS(coCreditedEntity))),
-					.uuid,
-					.name,
-					members: coCreditedCompanyCreditedMembers
-				}
-			END
-		) AS coCreditedEntities
-		ORDER BY crewRel.creditPosition
-
-	WITH producerProductions, creativeProductions, crewRel, production, creditedMembers,
-		[coCreditedEntity IN coCreditedEntities | CASE coCreditedEntity.model WHEN 'COMPANY'
-			THEN coCreditedEntity
-			ELSE coCreditedEntity { .model, .uuid, .name }
-		END] AS coCreditedEntities
-
-	OPTIONAL MATCH (production)-[:PLAYS_AT]->(venue:Venue)
-
-	OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
-
-	OPTIONAL MATCH (production)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
-
-	OPTIONAL MATCH (surProduction)<-[surSurProductionRel:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
-
-	WITH
-		producerProductions,
-		creativeProductions,
-		production,
-		venue,
-		surVenue,
-		surProduction,
-		surProductionRel,
-		surSurProduction,
-		surSurProductionRel,
-		COLLECT({
-			model: 'CREW_CREDIT',
-			name: crewRel.credit,
-			members: creditedMembers,
-			coEntities: coCreditedEntities
-		}) AS crewCredits
-		ORDER BY
-			production.startDate DESC,
-			COALESCE(surSurProduction.name, surProduction.name, production.name),
-			COALESCE(surSurProductionRel.position, surProductionRel.position, -1) DESC,
-			COALESCE(surSurProductionRel.position, -1) DESC,
-			COALESCE(surProductionRel.position, -1) DESC,
-			venue.name
+		RETURN
+			COLLECT(
+				CASE WHEN production IS NULL
+					THEN null
+					ELSE production {
+						model: 'PRODUCTION',
+						.uuid,
+						.name,
+						.startDate,
+						.endDate,
+						venue: CASE WHEN venue IS NULL
+							THEN null
+							ELSE venue {
+								model: 'VENUE',
+								.uuid,
+								.name,
+								surVenue: CASE WHEN surVenue IS NULL
+									THEN null
+									ELSE surVenue { model: 'VENUE', .uuid, .name }
+								END
+							}
+						END,
+						surProduction: CASE WHEN surProduction IS NULL
+							THEN null
+							ELSE surProduction {
+								model: 'PRODUCTION',
+								.uuid,
+								.name,
+								surProduction: CASE WHEN surSurProduction IS NULL
+									THEN null
+									ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+								END
+							}
+						END,
+						crewCredits
+					}
+				END
+			) AS crewProductions
+	}
 
 	RETURN
 		producerProductions,
 		creativeProductions,
-		COLLECT(
-			CASE WHEN production IS NULL
-				THEN null
-				ELSE production {
-					model: 'PRODUCTION',
-					.uuid,
-					.name,
-					.startDate,
-					.endDate,
-					venue: CASE WHEN venue IS NULL
-						THEN null
-						ELSE venue {
-							model: 'VENUE',
-							.uuid,
-							.name,
-							surVenue: CASE WHEN surVenue IS NULL
-								THEN null
-								ELSE surVenue { model: 'VENUE', .uuid, .name }
-							END
-						}
-					END,
-					surProduction: CASE WHEN surProduction IS NULL
-						THEN null
-						ELSE surProduction {
-							model: 'PRODUCTION',
-							.uuid,
-							.name,
-							surProduction: CASE WHEN surSurProduction IS NULL
-								THEN null
-								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
-							END
-						}
-					END,
-					crewCredits
-				}
-			END
-		) AS crewProductions
+		crewProductions
 `;

--- a/src/neo4j/cypher-queries/person/show/show-productions.js
+++ b/src/neo4j/cypher-queries/person/show/show-productions.js
@@ -1,627 +1,596 @@
 export default () => `
 	MATCH (person:Person { uuid: $uuid })
 
-	OPTIONAL MATCH (person)<-[:HAS_PRODUCER_ENTITY]-(production:Production)
+	CALL {
+		WITH person
 
-	OPTIONAL MATCH (production)-[entityRel:HAS_PRODUCER_ENTITY WHERE entityRel.creditedCompanyUuid IS NULL]->
-		(entity:Person|Company)
+		OPTIONAL MATCH (person)<-[:HAS_PRODUCER_ENTITY]-(production:Production)
 
-	UNWIND (CASE WHEN entityRel IS NOT NULL AND entityRel.creditedMemberUuids IS NOT NULL
-		THEN [uuid IN entityRel.creditedMemberUuids]
-		ELSE [null]
-	END) AS creditedMemberUuid
+		OPTIONAL MATCH (production)-[entityRel:HAS_PRODUCER_ENTITY WHERE entityRel.creditedCompanyUuid IS NULL]->
+			(entity:Person|Company)
 
-		OPTIONAL MATCH (production)-[creditedMemberRel:HAS_PRODUCER_ENTITY]->
-			(creditedMember:Person { uuid: creditedMemberUuid })
+		UNWIND (CASE WHEN entityRel IS NOT NULL AND entityRel.creditedMemberUuids IS NOT NULL
+			THEN [uuid IN entityRel.creditedMemberUuids]
+			ELSE [null]
+		END) AS creditedMemberUuid
+
+			OPTIONAL MATCH (production)-[creditedMemberRel:HAS_PRODUCER_ENTITY]->
+				(creditedMember:Person { uuid: creditedMemberUuid })
+				WHERE
+					entityRel.creditPosition IS NULL OR
+					entityRel.creditPosition = creditedMemberRel.creditPosition
+
+			WITH production, entityRel, entity, creditedMember
+				ORDER BY creditedMember.memberPosition
+
+			WITH production, entityRel, entity,
+				COLLECT(DISTINCT(creditedMember { model: 'PERSON', .uuid, .name })) AS creditedMembers
+			ORDER BY entityRel.creditPosition, entityRel.entityPosition
+
+		WITH production, entityRel.credit AS producerCreditName,
+			COLLECT(
+				CASE WHEN entity IS NULL
+					THEN null
+					ELSE entity { model: TOUPPER(HEAD(LABELS(entity))), .uuid, .name, members: creditedMembers }
+				END
+			) AS entities
+
+		WITH production, producerCreditName,
+			[entity IN entities | CASE entity.model WHEN 'COMPANY'
+				THEN entity
+				ELSE entity { .model, .uuid, .name }
+			END] AS entities
+
+		WITH production,
+			COLLECT(
+				CASE SIZE(entities) WHEN 0
+					THEN null
+					ELSE {
+						model: 'PRODUCER_CREDIT',
+						name: COALESCE(producerCreditName, 'produced by'),
+						entities: entities
+					}
+				END
+			) AS producerCredits
+
+		OPTIONAL MATCH (production)-[:PLAYS_AT]->(venue:Venue)
+
+		OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
+
+		OPTIONAL MATCH (production)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
+
+		OPTIONAL MATCH (surProduction)<-[surSurProductionRel:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+
+		WITH
+			production,
+			producerCredits,
+			venue,
+			surVenue,
+			surProduction,
+			surProductionRel,
+			surSurProduction,
+			surSurProductionRel
+			ORDER BY
+				production.startDate DESC,
+				COALESCE(surSurProduction.name, surProduction.name, production.name),
+				COALESCE(surSurProductionRel.position, surProductionRel.position, -1) DESC,
+				COALESCE(surSurProductionRel.position, -1) DESC,
+				COALESCE(surProductionRel.position, -1) DESC,
+				venue.name
+
+		RETURN
+			COLLECT(
+				CASE WHEN production IS NULL
+					THEN null
+					ELSE production {
+						model: 'PRODUCTION',
+						.uuid,
+						.name,
+						.startDate,
+						.endDate,
+						venue: CASE WHEN venue IS NULL
+							THEN null
+							ELSE venue {
+								model: 'VENUE',
+								.uuid,
+								.name,
+								surVenue: CASE WHEN surVenue IS NULL
+									THEN null
+									ELSE surVenue { model: 'VENUE', .uuid, .name }
+								END
+							}
+						END,
+						surProduction: CASE WHEN surProduction IS NULL
+							THEN null
+							ELSE surProduction {
+								model: 'PRODUCTION',
+								.uuid,
+								.name,
+								surProduction: CASE WHEN surSurProduction IS NULL
+									THEN null
+									ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+								END
+							}
+						END,
+						producerCredits
+					}
+				END
+			) AS producerProductions
+	}
+
+	CALL {
+		WITH person
+
+		OPTIONAL MATCH (person)<-[role:HAS_CAST_MEMBER]-(production:Production)
+
+		OPTIONAL MATCH (production)-[:PLAYS_AT]->(venue:Venue)
+
+		OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
+
+		OPTIONAL MATCH (production)-[:PRODUCTION_OF]->(:Material)-[characterRel:DEPICTS]->(character:Character)
 			WHERE
-				entityRel.creditPosition IS NULL OR
-				entityRel.creditPosition = creditedMemberRel.creditPosition
-
-		WITH person, production, entityRel, entity, creditedMember
-			ORDER BY creditedMember.memberPosition
-
-		WITH person, production, entityRel, entity,
-			COLLECT(DISTINCT(creditedMember { model: 'PERSON', .uuid, .name })) AS creditedMembers
-		ORDER BY entityRel.creditPosition, entityRel.entityPosition
-
-	WITH person, production, entityRel.credit AS producerCreditName,
-		COLLECT(
-			CASE WHEN entity IS NULL
-				THEN null
-				ELSE entity { model: TOUPPER(HEAD(LABELS(entity))), .uuid, .name, members: creditedMembers }
-			END
-		) AS entities
-
-	WITH person, production, producerCreditName,
-		[entity IN entities | CASE entity.model WHEN 'COMPANY'
-			THEN entity
-			ELSE entity { .model, .uuid, .name }
-		END] AS entities
-
-	WITH person, production,
-		COLLECT(
-			CASE SIZE(entities) WHEN 0
-				THEN null
-				ELSE {
-					model: 'PRODUCER_CREDIT',
-					name: COALESCE(producerCreditName, 'produced by'),
-					entities: entities
-				}
-			END
-		) AS producerCredits
-
-	OPTIONAL MATCH (production)-[:PLAYS_AT]->(venue:Venue)
-
-	OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
-
-	OPTIONAL MATCH (production)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
-
-	OPTIONAL MATCH (surProduction)<-[surSurProductionRel:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
-
-	WITH
-		person,
-		production,
-		producerCredits,
-		venue,
-		surVenue,
-		surProduction,
-		surProductionRel,
-		surSurProduction,
-		surSurProductionRel
-		ORDER BY
-			production.startDate DESC,
-			COALESCE(surSurProduction.name, surProduction.name, production.name),
-			COALESCE(surSurProductionRel.position, surProductionRel.position, -1) DESC,
-			COALESCE(surSurProductionRel.position, -1) DESC,
-			COALESCE(surProductionRel.position, -1) DESC,
-			venue.name
-
-	WITH person,
-		COLLECT(
-			CASE WHEN production IS NULL
-				THEN null
-				ELSE production {
-					model: 'PRODUCTION',
-					.uuid,
-					.name,
-					.startDate,
-					.endDate,
-					venue: CASE WHEN venue IS NULL
-						THEN null
-						ELSE venue {
-							model: 'VENUE',
-							.uuid,
-							.name,
-							surVenue: CASE WHEN surVenue IS NULL
-								THEN null
-								ELSE surVenue { model: 'VENUE', .uuid, .name }
-							END
-						}
-					END,
-					surProduction: CASE WHEN surProduction IS NULL
-						THEN null
-						ELSE surProduction {
-							model: 'PRODUCTION',
-							.uuid,
-							.name,
-							surProduction: CASE WHEN surSurProduction IS NULL
-								THEN null
-								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
-							END
-						}
-					END,
-					producerCredits
-				}
-			END
-		) AS producerProductions
-
-	OPTIONAL MATCH (person)<-[role:HAS_CAST_MEMBER]-(production:Production)
-
-	OPTIONAL MATCH (production)-[:PLAYS_AT]->(venue:Venue)
-
-	OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
-
-	OPTIONAL MATCH (production)-[:PRODUCTION_OF]->(:Material)-[characterRel:DEPICTS]->(character:Character)
-		WHERE
-			(
-				role.roleName IN [character.name, characterRel.displayName] OR
-				role.characterName IN [character.name, characterRel.displayName]
-			) AND
-			(role.characterDifferentiator IS NULL OR role.characterDifferentiator = character.differentiator)
-
-	WITH DISTINCT person, producerProductions, production, venue, surVenue, role, character
-		ORDER BY role.rolePosition
-
-	OPTIONAL MATCH (production)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
-
-	OPTIONAL MATCH (surProduction)<-[surSurProductionRel:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
-
-	WITH
-		person,
-		producerProductions,
-		production,
-		venue,
-		surVenue,
-		surProduction,
-		surProductionRel,
-		surSurProduction,
-		surSurProductionRel,
-		COLLECT(
-			CASE WHEN role.roleName IS NULL
-				THEN { name: 'Performer' }
-				ELSE role {
-					model: 'CHARACTER',
-					uuid: character.uuid,
-					name: role.roleName,
-					.qualifier,
-					isAlternate: COALESCE(role.isAlternate, false)
-				}
-			END
-		) AS roles
-		ORDER BY
-			production.startDate DESC,
-			COALESCE(surSurProduction.name, surProduction.name, production.name),
-			COALESCE(surSurProductionRel.position, surProductionRel.position, -1) DESC,
-			COALESCE(surSurProductionRel.position, -1) DESC,
-			COALESCE(surProductionRel.position, -1) DESC,
-			venue.name
-
-	WITH person, producerProductions,
-		COLLECT(
-			CASE WHEN production IS NULL
-				THEN null
-				ELSE production {
-					model: 'PRODUCTION',
-					.uuid,
-					.name,
-					.startDate,
-					.endDate,
-					venue: CASE WHEN venue IS NULL
-						THEN null
-						ELSE venue {
-							model: 'VENUE',
-							.uuid,
-							.name,
-							surVenue: CASE WHEN surVenue IS NULL
-								THEN null
-								ELSE surVenue { model: 'VENUE', .uuid, .name }
-							END
-						}
-					END,
-					surProduction: CASE WHEN surProduction IS NULL
-						THEN null
-						ELSE surProduction {
-							model: 'PRODUCTION',
-							.uuid,
-							.name,
-							surProduction: CASE WHEN surSurProduction IS NULL
-								THEN null
-								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
-							END
-						}
-					END,
-					roles
-				}
-			END
-		) AS castMemberProductions
-
-	OPTIONAL MATCH (person)<-[creativeRel:HAS_CREATIVE_ENTITY]-(production:Production)
-
-	OPTIONAL MATCH (production)-[creativeCompanyRel:HAS_CREATIVE_ENTITY]->
-		(creditedEmployerCompany:Company { uuid: creativeRel.creditedCompanyUuid })
-		WHERE
-			creativeRel.creditPosition IS NULL OR
-			creativeRel.creditPosition = creativeCompanyRel.creditPosition
-
-	UNWIND (CASE WHEN creativeCompanyRel IS NOT NULL AND creativeCompanyRel.creditedMemberUuids IS NOT NULL
-		THEN [uuid IN creativeCompanyRel.creditedMemberUuids]
-		ELSE [null]
-	END) AS coCreditedMemberUuid
-
-		OPTIONAL MATCH (production)-[coCreditedMemberRel:HAS_CREATIVE_ENTITY]->
-			(coCreditedMember:Person { uuid: coCreditedMemberUuid })
-			WHERE
-				coCreditedMember.uuid <> person.uuid AND
 				(
-					creativeCompanyRel.creditPosition IS NULL OR
-					creativeCompanyRel.creditPosition = coCreditedMemberRel.creditPosition
-				)
+					role.roleName IN [character.name, characterRel.displayName] OR
+					role.characterName IN [character.name, characterRel.displayName]
+				) AND
+				(role.characterDifferentiator IS NULL OR role.characterDifferentiator = character.differentiator)
+
+		WITH DISTINCT production, venue, surVenue, role, character
+			ORDER BY role.rolePosition
+
+		OPTIONAL MATCH (production)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
+
+		OPTIONAL MATCH (surProduction)<-[surSurProductionRel:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
 
 		WITH
-			person,
-			producerProductions,
-			castMemberProductions,
-			creativeRel,
 			production,
-			creativeCompanyRel,
-			creditedEmployerCompany,
-			coCreditedMember
-			ORDER BY coCreditedMemberRel.memberPosition
+			venue,
+			surVenue,
+			surProduction,
+			surProductionRel,
+			surSurProduction,
+			surSurProductionRel,
+			COLLECT(
+				CASE WHEN role.roleName IS NULL
+					THEN { name: 'Performer' }
+					ELSE role {
+						model: 'CHARACTER',
+						uuid: character.uuid,
+						name: role.roleName,
+						.qualifier,
+						isAlternate: COALESCE(role.isAlternate, false)
+					}
+				END
+			) AS roles
+			ORDER BY
+				production.startDate DESC,
+				COALESCE(surSurProduction.name, surProduction.name, production.name),
+				COALESCE(surSurProductionRel.position, surProductionRel.position, -1) DESC,
+				COALESCE(surSurProductionRel.position, -1) DESC,
+				COALESCE(surProductionRel.position, -1) DESC,
+				venue.name
 
-		WITH
-			person,
-			producerProductions,
-			castMemberProductions,
-			creativeRel,
-			production,
-			creativeCompanyRel,
-			creditedEmployerCompany,
-			COLLECT(coCreditedMember { model: 'PERSON', .uuid, .name }) AS coCreditedMembers
+		RETURN
+			COLLECT(
+				CASE WHEN production IS NULL
+					THEN null
+					ELSE production {
+						model: 'PRODUCTION',
+						.uuid,
+						.name,
+						.startDate,
+						.endDate,
+						venue: CASE WHEN venue IS NULL
+							THEN null
+							ELSE venue {
+								model: 'VENUE',
+								.uuid,
+								.name,
+								surVenue: CASE WHEN surVenue IS NULL
+									THEN null
+									ELSE surVenue { model: 'VENUE', .uuid, .name }
+								END
+							}
+						END,
+						surProduction: CASE WHEN surProduction IS NULL
+							THEN null
+							ELSE surProduction {
+								model: 'PRODUCTION',
+								.uuid,
+								.name,
+								surProduction: CASE WHEN surSurProduction IS NULL
+									THEN null
+									ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+								END
+							}
+						END,
+						roles
+					}
+				END
+			) AS castMemberProductions
+	}
 
-	WITH
-		person,
-		producerProductions,
-		castMemberProductions,
-		production,
-		CASE WHEN creditedEmployerCompany IS NULL
-			THEN null
-			ELSE creditedEmployerCompany { model: 'COMPANY', .uuid, .name, coMembers: coCreditedMembers }
-		END AS creditedEmployerCompany,
-		COALESCE(creditedEmployerCompany, person) AS entity,
-		COALESCE(creativeCompanyRel, creativeRel) AS entityRel
+	CALL {
+		WITH person
 
-	OPTIONAL MATCH (production)-[coCreditedEntityRel:HAS_CREATIVE_ENTITY]->(coCreditedEntity:Person|Company)
-		WHERE
-			coCreditedEntityRel.creditedCompanyUuid IS NULL AND
-			(
-				entityRel.creditPosition IS NULL OR
-				entityRel.creditPosition = coCreditedEntityRel.creditPosition
-			) AND
-			coCreditedEntity.uuid <> entity.uuid
+		OPTIONAL MATCH (person)<-[creativeRel:HAS_CREATIVE_ENTITY]-(production:Production)
 
-	UNWIND (CASE WHEN coCreditedEntityRel IS NOT NULL AND coCreditedEntityRel.creditedMemberUuids IS NOT NULL
-		THEN [uuid IN coCreditedEntityRel.creditedMemberUuids]
-		ELSE [null]
-	END) AS coCreditedCompanyCreditedMemberUuid
-
-		OPTIONAL MATCH (production)-[coCreditedCompanyCreditedMemberRel:HAS_CREATIVE_ENTITY]->
-			(coCreditedCompanyCreditedMember:Person { uuid: coCreditedCompanyCreditedMemberUuid })
+		OPTIONAL MATCH (production)-[creativeCompanyRel:HAS_CREATIVE_ENTITY]->
+			(creditedEmployerCompany:Company { uuid: creativeRel.creditedCompanyUuid })
 			WHERE
-				coCreditedEntityRel.creditPosition IS NULL OR
-				coCreditedEntityRel.creditPosition = coCreditedCompanyCreditedMemberRel.creditPosition
+				creativeRel.creditPosition IS NULL OR
+				creativeRel.creditPosition = creativeCompanyRel.creditPosition
+
+		UNWIND (CASE WHEN creativeCompanyRel IS NOT NULL AND creativeCompanyRel.creditedMemberUuids IS NOT NULL
+			THEN [uuid IN creativeCompanyRel.creditedMemberUuids]
+			ELSE [null]
+		END) AS coCreditedMemberUuid
+
+			OPTIONAL MATCH (production)-[coCreditedMemberRel:HAS_CREATIVE_ENTITY]->
+				(coCreditedMember:Person { uuid: coCreditedMemberUuid })
+				WHERE
+					coCreditedMember.uuid <> person.uuid AND
+					(
+						creativeCompanyRel.creditPosition IS NULL OR
+						creativeCompanyRel.creditPosition = coCreditedMemberRel.creditPosition
+					)
+
+			WITH
+				person,
+				creativeRel,
+				production,
+				creativeCompanyRel,
+				creditedEmployerCompany,
+				coCreditedMember
+				ORDER BY coCreditedMemberRel.memberPosition
+
+			WITH
+				person,
+				creativeRel,
+				production,
+				creativeCompanyRel,
+				creditedEmployerCompany,
+				COLLECT(coCreditedMember { model: 'PERSON', .uuid, .name }) AS coCreditedMembers
 
 		WITH
-			person,
-			producerProductions,
-			castMemberProductions,
 			production,
-			entityRel,
-			creditedEmployerCompany,
-			coCreditedEntityRel,
-			coCreditedEntity,
-			coCreditedCompanyCreditedMember
-			ORDER BY coCreditedCompanyCreditedMemberRel.memberPosition
-
-		WITH
-			person,
-			producerProductions,
-			castMemberProductions,
-			production,
-			entityRel,
-			creditedEmployerCompany,
-			coCreditedEntityRel,
-			coCreditedEntity,
-			COLLECT(coCreditedCompanyCreditedMember {
-				model: 'PERSON',
-				.uuid,
-				.name
-			}) AS coCreditedCompanyCreditedMembers
-			ORDER BY coCreditedEntityRel.entityPosition
-
-	WITH
-		person,
-		producerProductions,
-		castMemberProductions,
-		production,
-		entityRel,
-		creditedEmployerCompany,
-		COLLECT(
-			CASE WHEN coCreditedEntity IS NULL
+			CASE WHEN creditedEmployerCompany IS NULL
 				THEN null
-				ELSE coCreditedEntity {
-					model: TOUPPER(HEAD(LABELS(coCreditedEntity))),
-					.uuid,
-					.name,
-					members: coCreditedCompanyCreditedMembers
-				}
-			END
-		) AS coCreditedEntities
-		ORDER BY entityRel.creditPosition
+				ELSE creditedEmployerCompany { model: 'COMPANY', .uuid, .name, coMembers: coCreditedMembers }
+			END AS creditedEmployerCompany,
+			COALESCE(creditedEmployerCompany, person) AS entity,
+			COALESCE(creativeCompanyRel, creativeRel) AS entityRel
 
-	WITH
-		person,
-		producerProductions,
-		castMemberProductions,
-		production,
-		entityRel,
-		creditedEmployerCompany,
-		[coCreditedEntity IN coCreditedEntities | CASE coCreditedEntity.model WHEN 'COMPANY'
-			THEN coCreditedEntity
-			ELSE coCreditedEntity { .model, .uuid, .name }
-		END] AS coCreditedEntities
-
-	OPTIONAL MATCH (production)-[:PLAYS_AT]->(venue:Venue)
-
-	OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
-
-	OPTIONAL MATCH (production)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
-
-	OPTIONAL MATCH (surProduction)<-[surSurProductionRel:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
-
-	WITH
-		person,
-		producerProductions,
-		castMemberProductions,
-		production,
-		venue,
-		surVenue,
-		surProduction,
-		surProductionRel,
-		surSurProduction,
-		surSurProductionRel,
-		COLLECT({
-			model: 'CREATIVE_CREDIT',
-			name: entityRel.credit,
-			employerCompany: creditedEmployerCompany,
-			coEntities: coCreditedEntities
-		}) AS creativeCredits
-		ORDER BY
-			production.startDate DESC,
-			COALESCE(surSurProduction.name, surProduction.name, production.name),
-			COALESCE(surSurProductionRel.position, surProductionRel.position, -1) DESC,
-			COALESCE(surSurProductionRel.position, -1) DESC,
-			COALESCE(surProductionRel.position, -1) DESC,
-			venue.name
-
-	WITH person, producerProductions, castMemberProductions,
-		COLLECT(
-			CASE WHEN production IS NULL
-				THEN null
-				ELSE production {
-					model: 'PRODUCTION',
-					.uuid,
-					.name,
-					.startDate,
-					.endDate,
-					venue: CASE WHEN venue IS NULL
-						THEN null
-						ELSE venue {
-							model: 'VENUE',
-							.uuid,
-							.name,
-							surVenue: CASE WHEN surVenue IS NULL
-								THEN null
-								ELSE surVenue { model: 'VENUE', .uuid, .name }
-							END
-						}
-					END,
-					surProduction: CASE WHEN surProduction IS NULL
-						THEN null
-						ELSE surProduction {
-							model: 'PRODUCTION',
-							.uuid,
-							.name,
-							surProduction: CASE WHEN surSurProduction IS NULL
-								THEN null
-								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
-							END
-						}
-					END,
-					creativeCredits
-				}
-			END
-		) AS creativeProductions
-
-	OPTIONAL MATCH (person)<-[crewRel:HAS_CREW_ENTITY]-(production:Production)
-
-	OPTIONAL MATCH (production)-[crewCompanyRel:HAS_CREW_ENTITY]->
-		(creditedEmployerCompany:Company { uuid: crewRel.creditedCompanyUuid })
-		WHERE
-			crewRel.creditPosition IS NULL OR
-			crewRel.creditPosition = crewCompanyRel.creditPosition
-
-	UNWIND (CASE WHEN crewCompanyRel IS NOT NULL AND crewCompanyRel.creditedMemberUuids IS NOT NULL
-		THEN [uuid IN crewCompanyRel.creditedMemberUuids]
-		ELSE [null]
-	END) AS coCreditedMemberUuid
-
-		OPTIONAL MATCH (production)-[coCreditedMemberRel:HAS_CREW_ENTITY]->
-			(coCreditedMember:Person { uuid: coCreditedMemberUuid })
+		OPTIONAL MATCH (production)-[coCreditedEntityRel:HAS_CREATIVE_ENTITY]->(coCreditedEntity:Person|Company)
 			WHERE
-				coCreditedMember.uuid <> person.uuid AND
+				coCreditedEntityRel.creditedCompanyUuid IS NULL AND
 				(
-					crewCompanyRel.creditPosition IS NULL OR
-					crewCompanyRel.creditPosition = coCreditedMemberRel.creditPosition
-				)
+					entityRel.creditPosition IS NULL OR
+					entityRel.creditPosition = coCreditedEntityRel.creditPosition
+				) AND
+				coCreditedEntity.uuid <> entity.uuid
 
-		WITH
-			person,
-			producerProductions,
-			castMemberProductions,
-			creativeProductions,
-			crewRel,
-			production,
-			crewCompanyRel,
-			creditedEmployerCompany,
-			coCreditedMember
-			ORDER BY coCreditedMemberRel.memberPosition
+		UNWIND (CASE WHEN coCreditedEntityRel IS NOT NULL AND coCreditedEntityRel.creditedMemberUuids IS NOT NULL
+			THEN [uuid IN coCreditedEntityRel.creditedMemberUuids]
+			ELSE [null]
+		END) AS coCreditedCompanyCreditedMemberUuid
 
-		WITH
-			person,
-			producerProductions,
-			castMemberProductions,
-			creativeProductions,
-			crewRel,
-			production,
-			crewCompanyRel,
-			creditedEmployerCompany,
-			COLLECT(coCreditedMember { model: 'PERSON', .uuid, .name }) AS coCreditedMembers
+			OPTIONAL MATCH (production)-[coCreditedCompanyCreditedMemberRel:HAS_CREATIVE_ENTITY]->
+				(coCreditedCompanyCreditedMember:Person { uuid: coCreditedCompanyCreditedMemberUuid })
+				WHERE
+					coCreditedEntityRel.creditPosition IS NULL OR
+					coCreditedEntityRel.creditPosition = coCreditedCompanyCreditedMemberRel.creditPosition
 
-	WITH
-		person,
-		producerProductions,
-		castMemberProductions,
-		creativeProductions,
-		production,
-		CASE WHEN creditedEmployerCompany IS NULL
-			THEN null
-			ELSE creditedEmployerCompany { model: 'COMPANY', .uuid, .name, coMembers: coCreditedMembers }
-		END AS creditedEmployerCompany,
-		COALESCE(creditedEmployerCompany, person) AS entity,
-		COALESCE(crewCompanyRel, crewRel) AS entityRel
+			WITH
+				production,
+				entityRel,
+				creditedEmployerCompany,
+				coCreditedEntityRel,
+				coCreditedEntity,
+				coCreditedCompanyCreditedMember
+				ORDER BY coCreditedCompanyCreditedMemberRel.memberPosition
 
-	OPTIONAL MATCH (production)-[coCreditedEntityRel:HAS_CREW_ENTITY]->(coCreditedEntity:Person|Company)
-		WHERE
-			coCreditedEntityRel.creditedCompanyUuid IS NULL AND
-			(
-				entityRel.creditPosition IS NULL OR
-				entityRel.creditPosition = coCreditedEntityRel.creditPosition
-			) AND
-			coCreditedEntity.uuid <> entity.uuid
-
-	UNWIND (CASE WHEN coCreditedEntityRel IS NOT NULL AND coCreditedEntityRel.creditedMemberUuids IS NOT NULL
-		THEN [uuid IN coCreditedEntityRel.creditedMemberUuids]
-		ELSE [null]
-	END) AS coCreditedCompanyCreditedMemberUuid
-
-		OPTIONAL MATCH (production)-[coCreditedCompanyCreditedMemberRel:HAS_CREW_ENTITY]->
-			(coCreditedCompanyCreditedMember:Person { uuid: coCreditedCompanyCreditedMemberUuid })
-			WHERE
-				coCreditedEntityRel.creditPosition IS NULL OR
-				coCreditedEntityRel.creditPosition = coCreditedCompanyCreditedMemberRel.creditPosition
-
-		WITH
-			producerProductions,
-			castMemberProductions,
-			creativeProductions,
-			production,
-			entityRel,
-			creditedEmployerCompany,
-			coCreditedEntityRel,
-			coCreditedEntity,
-			coCreditedCompanyCreditedMember
-			ORDER BY coCreditedCompanyCreditedMemberRel.memberPosition
-
-		WITH
-			producerProductions,
-			castMemberProductions,
-			creativeProductions,
-			production,
-			entityRel,
-			creditedEmployerCompany,
-			coCreditedEntityRel,
-			coCreditedEntity,
-			COLLECT(coCreditedCompanyCreditedMember {
-				model: 'PERSON',
-				.uuid,
-				.name
-			}) AS coCreditedCompanyCreditedMembers
-			ORDER BY coCreditedEntityRel.entityPosition
-
-	WITH
-		producerProductions,
-		castMemberProductions,
-		creativeProductions,
-		production,
-		entityRel,
-		creditedEmployerCompany,
-		COLLECT(
-			CASE WHEN coCreditedEntity IS NULL
-				THEN null
-				ELSE coCreditedEntity {
-					model: TOUPPER(HEAD(LABELS(coCreditedEntity))),
+			WITH
+				production,
+				entityRel,
+				creditedEmployerCompany,
+				coCreditedEntityRel,
+				coCreditedEntity,
+				COLLECT(coCreditedCompanyCreditedMember {
+					model: 'PERSON',
 					.uuid,
-					.name,
-					members: coCreditedCompanyCreditedMembers
-				}
-			END
-		) AS coCreditedEntities
-		ORDER BY entityRel.creditPosition
+					.name
+				}) AS coCreditedCompanyCreditedMembers
+				ORDER BY coCreditedEntityRel.entityPosition
 
-	WITH
-		producerProductions,
-		castMemberProductions,
-		creativeProductions,
-		production,
-		entityRel,
-		creditedEmployerCompany,
-		[coCreditedEntity IN coCreditedEntities | CASE coCreditedEntity.model WHEN 'COMPANY'
-			THEN coCreditedEntity
-			ELSE coCreditedEntity { .model, .uuid, .name }
-		END] AS coCreditedEntities
+		WITH
+			production,
+			entityRel,
+			creditedEmployerCompany,
+			COLLECT(
+				CASE WHEN coCreditedEntity IS NULL
+					THEN null
+					ELSE coCreditedEntity {
+						model: TOUPPER(HEAD(LABELS(coCreditedEntity))),
+						.uuid,
+						.name,
+						members: coCreditedCompanyCreditedMembers
+					}
+				END
+			) AS coCreditedEntities
+			ORDER BY entityRel.creditPosition
 
-	OPTIONAL MATCH (production)-[:PLAYS_AT]->(venue:Venue)
+		WITH
+			production,
+			entityRel,
+			creditedEmployerCompany,
+			[coCreditedEntity IN coCreditedEntities | CASE coCreditedEntity.model WHEN 'COMPANY'
+				THEN coCreditedEntity
+				ELSE coCreditedEntity { .model, .uuid, .name }
+			END] AS coCreditedEntities
 
-	OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
+		OPTIONAL MATCH (production)-[:PLAYS_AT]->(venue:Venue)
 
-	OPTIONAL MATCH (production)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
+		OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
 
-	OPTIONAL MATCH (surProduction)<-[surSurProductionRel:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+		OPTIONAL MATCH (production)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
-	WITH
-		producerProductions,
-		castMemberProductions,
-		creativeProductions,
-		production,
-		venue,
-		surVenue,
-		surProduction,
-		surProductionRel,
-		surSurProduction,
-		surSurProductionRel,
-		COLLECT({
-			model: 'CREW_CREDIT',
-			name: entityRel.credit,
-			employerCompany: creditedEmployerCompany,
-			coEntities: coCreditedEntities
-		}) AS crewCredits
-		ORDER BY
-			production.startDate DESC,
-			COALESCE(surSurProduction.name, surProduction.name, production.name),
-			COALESCE(surSurProductionRel.position, surProductionRel.position, -1) DESC,
-			COALESCE(surSurProductionRel.position, -1) DESC,
-			COALESCE(surProductionRel.position, -1) DESC,
-			venue.name
+		OPTIONAL MATCH (surProduction)<-[surSurProductionRel:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+
+		WITH
+			production,
+			venue,
+			surVenue,
+			surProduction,
+			surProductionRel,
+			surSurProduction,
+			surSurProductionRel,
+			COLLECT({
+				model: 'CREATIVE_CREDIT',
+				name: entityRel.credit,
+				employerCompany: creditedEmployerCompany,
+				coEntities: coCreditedEntities
+			}) AS creativeCredits
+			ORDER BY
+				production.startDate DESC,
+				COALESCE(surSurProduction.name, surProduction.name, production.name),
+				COALESCE(surSurProductionRel.position, surProductionRel.position, -1) DESC,
+				COALESCE(surSurProductionRel.position, -1) DESC,
+				COALESCE(surProductionRel.position, -1) DESC,
+				venue.name
+
+		RETURN
+			COLLECT(
+				CASE WHEN production IS NULL
+					THEN null
+					ELSE production {
+						model: 'PRODUCTION',
+						.uuid,
+						.name,
+						.startDate,
+						.endDate,
+						venue: CASE WHEN venue IS NULL
+							THEN null
+							ELSE venue {
+								model: 'VENUE',
+								.uuid,
+								.name,
+								surVenue: CASE WHEN surVenue IS NULL
+									THEN null
+									ELSE surVenue { model: 'VENUE', .uuid, .name }
+								END
+							}
+						END,
+						surProduction: CASE WHEN surProduction IS NULL
+							THEN null
+							ELSE surProduction {
+								model: 'PRODUCTION',
+								.uuid,
+								.name,
+								surProduction: CASE WHEN surSurProduction IS NULL
+									THEN null
+									ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+								END
+							}
+						END,
+						creativeCredits
+					}
+				END
+			) AS creativeProductions
+	}
+
+	CALL {
+		WITH person
+
+		OPTIONAL MATCH (person)<-[crewRel:HAS_CREW_ENTITY]-(production:Production)
+
+		OPTIONAL MATCH (production)-[crewCompanyRel:HAS_CREW_ENTITY]->
+			(creditedEmployerCompany:Company { uuid: crewRel.creditedCompanyUuid })
+			WHERE
+				crewRel.creditPosition IS NULL OR
+				crewRel.creditPosition = crewCompanyRel.creditPosition
+
+		UNWIND (CASE WHEN crewCompanyRel IS NOT NULL AND crewCompanyRel.creditedMemberUuids IS NOT NULL
+			THEN [uuid IN crewCompanyRel.creditedMemberUuids]
+			ELSE [null]
+		END) AS coCreditedMemberUuid
+
+			OPTIONAL MATCH (production)-[coCreditedMemberRel:HAS_CREW_ENTITY]->
+				(coCreditedMember:Person { uuid: coCreditedMemberUuid })
+				WHERE
+					coCreditedMember.uuid <> person.uuid AND
+					(
+						crewCompanyRel.creditPosition IS NULL OR
+						crewCompanyRel.creditPosition = coCreditedMemberRel.creditPosition
+					)
+
+			WITH
+				person,
+				crewRel,
+				production,
+				crewCompanyRel,
+				creditedEmployerCompany,
+				coCreditedMember
+				ORDER BY coCreditedMemberRel.memberPosition
+
+			WITH
+				person,
+				crewRel,
+				production,
+				crewCompanyRel,
+				creditedEmployerCompany,
+				COLLECT(coCreditedMember { model: 'PERSON', .uuid, .name }) AS coCreditedMembers
+
+		WITH
+			production,
+			CASE WHEN creditedEmployerCompany IS NULL
+				THEN null
+				ELSE creditedEmployerCompany { model: 'COMPANY', .uuid, .name, coMembers: coCreditedMembers }
+			END AS creditedEmployerCompany,
+			COALESCE(creditedEmployerCompany, person) AS entity,
+			COALESCE(crewCompanyRel, crewRel) AS entityRel
+
+		OPTIONAL MATCH (production)-[coCreditedEntityRel:HAS_CREW_ENTITY]->(coCreditedEntity:Person|Company)
+			WHERE
+				coCreditedEntityRel.creditedCompanyUuid IS NULL AND
+				(
+					entityRel.creditPosition IS NULL OR
+					entityRel.creditPosition = coCreditedEntityRel.creditPosition
+				) AND
+				coCreditedEntity.uuid <> entity.uuid
+
+		UNWIND (CASE WHEN coCreditedEntityRel IS NOT NULL AND coCreditedEntityRel.creditedMemberUuids IS NOT NULL
+			THEN [uuid IN coCreditedEntityRel.creditedMemberUuids]
+			ELSE [null]
+		END) AS coCreditedCompanyCreditedMemberUuid
+
+			OPTIONAL MATCH (production)-[coCreditedCompanyCreditedMemberRel:HAS_CREW_ENTITY]->
+				(coCreditedCompanyCreditedMember:Person { uuid: coCreditedCompanyCreditedMemberUuid })
+				WHERE
+					coCreditedEntityRel.creditPosition IS NULL OR
+					coCreditedEntityRel.creditPosition = coCreditedCompanyCreditedMemberRel.creditPosition
+
+			WITH
+				production,
+				entityRel,
+				creditedEmployerCompany,
+				coCreditedEntityRel,
+				coCreditedEntity,
+				coCreditedCompanyCreditedMember
+				ORDER BY coCreditedCompanyCreditedMemberRel.memberPosition
+
+			WITH
+				production,
+				entityRel,
+				creditedEmployerCompany,
+				coCreditedEntityRel,
+				coCreditedEntity,
+				COLLECT(coCreditedCompanyCreditedMember {
+					model: 'PERSON',
+					.uuid,
+					.name
+				}) AS coCreditedCompanyCreditedMembers
+				ORDER BY coCreditedEntityRel.entityPosition
+
+		WITH
+			production,
+			entityRel,
+			creditedEmployerCompany,
+			COLLECT(
+				CASE WHEN coCreditedEntity IS NULL
+					THEN null
+					ELSE coCreditedEntity {
+						model: TOUPPER(HEAD(LABELS(coCreditedEntity))),
+						.uuid,
+						.name,
+						members: coCreditedCompanyCreditedMembers
+					}
+				END
+			) AS coCreditedEntities
+			ORDER BY entityRel.creditPosition
+
+		WITH
+			production,
+			entityRel,
+			creditedEmployerCompany,
+			[coCreditedEntity IN coCreditedEntities | CASE coCreditedEntity.model WHEN 'COMPANY'
+				THEN coCreditedEntity
+				ELSE coCreditedEntity { .model, .uuid, .name }
+			END] AS coCreditedEntities
+
+		OPTIONAL MATCH (production)-[:PLAYS_AT]->(venue:Venue)
+
+		OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
+
+		OPTIONAL MATCH (production)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
+
+		OPTIONAL MATCH (surProduction)<-[surSurProductionRel:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+
+		WITH
+			production,
+			venue,
+			surVenue,
+			surProduction,
+			surProductionRel,
+			surSurProduction,
+			surSurProductionRel,
+			COLLECT({
+				model: 'CREW_CREDIT',
+				name: entityRel.credit,
+				employerCompany: creditedEmployerCompany,
+				coEntities: coCreditedEntities
+			}) AS crewCredits
+			ORDER BY
+				production.startDate DESC,
+				COALESCE(surSurProduction.name, surProduction.name, production.name),
+				COALESCE(surSurProductionRel.position, surProductionRel.position, -1) DESC,
+				COALESCE(surSurProductionRel.position, -1) DESC,
+				COALESCE(surProductionRel.position, -1) DESC,
+				venue.name
+
+		RETURN
+			COLLECT(
+				CASE WHEN production IS NULL
+					THEN null
+					ELSE production {
+						model: 'PRODUCTION',
+						.uuid,
+						.name,
+						.startDate,
+						.endDate,
+						venue: CASE WHEN venue IS NULL
+							THEN null
+							ELSE venue {
+								model: 'VENUE',
+								.uuid,
+								.name,
+								surVenue: CASE WHEN surVenue IS NULL
+									THEN null
+									ELSE surVenue { model: 'VENUE', .uuid, .name }
+								END
+							}
+						END,
+						surProduction: CASE WHEN surProduction IS NULL
+							THEN null
+							ELSE surProduction {
+								model: 'PRODUCTION',
+								.uuid,
+								.name,
+								surProduction: CASE WHEN surSurProduction IS NULL
+									THEN null
+									ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+								END
+							}
+						END,
+						crewCredits
+					}
+				END
+			) AS crewProductions
+	}
 
 	RETURN
 		producerProductions,
 		castMemberProductions,
 		creativeProductions,
-		COLLECT(
-			CASE WHEN production IS NULL
-				THEN null
-				ELSE production {
-					model: 'PRODUCTION',
-					.uuid,
-					.name,
-					.startDate,
-					.endDate,
-					venue: CASE WHEN venue IS NULL
-						THEN null
-						ELSE venue {
-							model: 'VENUE',
-							.uuid,
-							.name,
-							surVenue: CASE WHEN surVenue IS NULL
-								THEN null
-								ELSE surVenue { model: 'VENUE', .uuid, .name }
-							END
-						}
-					END,
-					surProduction: CASE WHEN surProduction IS NULL
-						THEN null
-						ELSE surProduction {
-							model: 'PRODUCTION',
-							.uuid,
-							.name,
-							surProduction: CASE WHEN surSurProduction IS NULL
-								THEN null
-								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
-							END
-						}
-					END,
-					crewCredits
-				}
-			END
-		) AS crewProductions
+		crewProductions
 `;


### PR DESCRIPTION
This PR updates the Cypher queries to use subqueries (using the `CALL` command).

This has the effect of nicely consolidating sections of longer queries so that identifiers for the preceding sections do not need to be carried through the entire query via `WITH` statements, consequently making them easier to read.

### References:
- [Medium: The Power of Subqueries in Neo4j 4.x](https://medium.com/neo4j/the-power-of-subqueries-in-neo4j-4-x-4f1888739bec) by Michael Hunger (16 Jul 2020)