### PR TITLE
Include discrete Cypher show query for all models

### DIFF
--- a/src/neo4j/cypher-queries/award-ceremony/show.js
+++ b/src/neo4j/cypher-queries/award-ceremony/show.js
@@ -286,7 +286,6 @@ export default () => [`
 			) AS categories
 	}
 
-
 	RETURN
 		'AWARD_CEREMONY' AS model,
 		ceremony.uuid AS uuid,

--- a/src/neo4j/cypher-queries/character/show/index.js
+++ b/src/neo4j/cypher-queries/character/show/index.js
@@ -1,7 +1,9 @@
+import getShowQuery from './show';
 import getShowMaterialsQuery from './show-materials';
 import getShowProductionsQuery from './show-productions';
 
 export default () => [
+	getShowQuery(),
 	getShowMaterialsQuery(),
 	getShowProductionsQuery()
 ];

--- a/src/neo4j/cypher-queries/character/show/show-materials.js
+++ b/src/neo4j/cypher-queries/character/show/show-materials.js
@@ -163,10 +163,6 @@ export default () => `
 	}
 
 	RETURN
-		'CHARACTER' AS model,
-		character.uuid AS uuid,
-		character.name AS name,
-		character.differentiator AS differentiator,
 		variantNamedDepictions,
 		materials
 `;

--- a/src/neo4j/cypher-queries/character/show/show.js
+++ b/src/neo4j/cypher-queries/character/show/show.js
@@ -1,0 +1,9 @@
+export default () => `
+	MATCH (character:Character { uuid: $uuid })
+
+	RETURN
+		'CHARACTER' AS model,
+		character.uuid AS uuid,
+		character.name AS name,
+		character.differentiator AS differentiator
+`;

--- a/src/neo4j/cypher-queries/company/show/index.js
+++ b/src/neo4j/cypher-queries/company/show/index.js
@@ -1,3 +1,4 @@
+import getShowQuery from './show';
 import getShowAwardsQuery from './show-awards';
 import getShowAwardsSubsequentVersionMaterialQuery from './show-awards-subsequent-version-material';
 import getShowAwardsSourcingMaterialQuery from './show-awards-sourcing-material';
@@ -6,6 +7,7 @@ import getShowMaterialsQuery from './show-materials';
 import getShowProductionsQuery from './show-productions';
 
 export default () => [
+	getShowQuery(),
 	getShowAwardsQuery(),
 	getShowAwardsSubsequentVersionMaterialQuery(),
 	getShowAwardsSourcingMaterialQuery(),

--- a/src/neo4j/cypher-queries/company/show/show-materials.js
+++ b/src/neo4j/cypher-queries/company/show/show-materials.js
@@ -29,7 +29,6 @@ export default () => `
 			(sourceMaterialWriter:Person|Company)
 
 		WITH
-			company,
 			material,
 			writerRel.creditType AS creditType,
 			CASE WHEN writerRel IS NULL THEN false ELSE true END AS hasDirectCredit,
@@ -44,7 +43,6 @@ export default () => `
 			ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriterRel.entityPosition
 
 		WITH
-			company,
 			material,
 			creditType,
 			hasDirectCredit,
@@ -63,7 +61,6 @@ export default () => `
 			) AS sourceMaterialWriters
 
 		WITH
-			company,
 			material,
 			creditType,
 			hasDirectCredit,
@@ -86,7 +83,6 @@ export default () => `
 			ORDER BY entityRel.creditPosition, entityRel.entityPosition
 
 		WITH
-			company,
 			material,
 			creditType,
 			hasDirectCredit,
@@ -120,7 +116,6 @@ export default () => `
 			) AS entities
 
 		WITH
-			company,
 			material,
 			creditType,
 			hasDirectCredit,
@@ -137,7 +132,6 @@ export default () => `
 		OPTIONAL MATCH (surMaterial)<-[surSurMaterialRel:HAS_SUB_MATERIAL]-(surSurMaterial:Material)
 
 		WITH
-			company,
 			material,
 			creditType,
 			hasDirectCredit,
@@ -163,7 +157,7 @@ export default () => `
 				surSurMaterialRel.position DESC,
 				surMaterialRel.position DESC
 
-		WITH company,
+		WITH
 			COLLECT(
 				CASE WHEN material IS NULL
 					THEN null
@@ -195,10 +189,6 @@ export default () => `
 			) AS materials
 
 	RETURN
-		'COMPANY' AS model,
-		company.uuid AS uuid,
-		company.name AS name,
-		company.differentiator AS differentiator,
 		[
 			material IN materials WHERE
 				material.hasDirectCredit AND

--- a/src/neo4j/cypher-queries/company/show/show.js
+++ b/src/neo4j/cypher-queries/company/show/show.js
@@ -1,0 +1,9 @@
+export default () => `
+	MATCH (company:Company { uuid: $uuid })
+
+	RETURN
+		'COMPANY' AS model,
+		company.uuid AS uuid,
+		company.name AS name,
+		company.differentiator AS differentiator
+`;

--- a/src/neo4j/cypher-queries/person/show/index.js
+++ b/src/neo4j/cypher-queries/person/show/index.js
@@ -1,3 +1,4 @@
+import getShowQuery from './show';
 import getShowAwardsQuery from './show-awards';
 import getShowAwardsSubsequentVersionMaterialQuery from './show-awards-subsequent-version-material';
 import getShowAwardsSourcingMaterialQuery from './show-awards-sourcing-material';
@@ -6,6 +7,7 @@ import getShowMaterialsQuery from './show-materials';
 import getShowProductionsQuery from './show-productions';
 
 export default () => [
+	getShowQuery(),
 	getShowAwardsQuery(),
 	getShowAwardsSubsequentVersionMaterialQuery(),
 	getShowAwardsSourcingMaterialQuery(),

--- a/src/neo4j/cypher-queries/person/show/show-materials.js
+++ b/src/neo4j/cypher-queries/person/show/show-materials.js
@@ -29,7 +29,6 @@ export default () => `
 			(sourceMaterialWriter:Person|Company)
 
 		WITH
-			person,
 			material,
 			writerRel.creditType AS creditType,
 			CASE WHEN writerRel IS NULL THEN false ELSE true END AS hasDirectCredit,
@@ -44,7 +43,6 @@ export default () => `
 			ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriterRel.entityPosition
 
 		WITH
-			person,
 			material,
 			creditType,
 			hasDirectCredit,
@@ -63,7 +61,6 @@ export default () => `
 			) AS sourceMaterialWriters
 
 		WITH
-			person,
 			material,
 			creditType,
 			hasDirectCredit,
@@ -86,7 +83,6 @@ export default () => `
 			ORDER BY entityRel.creditPosition, entityRel.entityPosition
 
 		WITH
-			person,
 			material,
 			creditType,
 			hasDirectCredit,
@@ -120,7 +116,6 @@ export default () => `
 			) AS entities
 
 		WITH
-			person,
 			material,
 			creditType,
 			hasDirectCredit,
@@ -137,7 +132,6 @@ export default () => `
 		OPTIONAL MATCH (surMaterial)<-[surSurMaterialRel:HAS_SUB_MATERIAL]-(surSurMaterial:Material)
 
 		WITH
-			person,
 			material,
 			creditType,
 			hasDirectCredit,
@@ -163,7 +157,7 @@ export default () => `
 				surSurMaterialRel.position DESC,
 				surMaterialRel.position DESC
 
-		WITH person,
+		WITH
 			COLLECT(
 				CASE WHEN material IS NULL
 					THEN null
@@ -195,10 +189,6 @@ export default () => `
 			) AS materials
 
 	RETURN
-		'PERSON' AS model,
-		person.uuid AS uuid,
-		person.name AS name,
-		person.differentiator AS differentiator,
 		[
 			material IN materials WHERE
 				material.hasDirectCredit AND

--- a/src/neo4j/cypher-queries/person/show/show.js
+++ b/src/neo4j/cypher-queries/person/show/show.js
@@ -1,0 +1,9 @@
+export default () => `
+	MATCH (person:Person { uuid: $uuid })
+
+	RETURN
+		'PERSON' AS model,
+		person.uuid AS uuid,
+		person.name AS name,
+		person.differentiator AS differentiator
+`;


### PR DESCRIPTION
This PR adds a `show.js` file for the models that currently include their base 'show' data (e.g. model, uuid, name, differentiator) as part of a larger query for one of its facets.

E.g. currently the base 'show' data for the person model is included in its `show-materials.js` file, which is not any more intuitive a place than its `show-productions.js` file, so that is now extracted into a separate `show.js` file.

This admittedly results in an extra request make to the Neo4j database, potentially impacting performance, but in the future the queries will likely be exposed by different endpoints and require this sort of extraction in any case, so is laying the groundwork for that.