### PR TITLE
Add database seeds for duplicate instances

### DIFF
--- a/db-seeding/seeds/materials/decade-21-collection.json
+++ b/db-seeding/seeds/materials/decade-21-collection.json
@@ -25,7 +25,8 @@
 			"name": "Olive Garden"
 		},
 		{
-			"name": "Grounded"
+			"name": "Grounded",
+			"differentiator": "1"
 		},
 		{
 			"name": "The Sentinels"

--- a/db-seeding/seeds/materials/grounded.json
+++ b/db-seeding/seeds/materials/grounded.json
@@ -1,0 +1,24 @@
+{
+	"name": "Grounded",
+	"differentiator": "2",
+	"format": "play",
+	"year": "2013",
+	"writingCredits": [
+		{
+			"entities": [
+				{
+					"name": "George Brant"
+				}
+			]
+		}
+	],
+	"characterGroups": [
+		{
+			"characters": [
+				{
+					"name": "The Pilot"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/materials/love-story-01-novel.json
+++ b/db-seeding/seeds/materials/love-story-01-novel.json
@@ -1,13 +1,13 @@
 {
-	"name": "Grounded",
+	"name": "Love Story",
 	"differentiator": "1",
-	"format": "play",
-	"year": "2011",
+	"format": "novel",
+	"year": "1970",
 	"writingCredits": [
 		{
 			"entities": [
 				{
-					"name": "John Logan"
+					"name": "Erich Segal"
 				}
 			]
 		}

--- a/db-seeding/seeds/materials/love-story-02-screenplay.json
+++ b/db-seeding/seeds/materials/love-story-02-screenplay.json
@@ -1,0 +1,15 @@
+{
+	"name": "Love Story",
+	"differentiator": "2",
+	"format": "screenplay",
+	"year": "1970",
+	"writingCredits": [
+		{
+			"entities": [
+				{
+					"name": "Erich Segal"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/materials/love-story-03-musical.json
+++ b/db-seeding/seeds/materials/love-story-03-musical.json
@@ -1,0 +1,92 @@
+{
+	"name": "Love Story",
+	"differentiator": "3",
+	"format": "musical",
+	"year": "2010",
+	"writingCredits": [
+		{
+			"name": "music by",
+			"entities": [
+				{
+					"name": "Howard Goodall"
+				}
+			]
+		},
+		{
+			"name": "book and lyrics by",
+			"entities": [
+				{
+					"name": "Stephen Clark"
+				}
+			]
+		},
+		{
+			"name": "additional lyrics by",
+			"entities": [
+				{
+					"name": "Howard Goodall"
+				}
+			]
+		},
+		{
+			"name": "based on",
+			"entities": [
+				{
+					"model": "MATERIAL",
+					"name": "Love Story",
+					"differentiator": "1"
+				},
+				{
+					"model": "MATERIAL",
+					"name": "Love Story",
+					"differentiator": "2"
+				}
+			]
+		}
+	],
+	"characterGroups": [
+		{
+			"characters": [
+				{
+					"name": "Oliver Barrett IV"
+				},
+				{
+					"name": "Jenny Cavilleri"
+				},
+				{
+					"name": "Phil Cavilleri"
+				},
+				{
+					"name": "Oliver Barrett III"
+				},
+				{
+					"name": "Alison Barrett"
+				},
+				{
+					"name": "Matt",
+					"differentiator": "Love Story"
+				},
+				{
+					"name": "Doctor",
+					"differentiator": "Love Story"
+				},
+				{
+					"name": "Tony",
+					"differentiator": "Love Story"
+				},
+				{
+					"name": "Dr Ackerman"
+				},
+				{
+					"name": "Waitress"
+				},
+				{
+					"name": "Secretary"
+				},
+				{
+					"name": "Jenny's Mother"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/materials/sixty-six-books-57-the-letter.json
+++ b/db-seeding/seeds/materials/sixty-six-books-57-the-letter.json
@@ -1,5 +1,6 @@
 {
 	"name": "The Letter",
+	"differentiator": "2",
 	"format": "play",
 	"year": "2011",
 	"writingCredits": [

--- a/db-seeding/seeds/materials/sixty-six-books-68-the-books-of-the-new-testament.json
+++ b/db-seeding/seeds/materials/sixty-six-books-68-the-books-of-the-new-testament.json
@@ -55,7 +55,8 @@
 			"name": "A Sunday Sermon"
 		},
 		{
-			"name": "The Letter"
+			"name": "The Letter",
+			"differentiator": "2"
 		},
 		{
 			"name": "The Middle Man"

--- a/db-seeding/seeds/materials/the-letter.json
+++ b/db-seeding/seeds/materials/the-letter.json
@@ -1,0 +1,36 @@
+{
+	"name": "The Letter",
+	"differentiator": "1",
+	"format": "play",
+	"year": "1927",
+	"writingCredits": [
+		{
+			"entities": [
+				{
+					"name": "W Somerset Maugham"
+				}
+			]
+		}
+	],
+	"characterGroups": [
+		{
+			"characters": [
+				{
+					"name": "Leslie Crosbie"
+				},
+				{
+					"name": "Robert Crosbie"
+				},
+				{
+					"name": "Geoffrey Hammond"
+				},
+				{
+					"name": "Howard Joyce"
+				},
+				{
+					"name": "Ong Chi Seng"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/productions/calendar-girls.json
+++ b/db-seeding/seeds/productions/calendar-girls.json
@@ -155,6 +155,7 @@
 		},
 		{
 			"name": "Costume Designer",
+			"differentiator": "1",
 			"entities": [
 				{
 					"name": "Emma Williams"

--- a/db-seeding/seeds/productions/decade-08-grounded.json
+++ b/db-seeding/seeds/productions/decade-08-grounded.json
@@ -5,7 +5,8 @@
 	"pressDate": "2011-09-08",
 	"endDate": "2011-10-15",
 	"material": {
-		"name": "Grounded"
+		"name": "Grounded",
+		"differentiator": "1"
 	},
 	"venue": {
 		"name": "Commodity Quay"

--- a/db-seeding/seeds/productions/decade-21-collection.json
+++ b/db-seeding/seeds/productions/decade-21-collection.json
@@ -156,6 +156,7 @@
 		},
 		{
 			"name": "Costume Designer",
+			"differentiator": "1",
 			"entities": [
 				{
 					"name": "Emma Williams"

--- a/db-seeding/seeds/productions/grounded.json
+++ b/db-seeding/seeds/productions/grounded.json
@@ -1,0 +1,117 @@
+{
+	"name": "Grounded",
+	"startDate": "2013-08-28",
+	"pressDate": "2013-08-29",
+	"endDate": "2013-10-05",
+	"material": {
+		"name": "Grounded",
+		"differentiator": "2"
+	},
+	"venue": {
+		"name": "Gate Theatre",
+		"differentiator": "1"
+	},
+	"producerCredits": [
+		{
+			"entities": [
+				{
+					"model": "COMPANY",
+					"name": "Gate Theatre",
+					"differentiator": "1"
+				}
+			]
+		}
+	],
+	"cast": [
+		{
+			"name": "Lucy Ellinson",
+			"roles": [
+				{
+					"name": "The Pilot"
+				}
+			]
+		}
+	],
+	"creativeCredits": [
+		{
+			"name": "Director",
+			"entities": [
+				{
+					"name": "Christopher Haydon"
+				}
+			]
+		},
+		{
+			"name": "Designer",
+			"entities": [
+				{
+					"name": "Oliver Townsend"
+				}
+			]
+		},
+		{
+			"name": "Lighting Designer",
+			"entities": [
+				{
+					"name": "Mark Howland"
+				}
+			]
+		},
+		{
+			"name": "Sound Designer",
+			"entities": [
+				{
+					"name": "Tom Gibbons"
+				}
+			]
+		},
+		{
+			"name": "Video Designer",
+			"entities": [
+				{
+					"name": "Benjamin Walden"
+				}
+			]
+		},
+		{
+			"name": "Associate Director",
+			"entities": [
+				{
+					"name": "Caroline Byrne"
+				}
+			]
+		},
+		{
+			"name": "Associate Lighting Designer",
+			"entities": [
+				{
+					"name": "Joshua Pharo"
+				}
+			]
+		},
+		{
+			"name": "Dialect Coach",
+			"entities": [
+				{
+					"name": "Michaela Kennen"
+				}
+			]
+		},
+		{
+			"name": "Production Manager",
+			"entities": [
+				{
+					"name": "Ben Brown"
+				}
+			]
+		},
+		{
+			"name": "Deputy Stage Manager",
+			"entities": [
+				{
+					"name": "Katy Munroe Farlie"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/productions/love-story.json
+++ b/db-seeding/seeds/productions/love-story.json
@@ -1,0 +1,186 @@
+{
+	"name": "Love Story",
+	"startDate": "2010-05-29",
+	"pressDate": "2010-06-07",
+	"endDate": "2010-06-26",
+	"material": {
+		"name": "Love Story",
+		"differentiator": "3"
+	},
+	"venue": {
+		"name": "Minerva Theatre"
+	},
+	"producerCredits": [
+		{
+			"entities": [
+				{
+					"model": "COMPANY",
+					"name": "Chichester Festival Theatre"
+				}
+			]
+		}
+	],
+	"cast": [
+		{
+			"name": "Michael Xavier",
+			"roles": [
+				{
+					"name": "Oliver Barrett IV"
+				}
+			]
+		},
+		{
+			"name": "Emma Williams",
+			"differentiator": "2",
+			"roles": [
+				{
+					"name": "Jenny Cavilleri"
+				}
+			]
+		},
+		{
+			"name": "Peter Polycarpou",
+			"roles": [
+				{
+					"name": "Phil Cavilleri"
+				}
+			]
+		},
+		{
+			"name": "Rob Edwards",
+			"roles": [
+				{
+					"name": "Oliver Barrett III"
+				}
+			]
+		},
+		{
+			"name": "Claire Carrie",
+			"roles": [
+				{
+					"name": "Alison Barrett"
+				}
+			]
+		},
+		{
+			"name": "Jos Slovick",
+			"roles": [
+				{
+					"name": "Matt"
+				}
+			]
+		},
+		{
+			"name": "Keiron Crook",
+			"roles": [
+				{
+					"name": "Doctor"
+				},
+				{
+					"name": "Tony"
+				}
+			]
+		},
+		{
+			"name": "Simeon Truby",
+			"roles": [
+				{
+					"name": "Dr Ackerman"
+				}
+			]
+		},
+		{
+			"name": "Lillie Flynn",
+			"roles": [
+				{
+					"name": "Waitress"
+				},
+				{
+					"name": "Secretary"
+				}
+			]
+		},
+		{
+			"name": "Julia Worsley",
+			"roles": [
+				{
+					"name": "Jenny's Mother"
+				}
+			]
+		}
+	],
+	"creativeCredits": [
+		{
+			"name": "Director",
+			"entities": [
+				{
+					"name": "Rachel Kavanaugh"
+				}
+			]
+		},
+		{
+			"name": "Designer",
+			"entities": [
+				{
+					"name": "Peter McKintosh"
+				}
+			]
+		},
+		{
+			"name": "Lighting Designer",
+			"entities": [
+				{
+					"name": "Howard Harrison"
+				}
+			]
+		},
+		{
+			"name": "Sound Designer",
+			"entities": [
+				{
+					"name": "Matt McKenzie"
+				}
+			]
+		},
+		{
+			"name": "Choreographer",
+			"entities": [
+				{
+					"name": "Nick Winston"
+				}
+			]
+		},
+		{
+			"name": "Orchestrations",
+			"entities": [
+				{
+					"name": "Howard Goodall"
+				}
+			]
+		},
+		{
+			"name": "Musical Director",
+			"entities": [
+				{
+					"name": "Stephen Ridley"
+				}
+			]
+		},
+		{
+			"name": "Assistant Director",
+			"entities": [
+				{
+					"name": "Tom Attenborough"
+				}
+			]
+		},
+		{
+			"name": "Casting Director",
+			"entities": [
+				{
+					"name": "Pippa Ailion"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/productions/no-mans-land-duke-of-yorks-theatre.json
+++ b/db-seeding/seeds/productions/no-mans-land-duke-of-yorks-theatre.json
@@ -1,0 +1,117 @@
+{
+	"uuid": "42714861-a8e0-4f78-b336-04f4b78448ea",
+	"name": "No Man's Land",
+	"startDate": "2008-09-27",
+	"pressDate": "2008-10-07",
+	"endDate": "2009-01-03",
+	"material": {
+		"name": "No Man's Land"
+	},
+	"venue": {
+		"name": "Duke of York's Theatre"
+	},
+	"producerCredits": [
+		{
+			"name": "presented by",
+			"entities": [
+				{
+					"model": "COMPANY",
+					"name": "Sonia Friedman Productions"
+				}
+			]
+		},
+		{
+			"entities": [
+				{
+					"model": "COMPANY",
+					"name": "Gate Theatre",
+					"differentiator": "2"
+				}
+			]
+		}
+	],
+	"cast": [
+		{
+			"name": "Michael Gambon",
+			"roles": [
+				{
+					"name": "Hirst"
+				}
+			]
+		},
+		{
+			"name": "David Bradley",
+			"roles": [
+				{
+					"name": "Spooner"
+				}
+			]
+		},
+		{
+			"name": "David Walliams",
+			"roles": [
+				{
+					"name": "Foster"
+				}
+			]
+		},
+		{
+			"name": "Nick Dunning",
+			"roles": [
+				{
+					"name": "Briggs"
+				}
+			]
+		}
+	],
+	"creativeCredits": [
+		{
+			"name": "Director",
+			"entities": [
+				{
+					"name": "Rupert Goold"
+				}
+			]
+		},
+		{
+			"name": "Designer",
+			"entities": [
+				{
+					"name": "Giles Cadle"
+				}
+			]
+		},
+		{
+			"name": "Lighting Designer",
+			"entities": [
+				{
+					"name": "Neil Austin"
+				}
+			]
+		},
+		{
+			"name": "Music and Sound Designer",
+			"entities": [
+				{
+					"name": "Adam Cork"
+				}
+			]
+		},
+		{
+			"name": "Assistant Director",
+			"entities": [
+				{
+					"name": "Jeremy Whelehan"
+				}
+			]
+		},
+		{
+			"name": "Casting Director (understudies)",
+			"entities": [
+				{
+					"name": "Lisa Makin"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/productions/no-mans-land-gate-theatre.json
+++ b/db-seeding/seeds/productions/no-mans-land-gate-theatre.json
@@ -1,30 +1,22 @@
 {
-	"uuid": "42714861-a8e0-4f78-b336-04f4b78448ea",
 	"name": "No Man's Land",
-	"startDate": "2008-09-27",
-	"pressDate": "2008-10-07",
-	"endDate": "2009-01-03",
+	"startDate": "2008-08-21",
+	"pressDate": "2008-08-26",
+	"endDate": "2008-09-20",
 	"material": {
 		"name": "No Man's Land"
 	},
 	"venue": {
-		"name": "Duke of York's Theatre"
+		"name": "Gate Theatre",
+		"differentiator": "2"
 	},
 	"producerCredits": [
 		{
-			"name": "presented by",
 			"entities": [
 				{
 					"model": "COMPANY",
-					"name": "Sonia Friedman Productions"
-				}
-			]
-		},
-		{
-			"entities": [
-				{
-					"model": "COMPANY",
-					"name": "Gate Theatre (Dublin)"
+					"name": "Gate Theatre",
+					"differentiator": "2"
 				}
 			]
 		}

--- a/db-seeding/seeds/productions/nt-connections-2012-04-the-ritual.json
+++ b/db-seeding/seeds/productions/nt-connections-2012-04-the-ritual.json
@@ -90,7 +90,8 @@
 			"name": "Designer",
 			"entities": [
 				{
-					"name": "Emma Williams"
+					"name": "Emma Williams",
+					"differentiator": "3"
 				}
 			]
 		},

--- a/db-seeding/seeds/productions/sixty-six-books-57-the-letter.json
+++ b/db-seeding/seeds/productions/sixty-six-books-57-the-letter.json
@@ -5,7 +5,8 @@
 	"pressDate": "2011-10-14",
 	"endDate": "2011-10-28",
 	"material": {
-		"name": "The Letter"
+		"name": "The Letter",
+		"differentiator": "2"
 	},
 	"venue": {
 		"name": "Bush Theatre"

--- a/db-seeding/seeds/productions/the-coast-of-utopia-3-salvage.json
+++ b/db-seeding/seeds/productions/the-coast-of-utopia-3-salvage.json
@@ -166,7 +166,8 @@
 					"qualifier": "adult"
 				},
 				{
-					"name": "Doctor"
+					"name": "Doctor",
+					"differentiator": "Salvage"
 				}
 			]
 		},

--- a/db-seeding/seeds/productions/the-letter.json
+++ b/db-seeding/seeds/productions/the-letter.json
@@ -1,0 +1,179 @@
+{
+	"name": "The Letter",
+	"startDate": "2007-04-19",
+	"pressDate": "2007-05-01",
+	"endDate": "2007-08-11",
+	"material": {
+		"name": "The Letter",
+		"differentiator": "1"
+	},
+	"venue": {
+		"name": "Wyndham's Theatre"
+	},
+	"producerCredits": [
+		{
+			"name": "presented by",
+			"entities": [
+				{
+					"name": "Bill Kenwright"
+				}
+			]
+		}
+	],
+	"cast": [
+		{
+			"name": "Chris McCalphy",
+			"roles": [
+				{
+					"name": "Geoffrey Hammond"
+				}
+			]
+		},
+		{
+			"name": "Jenny Seagrove",
+			"roles": [
+				{
+					"name": "Leslie Crosbie"
+				}
+			]
+		},
+		{
+			"name": "Jamie Zubairi",
+			"roles": [
+				{
+					"name": "Head Boy"
+				}
+			]
+		},
+		{
+			"name": "Andrew Joshi",
+			"roles": [
+				{
+					"name": "Hassan"
+				}
+			]
+		},
+		{
+			"name": "Peter Sandys-Clarke",
+			"roles": [
+				{
+					"name": "John Withers"
+				}
+			]
+		},
+		{
+			"name": "Andrew Charleson",
+			"roles": [
+				{
+					"name": "Robert Crosbie"
+				}
+			]
+		},
+		{
+			"name": "Anthony Andrews",
+			"roles": [
+				{
+					"name": "Howard Joyce"
+				}
+			]
+		},
+		{
+			"name": "Jason Chan",
+			"roles": [
+				{
+					"name": "Ong Chi Seng"
+				}
+			]
+		},
+		{
+			"name": "Sioned Jones",
+			"roles": [
+				{
+					"name": "Mrs Parker"
+				}
+			]
+		},
+		{
+			"name": "Jon David Yu",
+			"roles": [
+				{
+					"name": "Chung Hi"
+				}
+			]
+		},
+		{
+			"name": "Liz Sutherland",
+			"roles": [
+				{
+					"name": "Chinese Woman"
+				}
+			]
+		},
+		{
+			"name": "Karen Ascoe",
+			"roles": [
+				{
+					"name": "Dorothy Joyce"
+				}
+			]
+		}
+	],
+	"creativeCredits": [
+		{
+			"name": "Director",
+			"entities": [
+				{
+					"name": "Alan Strachan"
+				}
+			]
+		},
+		{
+			"name": "Designer",
+			"entities": [
+				{
+					"name": "Paul Farnsworth"
+				}
+			]
+		},
+		{
+			"name": "Costume Designer",
+			"entities": [
+				{
+					"name": "Brigid Guy"
+				}
+			]
+		},
+		{
+			"name": "Lighting Designer",
+			"entities": [
+				{
+					"name": "Jason Taylor"
+				}
+			]
+		},
+		{
+			"name": "Sound Designer",
+			"entities": [
+				{
+					"name": "Ian Horrocks-Taylor"
+				}
+			]
+		},
+		{
+			"name": "Music",
+			"entities": [
+				{
+					"name": "Catherine Jayes"
+				}
+			]
+		},
+		{
+			"name": "Assistant Director",
+			"entities": [
+				{
+					"name": "Tom Littler"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
This PR adds database seeds that demonstrate duplicate-named instances:

- **Grounded (material)**
  - a play by George Brant
  - a play by John Logan (part of the Decade collection)

- **The Letter (material)**
  - a play by W Somerset Maugham
  - a play by Kamila Shamsie (part of the Sixty-Six Books collection)

- **Emma Williams (person)**
  - an actress in Love Story at Chichester Festival Theatre: Minerva Theatre
  - a costume designer of Calendar Girls at Noël Coward Theatre and Decade (collection) at Commodity Quay
  - a designer of The Ritual (part of NT Connections 2012) (presumably a different person to the above Emma Williams)

- **Gate Theatre (venue)**
  - a venue in Notting Hill (now relocated to Camden)
  - a venue in Dublin

- **Gate Theatre (company)**
  - a company for the London-based venue
  - a company for the Dublin-based venue