### PR TITLE
Increase Cypher list query limits from 100 -> 1000

### DIFF
--- a/src/neo4j/cypher-queries/award-ceremony/list.js
+++ b/src/neo4j/cypher-queries/award-ceremony/list.js
@@ -12,5 +12,5 @@ export default () => `
 	ORDER BY
 		ceremony.name DESC, award.name
 
-	LIMIT 100
+	LIMIT 1000
 `;

--- a/src/neo4j/cypher-queries/material/list.js
+++ b/src/neo4j/cypher-queries/material/list.js
@@ -122,5 +122,5 @@ export default () => `
 		surSurMaterialRel.position DESC,
 		surMaterialRel.position DESC
 
-	LIMIT 100
+	LIMIT 1000
 `;

--- a/src/neo4j/cypher-queries/production/list.js
+++ b/src/neo4j/cypher-queries/production/list.js
@@ -48,5 +48,5 @@ export default () => `
 		surProductionRel.position DESC,
 		venue.name
 
-	LIMIT 100
+	LIMIT 1000
 `;

--- a/src/neo4j/cypher-queries/shared/list.js
+++ b/src/neo4j/cypher-queries/shared/list.js
@@ -11,5 +11,5 @@ export default model => `
 	ORDER BY
 		n.name
 
-	LIMIT 100
+	LIMIT 1000
 `;

--- a/src/neo4j/cypher-queries/venue/list.js
+++ b/src/neo4j/cypher-queries/venue/list.js
@@ -21,5 +21,5 @@ export default () => `
 	ORDER BY
 		venue.name
 
-	LIMIT 100
+	LIMIT 1000
 `;

--- a/test-unit/src/neo4j/cypher-queries/shared.test.js
+++ b/test-unit/src/neo4j/cypher-queries/shared.test.js
@@ -139,7 +139,7 @@ describe('Cypher Queries Shared module', () => {
 				ORDER BY
 					n.name
 
-				LIMIT 100
+				LIMIT 1000
 			`));
 
 		});


### PR DESCRIPTION
This PR increases the Cypher list query limits from 100 to 1,000 so that more results are easily accessible during development.

These limits will be reduced (or apply pagination) once search functionality is added to make finding specific instances easier.

1,000 is also the default limit (i.e. the number of results returned if no `LIMIT` clause is included) — see: [Stack Overflow: Neo4j console returning only 1000 rows](https://stackoverflow.com/questions/23153555/neo4j-console-returning-only-1000-rows).

### References:
- [Stack Overflow: Neo4j console returning only 1000 rows](https://stackoverflow.com/questions/23153555/neo4j-console-returning-only-1000-rows)