### PR TITLE
Revise material + production show Cypher queries

### DIFF
--- a/src/neo4j/cypher-queries/material/show/show.js
+++ b/src/neo4j/cypher-queries/material/show/show.js
@@ -16,41 +16,11 @@ export default () => `
 
 	UNWIND (CASE collectionMaterials WHEN [] THEN [null] ELSE collectionMaterials END) AS collectionMaterial
 
-		OPTIONAL MATCH (collectionMaterial)-[surMaterialRel:HAS_SUB_MATERIAL]->(material)
-
-		OPTIONAL MATCH (collectionMaterial)-[surSurMaterialRel:HAS_SUB_MATERIAL]->
-			(:Material)-[:HAS_SUB_MATERIAL]->(material)
-
-		OPTIONAL MATCH (collectionMaterial)<-[subMaterialRel:HAS_SUB_MATERIAL]-(material)
-
-		OPTIONAL MATCH (collectionMaterial)<-[subSubMaterialRel:HAS_SUB_MATERIAL]-
-			(subSubMaterialSurMaterial:Material)<-[:HAS_SUB_MATERIAL]-(material)
-
-		WITH
-			material,
-			collectionMaterial,
-			CASE WHEN material = collectionMaterial THEN true ELSE false END AS isSubjectMaterial,
-			CASE WHEN surMaterialRel IS NULL THEN false ELSE true END AS isSurMaterial,
-			CASE WHEN surSurMaterialRel IS NULL THEN false ELSE true END AS isSurSurMaterial,
-			CASE WHEN subMaterialRel IS NULL THEN false ELSE true END AS isSubMaterial,
-			subMaterialRel.position AS subMaterialPosition,
-			CASE WHEN subSubMaterialRel IS NULL THEN false ELSE true END AS isSubSubMaterial,
-			subSubMaterialRel.position AS subSubMaterialPosition,
-			subSubMaterialSurMaterial.uuid AS subSubMaterialSurMaterialUuid
-
 		OPTIONAL MATCH (collectionMaterial)-[:SUBSEQUENT_VERSION_OF]->(originalVersionMaterial)
 
 		WITH
 			material,
 			collectionMaterial,
-			isSubjectMaterial,
-			isSurMaterial,
-			isSurSurMaterial,
-			isSubMaterial,
-			subMaterialPosition,
-			isSubSubMaterial,
-			subSubMaterialPosition,
-			subSubMaterialSurMaterialUuid,
 			[collectionMaterial, originalVersionMaterial] AS relatedMaterials
 
 		UNWIND (CASE relatedMaterials WHEN [] THEN [null] ELSE relatedMaterials END) AS relatedMaterial
@@ -70,14 +40,6 @@ export default () => `
 			WITH
 				material,
 				collectionMaterial,
-				isSubjectMaterial,
-				isSurMaterial,
-				isSurSurMaterial,
-				isSubMaterial,
-				subMaterialPosition,
-				isSubSubMaterial,
-				subSubMaterialPosition,
-				subSubMaterialSurMaterialUuid,
 				relatedMaterial,
 				CASE WHEN originalVersionRel IS NULL THEN false ELSE true END AS isOriginalVersion,
 				entityRel,
@@ -91,14 +53,6 @@ export default () => `
 			WITH
 				material,
 				collectionMaterial,
-				isSubjectMaterial,
-				isSurMaterial,
-				isSurSurMaterial,
-				isSubMaterial,
-				subMaterialPosition,
-				isSubSubMaterial,
-				subSubMaterialPosition,
-				subSubMaterialSurMaterialUuid,
 				relatedMaterial,
 				isOriginalVersion,
 				entityRel,
@@ -116,14 +70,6 @@ export default () => `
 			WITH
 				material,
 				collectionMaterial,
-				isSubjectMaterial,
-				isSurMaterial,
-				isSurSurMaterial,
-				isSubMaterial,
-				subMaterialPosition,
-				isSubSubMaterial,
-				subSubMaterialPosition,
-				subSubMaterialSurMaterialUuid,
 				relatedMaterial,
 				isOriginalVersion,
 				entityRel,
@@ -145,14 +91,6 @@ export default () => `
 			WITH
 				material,
 				collectionMaterial,
-				isSubjectMaterial,
-				isSurMaterial,
-				isSurSurMaterial,
-				isSubMaterial,
-				subMaterialPosition,
-				isSubSubMaterial,
-				subSubMaterialPosition,
-				subSubMaterialSurMaterialUuid,
 				relatedMaterial,
 				isOriginalVersion,
 				entityRel.credit AS writingCreditName,
@@ -185,14 +123,6 @@ export default () => `
 			WITH
 				material,
 				collectionMaterial,
-				isSubjectMaterial,
-				isSurMaterial,
-				isSurSurMaterial,
-				isSubMaterial,
-				subMaterialPosition,
-				isSubSubMaterial,
-				subSubMaterialPosition,
-				subSubMaterialSurMaterialUuid,
 				relatedMaterial,
 				isOriginalVersion,
 				writingCreditName,
@@ -204,14 +134,6 @@ export default () => `
 			WITH
 				material,
 				collectionMaterial,
-				isSubjectMaterial,
-				isSurMaterial,
-				isSurSurMaterial,
-				isSubMaterial,
-				subMaterialPosition,
-				isSubSubMaterial,
-				subSubMaterialPosition,
-				subSubMaterialSurMaterialUuid,
 				relatedMaterial,
 				isOriginalVersion,
 				COLLECT(
@@ -233,14 +155,6 @@ export default () => `
 			WITH
 				material,
 				collectionMaterial,
-				isSubjectMaterial,
-				isSurMaterial,
-				isSurSurMaterial,
-				isSubMaterial,
-				subMaterialPosition,
-				isSubSubMaterial,
-				subSubMaterialPosition,
-				subSubMaterialSurMaterialUuid,
 				COLLECT(
 					CASE WHEN relatedMaterial IS NULL
 						THEN null
@@ -271,14 +185,6 @@ export default () => `
 		WITH
 			material,
 			collectionMaterial,
-			isSubjectMaterial,
-			isSurMaterial,
-			isSurSurMaterial,
-			isSubMaterial,
-			subMaterialPosition,
-			isSubSubMaterial,
-			subSubMaterialPosition,
-			subSubMaterialSurMaterialUuid,
 			HEAD([
 				relatedMaterial IN relatedMaterials
 					WHERE relatedMaterial.uuid = collectionMaterial.uuid | relatedMaterial.writingCredits
@@ -293,14 +199,6 @@ export default () => `
 		WITH
 			material,
 			collectionMaterial,
-			isSubjectMaterial,
-			isSurMaterial,
-			isSurSurMaterial,
-			isSubMaterial,
-			subMaterialPosition,
-			isSubSubMaterial,
-			subSubMaterialPosition,
-			subSubMaterialSurMaterialUuid,
 			writingCredits,
 			originalVersionMaterial,
 			characterRel,
@@ -310,14 +208,6 @@ export default () => `
 		WITH
 			material,
 			collectionMaterial,
-			isSubjectMaterial,
-			isSurMaterial,
-			isSurSurMaterial,
-			isSubMaterial,
-			subMaterialPosition,
-			isSubSubMaterial,
-			subSubMaterialPosition,
-			subSubMaterialSurMaterialUuid,
 			writingCredits,
 			originalVersionMaterial,
 			characterRel.group AS characterGroupName,
@@ -337,14 +227,6 @@ export default () => `
 		WITH
 			material,
 			collectionMaterial,
-			isSubjectMaterial,
-			isSurMaterial,
-			isSurSurMaterial,
-			isSubMaterial,
-			subMaterialPosition,
-			isSubSubMaterial,
-			subSubMaterialPosition,
-			subSubMaterialSurMaterialUuid,
 			writingCredits,
 			originalVersionMaterial,
 			COLLECT(
@@ -358,7 +240,30 @@ export default () => `
 					}
 				END
 			) AS characterGroups
-			ORDER BY subMaterialPosition, subSubMaterialPosition
+
+		OPTIONAL MATCH (collectionMaterial)-[surMaterialRel:HAS_SUB_MATERIAL]->(material)
+
+		OPTIONAL MATCH (collectionMaterial)-[surSurMaterialRel:HAS_SUB_MATERIAL]->
+			(:Material)-[:HAS_SUB_MATERIAL]->(material)
+
+		OPTIONAL MATCH (collectionMaterial)<-[subMaterialRel:HAS_SUB_MATERIAL]-(material)
+
+		OPTIONAL MATCH (collectionMaterial)<-[subSubMaterialRel:HAS_SUB_MATERIAL]-
+			(subSubMaterialSurMaterial:Material)<-[:HAS_SUB_MATERIAL]-(material)
+
+		WITH
+			material,
+			collectionMaterial,
+			CASE WHEN material = collectionMaterial THEN true ELSE false END AS isSubjectMaterial,
+			CASE WHEN surMaterialRel IS NULL THEN false ELSE true END AS isSurMaterial,
+			CASE WHEN surSurMaterialRel IS NULL THEN false ELSE true END AS isSurSurMaterial,
+			CASE WHEN subMaterialRel IS NULL THEN false ELSE true END AS isSubMaterial,
+			CASE WHEN subSubMaterialRel IS NULL THEN false ELSE true END AS isSubSubMaterial,
+			subSubMaterialSurMaterial.uuid AS subSubMaterialSurMaterialUuid,
+			writingCredits,
+			originalVersionMaterial,
+			characterGroups
+			ORDER BY subMaterialRel.position, subSubMaterialRel.position
 
 		WITH material,
 			COLLECT(

--- a/src/neo4j/cypher-queries/production/show/show.js
+++ b/src/neo4j/cypher-queries/production/show/show.js
@@ -16,28 +16,6 @@ export default () => `
 
 	UNWIND (CASE collectionProductions WHEN [] THEN [null] ELSE collectionProductions END) AS collectionProduction
 
-		OPTIONAL MATCH (collectionProduction)-[surProductionRel:HAS_SUB_PRODUCTION]->(production)
-
-		OPTIONAL MATCH (collectionProduction)-[surSurProductionRel:HAS_SUB_PRODUCTION]->
-			(:Production)-[:HAS_SUB_PRODUCTION]->(production)
-
-		OPTIONAL MATCH (collectionProduction)<-[subProductionRel:HAS_SUB_PRODUCTION]-(production)
-
-		OPTIONAL MATCH (collectionProduction)<-[subSubProductionRel:HAS_SUB_PRODUCTION]-
-			(subSubProductionSurProduction:Production)<-[:HAS_SUB_PRODUCTION]-(production)
-
-		WITH
-			production,
-			collectionProduction,
-			CASE WHEN production = collectionProduction THEN true ELSE false END AS isSubjectProduction,
-			CASE WHEN surProductionRel IS NULL THEN false ELSE true END AS isSurProduction,
-			CASE WHEN surSurProductionRel IS NULL THEN false ELSE true END AS isSurSurProduction,
-			CASE WHEN subProductionRel IS NULL THEN false ELSE true END AS isSubProduction,
-			subProductionRel.position AS subProductionPosition,
-			CASE WHEN subSubProductionRel IS NULL THEN false ELSE true END AS isSubSubProduction,
-			subSubProductionRel.position AS subSubProductionPosition,
-			subSubProductionSurProduction.uuid AS subSubProductionSurProductionUuid
-
 		OPTIONAL MATCH (collectionProduction)-[:PRODUCTION_OF]->(material:Material)
 
 		OPTIONAL MATCH (material)<-[:HAS_SUB_MATERIAL]-(surMaterial:Material)
@@ -56,14 +34,6 @@ export default () => `
 		WITH
 			production,
 			collectionProduction,
-			isSubjectProduction,
-			isSurProduction,
-			isSurSurProduction,
-			isSubProduction,
-			subProductionPosition,
-			isSubSubProduction,
-			subSubProductionPosition,
-			subSubProductionSurProductionUuid,
 			material,
 			surMaterial,
 			surSurMaterial,
@@ -78,14 +48,6 @@ export default () => `
 		WITH
 			production,
 			collectionProduction,
-			isSubjectProduction,
-			isSurProduction,
-			isSurSurProduction,
-			isSubProduction,
-			subProductionPosition,
-			isSubSubProduction,
-			subSubProductionPosition,
-			subSubProductionSurProductionUuid,
 			material,
 			surMaterial,
 			surSurMaterial,
@@ -104,14 +66,6 @@ export default () => `
 		WITH
 			production,
 			collectionProduction,
-			isSubjectProduction,
-			isSurProduction,
-			isSurSurProduction,
-			isSubProduction,
-			subProductionPosition,
-			isSubSubProduction,
-			subSubProductionPosition,
-			subSubProductionSurProductionUuid,
 			material,
 			surMaterial,
 			surSurMaterial,
@@ -134,14 +88,6 @@ export default () => `
 		WITH
 			production,
 			collectionProduction,
-			isSubjectProduction,
-			isSurProduction,
-			isSurSurProduction,
-			isSubProduction,
-			subProductionPosition,
-			isSubSubProduction,
-			subSubProductionPosition,
-			subSubProductionSurProductionUuid,
 			material,
 			surMaterial,
 			surSurMaterial,
@@ -175,14 +121,6 @@ export default () => `
 		WITH
 			production,
 			collectionProduction,
-			isSubjectProduction,
-			isSurProduction,
-			isSurSurProduction,
-			isSubProduction,
-			subProductionPosition,
-			isSubSubProduction,
-			subSubProductionPosition,
-			subSubProductionSurProductionUuid,
 			material,
 			surMaterial,
 			surSurMaterial,
@@ -195,14 +133,6 @@ export default () => `
 		WITH
 			production,
 			collectionProduction,
-			isSubjectProduction,
-			isSurProduction,
-			isSurSurProduction,
-			isSubProduction,
-			subProductionPosition,
-			isSubSubProduction,
-			subSubProductionPosition,
-			subSubProductionSurProductionUuid,
 			material,
 			surMaterial,
 			surSurMaterial,
@@ -220,14 +150,6 @@ export default () => `
 		WITH
 			production,
 			collectionProduction,
-			isSubjectProduction,
-			isSurProduction,
-			isSurSurProduction,
-			isSubProduction,
-			subProductionPosition,
-			isSubSubProduction,
-			subSubProductionPosition,
-			subSubProductionSurProductionUuid,
 			CASE WHEN material IS NULL
 				THEN null
 				ELSE material {
@@ -259,14 +181,6 @@ export default () => `
 		WITH
 			production,
 			collectionProduction,
-			isSubjectProduction,
-			isSurProduction,
-			isSurSurProduction,
-			isSubProduction,
-			subProductionPosition,
-			isSubSubProduction,
-			subSubProductionPosition,
-			subSubProductionSurProductionUuid,
 			material,
 			CASE WHEN venue IS NULL
 				THEN null
@@ -289,14 +203,6 @@ export default () => `
 		WITH
 			production,
 			collectionProduction,
-			isSubjectProduction,
-			isSurProduction,
-			isSurSurProduction,
-			isSubProduction,
-			subProductionPosition,
-			isSubSubProduction,
-			subSubProductionPosition,
-			subSubProductionSurProductionUuid,
 			material,
 			venue,
 			producerEntityRel,
@@ -320,14 +226,6 @@ export default () => `
 				WITH
 					production,
 					collectionProduction,
-					isSubjectProduction,
-					isSurProduction,
-					isSurSurProduction,
-					isSubProduction,
-					subProductionPosition,
-					isSubSubProduction,
-					subSubProductionPosition,
-					subSubProductionSurProductionUuid,
 					material,
 					venue,
 					producerEntityRel,
@@ -338,14 +236,6 @@ export default () => `
 				WITH
 					production,
 					collectionProduction,
-					isSubjectProduction,
-					isSurProduction,
-					isSurSurProduction,
-					isSubProduction,
-					subProductionPosition,
-					isSubSubProduction,
-					subSubProductionPosition,
-					subSubProductionSurProductionUuid,
 					material,
 					venue,
 					producerEntityRel,
@@ -355,14 +245,6 @@ export default () => `
 		WITH
 			production,
 			collectionProduction,
-			isSubjectProduction,
-			isSurProduction,
-			isSurSurProduction,
-			isSubProduction,
-			subProductionPosition,
-			isSubSubProduction,
-			subSubProductionPosition,
-			subSubProductionSurProductionUuid,
 			material,
 			venue,
 			producerEntityRel,
@@ -373,14 +255,6 @@ export default () => `
 		WITH
 			production,
 			collectionProduction,
-			isSubjectProduction,
-			isSurProduction,
-			isSurSurProduction,
-			isSubProduction,
-			subProductionPosition,
-			isSubSubProduction,
-			subSubProductionPosition,
-			subSubProductionSurProductionUuid,
 			material,
 			venue,
 			producerEntityRel.credit AS producerCreditName,
@@ -394,14 +268,6 @@ export default () => `
 		WITH
 			production,
 			collectionProduction,
-			isSubjectProduction,
-			isSurProduction,
-			isSurSurProduction,
-			isSubProduction,
-			subProductionPosition,
-			isSubSubProduction,
-			subSubProductionPosition,
-			subSubProductionSurProductionUuid,
 			material,
 			venue,
 			producerCreditName,
@@ -413,14 +279,6 @@ export default () => `
 		WITH
 			production,
 			collectionProduction,
-			isSubjectProduction,
-			isSurProduction,
-			isSurSurProduction,
-			isSubProduction,
-			subProductionPosition,
-			isSubSubProduction,
-			subSubProductionPosition,
-			subSubProductionSurProductionUuid,
 			material,
 			venue,
 			COLLECT(
@@ -448,14 +306,6 @@ export default () => `
 		WITH DISTINCT
 			production,
 			collectionProduction,
-			isSubjectProduction,
-			isSurProduction,
-			isSurSurProduction,
-			isSubProduction,
-			subProductionPosition,
-			isSubSubProduction,
-			subSubProductionPosition,
-			subSubProductionSurProductionUuid,
 			material,
 			venue,
 			producerCredits,
@@ -467,14 +317,6 @@ export default () => `
 		WITH
 			production,
 			collectionProduction,
-			isSubjectProduction,
-			isSurProduction,
-			isSurSurProduction,
-			isSubProduction,
-			subProductionPosition,
-			isSubSubProduction,
-			subSubProductionPosition,
-			subSubProductionSurProductionUuid,
 			material,
 			venue,
 			producerCredits,
@@ -495,14 +337,6 @@ export default () => `
 		WITH
 			production,
 			collectionProduction,
-			isSubjectProduction,
-			isSurProduction,
-			isSurSurProduction,
-			isSubProduction,
-			subProductionPosition,
-			isSubSubProduction,
-			subSubProductionPosition,
-			subSubProductionSurProductionUuid,
 			material,
 			venue,
 			producerCredits,
@@ -521,14 +355,6 @@ export default () => `
 		WITH
 			production,
 			collectionProduction,
-			isSubjectProduction,
-			isSurProduction,
-			isSurSurProduction,
-			isSubProduction,
-			subProductionPosition,
-			isSubSubProduction,
-			subSubProductionPosition,
-			subSubProductionSurProductionUuid,
 			material,
 			venue,
 			producerCredits,
@@ -554,14 +380,6 @@ export default () => `
 				WITH
 					production,
 					collectionProduction,
-					isSubjectProduction,
-					isSurProduction,
-					isSurSurProduction,
-					isSubProduction,
-					subProductionPosition,
-					isSubSubProduction,
-					subSubProductionPosition,
-					subSubProductionSurProductionUuid,
 					material,
 					venue,
 					producerCredits,
@@ -574,14 +392,6 @@ export default () => `
 				WITH
 					production,
 					collectionProduction,
-					isSubjectProduction,
-					isSurProduction,
-					isSurSurProduction,
-					isSubProduction,
-					subProductionPosition,
-					isSubSubProduction,
-					subSubProductionPosition,
-					subSubProductionSurProductionUuid,
 					material,
 					venue,
 					producerCredits,
@@ -593,14 +403,6 @@ export default () => `
 		WITH
 			production,
 			collectionProduction,
-			isSubjectProduction,
-			isSurProduction,
-			isSurSurProduction,
-			isSubProduction,
-			subProductionPosition,
-			isSubSubProduction,
-			subSubProductionPosition,
-			subSubProductionSurProductionUuid,
 			material,
 			venue,
 			producerCredits,
@@ -613,14 +415,6 @@ export default () => `
 		WITH
 			production,
 			collectionProduction,
-			isSubjectProduction,
-			isSurProduction,
-			isSurSurProduction,
-			isSubProduction,
-			subProductionPosition,
-			isSubSubProduction,
-			subSubProductionPosition,
-			subSubProductionSurProductionUuid,
 			material,
 			venue,
 			producerCredits,
@@ -636,14 +430,6 @@ export default () => `
 		WITH
 			production,
 			collectionProduction,
-			isSubjectProduction,
-			isSurProduction,
-			isSurSurProduction,
-			isSubProduction,
-			subProductionPosition,
-			isSubSubProduction,
-			subSubProductionPosition,
-			subSubProductionSurProductionUuid,
 			material,
 			venue,
 			producerCredits,
@@ -657,14 +443,6 @@ export default () => `
 		WITH
 			production,
 			collectionProduction,
-			isSubjectProduction,
-			isSurProduction,
-			isSurSurProduction,
-			isSubProduction,
-			subProductionPosition,
-			isSubSubProduction,
-			subSubProductionPosition,
-			subSubProductionSurProductionUuid,
 			material,
 			venue,
 			producerCredits,
@@ -688,14 +466,6 @@ export default () => `
 		WITH
 			production,
 			collectionProduction,
-			isSubjectProduction,
-			isSurProduction,
-			isSurSurProduction,
-			isSubProduction,
-			subProductionPosition,
-			isSubSubProduction,
-			subSubProductionPosition,
-			subSubProductionSurProductionUuid,
 			material,
 			venue,
 			producerCredits,
@@ -722,14 +492,6 @@ export default () => `
 				WITH
 					production,
 					collectionProduction,
-					isSubjectProduction,
-					isSurProduction,
-					isSurSurProduction,
-					isSubProduction,
-					subProductionPosition,
-					isSubSubProduction,
-					subSubProductionPosition,
-					subSubProductionSurProductionUuid,
 					material,
 					venue,
 					producerCredits,
@@ -743,14 +505,6 @@ export default () => `
 				WITH
 					production,
 					collectionProduction,
-					isSubjectProduction,
-					isSurProduction,
-					isSurSurProduction,
-					isSubProduction,
-					subProductionPosition,
-					isSubSubProduction,
-					subSubProductionPosition,
-					subSubProductionSurProductionUuid,
 					material,
 					venue,
 					producerCredits,
@@ -763,14 +517,6 @@ export default () => `
 		WITH
 			production,
 			collectionProduction,
-			isSubjectProduction,
-			isSurProduction,
-			isSurSurProduction,
-			isSubProduction,
-			subProductionPosition,
-			isSubSubProduction,
-			subSubProductionPosition,
-			subSubProductionSurProductionUuid,
 			material,
 			venue,
 			producerCredits,
@@ -784,14 +530,6 @@ export default () => `
 		WITH
 			production,
 			collectionProduction,
-			isSubjectProduction,
-			isSurProduction,
-			isSurSurProduction,
-			isSubProduction,
-			subProductionPosition,
-			isSubSubProduction,
-			subSubProductionPosition,
-			subSubProductionSurProductionUuid,
 			material,
 			venue,
 			producerCredits,
@@ -808,14 +546,6 @@ export default () => `
 		WITH
 			production,
 			collectionProduction,
-			isSubjectProduction,
-			isSurProduction,
-			isSurSurProduction,
-			isSubProduction,
-			subProductionPosition,
-			isSubSubProduction,
-			subSubProductionPosition,
-			subSubProductionSurProductionUuid,
 			material,
 			venue,
 			producerCredits,
@@ -830,14 +560,6 @@ export default () => `
 		WITH
 			production,
 			collectionProduction,
-			isSubjectProduction,
-			isSurProduction,
-			isSurSurProduction,
-			isSubProduction,
-			subProductionPosition,
-			isSubSubProduction,
-			subSubProductionPosition,
-			subSubProductionSurProductionUuid,
 			material,
 			venue,
 			producerCredits,
@@ -853,7 +575,33 @@ export default () => `
 					}
 				END
 			) AS crewCredits
-			ORDER BY subProductionPosition, subSubProductionPosition
+
+		OPTIONAL MATCH (collectionProduction)-[surProductionRel:HAS_SUB_PRODUCTION]->(production)
+
+		OPTIONAL MATCH (collectionProduction)-[surSurProductionRel:HAS_SUB_PRODUCTION]->
+			(:Production)-[:HAS_SUB_PRODUCTION]->(production)
+
+		OPTIONAL MATCH (collectionProduction)<-[subProductionRel:HAS_SUB_PRODUCTION]-(production)
+
+		OPTIONAL MATCH (collectionProduction)<-[subSubProductionRel:HAS_SUB_PRODUCTION]-
+			(subSubProductionSurProduction:Production)<-[:HAS_SUB_PRODUCTION]-(production)
+
+		WITH
+			production,
+			collectionProduction,
+			CASE WHEN production = collectionProduction THEN true ELSE false END AS isSubjectProduction,
+			CASE WHEN surProductionRel IS NULL THEN false ELSE true END AS isSurProduction,
+			CASE WHEN surSurProductionRel IS NULL THEN false ELSE true END AS isSurSurProduction,
+			CASE WHEN subProductionRel IS NULL THEN false ELSE true END AS isSubProduction,
+			CASE WHEN subSubProductionRel IS NULL THEN false ELSE true END AS isSubSubProduction,
+			subSubProductionSurProduction.uuid AS subSubProductionSurProductionUuid,
+			material,
+			venue,
+			producerCredits,
+			cast,
+			creativeCredits,
+			crewCredits
+			ORDER BY subProductionRel.position, subSubProductionRel.position
 
 		WITH production,
 			COLLECT(


### PR DESCRIPTION
This PR revises the material and production show Cypher queries so that a list of values that are `MATCH`ed early on and carried throughout the query via `WITH` statements are instead `MATCH`ed only when they are required, which is much closer to the end of the query.

This results in much shorter and consequently more readable query files.