### PR TITLE
Revise multi-tiered material format values in end-to-end tests

### DIFF
--- a/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-mats-via-assocs.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-mats-via-assocs.test.js
@@ -359,7 +359,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 			.post('/materials')
 			.send({
 				name: 'Sur-Waldo',
-				format: 'trilogy of novels',
+				format: 'collection of novels',
 				year: '1974',
 				writingCredits: [
 					{
@@ -426,7 +426,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 			.post('/materials')
 			.send({
 				name: 'Sur-Wibble',
-				format: 'trilogy of plays',
+				format: 'collection of plays',
 				year: '2009',
 				writingCredits: [
 					{
@@ -3069,7 +3069,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of plays',
+													format: 'collection of plays',
 													year: 2009,
 													surMaterial: null
 												}
@@ -3177,7 +3177,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 
 	});
 
-	describe('Sur-Waldo (trilogy of novels, 1974) (material): materials that used it as source material have nominations', () => {
+	describe('Sur-Waldo (collection of novels, 1974) (material): materials that used it as source material have nominations', () => {
 
 		it('includes awards of materials (and their respective sub-materials) that used it or its sub-materials as source material', () => {
 
@@ -3241,7 +3241,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of plays',
+													format: 'collection of plays',
 													year: 2009,
 													surMaterial: null
 												}
@@ -3456,7 +3456,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of plays',
+													format: 'collection of plays',
 													year: 2009,
 													surMaterial: null
 												}
@@ -3628,7 +3628,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of plays',
+													format: 'collection of plays',
 													year: 2009,
 													surMaterial: null
 												}
@@ -3843,7 +3843,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of plays',
+													format: 'collection of plays',
 													year: 2009,
 													surMaterial: null
 												}
@@ -4015,7 +4015,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of plays',
+													format: 'collection of plays',
 													year: 2009,
 													surMaterial: null
 												}

--- a/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-mats.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-mats.test.js
@@ -288,7 +288,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 			.post('/materials')
 			.send({
 				name: 'Sur-Waldo',
-				format: 'trilogy of novels',
+				format: 'collection of novels',
 				year: '1974',
 				writingCredits: [
 					{
@@ -344,7 +344,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 			.post('/materials')
 			.send({
 				name: 'Sur-Wibble',
-				format: 'trilogy of plays',
+				format: 'collection of plays',
 				year: '2009',
 				writingCredits: [
 					{
@@ -1513,7 +1513,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 									model: 'MATERIAL',
 									uuid: SUR_WIBBLE_MATERIAL_UUID,
 									name: 'Sur-Wibble',
-									format: 'trilogy of plays',
+									format: 'collection of plays',
 									year: 2009,
 									surMaterial: null,
 									writingCredits: [
@@ -1541,7 +1541,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 													model: 'MATERIAL',
 													uuid: SUR_WALDO_MATERIAL_UUID,
 													name: 'Sur-Waldo',
-													format: 'trilogy of novels',
+													format: 'collection of novels',
 													year: 1974,
 													surMaterial: null,
 													writingCredits: [
@@ -2423,7 +2423,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of plays',
+													format: 'collection of plays',
 													year: 2009,
 													surMaterial: null
 												}
@@ -2595,7 +2595,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of plays',
+													format: 'collection of plays',
 													year: 2009,
 													surMaterial: null
 												}

--- a/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-sub-mats-via-assocs.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-sub-mats-via-assocs.test.js
@@ -538,7 +538,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 			.post('/materials')
 			.send({
 				name: 'Mid-Waldo: Section I',
-				format: 'sub-trilogy of novels',
+				format: 'sub-collection of novels',
 				year: '1974',
 				writingCredits: [
 					{
@@ -567,7 +567,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 			.post('/materials')
 			.send({
 				name: 'Mid-Waldo: Section II',
-				format: 'sub-trilogy of novels',
+				format: 'sub-collection of novels',
 				year: '1974'
 			});
 
@@ -575,7 +575,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 			.post('/materials')
 			.send({
 				name: 'Sur-Waldo',
-				format: 'trilogy of trilogies of novels',
+				format: 'collection of novels',
 				year: '1974',
 				writingCredits: [
 					{
@@ -653,7 +653,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 			.post('/materials')
 			.send({
 				name: 'Mid-Wibble: Section I',
-				format: 'sub-trilogy of plays',
+				format: 'sub-collection of plays',
 				year: '2009',
 				writingCredits: [
 					{
@@ -691,7 +691,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 			.post('/materials')
 			.send({
 				name: 'Mid-Wibble: Section II',
-				format: 'sub-trilogy of plays',
+				format: 'sub-collection of plays',
 				year: '2009',
 				writingCredits: [
 					{
@@ -710,7 +710,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 			.post('/materials')
 			.send({
 				name: 'Sur-Wibble',
-				format: 'trilogy of trilogies of plays',
+				format: 'collection of plays',
 				year: '2009',
 				writingCredits: [
 					{
@@ -6501,7 +6501,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
 													name: 'Mid-Wibble: Section I',
-													format: 'sub-trilogy of plays',
+													format: 'sub-collection of plays',
 													year: 2009,
 													surMaterial: {
 														model: 'MATERIAL',
@@ -6577,7 +6577,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of trilogies of plays',
+													format: 'collection of plays',
 													year: 2009,
 													surMaterial: null
 												}
@@ -6697,7 +6697,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 
 	});
 
-	describe('Mid-Waldo: Section I (sub-trilogy of novels, 1974) (material): materials that used it as source material have nominations', () => {
+	describe('Mid-Waldo: Section I (sub-collection of novels, 1974) (material): materials that used it as source material have nominations', () => {
 
 		it('includes awards of materials (and their respective sur-material and sub-materials) that used it or its sur-material or sub-materials as source material', () => {
 
@@ -6771,7 +6771,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
 													name: 'Mid-Wibble: Section I',
-													format: 'sub-trilogy of plays',
+													format: 'sub-collection of plays',
 													year: 2009,
 													surMaterial: {
 														model: 'MATERIAL',
@@ -6847,7 +6847,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of trilogies of plays',
+													format: 'collection of plays',
 													year: 2009,
 													surMaterial: null
 												}
@@ -7014,7 +7014,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 
 	});
 
-	describe('Sur-Waldo (trilogy of trilogies of novels, 1974) (material): materials that used it as source material have nominations', () => {
+	describe('Sur-Waldo (collection of novels, 1974) (material): materials that used it as source material have nominations', () => {
 
 		it('includes awards of materials (and their respective sub-materials and sub-sub-materials) that used it or its sub-materials or sub-sub-materials as source material', () => {
 
@@ -7088,7 +7088,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
 													name: 'Mid-Wibble: Section I',
-													format: 'sub-trilogy of plays',
+													format: 'sub-collection of plays',
 													year: 2009,
 													surMaterial: {
 														model: 'MATERIAL',
@@ -7164,7 +7164,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of trilogies of plays',
+													format: 'collection of plays',
 													year: 2009,
 													surMaterial: null
 												}
@@ -7249,7 +7249,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_II_MATERIAL_UUID,
 													name: 'Mid-Wibble: Section II',
-													format: 'sub-trilogy of plays',
+													format: 'sub-collection of plays',
 													year: 2009,
 													surMaterial: {
 														model: 'MATERIAL',
@@ -7448,7 +7448,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
 													name: 'Mid-Wibble: Section I',
-													format: 'sub-trilogy of plays',
+													format: 'sub-collection of plays',
 													year: 2009,
 													surMaterial: {
 														model: 'MATERIAL',
@@ -7524,7 +7524,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of trilogies of plays',
+													format: 'collection of plays',
 													year: 2009,
 													surMaterial: null
 												}
@@ -7718,7 +7718,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
 													name: 'Mid-Wibble: Section I',
-													format: 'sub-trilogy of plays',
+													format: 'sub-collection of plays',
 													year: 2009,
 													surMaterial: {
 														model: 'MATERIAL',
@@ -7794,7 +7794,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of trilogies of plays',
+													format: 'collection of plays',
 													year: 2009,
 													surMaterial: null
 												}
@@ -8035,7 +8035,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
 													name: 'Mid-Wibble: Section I',
-													format: 'sub-trilogy of plays',
+													format: 'sub-collection of plays',
 													year: 2009,
 													surMaterial: {
 														model: 'MATERIAL',
@@ -8111,7 +8111,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of trilogies of plays',
+													format: 'collection of plays',
 													year: 2009,
 													surMaterial: null
 												}
@@ -8196,7 +8196,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_II_MATERIAL_UUID,
 													name: 'Mid-Wibble: Section II',
-													format: 'sub-trilogy of plays',
+													format: 'sub-collection of plays',
 													year: 2009,
 													surMaterial: {
 														model: 'MATERIAL',
@@ -8395,7 +8395,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
 													name: 'Mid-Wibble: Section I',
-													format: 'sub-trilogy of plays',
+													format: 'sub-collection of plays',
 													year: 2009,
 													surMaterial: {
 														model: 'MATERIAL',
@@ -8471,7 +8471,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of trilogies of plays',
+													format: 'collection of plays',
 													year: 2009,
 													surMaterial: null
 												}
@@ -8665,7 +8665,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
 													name: 'Mid-Wibble: Section I',
-													format: 'sub-trilogy of plays',
+													format: 'sub-collection of plays',
 													year: 2009,
 													surMaterial: {
 														model: 'MATERIAL',
@@ -8741,7 +8741,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of trilogies of plays',
+													format: 'collection of plays',
 													year: 2009,
 													surMaterial: null
 												}
@@ -8982,7 +8982,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
 													name: 'Mid-Wibble: Section I',
-													format: 'sub-trilogy of plays',
+													format: 'sub-collection of plays',
 													year: 2009,
 													surMaterial: {
 														model: 'MATERIAL',
@@ -9058,7 +9058,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of trilogies of plays',
+													format: 'collection of plays',
 													year: 2009,
 													surMaterial: null
 												}
@@ -9143,7 +9143,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_II_MATERIAL_UUID,
 													name: 'Mid-Wibble: Section II',
-													format: 'sub-trilogy of plays',
+													format: 'sub-collection of plays',
 													year: 2009,
 													surMaterial: {
 														model: 'MATERIAL',

--- a/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-sub-mats.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-sub-mats.test.js
@@ -402,7 +402,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 			.post('/materials')
 			.send({
 				name: 'Mid-Waldo',
-				format: 'sub-trilogy of novels',
+				format: 'sub-collection of novels',
 				year: '1974',
 				writingCredits: [
 					{
@@ -428,7 +428,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 			.post('/materials')
 			.send({
 				name: 'Sur-Waldo',
-				format: 'trilogy of trilogies of novels',
+				format: 'collection of novels',
 				year: '1974',
 				writingCredits: [
 					{
@@ -484,7 +484,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 			.post('/materials')
 			.send({
 				name: 'Mid-Wibble',
-				format: 'sub-trilogy of plays',
+				format: 'sub-collection of plays',
 				year: '2009',
 				writingCredits: [
 					{
@@ -519,7 +519,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 			.post('/materials')
 			.send({
 				name: 'Sur-Wibble',
-				format: 'trilogy of trilogies of plays',
+				format: 'collection of plays',
 				year: '2009',
 				writingCredits: [
 					{
@@ -1988,7 +1988,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 									model: 'MATERIAL',
 									uuid: SUR_WIBBLE_MATERIAL_UUID,
 									name: 'Sur-Wibble',
-									format: 'trilogy of trilogies of plays',
+									format: 'collection of plays',
 									year: 2009,
 									surMaterial: null,
 									writingCredits: [
@@ -2016,7 +2016,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													model: 'MATERIAL',
 													uuid: SUR_WALDO_MATERIAL_UUID,
 													name: 'Sur-Waldo',
-													format: 'trilogy of trilogies of novels',
+													format: 'collection of novels',
 													year: 1974,
 													surMaterial: null,
 													writingCredits: [
@@ -2385,7 +2385,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 									model: 'MATERIAL',
 									uuid: MID_WIBBLE_MATERIAL_UUID,
 									name: 'Mid-Wibble',
-									format: 'sub-trilogy of plays',
+									format: 'sub-collection of plays',
 									year: 2009,
 									surMaterial: {
 										model: 'MATERIAL',
@@ -2418,7 +2418,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													model: 'MATERIAL',
 													uuid: MID_WALDO_MATERIAL_UUID,
 													name: 'Mid-Waldo',
-													format: 'sub-trilogy of novels',
+													format: 'sub-collection of novels',
 													year: 1974,
 													surMaterial: {
 														model: 'MATERIAL',
@@ -3722,7 +3722,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_MATERIAL_UUID,
 													name: 'Mid-Wibble',
-													format: 'sub-trilogy of plays',
+													format: 'sub-collection of plays',
 													year: 2009,
 													surMaterial: {
 														model: 'MATERIAL',
@@ -3798,7 +3798,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of trilogies of plays',
+													format: 'collection of plays',
 													year: 2009,
 													surMaterial: null
 												}
@@ -3992,7 +3992,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_MATERIAL_UUID,
 													name: 'Mid-Wibble',
-													format: 'sub-trilogy of plays',
+													format: 'sub-collection of plays',
 													year: 2009,
 													surMaterial: {
 														model: 'MATERIAL',
@@ -4068,7 +4068,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of trilogies of plays',
+													format: 'collection of plays',
 													year: 2009,
 													surMaterial: null
 												}

--- a/test-e2e/model-interaction/award-ceremonies-with-sub-mats-sub-prods.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-sub-mats-sub-prods.test.js
@@ -108,7 +108,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 			.post('/materials')
 			.send({
 				name: 'Sur-Wibble',
-				format: 'trilogy of plays',
+				format: 'collection of plays',
 				year: '2019',
 				subMaterials: [
 					{
@@ -554,7 +554,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 									model: 'MATERIAL',
 									uuid: SUR_WIBBLE_MATERIAL_UUID,
 									name: 'Sur-Wibble',
-									format: 'trilogy of plays',
+									format: 'collection of plays',
 									year: 2019,
 									surMaterial: null,
 									writingCredits: []
@@ -658,7 +658,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of plays',
+													format: 'collection of plays',
 													year: 2019,
 													surMaterial: null
 												}
@@ -876,7 +876,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of plays',
+													format: 'collection of plays',
 													year: 2019,
 													surMaterial: null
 												}
@@ -1092,7 +1092,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of plays',
+													format: 'collection of plays',
 													year: 2019,
 													surMaterial: null
 												}
@@ -1312,7 +1312,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of plays',
+													format: 'collection of plays',
 													year: 2019,
 													surMaterial: null
 												}
@@ -1508,7 +1508,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of plays',
+													format: 'collection of plays',
 													year: 2019,
 													surMaterial: null
 												}
@@ -1728,7 +1728,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of plays',
+													format: 'collection of plays',
 													year: 2019,
 													surMaterial: null
 												}
@@ -1975,7 +1975,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of plays',
+													format: 'collection of plays',
 													year: 2019,
 													surMaterial: null
 												}
@@ -2134,7 +2134,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 												model: 'MATERIAL',
 												uuid: SUR_WIBBLE_MATERIAL_UUID,
 												name: 'Sur-Wibble',
-												format: 'trilogy of plays',
+												format: 'collection of plays',
 												year: 2019
 											},
 											entities: [
@@ -2321,7 +2321,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 
 	});
 
-	describe('Sur-Wibble (trilogy of plays) (material)', () => {
+	describe('Sur-Wibble (collection of plays) (material)', () => {
 
 		it('includes its and its sub-materials\' award nominations, in the latter case specifying the recipient', () => {
 

--- a/test-e2e/model-interaction/award-ceremonies-with-sub-sub-mats-sub-sub-prods.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-sub-sub-mats-sub-sub-prods.test.js
@@ -135,7 +135,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 			.post('/materials')
 			.send({
 				name: 'Mid-Wibble: Section I',
-				format: 'sub-trilogy of plays',
+				format: 'sub-collection of plays',
 				year: '2019',
 				subMaterials: [
 					{
@@ -151,7 +151,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 			.post('/materials')
 			.send({
 				name: 'Mid-Wibble: Section II',
-				format: 'sub-trilogy of plays',
+				format: 'sub-collection of plays',
 				year: '2019'
 			});
 
@@ -159,7 +159,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 			.post('/materials')
 			.send({
 				name: 'Sur-Wibble',
-				format: 'trilogy of trilogies of plays',
+				format: 'collection of plays',
 				year: '2019',
 				subMaterials: [
 					{
@@ -756,7 +756,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 									model: 'MATERIAL',
 									uuid: SUR_WIBBLE_MATERIAL_UUID,
 									name: 'Sur-Wibble',
-									format: 'trilogy of trilogies of plays',
+									format: 'collection of plays',
 									year: 2019,
 									surMaterial: null,
 									writingCredits: []
@@ -870,7 +870,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 									model: 'MATERIAL',
 									uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
 									name: 'Mid-Wibble: Section I',
-									format: 'sub-trilogy of plays',
+									format: 'sub-collection of plays',
 									year: 2019,
 									surMaterial: {
 										model: 'MATERIAL',
@@ -994,7 +994,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
 													name: 'Mid-Wibble: Section I',
-													format: 'sub-trilogy of plays',
+													format: 'sub-collection of plays',
 													year: 2019,
 													surMaterial: {
 														model: 'MATERIAL',
@@ -1091,7 +1091,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of trilogies of plays',
+													format: 'collection of plays',
 													year: 2019,
 													surMaterial: null
 												}
@@ -1340,7 +1340,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
 													name: 'Mid-Wibble: Section I',
-													format: 'sub-trilogy of plays',
+													format: 'sub-collection of plays',
 													year: 2019,
 													surMaterial: {
 														model: 'MATERIAL',
@@ -1436,7 +1436,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of trilogies of plays',
+													format: 'collection of plays',
 													year: 2019,
 													surMaterial: null
 												}
@@ -1683,7 +1683,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
 													name: 'Mid-Wibble: Section I',
-													format: 'sub-trilogy of plays',
+													format: 'sub-collection of plays',
 													year: 2019,
 													surMaterial: {
 														model: 'MATERIAL',
@@ -1778,7 +1778,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of trilogies of plays',
+													format: 'collection of plays',
 													year: 2019,
 													surMaterial: null
 												}
@@ -2024,7 +2024,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
 													name: 'Mid-Wibble: Section I',
-													format: 'sub-trilogy of plays',
+													format: 'sub-collection of plays',
 													year: 2019,
 													surMaterial: {
 														model: 'MATERIAL',
@@ -2124,7 +2124,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of trilogies of plays',
+													format: 'collection of plays',
 													year: 2019,
 													surMaterial: null
 												}
@@ -2342,7 +2342,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
 													name: 'Mid-Wibble: Section I',
-													format: 'sub-trilogy of plays',
+													format: 'sub-collection of plays',
 													year: 2019,
 													surMaterial: {
 														model: 'MATERIAL',
@@ -2442,7 +2442,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of trilogies of plays',
+													format: 'collection of plays',
 													year: 2019,
 													surMaterial: null
 												}
@@ -2684,7 +2684,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
 													name: 'Mid-Wibble: Section I',
-													format: 'sub-trilogy of plays',
+													format: 'sub-collection of plays',
 													year: 2019,
 													surMaterial: {
 														model: 'MATERIAL',
@@ -2772,7 +2772,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of trilogies of plays',
+													format: 'collection of plays',
 													year: 2019,
 													surMaterial: null
 												}
@@ -3014,7 +3014,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
 													name: 'Mid-Wibble: Section I',
-													format: 'sub-trilogy of plays',
+													format: 'sub-collection of plays',
 													year: 2019,
 													surMaterial: {
 														model: 'MATERIAL',
@@ -3114,7 +3114,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of trilogies of plays',
+													format: 'collection of plays',
 													year: 2019,
 													surMaterial: null
 												}
@@ -3324,7 +3324,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
 													name: 'Mid-Wibble: Section I',
-													format: 'sub-trilogy of plays',
+													format: 'sub-collection of plays',
 													year: 2019,
 													surMaterial: {
 														model: 'MATERIAL',
@@ -3424,7 +3424,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of trilogies of plays',
+													format: 'collection of plays',
 													year: 2019,
 													surMaterial: null
 												}
@@ -3729,7 +3729,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
 													name: 'Mid-Wibble: Section I',
-													format: 'sub-trilogy of plays',
+													format: 'sub-collection of plays',
 													year: 2019,
 													surMaterial: {
 														model: 'MATERIAL',
@@ -3813,7 +3813,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
 													name: 'Sur-Wibble',
-													format: 'trilogy of trilogies of plays',
+													format: 'collection of plays',
 													year: 2019,
 													surMaterial: null
 												}
@@ -4052,7 +4052,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_II_MATERIAL_UUID,
 													name: 'Mid-Wibble: Section II',
-													format: 'sub-trilogy of plays',
+													format: 'sub-collection of plays',
 													year: 2019,
 													surMaterial: {
 														model: 'MATERIAL',
@@ -4106,7 +4106,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 												model: 'MATERIAL',
 												uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
 												name: 'Mid-Wibble: Section I',
-												format: 'sub-trilogy of plays',
+												format: 'sub-collection of plays',
 												year: 2019
 											},
 											entities: [
@@ -4216,7 +4216,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 												model: 'MATERIAL',
 												uuid: SUR_WIBBLE_MATERIAL_UUID,
 												name: 'Sur-Wibble',
-												format: 'trilogy of trilogies of plays',
+												format: 'collection of plays',
 												year: 2019
 											},
 											entities: [
@@ -4415,7 +4415,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 
 	});
 
-	describe('Mid-Wibble: Section I (trilogy of plays) (material)', () => {
+	describe('Mid-Wibble: Section I (sub-collection of plays) (material)', () => {
 
 		it('includes its and its sur-material\'s and sub-materials\' award nominations, in the latter case specifying the recipient', () => {
 
@@ -4546,7 +4546,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 												model: 'MATERIAL',
 												uuid: SUR_WIBBLE_MATERIAL_UUID,
 												name: 'Sur-Wibble',
-												format: 'trilogy of trilogies of plays',
+												format: 'collection of plays',
 												year: 2019
 											},
 											entities: [
@@ -4814,7 +4814,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 
 	});
 
-	describe('Sur-Wibble (trilogy of trilogies of plays) (material)', () => {
+	describe('Sur-Wibble (collection of plays) (material)', () => {
 
 		it('includes its and its sub-materials\' and sub-sub-materials\' award nominations, in the latter case specifying the recipient', () => {
 
@@ -4841,7 +4841,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 												model: 'MATERIAL',
 												uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
 												name: 'Mid-Wibble: Section I',
-												format: 'sub-trilogy of plays',
+												format: 'sub-collection of plays',
 												year: 2019
 											},
 											entities: [
@@ -5225,7 +5225,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 												model: 'MATERIAL',
 												uuid: MID_WIBBLE_SECTION_II_MATERIAL_UUID,
 												name: 'Mid-Wibble: Section II',
-												format: 'sub-trilogy of plays',
+												format: 'sub-collection of plays',
 												year: 2019
 											},
 											entities: [],


### PR DESCRIPTION
This PR revises the format values of multi-tiered materials that appear in end-to-end tests.

The term 'trilogy' can be misleading given the instances invented purely for the purposes of testing are often incomplete collections, including only the minimum components required to perform the tests. Consequently, instances termed 'trilogy' often contain only one or two sub-materials, making the term misleading and potentially confusing (i.e. it may result in time wasted trying to identify all three sub-materials or understand why there are not three).

This PR changes usage of the term 'trilogy' to the broader term of 'collection'.