### PR TITLE
Add E2E tests for loosely-connected multi-tiered material collections

### DIFF
--- a/src/neo4j/cypher-queries/company/show/show-awards-sourcing-material.js
+++ b/src/neo4j/cypher-queries/company/show/show-awards-sourcing-material.js
@@ -19,6 +19,9 @@ export default () => `
 				) OR (
 					(creditingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(sourceMaterial) AND
 					(sourcingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSourcingMaterial)
+				) OR (
+					(creditingMaterial)-[:HAS_SUB_MATERIAL*0..2]->(sourceMaterial) AND
+					(sourcingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSourcingMaterial)
 				)
 			)
 

--- a/src/neo4j/cypher-queries/company/show/show-awards-subsequent-version-material.js
+++ b/src/neo4j/cypher-queries/company/show/show-awards-subsequent-version-material.js
@@ -14,6 +14,9 @@ export default () => `
 			) OR (
 				(creditingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(originalVersionMaterial) AND
 				(subsequentVersionMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSubsequentVersionMaterial)
+			) OR (
+				(creditingMaterial)-[:HAS_SUB_MATERIAL*0..2]->(originalVersionMaterial) AND
+				(subsequentVersionMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSubsequentVersionMaterial)
 			)
 
 	OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)

--- a/src/neo4j/cypher-queries/material/show/show-awards-sourcing-material.js
+++ b/src/neo4j/cypher-queries/material/show/show-awards-sourcing-material.js
@@ -13,6 +13,9 @@ export default () => `
 			) OR (
 				(material)<-[:HAS_SUB_MATERIAL*0..2]-(sourceMaterial) AND
 				(sourcingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSourcingMaterial)
+			) OR (
+				(material)-[:HAS_SUB_MATERIAL*0..2]->(sourceMaterial) AND
+				(sourcingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSourcingMaterial)
 			)
 
 	OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)

--- a/src/neo4j/cypher-queries/material/show/show-awards-subsequent-version-material.js
+++ b/src/neo4j/cypher-queries/material/show/show-awards-subsequent-version-material.js
@@ -13,6 +13,9 @@ export default () => `
 			) OR (
 				(material)<-[:HAS_SUB_MATERIAL*0..2]-(originalVersionMaterial) AND
 				(subsequentVersionMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSubsequentVersionMaterial)
+			) OR (
+				(material)-[:HAS_SUB_MATERIAL*0..2]->(originalVersionMaterial) AND
+				(subsequentVersionMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSubsequentVersionMaterial)
 			)
 
 	OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)

--- a/src/neo4j/cypher-queries/person/show/show-awards-sourcing-material.js
+++ b/src/neo4j/cypher-queries/person/show/show-awards-sourcing-material.js
@@ -19,6 +19,9 @@ export default () => `
 				) OR (
 					(creditingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(sourceMaterial) AND
 					(sourcingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSourcingMaterial)
+				) OR (
+					(creditingMaterial)-[:HAS_SUB_MATERIAL*0..2]->(sourceMaterial) AND
+					(sourcingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSourcingMaterial)
 				)
 			)
 

--- a/src/neo4j/cypher-queries/person/show/show-awards-subsequent-version-material.js
+++ b/src/neo4j/cypher-queries/person/show/show-awards-subsequent-version-material.js
@@ -14,6 +14,9 @@ export default () => `
 			) OR (
 				(creditingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(originalVersionMaterial) AND
 				(subsequentVersionMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSubsequentVersionMaterial)
+			) OR (
+				(creditingMaterial)-[:HAS_SUB_MATERIAL*0..2]->(originalVersionMaterial) AND
+				(subsequentVersionMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSubsequentVersionMaterial)
 			)
 
 	OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)

--- a/test-e2e/model-interaction/award-ceremonies-with-crediting-mat-collections-via-assocs.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-crediting-mat-collections-via-assocs.test.js
@@ -1,0 +1,8480 @@
+import crypto from 'crypto';
+
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import { createSandbox } from 'sinon';
+
+import app from '../../src/app';
+import createRelationship from '../test-helpers/neo4j/create-relationship';
+import deleteRelationship from '../test-helpers/neo4j/delete-relationship';
+import purgeDatabase from '../test-helpers/neo4j/purge-database';
+
+describe('Award ceremonies with crediting material collections loosely connected to source material/original version (with person/company/material nominations gained via associations to sur-sur and sub-sub-materials)', () => {
+
+	chai.use(chaiHttp);
+
+	const SUB_PLUGH_PART_I_ORIGINAL_VERSION_MATERIAL_UUID = '4';
+	const FRANCIS_FLOB_JR_PERSON_UUID = '6';
+	const SUB_CURTAIN_UP_LTD_COMPANY_UUID = '7';
+	const MID_PLUGH_SECTION_I_ORIGINAL_VERSION_MATERIAL_UUID = '20';
+	const FRANCIS_FLOB_PERSON_UUID = '22';
+	const MID_CURTAIN_UP_LTD_COMPANY_UUID = '23';
+	const SUR_PLUGH_ORIGINAL_VERSION_MATERIAL_UUID = '38';
+	const FRANCIS_FLOB_SR_PERSON_UUID = '40';
+	const SUR_CURTAIN_UP_LTD_COMPANY_UUID = '41';
+	const SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID = '50';
+	const SUB_PLUGH_PART_II_SUBSEQUENT_VERSION_MATERIAL_UUID = '58';
+	const MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID = '70';
+	const MID_PLUGH_SECTION_II_SUBSEQUENT_VERSION_MATERIAL_UUID = '80';
+	const SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID = '92';
+	const SUB_WALDO_PART_I_MATERIAL_UUID = '104';
+	const JANE_ROE_JR_PERSON_UUID = '106';
+	const SUB_FICTIONEERS_LTD_COMPANY_UUID = '107';
+	const MID_WALDO_SECTION_I_MATERIAL_UUID = '120';
+	const JANE_ROE_PERSON_UUID = '122';
+	const MID_FICTIONEERS_LTD_COMPANY_UUID = '123';
+	const SUR_WALDO_MATERIAL_UUID = '138';
+	const JANE_ROE_SR_PERSON_UUID = '140';
+	const SUR_FICTIONEERS_LTD_COMPANY_UUID = '141';
+	const SUB_WIBBLE_PART_I_MATERIAL_UUID = '148';
+	const SUB_WIBBLE_PART_II_MATERIAL_UUID = '154';
+	const MID_WIBBLE_SECTION_I_MATERIAL_UUID = '164';
+	const MID_WIBBLE_SECTION_II_MATERIAL_UUID = '172';
+	const SUR_WIBBLE_MATERIAL_UUID = '182';
+	const WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID = '192';
+	const WORDSMITH_AWARD_UUID = '193';
+	const PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID = '200';
+	const PLAYWRITING_PRIZE_AWARD_UUID = '201';
+	const DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID = '208';
+	const DRAMATISTS_MEDAL_AWARD_UUID = '209';
+	const SCRIPTING_SHIELD_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID = '216';
+	const SCRIPTING_SHIELD_AWARD_UUID = '217';
+	const TRAGEDIANS_TROPHY_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID = '224';
+	const TRAGEDIANS_TROPHY_AWARD_UUID = '225';
+
+	let subPlughPartIOriginalVersionMaterial;
+	let midPlughSectionIOriginalVersionMaterial;
+	let surPlughOriginalVersionMaterial;
+	let francisFlobJrPerson;
+	let francisFlobPerson;
+	let francisFlobSrPerson;
+	let subCurtainUpLtdCompany;
+	let midCurtainUpLtdCompany;
+	let surCurtainUpLtdCompany;
+	let subWaldoPartIMaterial;
+	let midWaldoSectionIMaterial;
+	let surWaldoMaterial;
+	let janeRoeJrPerson;
+	let janeRoePerson;
+	let janeRoeSrPerson;
+	let subFictioneersLtdCompany;
+	let midFictioneersLtdCompany;
+	let surFictioneersLtdCompany;
+
+	const sandbox = createSandbox();
+
+	before(async () => {
+
+		let uuidCallCount = 0;
+
+		sandbox.stub(crypto, 'randomUUID').callsFake(() => (uuidCallCount++).toString());
+
+		await purgeDatabase();
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sub-Plugh: Part I',
+				differentiator: '1',
+				format: 'play',
+				year: '1899',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Francis Flob Jr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sub-Curtain Up Ltd'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sub-Plugh: Part II',
+				differentiator: '1',
+				format: 'play',
+				year: '1899'
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Mid-Plugh: Section I',
+				differentiator: '1',
+				format: 'sub-collection of plays',
+				year: '1899',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Francis Flob'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Mid-Curtain Up Ltd'
+							}
+						]
+					}
+				],
+				subMaterials: [
+					{
+						name: 'Sub-Plugh: Part I',
+						differentiator: '1'
+					},
+					{
+						name: 'Sub-Plugh: Part II',
+						differentiator: '1'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Mid-Plugh: Section II',
+				differentiator: '1',
+				format: 'sub-collection of plays',
+				year: '1899'
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sur-Plugh',
+				differentiator: '1',
+				format: 'collection of plays',
+				year: '1899',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Francis Flob Sr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sur-Curtain Up Ltd'
+							}
+						]
+					}
+				],
+				subMaterials: [
+					{
+						name: 'Mid-Plugh: Section I',
+						differentiator: '1'
+					},
+					{
+						name: 'Mid-Plugh: Section II',
+						differentiator: '1'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sub-Plugh: Part I',
+				differentiator: '2',
+				format: 'play',
+				year: '2009',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Francis Flob Jr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sub-Curtain Up Ltd'
+							}
+						]
+					},
+					{
+						name: 'version by',
+						entities: [
+							{
+								name: 'Beatrice Bar Jr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sub-Stagecraft Ltd'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sub-Plugh: Part II',
+				differentiator: '2',
+				format: 'play',
+				year: '2009'
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Mid-Plugh: Section I',
+				differentiator: '2',
+				format: 'sub-collection of plays',
+				year: '2009',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Francis Flob'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Mid-Curtain Up Ltd'
+							}
+						]
+					},
+					{
+						name: 'version by',
+						entities: [
+							{
+								name: 'Beatrice Bar'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Mid-Stagecraft Ltd'
+							}
+						]
+					}
+				],
+				subMaterials: [
+					{
+						name: 'Sub-Plugh: Part I',
+						differentiator: '2'
+					},
+					{
+						name: 'Sub-Plugh: Part II',
+						differentiator: '2'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Mid-Plugh: Section II',
+				differentiator: '2',
+				format: 'sub-collection of plays',
+				year: '2009'
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sur-Plugh',
+				differentiator: '2',
+				format: 'collection of plays',
+				year: '2009',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Francis Flob Sr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sur-Curtain Up Ltd'
+							}
+						]
+					},
+					{
+						name: 'version by',
+						entities: [
+							{
+								name: 'Beatrice Bar Sr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sur-Stagecraft Ltd'
+							}
+						]
+					}
+				],
+				subMaterials: [
+					{
+						name: 'Mid-Plugh: Section I',
+						differentiator: '2'
+					},
+					{
+						name: 'Mid-Plugh: Section II',
+						differentiator: '2'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sub-Waldo: Part I',
+				format: 'novel',
+				year: '1974',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Jane Roe Jr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sub-Fictioneers Ltd'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sub-Waldo: Part II',
+				format: 'novel',
+				year: '1974'
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Mid-Waldo: Section I',
+				format: 'sub-collection of novels',
+				year: '1974',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Jane Roe'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Mid-Fictioneers Ltd'
+							}
+						]
+					}
+				],
+				subMaterials: [
+					{
+						name: 'Sub-Waldo: Part I'
+					},
+					{
+						name: 'Sub-Waldo: Part II'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Mid-Waldo: Section II',
+				format: 'sub-collection of novels',
+				year: '1974'
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sur-Waldo',
+				format: 'collection of novels',
+				year: '1974',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Jane Roe Sr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sur-Fictioneers Ltd'
+							}
+						]
+					}
+				],
+				subMaterials: [
+					{
+						name: 'Mid-Waldo: Section I'
+					},
+					{
+						name: 'Mid-Waldo: Section II'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sub-Wibble: Part I',
+				format: 'play',
+				year: '2009',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Quincy Qux Jr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sub-Theatricals Ltd'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sub-Wibble: Part II',
+				format: 'play',
+				year: '2009'
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Mid-Wibble: Section I',
+				format: 'sub-collection of plays',
+				year: '2009',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Quincy Qux'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Mid-Theatricals Ltd'
+							}
+						]
+					}
+				],
+				subMaterials: [
+					{
+						name: 'Sub-Wibble: Part I'
+					},
+					{
+						name: 'Sub-Wibble: Part II'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Mid-Wibble: Section II',
+				format: 'sub-collection of plays',
+				year: '2009'
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sur-Wibble',
+				format: 'collection of plays',
+				year: '2009',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Quincy Qux Sr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sur-Theatricals Ltd'
+							}
+						]
+					}
+				],
+				subMaterials: [
+					{
+						name: 'Mid-Wibble: Section I'
+					},
+					{
+						name: 'Mid-Wibble: Section II'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/award-ceremonies')
+			.send({
+				name: '2010',
+				award: {
+					name: 'Wordsmith Award'
+				},
+				categories: [
+					{
+						name: 'Best Miscellaneous Play',
+						nominations: [
+							{
+								materials: [
+									{
+										name: 'Sub-Plugh: Part I',
+										differentiator: '2'
+									}
+								]
+							},
+							{
+								isWinner: true,
+								materials: [
+									{
+										name: 'Sub-Wibble: Part I'
+									}
+								]
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/award-ceremonies')
+			.send({
+				name: '2009',
+				award: {
+					name: 'Playwriting Prize'
+				},
+				categories: [
+					{
+						name: 'Best Random Play',
+						nominations: [
+							{
+								isWinner: true,
+								materials: [
+									{
+										name: 'Sur-Plugh',
+										differentiator: '2'
+									}
+								]
+							},
+							{
+								materials: [
+									{
+										name: 'Sur-Wibble'
+									}
+								]
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/award-ceremonies')
+			.send({
+				name: '2008',
+				award: {
+					name: 'Dramatists Medal'
+				},
+				categories: [
+					{
+						name: 'Most Remarkable Play',
+						nominations: [
+							{
+								materials: [
+									{
+										name: 'Mid-Plugh: Section I',
+										differentiator: '2'
+									}
+								]
+							},
+							{
+								isWinner: true,
+								materials: [
+									{
+										name: 'Mid-Wibble: Section I'
+									}
+								]
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/award-ceremonies')
+			.send({
+				name: '2009',
+				award: {
+					name: 'Scripting Shield'
+				},
+				categories: [
+					{
+						name: 'Most Notable Play',
+						nominations: [
+							{
+								isWinner: true,
+								materials: [
+									{
+										name: 'Sub-Plugh: Part II',
+										differentiator: '2'
+									}
+								]
+							},
+							{
+								materials: [
+									{
+										name: 'Sub-Wibble: Part II'
+									}
+								]
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/award-ceremonies')
+			.send({
+				name: '2009',
+				award: {
+					name: 'Tragedians Trophy'
+				},
+				categories: [
+					{
+						name: 'Most Interesting Play',
+						nominations: [
+							{
+								materials: [
+									{
+										name: 'Mid-Plugh: Section II',
+										differentiator: '2'
+									}
+								]
+							},
+							{
+								isWinner: true,
+								materials: [
+									{
+										name: 'Mid-Wibble: Section II'
+									}
+								]
+							}
+						]
+					}
+				]
+			});
+
+	});
+
+	after(() => {
+
+		sandbox.restore();
+
+	});
+
+	describe('Subsequent versions have nominations; connected only via sub-instances', () => {
+
+		before(async () => {
+
+			await createRelationship({
+				sourceLabel: 'Material',
+				sourceUuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+				destinationLabel: 'Material',
+				destinationUuid: SUB_PLUGH_PART_I_ORIGINAL_VERSION_MATERIAL_UUID,
+				relationshipName: 'SUBSEQUENT_VERSION_OF'
+			});
+
+		});
+
+		after(async () => {
+
+			await deleteRelationship({
+				sourceLabel: 'Material',
+				sourceUuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+				destinationLabel: 'Material',
+				destinationUuid: SUB_PLUGH_PART_I_ORIGINAL_VERSION_MATERIAL_UUID,
+				relationshipName: 'SUBSEQUENT_VERSION_OF'
+			});
+
+		});
+
+		describe('Sub-Plugh: Part I (play, 1899) (material): its subsequent versions have nominations', () => {
+
+			it('includes awards of its subsequent versions (and their sur-material and sur-sur-material)', async () => {
+
+				subPlughPartIOriginalVersionMaterial = await chai.request(app)
+					.get(`/materials/${SUB_PLUGH_PART_I_ORIGINAL_VERSION_MATERIAL_UUID}`);
+
+				const expectedSubsequentVersionMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Mid-Plugh: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Sur-Plugh',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sub-Plugh: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Mid-Plugh: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+																name: 'Sur-Plugh'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { subsequentVersionMaterialAwards } = subPlughPartIOriginalVersionMaterial.body;
+
+				expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+			});
+
+		});
+
+		describe('Mid-Plugh: Section I (sub-collection of plays, 1899) (material): its sub-material\'s subsequent versions have nominations', () => {
+
+			it('includes awards of its sub-material\'s subsequent versions (and their sur-material and sur-sur-material)', async () => {
+
+				midPlughSectionIOriginalVersionMaterial = await chai.request(app)
+					.get(`/materials/${MID_PLUGH_SECTION_I_ORIGINAL_VERSION_MATERIAL_UUID}`);
+
+				const expectedSubsequentVersionMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Mid-Plugh: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Sur-Plugh',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sub-Plugh: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Mid-Plugh: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+																name: 'Sur-Plugh'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { subsequentVersionMaterialAwards } = midPlughSectionIOriginalVersionMaterial.body;
+
+				expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+			});
+
+		});
+
+		describe('Sur-Plugh (collection of plays, 1899) (material): its sub-sub-material\'s subsequent versions have nominations', () => {
+
+			it('includes awards of its sub-sub-material\'s subsequent versions (and their sur-material and sur-sur-material)', async () => {
+
+				surPlughOriginalVersionMaterial = await chai.request(app)
+					.get(`/materials/${SUR_PLUGH_ORIGINAL_VERSION_MATERIAL_UUID}`);
+
+				const expectedSubsequentVersionMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Mid-Plugh: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Sur-Plugh',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sub-Plugh: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Mid-Plugh: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+																name: 'Sur-Plugh'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { subsequentVersionMaterialAwards } = surPlughOriginalVersionMaterial.body;
+
+				expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+			});
+
+		});
+
+		describe('Francis Flob Jr (person): their work\'s subsequent versions have nominations', () => {
+
+			it('includes awards of their work\'s subsequent versions (and their sur-material and sur-sur-material)', async () => {
+
+				francisFlobJrPerson = await chai.request(app)
+					.get(`/people/${FRANCIS_FLOB_JR_PERSON_UUID}`);
+
+				const expectedSubsequentVersionMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Mid-Plugh: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Sur-Plugh',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sub-Plugh: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Mid-Plugh: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+																name: 'Sur-Plugh'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { subsequentVersionMaterialAwards } = francisFlobJrPerson.body;
+
+				expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+			});
+
+		});
+
+		describe('Francis Flob (person): their work\'s sub-material\'s subsequent versions have nominations', () => {
+
+			it('includes awards of their work\'s sub-material\'s subsequent versions (and their sur-material and sur-sur-material)', async () => {
+
+				francisFlobPerson = await chai.request(app)
+					.get(`/people/${FRANCIS_FLOB_PERSON_UUID}`);
+
+				const expectedSubsequentVersionMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Mid-Plugh: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Sur-Plugh',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sub-Plugh: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Mid-Plugh: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+																name: 'Sur-Plugh'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { subsequentVersionMaterialAwards } = francisFlobPerson.body;
+
+				expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+			});
+
+		});
+
+		describe('Francis Flob Sr (person): their work\'s sub-sub-material\'s subsequent versions have nominations', () => {
+
+			it('includes awards of their work\'s sub-sub-material\'s subsequent versions (and their sur-material and sur-sur-material)', async () => {
+
+				francisFlobSrPerson = await chai.request(app)
+					.get(`/people/${FRANCIS_FLOB_SR_PERSON_UUID}`);
+
+				const expectedSubsequentVersionMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Mid-Plugh: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Sur-Plugh',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sub-Plugh: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Mid-Plugh: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+																name: 'Sur-Plugh'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { subsequentVersionMaterialAwards } = francisFlobSrPerson.body;
+
+				expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+			});
+
+		});
+
+		describe('Sub-Curtain Up Ltd (company): their work\'s subsequent versions have nominations', () => {
+
+			it('includes awards of their work\'s subsequent versions (and their sur-material and sur-sur-material)', async () => {
+
+				subCurtainUpLtdCompany = await chai.request(app)
+					.get(`/companies/${SUB_CURTAIN_UP_LTD_COMPANY_UUID}`);
+
+				const expectedSubsequentVersionMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Mid-Plugh: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Sur-Plugh',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sub-Plugh: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Mid-Plugh: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+																name: 'Sur-Plugh'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { subsequentVersionMaterialAwards } = subCurtainUpLtdCompany.body;
+
+				expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+			});
+
+		});
+
+		describe('Mid-Curtain Up Ltd (company): their work\'s sub-material\'s subsequent versions have nominations', () => {
+
+			it('includes awards of their work\'s sub-material\'s subsequent versions (and their sur-material and sur-sur-material)', async () => {
+
+				midCurtainUpLtdCompany = await chai.request(app)
+					.get(`/companies/${MID_CURTAIN_UP_LTD_COMPANY_UUID}`);
+
+				const expectedSubsequentVersionMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Mid-Plugh: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Sur-Plugh',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sub-Plugh: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Mid-Plugh: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+																name: 'Sur-Plugh'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { subsequentVersionMaterialAwards } = midCurtainUpLtdCompany.body;
+
+				expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+			});
+
+		});
+
+		describe('Sur-Curtain Up Ltd (company): their work\'s sub-sub-material\'s subsequent versions have nominations', () => {
+
+			it('includes awards of their work\'s sub-sub-material\'s subsequent versions (and their sur-material and sur-sur-material)', async () => {
+
+				surCurtainUpLtdCompany = await chai.request(app)
+					.get(`/companies/${SUR_CURTAIN_UP_LTD_COMPANY_UUID}`);
+
+				const expectedSubsequentVersionMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Mid-Plugh: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Sur-Plugh',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sub-Plugh: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Mid-Plugh: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+																name: 'Sur-Plugh'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { subsequentVersionMaterialAwards } = surCurtainUpLtdCompany.body;
+
+				expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+			});
+
+		});
+
+	});
+
+	describe('Subsequent versions have nominations; connected only via mid-instances', () => {
+
+		before(async () => {
+
+			await createRelationship({
+				sourceLabel: 'Material',
+				sourceUuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+				destinationLabel: 'Material',
+				destinationUuid: MID_PLUGH_SECTION_I_ORIGINAL_VERSION_MATERIAL_UUID,
+				relationshipName: 'SUBSEQUENT_VERSION_OF'
+			});
+
+		});
+
+		after(async () => {
+
+			await deleteRelationship({
+				sourceLabel: 'Material',
+				sourceUuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+				destinationLabel: 'Material',
+				destinationUuid: MID_PLUGH_SECTION_I_ORIGINAL_VERSION_MATERIAL_UUID,
+				relationshipName: 'SUBSEQUENT_VERSION_OF'
+			});
+
+		});
+
+		describe('Sub-Plugh: Part I (play, 1899) (material): its sur-material\'s subsequent versions have nominations', () => {
+
+			it('includes awards of its sur-material\'s subsequent versions (and their sur-material, but not their sub-materials)', async () => {
+
+				subPlughPartIOriginalVersionMaterial = await chai.request(app)
+					.get(`/materials/${SUB_PLUGH_PART_I_ORIGINAL_VERSION_MATERIAL_UUID}`);
+
+				const expectedSubsequentVersionMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Mid-Plugh: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Sur-Plugh',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { subsequentVersionMaterialAwards } = subPlughPartIOriginalVersionMaterial.body;
+
+				expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+			});
+
+		});
+
+		describe('Mid-Plugh: Section I (sub-collection of plays, 1899) (material): its subsequent versions have nominations', () => {
+
+			it('includes awards of its subsequent versions (and their sur-material and sub-materials)', async () => {
+
+				midPlughSectionIOriginalVersionMaterial = await chai.request(app)
+					.get(`/materials/${MID_PLUGH_SECTION_I_ORIGINAL_VERSION_MATERIAL_UUID}`);
+
+				const expectedSubsequentVersionMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Mid-Plugh: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Sur-Plugh',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: SCRIPTING_SHIELD_AWARD_UUID,
+						name: 'Scripting Shield',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: SCRIPTING_SHIELD_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Notable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_PLUGH_PART_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sub-Plugh: Part II',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Mid-Plugh: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+																name: 'Sur-Plugh'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sub-Plugh: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Mid-Plugh: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+																name: 'Sur-Plugh'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { subsequentVersionMaterialAwards } = midPlughSectionIOriginalVersionMaterial.body;
+
+				expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+			});
+
+		});
+
+		describe('Sur-Plugh (collection of plays, 1899) (material): its sub-material\'s subsequent versions have nominations', () => {
+
+			it('includes awards of its sub-material\'s subsequent versions (and their sur-material and sub-materials)', async () => {
+
+				surPlughOriginalVersionMaterial = await chai.request(app)
+					.get(`/materials/${SUR_PLUGH_ORIGINAL_VERSION_MATERIAL_UUID}`);
+
+				const expectedSubsequentVersionMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Mid-Plugh: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Sur-Plugh',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: SCRIPTING_SHIELD_AWARD_UUID,
+						name: 'Scripting Shield',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: SCRIPTING_SHIELD_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Notable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_PLUGH_PART_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sub-Plugh: Part II',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Mid-Plugh: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+																name: 'Sur-Plugh'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sub-Plugh: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Mid-Plugh: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+																name: 'Sur-Plugh'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { subsequentVersionMaterialAwards } = surPlughOriginalVersionMaterial.body;
+
+				expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+			});
+
+		});
+
+		describe('Francis Flob Jr (person): their work\'s sur-material\'s subsequent versions have nominations', () => {
+
+			it('includes awards of their work\'s sur-material\'s subsequent versions (and their sur-material, but not their sub-materials)', async () => {
+
+				francisFlobJrPerson = await chai.request(app)
+					.get(`/people/${FRANCIS_FLOB_JR_PERSON_UUID}`);
+
+				const expectedSubsequentVersionMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Mid-Plugh: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Sur-Plugh',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { subsequentVersionMaterialAwards } = francisFlobJrPerson.body;
+
+				expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+			});
+
+		});
+
+		describe('Francis Flob (person): their work\'s subsequent versions have nominations', () => {
+
+			it('includes awards of their work\'s subsequent versions (and their sur-material and sub-materials)', async () => {
+
+				francisFlobPerson = await chai.request(app)
+					.get(`/people/${FRANCIS_FLOB_PERSON_UUID}`);
+
+				const expectedSubsequentVersionMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Mid-Plugh: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Sur-Plugh',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: SCRIPTING_SHIELD_AWARD_UUID,
+						name: 'Scripting Shield',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: SCRIPTING_SHIELD_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Notable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_PLUGH_PART_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sub-Plugh: Part II',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Mid-Plugh: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+																name: 'Sur-Plugh'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sub-Plugh: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Mid-Plugh: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+																name: 'Sur-Plugh'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { subsequentVersionMaterialAwards } = francisFlobPerson.body;
+
+				expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+			});
+
+		});
+
+		describe('Francis Flob Sr (person): their work\'s sub-material\'s subsequent versions have nominations', () => {
+
+			it('includes awards of their work\'s sub-material\'s subsequent versions (and their sur-material and sub-materials)', async () => {
+
+				francisFlobSrPerson = await chai.request(app)
+					.get(`/people/${FRANCIS_FLOB_SR_PERSON_UUID}`);
+
+				const expectedSubsequentVersionMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Mid-Plugh: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Sur-Plugh',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: SCRIPTING_SHIELD_AWARD_UUID,
+						name: 'Scripting Shield',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: SCRIPTING_SHIELD_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Notable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_PLUGH_PART_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sub-Plugh: Part II',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Mid-Plugh: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+																name: 'Sur-Plugh'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sub-Plugh: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Mid-Plugh: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+																name: 'Sur-Plugh'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { subsequentVersionMaterialAwards } = francisFlobSrPerson.body;
+
+				expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+			});
+
+		});
+
+		describe('Sub-Curtain Up Ltd (company): their work\'s sur-material\'s subsequent versions have nominations', () => {
+
+			it('includes awards of their work\'s sur-material\'s subsequent versions (and their sur-material, but not their sub-materials)', async () => {
+
+				subCurtainUpLtdCompany = await chai.request(app)
+					.get(`/companies/${SUB_CURTAIN_UP_LTD_COMPANY_UUID}`);
+
+				const expectedSubsequentVersionMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Mid-Plugh: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Sur-Plugh',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { subsequentVersionMaterialAwards } = subCurtainUpLtdCompany.body;
+
+				expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+			});
+
+		});
+
+		describe('Mid-Curtain Up Ltd (company): their work\'s subsequent versions have nominations', () => {
+
+			it('includes awards of their work\'s subsequent versions (and their sur-material and sub-materials)', async () => {
+
+				midCurtainUpLtdCompany = await chai.request(app)
+					.get(`/companies/${MID_CURTAIN_UP_LTD_COMPANY_UUID}`);
+
+				const expectedSubsequentVersionMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Mid-Plugh: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Sur-Plugh',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: SCRIPTING_SHIELD_AWARD_UUID,
+						name: 'Scripting Shield',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: SCRIPTING_SHIELD_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Notable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_PLUGH_PART_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sub-Plugh: Part II',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Mid-Plugh: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+																name: 'Sur-Plugh'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sub-Plugh: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Mid-Plugh: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+																name: 'Sur-Plugh'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { subsequentVersionMaterialAwards } = midCurtainUpLtdCompany.body;
+
+				expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+			});
+
+		});
+
+		describe('Sur-Curtain Up Ltd (company): their work\'s sub-material\'s subsequent versions have nominations', () => {
+
+			it('includes awards of their work\'s sub-material\'s subsequent versions (and their sur-material and sub-materials)', async () => {
+
+				surCurtainUpLtdCompany = await chai.request(app)
+					.get(`/companies/${SUR_CURTAIN_UP_LTD_COMPANY_UUID}`);
+
+				const expectedSubsequentVersionMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Mid-Plugh: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Sur-Plugh',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: SCRIPTING_SHIELD_AWARD_UUID,
+						name: 'Scripting Shield',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: SCRIPTING_SHIELD_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Notable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_PLUGH_PART_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sub-Plugh: Part II',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Mid-Plugh: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+																name: 'Sur-Plugh'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sub-Plugh: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Mid-Plugh: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+																name: 'Sur-Plugh'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { subsequentVersionMaterialAwards } = surCurtainUpLtdCompany.body;
+
+				expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+			});
+
+		});
+
+	});
+
+	describe('Subsequent versions have nominations; connected only via sur-instances', () => {
+
+		before(async () => {
+
+			await createRelationship({
+				sourceLabel: 'Material',
+				sourceUuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+				destinationLabel: 'Material',
+				destinationUuid: SUR_PLUGH_ORIGINAL_VERSION_MATERIAL_UUID,
+				relationshipName: 'SUBSEQUENT_VERSION_OF'
+			});
+
+		});
+
+		after(async () => {
+
+			await deleteRelationship({
+				sourceLabel: 'Material',
+				sourceUuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+				destinationLabel: 'Material',
+				destinationUuid: SUR_PLUGH_ORIGINAL_VERSION_MATERIAL_UUID,
+				relationshipName: 'SUBSEQUENT_VERSION_OF'
+			});
+
+		});
+
+		describe('Sub-Plugh: Part I (play, 1899) (material): its sur-sur-material\'s subsequent versions have nominations', () => {
+
+			it('includes awards of its sur-sur-material\'s subsequent versions (but not their sub-materials and sub-sub-materials)', async () => {
+
+				subPlughPartIOriginalVersionMaterial = await chai.request(app)
+					.get(`/materials/${SUB_PLUGH_PART_I_ORIGINAL_VERSION_MATERIAL_UUID}`);
+
+				const expectedSubsequentVersionMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { subsequentVersionMaterialAwards } = subPlughPartIOriginalVersionMaterial.body;
+
+				expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+			});
+
+		});
+
+		describe('Mid-Plugh: Section I (sub-collection of plays, 1899) (material): its sur-material\'s subsequent versions have nominations', () => {
+
+			it('includes awards of its sur-material\'s subsequent versions (but not their sub-materials and sub-sub-materials)', async () => {
+
+				midPlughSectionIOriginalVersionMaterial = await chai.request(app)
+					.get(`/materials/${MID_PLUGH_SECTION_I_ORIGINAL_VERSION_MATERIAL_UUID}`);
+
+				const expectedSubsequentVersionMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { subsequentVersionMaterialAwards } = midPlughSectionIOriginalVersionMaterial.body;
+
+				expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+			});
+
+		});
+
+		describe('Sur-Plugh (collection of plays, 1899) (material): subsequent versions have nominations', () => {
+
+			it('includes awards of its subsequent versions (and their sub-materials and sub-sub-materials)', async () => {
+
+				surPlughOriginalVersionMaterial = await chai.request(app)
+					.get(`/materials/${SUR_PLUGH_ORIGINAL_VERSION_MATERIAL_UUID}`);
+
+				const expectedSubsequentVersionMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Mid-Plugh: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Sur-Plugh',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: SCRIPTING_SHIELD_AWARD_UUID,
+						name: 'Scripting Shield',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: SCRIPTING_SHIELD_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Notable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_PLUGH_PART_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sub-Plugh: Part II',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Mid-Plugh: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+																name: 'Sur-Plugh'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: TRAGEDIANS_TROPHY_AWARD_UUID,
+						name: 'Tragedians Trophy',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: TRAGEDIANS_TROPHY_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Interesting Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_PLUGH_SECTION_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Mid-Plugh: Section II',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Sur-Plugh',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sub-Plugh: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Mid-Plugh: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+																name: 'Sur-Plugh'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { subsequentVersionMaterialAwards } = surPlughOriginalVersionMaterial.body;
+
+				expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+			});
+
+		});
+
+		describe('Francis Flob Jr (person): their work\'s sur-sur-material\'s subsequent versions have nominations', () => {
+
+			it('includes awards of their work\'s sur-sur-material\'s subsequent versions (but not their sub-materials and sub-sub-materials)', async () => {
+
+				francisFlobJrPerson = await chai.request(app)
+					.get(`/people/${FRANCIS_FLOB_JR_PERSON_UUID}`);
+
+				const expectedSubsequentVersionMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { subsequentVersionMaterialAwards } = francisFlobJrPerson.body;
+
+				expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+			});
+
+		});
+
+		describe('Francis Flob (person): their work\'s sur-material\'s subsequent versions have nominations', () => {
+
+			it('includes awards of their work\'s sur-material\'s subsequent versions (but not their sub-materials and sub-sub-materials)', async () => {
+
+				francisFlobPerson = await chai.request(app)
+					.get(`/people/${FRANCIS_FLOB_PERSON_UUID}`);
+
+				const expectedSubsequentVersionMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { subsequentVersionMaterialAwards } = francisFlobPerson.body;
+
+				expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+			});
+
+		});
+
+		describe('Francis Flob Sr (person): their work\'s subsequent versions have nominations', () => {
+
+			it('includes awards of their work\'s subsequent versions (and their sub-materials and sub-sub-materials)', async () => {
+
+				francisFlobSrPerson = await chai.request(app)
+					.get(`/people/${FRANCIS_FLOB_SR_PERSON_UUID}`);
+
+				const expectedSubsequentVersionMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Mid-Plugh: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Sur-Plugh',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: SCRIPTING_SHIELD_AWARD_UUID,
+						name: 'Scripting Shield',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: SCRIPTING_SHIELD_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Notable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_PLUGH_PART_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sub-Plugh: Part II',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Mid-Plugh: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+																name: 'Sur-Plugh'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: TRAGEDIANS_TROPHY_AWARD_UUID,
+						name: 'Tragedians Trophy',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: TRAGEDIANS_TROPHY_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Interesting Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_PLUGH_SECTION_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Mid-Plugh: Section II',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Sur-Plugh',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sub-Plugh: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Mid-Plugh: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+																name: 'Sur-Plugh'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { subsequentVersionMaterialAwards } = francisFlobSrPerson.body;
+
+				expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+			});
+
+		});
+
+		describe('Sub-Curtain Up Ltd (company): their work\'s sur-sur-material\'s subsequent versions have nominations', () => {
+
+			it('includes awards of their work\'s sur-sur-material\'s subsequent versions (but not their sub-materials and sub-sub-materials)', async () => {
+
+				subCurtainUpLtdCompany = await chai.request(app)
+					.get(`/companies/${SUB_CURTAIN_UP_LTD_COMPANY_UUID}`);
+
+				const expectedSubsequentVersionMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { subsequentVersionMaterialAwards } = subCurtainUpLtdCompany.body;
+
+				expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+			});
+
+		});
+
+		describe('Mid-Curtain Up Ltd (company): their work\'s sur-material\'s subsequent versions have nominations', () => {
+
+			it('includes awards of their work\'s sur-material\'s subsequent versions (but not their sub-materials and sub-sub-materials)', async () => {
+
+				midCurtainUpLtdCompany = await chai.request(app)
+					.get(`/companies/${MID_CURTAIN_UP_LTD_COMPANY_UUID}`);
+
+				const expectedSubsequentVersionMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { subsequentVersionMaterialAwards } = midCurtainUpLtdCompany.body;
+
+				expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+			});
+
+		});
+
+		describe('Sur-Curtain Up Ltd (company): their work\'s subsequent versions have nominations', () => {
+
+			it('includes awards of their work\'s subsequent versions (and their sub-materials and sub-sub-materials)', async () => {
+
+				surCurtainUpLtdCompany = await chai.request(app)
+					.get(`/companies/${SUR_CURTAIN_UP_LTD_COMPANY_UUID}`);
+
+				const expectedSubsequentVersionMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Mid-Plugh: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Sur-Plugh',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sur-Plugh',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: SCRIPTING_SHIELD_AWARD_UUID,
+						name: 'Scripting Shield',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: SCRIPTING_SHIELD_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Notable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_PLUGH_PART_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sub-Plugh: Part II',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Mid-Plugh: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+																name: 'Sur-Plugh'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: TRAGEDIANS_TROPHY_AWARD_UUID,
+						name: 'Tragedians Trophy',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: TRAGEDIANS_TROPHY_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Interesting Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_PLUGH_SECTION_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Mid-Plugh: Section II',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Sur-Plugh',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												subsequentVersionMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+														name: 'Sub-Plugh: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
+															name: 'Mid-Plugh: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+																name: 'Sur-Plugh'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { subsequentVersionMaterialAwards } = surCurtainUpLtdCompany.body;
+
+				expect(subsequentVersionMaterialAwards).to.deep.equal(expectedSubsequentVersionMaterialAwards);
+
+			});
+
+		});
+
+	});
+
+	describe('Sourcing materials have nominations; connected only via sub-instances', () => {
+
+		before(async () => {
+
+			await createRelationship({
+				sourceLabel: 'Material',
+				sourceUuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
+				destinationLabel: 'Material',
+				destinationUuid: SUB_WALDO_PART_I_MATERIAL_UUID,
+				relationshipName: 'USES_SOURCE_MATERIAL'
+			});
+
+		});
+
+		after(async () => {
+
+			await deleteRelationship({
+				sourceLabel: 'Material',
+				sourceUuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
+				destinationLabel: 'Material',
+				destinationUuid: SUB_WALDO_PART_I_MATERIAL_UUID,
+				relationshipName: 'USES_SOURCE_MATERIAL'
+			});
+
+		});
+
+		describe('Sub-Waldo: Part I (novel, 1974) (material): its sourcing materials have nominations', () => {
+
+			it('includes awards of its sourcing materials (and their sur-material and sur-sur-material)', async () => {
+
+				subWaldoPartIMaterial = await chai.request(app)
+					.get(`/materials/${SUB_WALDO_PART_I_MATERIAL_UUID}`);
+
+				const expectedSourcingMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+														name: 'Mid-Wibble: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
+														name: 'Sub-Wibble: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+															name: 'Mid-Wibble: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_WIBBLE_MATERIAL_UUID,
+																name: 'Sur-Wibble'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { sourcingMaterialAwards } = subWaldoPartIMaterial.body;
+
+				expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+			});
+
+		});
+
+		describe('Mid-Waldo: Section I (sub-collection of plays, 1899) (material): its sub-material\'s sourcing materials have nominations', () => {
+
+			it('includes awards of its sub-material\'s sourcing materials (and their sur-material and sur-sur-material)', async () => {
+
+				midWaldoSectionIMaterial = await chai.request(app)
+					.get(`/materials/${MID_WALDO_SECTION_I_MATERIAL_UUID}`);
+
+				const expectedSourcingMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+														name: 'Mid-Wibble: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
+														name: 'Sub-Wibble: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+															name: 'Mid-Wibble: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_WIBBLE_MATERIAL_UUID,
+																name: 'Sur-Wibble'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { sourcingMaterialAwards } = midWaldoSectionIMaterial.body;
+
+				expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+			});
+
+		});
+
+		describe('Sur-Waldo (collection of plays, 1899) (material): its sub-sub-material\'s sourcing materials have nominations', () => {
+
+			it('includes awards of its sub-sub-material\'s sourcing materials (and their sur-material and sur-sur-material)', async () => {
+
+				surWaldoMaterial = await chai.request(app)
+					.get(`/materials/${SUR_WALDO_MATERIAL_UUID}`);
+
+				const expectedSourcingMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+														name: 'Mid-Wibble: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
+														name: 'Sub-Wibble: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+															name: 'Mid-Wibble: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_WIBBLE_MATERIAL_UUID,
+																name: 'Sur-Wibble'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { sourcingMaterialAwards } = surWaldoMaterial.body;
+
+				expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+			});
+
+		});
+
+		describe('Jane Roe Jr (person): their work\'s sourcing materials have nominations', () => {
+
+			it('includes awards of their work\'s sourcing materials (and their sur-material and sur-sur-material)', async () => {
+
+				janeRoeJrPerson = await chai.request(app)
+					.get(`/people/${JANE_ROE_JR_PERSON_UUID}`);
+
+				const expectedSourcingMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+														name: 'Mid-Wibble: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
+														name: 'Sub-Wibble: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+															name: 'Mid-Wibble: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_WIBBLE_MATERIAL_UUID,
+																name: 'Sur-Wibble'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { sourcingMaterialAwards } = janeRoeJrPerson.body;
+
+				expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+			});
+
+		});
+
+		describe('Jane Roe (person): their work\'s sub-material\'s sourcing materials have nominations', () => {
+
+			it('includes awards of their work\'s sub-material\'s sourcing materials (and their sur-material and sur-sur-material)', async () => {
+
+				janeRoePerson = await chai.request(app)
+					.get(`/people/${JANE_ROE_PERSON_UUID}`);
+
+				const expectedSourcingMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+														name: 'Mid-Wibble: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
+														name: 'Sub-Wibble: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+															name: 'Mid-Wibble: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_WIBBLE_MATERIAL_UUID,
+																name: 'Sur-Wibble'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { sourcingMaterialAwards } = janeRoePerson.body;
+
+				expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+			});
+
+		});
+
+		describe('Jane Roe Sr (person): their work\'s sub-sub-material\'s sourcing materials have nominations', () => {
+
+			it('includes awards of their work\'s sub-sub-material\'s sourcing materials (and their sur-material and sur-sur-material)', async () => {
+
+				janeRoeSrPerson = await chai.request(app)
+					.get(`/people/${JANE_ROE_SR_PERSON_UUID}`);
+
+				const expectedSourcingMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+														name: 'Mid-Wibble: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
+														name: 'Sub-Wibble: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+															name: 'Mid-Wibble: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_WIBBLE_MATERIAL_UUID,
+																name: 'Sur-Wibble'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { sourcingMaterialAwards } = janeRoeSrPerson.body;
+
+				expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+			});
+
+		});
+
+		describe('Sub-Fictioneers Ltd (company): their work\'s sourcing materials have nominations', () => {
+
+			it('includes awards of their work\'s sourcing materials (and their sur-material and sur-sur-material)', async () => {
+
+				subFictioneersLtdCompany = await chai.request(app)
+					.get(`/companies/${SUB_FICTIONEERS_LTD_COMPANY_UUID}`);
+
+				const expectedSourcingMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+														name: 'Mid-Wibble: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
+														name: 'Sub-Wibble: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+															name: 'Mid-Wibble: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_WIBBLE_MATERIAL_UUID,
+																name: 'Sur-Wibble'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { sourcingMaterialAwards } = subFictioneersLtdCompany.body;
+
+				expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+			});
+
+		});
+
+		describe('Mid-Fictioneers Ltd (company): their work\'s sub-material\'s sourcing materials have nominations', () => {
+
+			it('includes awards of their work\'s sub-material\'s sourcing materials (and their sur-material and sur-sur-material)', async () => {
+
+				midFictioneersLtdCompany = await chai.request(app)
+					.get(`/companies/${MID_FICTIONEERS_LTD_COMPANY_UUID}`);
+
+				const expectedSourcingMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+														name: 'Mid-Wibble: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
+														name: 'Sub-Wibble: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+															name: 'Mid-Wibble: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_WIBBLE_MATERIAL_UUID,
+																name: 'Sur-Wibble'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { sourcingMaterialAwards } = midFictioneersLtdCompany.body;
+
+				expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+			});
+
+		});
+
+		describe('Sur-Fictioneers Ltd (company): their work\'s sub-sub-material\'s sourcing materials have nominations', () => {
+
+			it('includes awards of their work\'s sub-sub-material\'s sourcing materials (and their sur-material and sur-sur-material)', async () => {
+
+				surFictioneersLtdCompany = await chai.request(app)
+					.get(`/companies/${SUR_FICTIONEERS_LTD_COMPANY_UUID}`);
+
+				const expectedSourcingMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+														name: 'Mid-Wibble: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
+														name: 'Sub-Wibble: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+															name: 'Mid-Wibble: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_WIBBLE_MATERIAL_UUID,
+																name: 'Sur-Wibble'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { sourcingMaterialAwards } = surFictioneersLtdCompany.body;
+
+				expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+			});
+
+		});
+
+	});
+
+	describe('Sourcing materials have nominations; connected only via mid-instances', () => {
+
+		before(async () => {
+
+			await createRelationship({
+				sourceLabel: 'Material',
+				sourceUuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+				destinationLabel: 'Material',
+				destinationUuid: MID_WALDO_SECTION_I_MATERIAL_UUID,
+				relationshipName: 'USES_SOURCE_MATERIAL'
+			});
+
+		});
+
+		after(async () => {
+
+			await deleteRelationship({
+				sourceLabel: 'Material',
+				sourceUuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+				destinationLabel: 'Material',
+				destinationUuid: MID_WALDO_SECTION_I_MATERIAL_UUID,
+				relationshipName: 'USES_SOURCE_MATERIAL'
+			});
+
+		});
+
+		describe('Sub-Waldo: Part I (play, 1899) (material): its sur-material\'s sourcing materials have nominations', () => {
+
+			it('includes awards of its sur-material\'s sourcing materials (and their sur-material, but not their sub-materials)', async () => {
+
+				subWaldoPartIMaterial = await chai.request(app)
+					.get(`/materials/${SUB_WALDO_PART_I_MATERIAL_UUID}`);
+
+				const expectedSourcingMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+														name: 'Mid-Wibble: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { sourcingMaterialAwards } = subWaldoPartIMaterial.body;
+
+				expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+			});
+
+		});
+
+		describe('Mid-Waldo: Section I (sub-collection of plays, 1899) (material): its sourcing materials have nominations', () => {
+
+			it('includes awards of its sourcing materials (and their sur-material and sub-materials)', async () => {
+
+				midWaldoSectionIMaterial = await chai.request(app)
+					.get(`/materials/${MID_WALDO_SECTION_I_MATERIAL_UUID}`);
+
+				const expectedSourcingMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+														name: 'Mid-Wibble: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: SCRIPTING_SHIELD_AWARD_UUID,
+						name: 'Scripting Shield',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: SCRIPTING_SHIELD_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Notable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
+														name: 'Sub-Wibble: Part II',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+															name: 'Mid-Wibble: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_WIBBLE_MATERIAL_UUID,
+																name: 'Sur-Wibble'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
+														name: 'Sub-Wibble: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+															name: 'Mid-Wibble: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_WIBBLE_MATERIAL_UUID,
+																name: 'Sur-Wibble'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { sourcingMaterialAwards } = midWaldoSectionIMaterial.body;
+
+				expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+			});
+
+		});
+
+		describe('Sur-Waldo (collection of plays, 1899) (material): its sub-material\'s sourcing materials have nominations', () => {
+
+			it('includes awards of its sub-material\'s sourcing materials (and their sur-material and sub-materials)', async () => {
+
+				surWaldoMaterial = await chai.request(app)
+					.get(`/materials/${SUR_WALDO_MATERIAL_UUID}`);
+
+				const expectedSourcingMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+														name: 'Mid-Wibble: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: SCRIPTING_SHIELD_AWARD_UUID,
+						name: 'Scripting Shield',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: SCRIPTING_SHIELD_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Notable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
+														name: 'Sub-Wibble: Part II',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+															name: 'Mid-Wibble: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_WIBBLE_MATERIAL_UUID,
+																name: 'Sur-Wibble'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
+														name: 'Sub-Wibble: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+															name: 'Mid-Wibble: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_WIBBLE_MATERIAL_UUID,
+																name: 'Sur-Wibble'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { sourcingMaterialAwards } = surWaldoMaterial.body;
+
+				expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+			});
+
+		});
+
+		describe('Jane Roe Jr (person): their work\'s sur-material\'s sourcing materials have nominations', () => {
+
+			it('includes awards of their work\'s sur-material\'s sourcing materials (and their sur-material, but not their sub-materials)', async () => {
+
+				janeRoeJrPerson = await chai.request(app)
+					.get(`/people/${JANE_ROE_JR_PERSON_UUID}`);
+
+				const expectedSourcingMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+														name: 'Mid-Wibble: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { sourcingMaterialAwards } = janeRoeJrPerson.body;
+
+				expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+			});
+
+		});
+
+		describe('Jane Roe (person): their work\'s sourcing materials have nominations', () => {
+
+			it('includes awards of their work\'s sourcing materials (and their sur-material and sub-materials)', async () => {
+
+				janeRoePerson = await chai.request(app)
+					.get(`/people/${JANE_ROE_PERSON_UUID}`);
+
+				const expectedSourcingMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+														name: 'Mid-Wibble: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: SCRIPTING_SHIELD_AWARD_UUID,
+						name: 'Scripting Shield',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: SCRIPTING_SHIELD_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Notable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
+														name: 'Sub-Wibble: Part II',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+															name: 'Mid-Wibble: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_WIBBLE_MATERIAL_UUID,
+																name: 'Sur-Wibble'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
+														name: 'Sub-Wibble: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+															name: 'Mid-Wibble: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_WIBBLE_MATERIAL_UUID,
+																name: 'Sur-Wibble'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { sourcingMaterialAwards } = janeRoePerson.body;
+
+				expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+			});
+
+		});
+
+		describe('Jane Roe Sr (person): their work\'s sub-material\'s sourcing materials have nominations', () => {
+
+			it('includes awards of their work\'s sub-material\'s sourcing materials (and their sur-material and sub-materials)', async () => {
+
+				janeRoeSrPerson = await chai.request(app)
+					.get(`/people/${JANE_ROE_SR_PERSON_UUID}`);
+
+				const expectedSourcingMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+														name: 'Mid-Wibble: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: SCRIPTING_SHIELD_AWARD_UUID,
+						name: 'Scripting Shield',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: SCRIPTING_SHIELD_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Notable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
+														name: 'Sub-Wibble: Part II',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+															name: 'Mid-Wibble: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_WIBBLE_MATERIAL_UUID,
+																name: 'Sur-Wibble'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
+														name: 'Sub-Wibble: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+															name: 'Mid-Wibble: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_WIBBLE_MATERIAL_UUID,
+																name: 'Sur-Wibble'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { sourcingMaterialAwards } = janeRoeSrPerson.body;
+
+				expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+			});
+
+		});
+
+		describe('Sub-Fictioneers Ltd (company): their work\'s sur-material\'s sourcing materials have nominations', () => {
+
+			it('includes awards of their work\'s sur-material\'s sourcing materials (and their sur-material, but not their sub-materials)', async () => {
+
+				subFictioneersLtdCompany = await chai.request(app)
+					.get(`/companies/${SUB_FICTIONEERS_LTD_COMPANY_UUID}`);
+
+				const expectedSourcingMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+														name: 'Mid-Wibble: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { sourcingMaterialAwards } = subFictioneersLtdCompany.body;
+
+				expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+			});
+
+		});
+
+		describe('Mid-Fictioneers Ltd (company): their work\'s sub-material\'s sourcing materials have nominations', () => {
+
+			it('includes awards of their work\'s sub-material\'s sourcing materials (and their sur-material and sur-sur-material)', async () => {
+
+				midFictioneersLtdCompany = await chai.request(app)
+					.get(`/companies/${MID_FICTIONEERS_LTD_COMPANY_UUID}`);
+
+				const expectedSourcingMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+														name: 'Mid-Wibble: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: SCRIPTING_SHIELD_AWARD_UUID,
+						name: 'Scripting Shield',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: SCRIPTING_SHIELD_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Notable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
+														name: 'Sub-Wibble: Part II',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+															name: 'Mid-Wibble: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_WIBBLE_MATERIAL_UUID,
+																name: 'Sur-Wibble'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
+														name: 'Sub-Wibble: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+															name: 'Mid-Wibble: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_WIBBLE_MATERIAL_UUID,
+																name: 'Sur-Wibble'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { sourcingMaterialAwards } = midFictioneersLtdCompany.body;
+
+				expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+			});
+
+		});
+
+		describe('Sur-Fictioneers Ltd (company): their work\'s sub-material\'s sourcing materials have nominations', () => {
+
+			it('includes awards of their work\'s sub-material\'s sourcing materials (and their sur-material and sub-materials)', async () => {
+
+				surFictioneersLtdCompany = await chai.request(app)
+					.get(`/companies/${SUR_FICTIONEERS_LTD_COMPANY_UUID}`);
+
+				const expectedSourcingMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+														name: 'Mid-Wibble: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: SCRIPTING_SHIELD_AWARD_UUID,
+						name: 'Scripting Shield',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: SCRIPTING_SHIELD_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Notable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
+														name: 'Sub-Wibble: Part II',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+															name: 'Mid-Wibble: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_WIBBLE_MATERIAL_UUID,
+																name: 'Sur-Wibble'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
+														name: 'Sub-Wibble: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+															name: 'Mid-Wibble: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_WIBBLE_MATERIAL_UUID,
+																name: 'Sur-Wibble'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { sourcingMaterialAwards } = surFictioneersLtdCompany.body;
+
+				expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+			});
+
+		});
+
+	});
+
+	describe('Sourcing materials have nominations; connected only via sur-instances', () => {
+
+		before(async () => {
+
+			await createRelationship({
+				sourceLabel: 'Material',
+				sourceUuid: SUR_WIBBLE_MATERIAL_UUID,
+				destinationLabel: 'Material',
+				destinationUuid: SUR_WALDO_MATERIAL_UUID,
+				relationshipName: 'USES_SOURCE_MATERIAL'
+			});
+
+		});
+
+		after(async () => {
+
+			await deleteRelationship({
+				sourceLabel: 'Material',
+				sourceUuid: SUR_WIBBLE_MATERIAL_UUID,
+				destinationLabel: 'Material',
+				destinationUuid: SUR_WALDO_MATERIAL_UUID,
+				relationshipName: 'USES_SOURCE_MATERIAL'
+			});
+
+		});
+
+		describe('Sub-Waldo: Part I (play, 1899) (material): its sur-sur-material\'s sourcing materials have nominations', () => {
+
+			it('includes awards of its sur-sur-material\'s sourcing materials (but not their sub-materials and sub-sub-materials)', async () => {
+
+				subWaldoPartIMaterial = await chai.request(app)
+					.get(`/materials/${SUB_WALDO_PART_I_MATERIAL_UUID}`);
+
+				const expectedSourcingMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { sourcingMaterialAwards } = subWaldoPartIMaterial.body;
+
+				expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+			});
+
+		});
+
+		describe('Mid-Waldo: Section I (sub-collection of plays, 1899) (material): its sur-material\'s sourcing materials have nominations', () => {
+
+			it('includes awards of its sur-material\'s sourcing materials (but not their sub-materials and sub-sub-materials)', async () => {
+
+				midWaldoSectionIMaterial = await chai.request(app)
+					.get(`/materials/${MID_WALDO_SECTION_I_MATERIAL_UUID}`);
+
+				const expectedSourcingMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { sourcingMaterialAwards } = midWaldoSectionIMaterial.body;
+
+				expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+			});
+
+		});
+
+		describe('Sur-Waldo (collection of plays, 1899) (material): sourcing materials have nominations', () => {
+
+			it('includes awards of its sourcing materials (and their sub-materials and sub-sub-materials)', async () => {
+
+				surWaldoMaterial = await chai.request(app)
+					.get(`/materials/${SUR_WALDO_MATERIAL_UUID}`);
+
+				const expectedSourcingMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+														name: 'Mid-Wibble: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: SCRIPTING_SHIELD_AWARD_UUID,
+						name: 'Scripting Shield',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: SCRIPTING_SHIELD_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Notable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
+														name: 'Sub-Wibble: Part II',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+															name: 'Mid-Wibble: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_WIBBLE_MATERIAL_UUID,
+																name: 'Sur-Wibble'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: TRAGEDIANS_TROPHY_AWARD_UUID,
+						name: 'Tragedians Trophy',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: TRAGEDIANS_TROPHY_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Interesting Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_SECTION_II_MATERIAL_UUID,
+														name: 'Mid-Wibble: Section II',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
+														name: 'Sub-Wibble: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+															name: 'Mid-Wibble: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_WIBBLE_MATERIAL_UUID,
+																name: 'Sur-Wibble'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { sourcingMaterialAwards } = surWaldoMaterial.body;
+
+				expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+			});
+
+		});
+
+		describe('Jane Roe Jr (person): their work\'s sur-sur-material\'s sourcing materials have nominations', () => {
+
+			it('includes awards of their work\'s sur-sur-material\'s sourcing materials (but not their sub-materials and sub-sub-materials)', async () => {
+
+				janeRoeJrPerson = await chai.request(app)
+					.get(`/people/${JANE_ROE_JR_PERSON_UUID}`);
+
+				const expectedSourcingMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { sourcingMaterialAwards } = janeRoeJrPerson.body;
+
+				expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+			});
+
+		});
+
+		describe('Jane Roe (person): their work\'s sur-material\'s sourcing materials have nominations', () => {
+
+			it('includes awards of their work\'s sur-material\'s sourcing materials (but not their sub-materials and sub-sub-materials)', async () => {
+
+				janeRoePerson = await chai.request(app)
+					.get(`/people/${JANE_ROE_PERSON_UUID}`);
+
+				const expectedSourcingMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { sourcingMaterialAwards } = janeRoePerson.body;
+
+				expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+			});
+
+		});
+
+		describe('Jane Roe Sr (person): their work\'s sourcing materials have nominations', () => {
+
+			it('includes awards of their work\'s sourcing materials (and their sub-materials and sub-sub-materials)', async () => {
+
+				janeRoeSrPerson = await chai.request(app)
+					.get(`/people/${JANE_ROE_SR_PERSON_UUID}`);
+
+				const expectedSourcingMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+														name: 'Mid-Wibble: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: SCRIPTING_SHIELD_AWARD_UUID,
+						name: 'Scripting Shield',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: SCRIPTING_SHIELD_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Notable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
+														name: 'Sub-Wibble: Part II',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+															name: 'Mid-Wibble: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_WIBBLE_MATERIAL_UUID,
+																name: 'Sur-Wibble'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: TRAGEDIANS_TROPHY_AWARD_UUID,
+						name: 'Tragedians Trophy',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: TRAGEDIANS_TROPHY_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Interesting Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_SECTION_II_MATERIAL_UUID,
+														name: 'Mid-Wibble: Section II',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
+														name: 'Sub-Wibble: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+															name: 'Mid-Wibble: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_WIBBLE_MATERIAL_UUID,
+																name: 'Sur-Wibble'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { sourcingMaterialAwards } = janeRoeSrPerson.body;
+
+				expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+			});
+
+		});
+
+		describe('Sub-Fictioneers Ltd (company): their work\'s sur-sur-material\'s sourcing materials have nominations', () => {
+
+			it('includes awards of their work\'s sur-sur-material\'s sourcing materials (but not their sub-materials and sub-sub-materials)', async () => {
+
+				subFictioneersLtdCompany = await chai.request(app)
+					.get(`/companies/${SUB_FICTIONEERS_LTD_COMPANY_UUID}`);
+
+				const expectedSourcingMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { sourcingMaterialAwards } = subFictioneersLtdCompany.body;
+
+				expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+			});
+
+		});
+
+		describe('Mid-Fictioneers Ltd (company): their work\'s sur-material\'s sourcing materials have nominations', () => {
+
+			it('includes awards of their work\'s sur-material\'s sourcing materials (but not their sub-materials and sub-sub-materials)', async () => {
+
+				midFictioneersLtdCompany = await chai.request(app)
+					.get(`/companies/${MID_FICTIONEERS_LTD_COMPANY_UUID}`);
+
+				const expectedSourcingMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { sourcingMaterialAwards } = midFictioneersLtdCompany.body;
+
+				expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+			});
+
+		});
+
+		describe('Sur-Fictioneers Ltd (company): their work\'s sourcing materials have nominations', () => {
+
+			it('includes awards of their work\'s sourcing materials (and their sub-materials and sub-sub-materials)', async () => {
+
+				surFictioneersLtdCompany = await chai.request(app)
+					.get(`/companies/${SUR_FICTIONEERS_LTD_COMPANY_UUID}`);
+
+				const expectedSourcingMaterialAwards = [
+					{
+						model: 'AWARD',
+						uuid: DRAMATISTS_MEDAL_AWARD_UUID,
+						name: 'Dramatists Medal',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: DRAMATISTS_MEDAL_TWO_THOUSAND_AND_EIGHT_AWARD_CEREMONY_UUID,
+								name: '2008',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Remarkable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+														name: 'Mid-Wibble: Section I',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: PLAYWRITING_PRIZE_AWARD_UUID,
+						name: 'Playwriting Prize',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: PLAYWRITING_PRIZE_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Random Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUR_WIBBLE_MATERIAL_UUID,
+														name: 'Sur-Wibble',
+														format: 'collection of plays',
+														year: 2009,
+														surMaterial: null
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: SCRIPTING_SHIELD_AWARD_UUID,
+						name: 'Scripting Shield',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: SCRIPTING_SHIELD_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Notable Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: false,
+												type: 'Nomination',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
+														name: 'Sub-Wibble: Part II',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+															name: 'Mid-Wibble: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_WIBBLE_MATERIAL_UUID,
+																name: 'Sur-Wibble'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: TRAGEDIANS_TROPHY_AWARD_UUID,
+						name: 'Tragedians Trophy',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: TRAGEDIANS_TROPHY_TWO_THOUSAND_AND_NINE_AWARD_CEREMONY_UUID,
+								name: '2009',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Most Interesting Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: MID_WIBBLE_SECTION_II_MATERIAL_UUID,
+														name: 'Mid-Wibble: Section II',
+														format: 'sub-collection of plays',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: SUR_WIBBLE_MATERIAL_UUID,
+															name: 'Sur-Wibble',
+															surMaterial: null
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						model: 'AWARD',
+						uuid: WORDSMITH_AWARD_UUID,
+						name: 'Wordsmith Award',
+						ceremonies: [
+							{
+								model: 'AWARD_CEREMONY',
+								uuid: WORDSMITH_AWARD_TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID,
+								name: '2010',
+								categories: [
+									{
+										model: 'AWARD_CEREMONY_CATEGORY',
+										name: 'Best Miscellaneous Play',
+										nominations: [
+											{
+												model: 'NOMINATION',
+												isWinner: true,
+												type: 'Winner',
+												entities: [],
+												productions: [],
+												materials: [],
+												sourcingMaterials: [
+													{
+														model: 'MATERIAL',
+														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
+														name: 'Sub-Wibble: Part I',
+														format: 'play',
+														year: 2009,
+														surMaterial: {
+															model: 'MATERIAL',
+															uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+															name: 'Mid-Wibble: Section I',
+															surMaterial: {
+																model: 'MATERIAL',
+																uuid: SUR_WIBBLE_MATERIAL_UUID,
+																name: 'Sur-Wibble'
+															}
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				];
+
+				const { sourcingMaterialAwards } = surFictioneersLtdCompany.body;
+
+				expect(sourcingMaterialAwards).to.deep.equal(expectedSourcingMaterialAwards);
+
+			});
+
+		});
+
+	});
+
+});

--- a/test-e2e/test-helpers/neo4j/delete-relationship.js
+++ b/test-e2e/test-helpers/neo4j/delete-relationship.js
@@ -1,0 +1,29 @@
+import { neo4jQuery } from '../../../src/neo4j/query';
+
+export default async opts => {
+
+	const {
+		sourceLabel,
+		sourceUuid,
+		destinationLabel,
+		destinationUuid,
+		relationshipName
+	} = opts;
+
+	const params = { sourceUuid, destinationUuid };
+
+	const query = `
+		MATCH (a:${sourceLabel} { uuid: $sourceUuid })-[relationship:${relationshipName}]->
+			(b:${destinationLabel} { uuid: $destinationUuid })
+
+		DELETE relationship
+	`;
+
+	await neo4jQuery(
+		{ query, params },
+		{ isOptionalResult: true }
+	);
+
+	return;
+
+};


### PR DESCRIPTION
PR https://github.com/andygout/theatrebase-api/pull/530 ("Modify variable length paths for multi-tiered materials") applied changes that accommodated the scenario of a multi-tiered material where not all its tiers had a corresponding subsequent version or sourcing material (i.e. material that used a tier of the multi-tiered material as its source material). This can be referred to as a loosely-connected multi-tiered material collection.

PR https://github.com/andygout/theatrebase-api/pull/580 ("Prevent show awards Cypher queries from capturing multi-tier siblings") applied changes that (as described at the bottom of its PR description) removed the logic to accommodate both cases (i.e. original and subsequent versions; source and sourcing materials) of scenario 4 described in PR https://github.com/andygout/theatrebase-api/pull/530.

This PR reinstates that logic and adds end-to-end tests for the below scenarios, in each one testing from the perspective of the material (e.g. `sur-original`, `mid-original I`, `sub-original I` / `sur-source`, `mid-source I`, `sub-source I`), or its credited writer (person/company).

These are very unexpected (even unlikely) cases, though this work takes care of the eventuality should it occur. A potential scenario might be a collection of plays that are all adaptations of short stories from varying collections by different authors, though I have yet to think of or find such an example.

---

## Hypothetical scenarios of multi-tiered material where not all tiers have a corresponding subsequent version

## Original and subsequent versions

### 1: Subsequent versions have nominations; connected only via sub-instances

Owing to the Cypher query changes in this PR, `sur-original` (and its writers) is able to navigate down the 'original versions' tree, traverse across to the 'subsequent versions' tree and then navigate up to `sur-subsequent` and to any awards/nominations it has received.

This route is allowed because the upward route in the 'subsequent versions' tree will only encounter parent and grandparent nodes of `sub-subsequent I`, meaning their scope is guaranteed to encompass it.

```mermaid
flowchart TB
    subgraph original versions
    A((sur-original))
    B((mid-original II))
    C((mid-original I))
    D((sub-original IV))
    E((sub-original III))
    F((sub-original II))
    G((sub-original I))
    A --> |HAS_SUB_MATERIAL| B
    A --> |HAS_SUB_MATERIAL| C
    B --> |HAS_SUB_MATERIAL| D
    B --> |HAS_SUB_MATERIAL| E
    C --> |HAS_SUB_MATERIAL| F
    C --> |HAS_SUB_MATERIAL| G
    end
    subgraph subsequent versions
    H((sur-subsequent))
    I((mid-subsequent I))
    J((mid-subsequent II))
    K((sub-subsequent I))
    L((sub-subsequent II))
    M((sub-subsequent III))
    N((sub-subsequent IV))
    H --> |HAS_SUB_MATERIAL| I
    H --> |HAS_SUB_MATERIAL| J
    I --> |HAS_SUB_MATERIAL| K
    I --> |HAS_SUB_MATERIAL| L
    J --> |HAS_SUB_MATERIAL| M
    J --> |HAS_SUB_MATERIAL| N
    end
    K --> |SUBSEQUENT_VERSION_OF| G
```

---

### 2: Subsequent versions have nominations; connected only via mid-instances

```mermaid
flowchart TB
    subgraph subsequent versions
    A((sur-subsequent))
    B((mid-subsequent II))
    C((mid-subsequent I))
    D((sub-subsequent IV))
    E((sub-subsequent III))
    F((sub-subsequent II))
    G((sub-subsequent I))
    A --> |HAS_SUB_MATERIAL| B
    A --> |HAS_SUB_MATERIAL| C
    B --> |HAS_SUB_MATERIAL| D
    B --> |HAS_SUB_MATERIAL| E
    C --> |HAS_SUB_MATERIAL| F
    C --> |HAS_SUB_MATERIAL| G
    end
    subgraph original versions
    H((sur-original))
    I((mid-original I))
    J((mid-original II))
    K((sub-original I))
    L((sub-original II))
    M((sub-original III))
    N((sub-original IV))
    H --> |HAS_SUB_MATERIAL| I
    H --> |HAS_SUB_MATERIAL| J
    I --> |HAS_SUB_MATERIAL| K
    I --> |HAS_SUB_MATERIAL| L
    J --> |HAS_SUB_MATERIAL| M
    J --> |HAS_SUB_MATERIAL| N
    end
    C --> |SUBSEQUENT_VERSION_OF| I
```

---

### 3: Subsequent versions have nominations; connected only via sur-instances

`sub-original I` is able to navigate up the 'original versions' tree, traverse across to the 'subsequent versions' tree to `sur-subsequent` and to any awards/nominations it has received, but is unable to navigate downwards from that node.

This is because the downward route in the 'subsequent versions' tree would encounter all the child and grandchild nodes of `sur-subsequent`, some of which will almost certainly be in a different scope to `sub-original I` and whose awards it would therefore not make sense to include in those of `sub-original I`.

```mermaid
flowchart TB
    subgraph subsequent versions
    A((sur-subsequent))
    B((mid-subsequent II))
    C((mid-subsequent I))
    D((sub-subsequent IV))
    E((sub-subsequent III))
    F((sub-subsequent II))
    G((sub-subsequent I))
    A --> |HAS_SUB_MATERIAL| B
    A --> |HAS_SUB_MATERIAL| C
    B --> |HAS_SUB_MATERIAL| D
    B --> |HAS_SUB_MATERIAL| E
    C --> |HAS_SUB_MATERIAL| F
    C --> |HAS_SUB_MATERIAL| G
    end
    subgraph original versions
    H((sur-original))
    I((mid-original I))
    J((mid-original II))
    K((sub-original I))
    L((sub-original II))
    M((sub-original III))
    N((sub-original IV))
    H --> |HAS_SUB_MATERIAL| I
    H --> |HAS_SUB_MATERIAL| J
    I --> |HAS_SUB_MATERIAL| K
    I --> |HAS_SUB_MATERIAL| L
    J --> |HAS_SUB_MATERIAL| M
    J --> |HAS_SUB_MATERIAL| N
    end
    A --> |SUBSEQUENT_VERSION_OF| H
```

---

## Source and sourcing materials

### 1: Sourcing materials have nominations; connected only via sub-instances

Owing to the Cypher query changes in this PR, `sur-source` (and its writers) is able to navigate down the 'source materials' tree, traverse across to the 'sourcing materials' tree and then navigate up to `sur-sourcing` and to any awards/nominations it has received.

This route is allowed because the upward route in the 'sourcing materials' tree will only encounter parent and grandparent nodes of `sub-sourcing I`, meaning their scope is guaranteed to encompass it.

```mermaid
flowchart TB
    subgraph source materials
    A((sur-source))
    B((mid-source II))
    C((mid-source I))
    D((sub-source IV))
    E((sub-source III))
    F((sub-source II))
    G((sub-source I))
    A --> |HAS_SUB_MATERIAL| B
    A --> |HAS_SUB_MATERIAL| C
    B --> |HAS_SUB_MATERIAL| D
    B --> |HAS_SUB_MATERIAL| E
    C --> |HAS_SUB_MATERIAL| F
    C --> |HAS_SUB_MATERIAL| G
    end
    subgraph sourcing materials
    H((sur-sourcing))
    I((mid-sourcing I))
    J((mid-sourcing II))
    K((sub-sourcing I))
    L((sub-sourcing II))
    M((sub-sourcing III))
    N((sub-sourcing IV))
    H --> |HAS_SUB_MATERIAL| I
    H --> |HAS_SUB_MATERIAL| J
    I --> |HAS_SUB_MATERIAL| K
    I --> |HAS_SUB_MATERIAL| L
    J --> |HAS_SUB_MATERIAL| M
    J --> |HAS_SUB_MATERIAL| N
    end
    K --> |USES_SOURCE_MATERIAL| G
```

---

### 2: Sourcing materials have nominations; connected only via mid-instances

```mermaid
flowchart TB
    subgraph sourcing materials
    A((sur-sourcing))
    B((mid-sourcing II))
    C((mid-sourcing I))
    D((sub-sourcing IV))
    E((sub-sourcing III))
    F((sub-sourcing II))
    G((sub-sourcing I))
    A --> |HAS_SUB_MATERIAL| B
    A --> |HAS_SUB_MATERIAL| C
    B --> |HAS_SUB_MATERIAL| D
    B --> |HAS_SUB_MATERIAL| E
    C --> |HAS_SUB_MATERIAL| F
    C --> |HAS_SUB_MATERIAL| G
    end
    subgraph source materials
    H((sur-source))
    I((mid-source I))
    J((mid-source II))
    K((sub-source I))
    L((sub-source II))
    M((sub-source III))
    N((sub-source IV))
    H --> |HAS_SUB_MATERIAL| I
    H --> |HAS_SUB_MATERIAL| J
    I --> |HAS_SUB_MATERIAL| K
    I --> |HAS_SUB_MATERIAL| L
    J --> |HAS_SUB_MATERIAL| M
    J --> |HAS_SUB_MATERIAL| N
    end
    C --> |USES_SOURCE_MATERIAL| I
```

---

### 3: Sourcing materials have nominations; connected only via sur-instances

`sub-source I` is able to navigate up the 'source materials' tree, traverse across to the 'sourcing materials' tree to `sur-sourcing` and to any awards/nominations it has received, but is unable to navigate downwards from that node.

This is because the downward route in the 'sourcing materials' tree would encounter all the child and grandchild nodes of `sur-sourcing`, some of which will almost certainly be in a different scope to `sub-source I` and whose awards it would therefore not make sense to include in those of `sub-source I`.

```mermaid
flowchart TB
    subgraph sourcing materials
    A((sur-sourcing))
    B((mid-sourcing II))
    C((mid-sourcing I))
    D((sub-sourcing IV))
    E((sub-sourcing III))
    F((sub-sourcing II))
    G((sub-sourcing I))
    A --> |HAS_SUB_MATERIAL| B
    A --> |HAS_SUB_MATERIAL| C
    B --> |HAS_SUB_MATERIAL| D
    B --> |HAS_SUB_MATERIAL| E
    C --> |HAS_SUB_MATERIAL| F
    C --> |HAS_SUB_MATERIAL| G
    end
    subgraph source materials
    H((sur-source))
    I((mid-source I))
    J((mid-source II))
    K((sub-source I))
    L((sub-source II))
    M((sub-source III))
    N((sub-source IV))
    H --> |HAS_SUB_MATERIAL| I
    H --> |HAS_SUB_MATERIAL| J
    I --> |HAS_SUB_MATERIAL| K
    I --> |HAS_SUB_MATERIAL| L
    J --> |HAS_SUB_MATERIAL| M
    J --> |HAS_SUB_MATERIAL| N
    end
    A --> |USES_SOURCE_MATERIAL| H