### PR TITLE
Exclude sur-instances in credits where sub-instances exist

### DIFF
--- a/src/neo4j/cypher-queries/material/show/show-materials.js
+++ b/src/neo4j/cypher-queries/material/show/show-materials.js
@@ -2,8 +2,14 @@ export default () => `
 	MATCH (material:Material { uuid: $uuid })
 
 	OPTIONAL MATCH (material)<-[:SUBSEQUENT_VERSION_OF]-(subsequentVersionMaterial)
+		WHERE NOT EXISTS(
+			(material)<-[:SUBSEQUENT_VERSION_OF]-(:Material)<-[:HAS_SUB_MATERIAL*1..2]-(subsequentVersionMaterial)
+		)
 
 	OPTIONAL MATCH (material)<-[:USES_SOURCE_MATERIAL]-(sourcingMaterial:Material)
+		WHERE NOT EXISTS(
+			(material)<-[:USES_SOURCE_MATERIAL]-(:Material)<-[:HAS_SUB_MATERIAL*1..2]-(sourcingMaterial)
+		)
 
 	WITH
 		material,

--- a/src/neo4j/cypher-queries/material/show/show-productions.js
+++ b/src/neo4j/cypher-queries/material/show/show-productions.js
@@ -2,6 +2,10 @@ export default () => `
 	MATCH (material:Material { uuid: $uuid })
 
 	OPTIONAL MATCH (material)<-[:USES_SOURCE_MATERIAL*0..1]-(:Material)<-[:PRODUCTION_OF]-(production:Production)
+		WHERE NOT EXISTS(
+			(material)<-[:USES_SOURCE_MATERIAL]-(:Material)
+			<-[:HAS_SUB_MATERIAL*1..2]-(:Material)<-[:PRODUCTION_OF]-(production:Production)
+		)
 
 	WITH material, COLLECT(production) AS productions
 

--- a/test-e2e/model-interaction/mat-with-sub-mats-source-mats.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-mats-source-mats.test.js
@@ -23,6 +23,16 @@ describe('Material with sub-materials and source materials thereof', () => {
 	const BRING_UP_THE_BODIES_SWAN_THEATRE_PRODUCTION_UUID = '44';
 	const SWAN_THEATRE_VENUE_UUID = '46';
 	const THE_WOLF_HALL_TRILOGY_SWAN_THEATRE_PRODUCTION_UUID = '47';
+	const THE_LIFE_AND_ADVENTURES_OF_NICHOLAS_NICKLEBY_NOVEL_MATERIAL_UUID = '54';
+	const CHARLES_DICKENS_PERSON_UUID = '56';
+	const DOMBEY_AND_SON_LTD_COMPANY_UUID = '57';
+	const THE_LIFE_AND_ADVENTURES_OF_NICHOLAS_NICKLEBY_PART_I_PLAY_MATERIAL_UUID = '63';
+	const DAVID_EDGAR_PERSON_UUID = '65';
+	const EDGAR_WORKS_LTD_COMPANY_UUID = '66';
+	const THE_LIFE_AND_ADVENTURES_OF_NICHOLAS_NICKLEBY_PLAYS_MATERIAL_UUID = '75';
+	const THE_LIFE_AND_ADVENTURES_OF_NICHOLAS_NICKLEBY_PART_I_GIELGUD_THEATRE_PRODUCTION_UUID = '81';
+	const GIELGUD_THEATRE_VENUE_UUID = '83';
+	const THE_LIFE_AND_ADVENTURES_OF_NICHOLAS_NICKLEBY_GIELGUD_THEATRE_PRODUCTION_UUID = '84';
 
 	let bringUpTheBodiesNovelMaterial;
 	let bringUpTheBodiesPlayMaterial;
@@ -32,6 +42,7 @@ describe('Material with sub-materials and source materials thereof', () => {
 	let royalShakespeareCompany;
 	let bringUpTheBodiesSwanTheatreProduction;
 	let thomasCromwellCharacter;
+	let theLifeAndAdventuresOfNicholasNicklebyNovelMaterial;
 
 	const sandbox = createSandbox();
 
@@ -209,6 +220,134 @@ describe('Material with sub-materials and source materials thereof', () => {
 				]
 			});
 
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'The Life and Adventures of Nicholas Nickleby',
+				differentiator: '1',
+				format: 'novel',
+				year: '1839',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Charles Dickens'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Dombey and Son Ltd'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'The Life and Adventures of Nicholas Nickleby: Part I',
+				format: 'play',
+				year: '1980',
+				writingCredits: [
+					{
+						name: 'adapted for the stage by',
+						entities: [
+							{
+								name: 'David Edgar'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Edgar Works Ltd'
+							}
+						]
+					},
+					{
+						name: 'from',
+						entities: [
+							{
+								model: 'MATERIAL',
+								name: 'The Life and Adventures of Nicholas Nickleby',
+								differentiator: '1'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'The Life and Adventures of Nicholas Nickleby',
+				differentiator: '2',
+				format: 'play in two parts',
+				year: '1980',
+				writingCredits: [
+					{
+						name: 'adapted for the stage by',
+						entities: [
+							{
+								name: 'David Edgar'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Edgar Works Ltd'
+							}
+						]
+					},
+					{
+						name: 'from',
+						entities: [
+							{
+								model: 'MATERIAL',
+								name: 'The Life and Adventures of Nicholas Nickleby',
+								differentiator: '1'
+							}
+						]
+					}
+				],
+				subMaterials: [
+					{
+						name: 'The Life and Adventures of Nicholas Nickleby: Part I'
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'The Life and Adventures of Nicholas Nickleby: Part I',
+				startDate: '2007-12-07',
+				pressDate: '2007-12-08',
+				endDate: '2008-01-27',
+				material: {
+					name: 'The Life and Adventures of Nicholas Nickleby: Part I'
+				},
+				venue: {
+					name: 'Gielgud Theatre'
+				}
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'The Life and Adventures of Nicholas Nickleby',
+				startDate: '2007-12-07',
+				pressDate: '2007-12-08',
+				endDate: '2008-01-27',
+				material: {
+					name: 'The Life and Adventures of Nicholas Nickleby',
+					differentiator: '2'
+				},
+				venue: {
+					name: 'Gielgud Theatre'
+				},
+				subProductions: [
+					{
+						uuid: THE_LIFE_AND_ADVENTURES_OF_NICHOLAS_NICKLEBY_PART_I_GIELGUD_THEATRE_PRODUCTION_UUID
+					}
+				]
+			});
+
 		bringUpTheBodiesNovelMaterial = await chai.request(app)
 			.get(`/materials/${BRING_UP_THE_BODIES_NOVEL_MATERIAL_UUID}`);
 
@@ -232,6 +371,9 @@ describe('Material with sub-materials and source materials thereof', () => {
 
 		thomasCromwellCharacter = await chai.request(app)
 			.get(`/characters/${THOMAS_CROMWELL_CHARACTER_UUID}`);
+
+		theLifeAndAdventuresOfNicholasNicklebyNovelMaterial = await chai.request(app)
+			.get(`/materials/${THE_LIFE_AND_ADVENTURES_OF_NICHOLAS_NICKLEBY_NOVEL_MATERIAL_UUID}`);
 
 	});
 
@@ -493,7 +635,7 @@ describe('Material with sub-materials and source materials thereof', () => {
 
 	describe('Hilary Mantel (person)', () => {
 
-		it('includes materials that used their work as source material, with corresponding sur-material', () => {
+		it('includes materials that used their work as source material, with corresponding sur-material; will exclude sur-materials when included via sub-material association', () => {
 
 			const expectedSourcingMaterials = [
 				{
@@ -576,7 +718,7 @@ describe('Material with sub-materials and source materials thereof', () => {
 
 	describe('The Mantel Group (company)', () => {
 
-		it('includes materials that used their work as source material, with corresponding sur-material', () => {
+		it('includes materials that used their work as source material, with corresponding sur-material; will exclude sur-materials when included via sub-material association', () => {
 
 			const expectedSourcingMaterials = [
 				{
@@ -659,7 +801,7 @@ describe('Material with sub-materials and source materials thereof', () => {
 
 	describe('Mike Poulton (person)', () => {
 
-		it('includes materials they have written, with corresponding sur-material', () => {
+		it('includes materials they have written, with corresponding sur-material; will exclude sur-materials when included via sub-material association', () => {
 
 			const expectedMaterials = [
 				{
@@ -742,7 +884,7 @@ describe('Material with sub-materials and source materials thereof', () => {
 
 	describe('Royal Shakespeare Company (company)', () => {
 
-		it('includes materials it has written, with corresponding sur-material', () => {
+		it('includes materials it has written, with corresponding sur-material; will exclude sur-materials when included via sub-material association', () => {
 
 			const expectedMaterials = [
 				{
@@ -988,6 +1130,114 @@ describe('Material with sub-materials and source materials thereof', () => {
 
 	});
 
+	describe('The Life and Adventures of Nicholas Nickleby (novel) (material)', () => {
+
+		it('includes materials that used it as source material, with corresponding sur-material; will exclude sur-materials when included via sub-material association', () => {
+
+			const expectedSourcingMaterials = [
+				{
+					model: 'MATERIAL',
+					uuid: THE_LIFE_AND_ADVENTURES_OF_NICHOLAS_NICKLEBY_PART_I_PLAY_MATERIAL_UUID,
+					name: 'The Life and Adventures of Nicholas Nickleby: Part I',
+					format: 'play',
+					year: 1980,
+					surMaterial: {
+						model: 'MATERIAL',
+						uuid: THE_LIFE_AND_ADVENTURES_OF_NICHOLAS_NICKLEBY_PLAYS_MATERIAL_UUID,
+						name: 'The Life and Adventures of Nicholas Nickleby',
+						surMaterial: null
+					},
+					writingCredits: [
+						{
+							model: 'WRITING_CREDIT',
+							name: 'adapted for the stage by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: DAVID_EDGAR_PERSON_UUID,
+									name: 'David Edgar'
+								},
+								{
+									model: 'COMPANY',
+									uuid: EDGAR_WORKS_LTD_COMPANY_UUID,
+									name: 'Edgar Works Ltd'
+								}
+							]
+						},
+						{
+							model: 'WRITING_CREDIT',
+							name: 'from',
+							entities: [
+								{
+									model: 'MATERIAL',
+									uuid: THE_LIFE_AND_ADVENTURES_OF_NICHOLAS_NICKLEBY_NOVEL_MATERIAL_UUID,
+									name: 'The Life and Adventures of Nicholas Nickleby',
+									format: 'novel',
+									year: 1839,
+									surMaterial: null,
+									writingCredits: [
+										{
+											model: 'WRITING_CREDIT',
+											name: 'by',
+											entities: [
+												{
+													model: 'PERSON',
+													uuid: CHARLES_DICKENS_PERSON_UUID,
+													name: 'Charles Dickens'
+												},
+												{
+													model: 'COMPANY',
+													uuid: DOMBEY_AND_SON_LTD_COMPANY_UUID,
+													name: 'Dombey and Son Ltd'
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { sourcingMaterials } = theLifeAndAdventuresOfNicholasNicklebyNovelMaterial.body;
+
+			expect(sourcingMaterials).to.deep.equal(expectedSourcingMaterials);
+
+		});
+
+		it('includes productions of material that used it as source material, including the sur-production; will exclude sur-productions when included via sub-production association', () => {
+
+			const expectedSourcingMaterialProductions = [
+				{
+					model: 'PRODUCTION',
+					uuid: THE_LIFE_AND_ADVENTURES_OF_NICHOLAS_NICKLEBY_PART_I_GIELGUD_THEATRE_PRODUCTION_UUID,
+					name: 'The Life and Adventures of Nicholas Nickleby: Part I',
+					startDate: '2007-12-07',
+					endDate: '2008-01-27',
+					venue: {
+						model: 'VENUE',
+						uuid: GIELGUD_THEATRE_VENUE_UUID,
+						name: 'Gielgud Theatre',
+						surVenue: null
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: THE_LIFE_AND_ADVENTURES_OF_NICHOLAS_NICKLEBY_GIELGUD_THEATRE_PRODUCTION_UUID,
+						name: 'The Life and Adventures of Nicholas Nickleby',
+						surProduction: null
+					}
+				}
+			];
+
+			const { sourcingMaterialProductions } = theLifeAndAdventuresOfNicholasNicklebyNovelMaterial.body;
+
+			expect(sourcingMaterialProductions).to.deep.equal(expectedSourcingMaterialProductions);
+
+		});
+
+	});
+
 	describe('materials list', () => {
 
 		it('includes writers of the materials and their corresponding source material (with corresponding sur-material)', async () => {
@@ -1090,6 +1340,95 @@ describe('Material with sub-materials and source materials thereof', () => {
 									model: 'COMPANY',
 									uuid: THE_MANTEL_GROUP_COMPANY_UUID,
 									name: 'The Mantel Group'
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'MATERIAL',
+					uuid: THE_LIFE_AND_ADVENTURES_OF_NICHOLAS_NICKLEBY_PART_I_PLAY_MATERIAL_UUID,
+					name: 'The Life and Adventures of Nicholas Nickleby: Part I',
+					format: 'play',
+					year: 1980,
+					surMaterial: {
+						model: 'MATERIAL',
+						uuid: THE_LIFE_AND_ADVENTURES_OF_NICHOLAS_NICKLEBY_PLAYS_MATERIAL_UUID,
+						name: 'The Life and Adventures of Nicholas Nickleby',
+						surMaterial: null
+					},
+					writingCredits: [
+						{
+							model: 'WRITING_CREDIT',
+							name: 'adapted for the stage by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: DAVID_EDGAR_PERSON_UUID,
+									name: 'David Edgar'
+								},
+								{
+									model: 'COMPANY',
+									uuid: EDGAR_WORKS_LTD_COMPANY_UUID,
+									name: 'Edgar Works Ltd'
+								}
+							]
+						},
+						{
+							model: 'WRITING_CREDIT',
+							name: 'from',
+							entities: [
+								{
+									model: 'MATERIAL',
+									uuid: THE_LIFE_AND_ADVENTURES_OF_NICHOLAS_NICKLEBY_NOVEL_MATERIAL_UUID,
+									name: 'The Life and Adventures of Nicholas Nickleby',
+									format: 'novel',
+									year: 1839,
+									surMaterial: null,
+									writingCredits: [
+										{
+											model: 'WRITING_CREDIT',
+											name: 'by',
+											entities: [
+												{
+													model: 'PERSON',
+													uuid: CHARLES_DICKENS_PERSON_UUID,
+													name: 'Charles Dickens'
+												},
+												{
+													model: 'COMPANY',
+													uuid: DOMBEY_AND_SON_LTD_COMPANY_UUID,
+													name: 'Dombey and Son Ltd'
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					model: 'MATERIAL',
+					uuid: THE_LIFE_AND_ADVENTURES_OF_NICHOLAS_NICKLEBY_NOVEL_MATERIAL_UUID,
+					name: 'The Life and Adventures of Nicholas Nickleby',
+					format: 'novel',
+					year: 1839,
+					surMaterial: null,
+					writingCredits: [
+						{
+							model: 'WRITING_CREDIT',
+							name: 'by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: CHARLES_DICKENS_PERSON_UUID,
+									name: 'Charles Dickens'
+								},
+								{
+									model: 'COMPANY',
+									uuid: DOMBEY_AND_SON_LTD_COMPANY_UUID,
+									name: 'Dombey and Son Ltd'
 								}
 							]
 						}

--- a/test-e2e/model-interaction/mat-with-sub-mats-subsequent-versions.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-mats-subsequent-versions.test.js
@@ -19,12 +19,18 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 	const ROBERT_ICKE_PERSON_UUID = '29';
 	const THE_GREAT_HOPE_COMPANY_UUID = '30';
 	const THE_ORESTEIA_SUBSEQUENT_VERSION_MATERIAL_UUID = '39';
+	const PLUGH_ORIGINAL_VERSION_MATERIAL_UUID = '50';
+	const SUB_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID = '60';
+	const BEATRICE_BAR_PERSON_UUID = '64';
+	const STAGECRAFT_LTD_COMPANY_UUID = '65';
+	const SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID = '74';
 
 	let agamemnonOriginalVersionMaterial;
 	let agamemnonSubsequentVersionMaterial;
 	let theOresteiaSubsequentVersionMaterial;
 	let aeschylusPerson;
 	let theFathersOfTragedyCompany;
+	let plughOriginalVersionMaterial;
 
 	const sandbox = createSandbox();
 
@@ -168,6 +174,106 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 				]
 			});
 
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Plugh',
+				format: 'play',
+				year: '1899',
+				writingCredits: [
+					{
+						entities: [
+							{
+								name: 'Francis Flob'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Curtain Up Ltd'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sub-Plugh',
+				format: 'play',
+				year: '2009',
+				originalVersionMaterial: {
+					name: 'Plugh'
+				},
+				writingCredits: [
+					{
+						name: 'after',
+						entities: [
+							{
+								name: 'Francis Flob'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Curtain Up Ltd'
+							}
+						]
+					},
+					{
+						name: 'version by',
+						entities: [
+							{
+								name: 'Beatrice Bar'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Stagecraft Ltd'
+							}
+						]
+					}
+				]
+			});
+
+		await chai.request(app)
+			.post('/materials')
+			.send({
+				name: 'Sur-Plugh',
+				format: 'play',
+				year: '2009',
+				originalVersionMaterial: {
+					name: 'Plugh'
+				},
+				writingCredits: [
+					{
+						name: 'after',
+						entities: [
+							{
+								name: 'Francis Flob'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Curtain Up Ltd'
+							}
+						]
+					},
+					{
+						name: 'version by',
+						entities: [
+							{
+								name: 'Beatrice Bar Jr'
+							},
+							{
+								model: 'COMPANY',
+								name: 'Sub-Stagecraft Ltd'
+							}
+						]
+					}
+				],
+				subMaterials: [
+					{
+						name: 'Sub-Plugh'
+					}
+				]
+			});
+
 		agamemnonOriginalVersionMaterial = await chai.request(app)
 			.get(`/materials/${AGAMEMNON_ORIGINAL_VERSION_MATERIAL_UUID}`);
 
@@ -182,6 +288,9 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 
 		theFathersOfTragedyCompany = await chai.request(app)
 			.get(`/companies/${THE_FATHERS_OF_TRAGEDY_COMPANY_UUID}`);
+
+		plughOriginalVersionMaterial = await chai.request(app)
+			.get(`/materials/${PLUGH_ORIGINAL_VERSION_MATERIAL_UUID}`);
 
 	});
 
@@ -452,7 +561,7 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 
 	describe('Aeschylus (person)', () => {
 
-		it('includes subsequent versions of materials they originally wrote, with corresponding sur-material', () => {
+		it('includes subsequent versions of materials they originally wrote, with corresponding sur-material; will exclude sur-materials when included via sub-material association', () => {
 
 			const expectedSubsequentVersionMaterials = [
 				{
@@ -514,7 +623,7 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 
 	describe('The Fathers of Tragedy (company)', () => {
 
-		it('includes subsequent versions of materials it originally wrote, with corresponding sur-material', () => {
+		it('includes subsequent versions of materials it originally wrote, with corresponding sur-material; will exclude sur-materials when included via sub-material association', () => {
 
 			const expectedSubsequentVersionMaterials = [
 				{
@@ -567,6 +676,52 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 			];
 
 			const { subsequentVersionMaterials } = theFathersOfTragedyCompany.body;
+
+			expect(subsequentVersionMaterials).to.deep.equal(expectedSubsequentVersionMaterials);
+
+		});
+
+	});
+
+	describe('Plugh (original version, 1899) (material): single original version is attached to multiple tiers of subsequent version', () => {
+
+		it('includes subsequent versions of this material, with corresponding sur-material; will exclude sur-materials when included via sub-material association', () => {
+
+			const expectedSubsequentVersionMaterials = [
+				{
+					model: 'MATERIAL',
+					uuid: SUB_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+					name: 'Sub-Plugh',
+					format: 'play',
+					year: 2009,
+					surMaterial: {
+						model: 'MATERIAL',
+						uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
+						name: 'Sur-Plugh',
+						surMaterial: null
+					},
+					writingCredits: [
+						{
+							model: 'WRITING_CREDIT',
+							name: 'version by',
+							entities: [
+								{
+									model: 'PERSON',
+									uuid: BEATRICE_BAR_PERSON_UUID,
+									name: 'Beatrice Bar'
+								},
+								{
+									model: 'COMPANY',
+									uuid: STAGECRAFT_LTD_COMPANY_UUID,
+									name: 'Stagecraft Ltd'
+								}
+							]
+						}
+					]
+				}
+			];
+
+			const { subsequentVersionMaterials } = plughOriginalVersionMaterial.body;
 
 			expect(subsequentVersionMaterials).to.deep.equal(expectedSubsequentVersionMaterials);
 


### PR DESCRIPTION
This PR fixes scenarios where sur-instances are unnecessarily present in credits (as outlined in below screengrabs) because they are already present via a sur-instance association.

---

An original version material's credits for:
- subsequent version materials

#### Before
<img width="528" alt="original-version-materials-before" src="https://github.com/andygout/theatrebase-api/assets/10484515/16fb93ad-6c80-4f10-a6f3-ca7e7ee141d9">

---

#### After
<img width="520" alt="original-version-materials-after" src="https://github.com/andygout/theatrebase-api/assets/10484515/a8a2ba64-f6b3-422d-a704-904489639104">

---

A source material's credits for:
- materials that used it as a source material
- productions of materials that used it as a source material

#### Before
<img width="927" alt="source-material-materials-productions-before" src="https://github.com/andygout/theatrebase-api/assets/10484515/e793cbd8-70b4-467c-ba02-9ef663ab63ba">

---

#### After
<img width="920" alt="source-material-materials-productions-after" src="https://github.com/andygout/theatrebase-api/assets/10484515/8aea48da-1dcb-4ab0-835e-4922e567fed8">

---