### PR TITLE
Rename award/nomination recipient material properties

### DIFF
--- a/src/neo4j/cypher-queries/company/show/show-awards-rights-grantor-material.js
+++ b/src/neo4j/cypher-queries/company/show/show-awards-rights-grantor-material.js
@@ -249,7 +249,7 @@ export default () => `
 			entities: nominatedEntities,
 			productions: nominatedProductions,
 			materials: nominatedMaterials,
-			rightsGrantorMaterials: nominatedRightsGrantorMaterials
+			recipientRightsGrantorMaterials: nominatedRightsGrantorMaterials
 		}) AS nominations
 		ORDER BY categoryRel.position
 

--- a/src/neo4j/cypher-queries/company/show/show-awards-sourcing-material.js
+++ b/src/neo4j/cypher-queries/company/show/show-awards-sourcing-material.js
@@ -263,7 +263,7 @@ export default () => `
 			entities: nominatedEntities,
 			productions: nominatedProductions,
 			materials: nominatedMaterials,
-			sourcingMaterials: nominatedSourcingMaterials
+			recipientSourcingMaterials: nominatedSourcingMaterials
 		}) AS nominations
 		ORDER BY categoryRel.position
 

--- a/src/neo4j/cypher-queries/company/show/show-awards-subsequent-version-material.js
+++ b/src/neo4j/cypher-queries/company/show/show-awards-subsequent-version-material.js
@@ -260,7 +260,7 @@ export default () => `
 			entities: nominatedEntities,
 			productions: nominatedProductions,
 			materials: nominatedMaterials,
-			subsequentVersionMaterials: nominatedSubsequentVersionMaterials
+			recipientSubsequentVersionMaterials: nominatedSubsequentVersionMaterials
 		}) AS nominations
 		ORDER BY categoryRel.position
 

--- a/src/neo4j/cypher-queries/material/show/show-awards-sourcing-material.js
+++ b/src/neo4j/cypher-queries/material/show/show-awards-sourcing-material.js
@@ -248,7 +248,7 @@ export default () => `
 			entities: nominatedEntities,
 			productions: nominatedProductions,
 			materials: nominatedMaterials,
-			sourcingMaterials: nominatedSourcingMaterials
+			recipientSourcingMaterials: nominatedSourcingMaterials
 		}) AS nominations
 		ORDER BY categoryRel.position
 

--- a/src/neo4j/cypher-queries/material/show/show-awards-subsequent-version-material.js
+++ b/src/neo4j/cypher-queries/material/show/show-awards-subsequent-version-material.js
@@ -250,7 +250,7 @@ export default () => `
 			entities: nominatedEntities,
 			productions: nominatedProductions,
 			materials: nominatedMaterials,
-			subsequentVersionMaterials: nominatedSubsequentVersionMaterials
+			recipientSubsequentVersionMaterials: nominatedSubsequentVersionMaterials
 		}) AS nominations
 		ORDER BY categoryRel.position
 

--- a/src/neo4j/cypher-queries/person/show/show-awards-rights-grantor-material.js
+++ b/src/neo4j/cypher-queries/person/show/show-awards-rights-grantor-material.js
@@ -249,7 +249,7 @@ export default () => `
 			entities: nominatedEntities,
 			productions: nominatedProductions,
 			materials: nominatedMaterials,
-			rightsGrantorMaterials: nominatedRightsGrantorMaterials
+			recipientRightsGrantorMaterials: nominatedRightsGrantorMaterials
 		}) AS nominations
 		ORDER BY categoryRel.position
 

--- a/src/neo4j/cypher-queries/person/show/show-awards-sourcing-material.js
+++ b/src/neo4j/cypher-queries/person/show/show-awards-sourcing-material.js
@@ -263,7 +263,7 @@ export default () => `
 			entities: nominatedEntities,
 			productions: nominatedProductions,
 			materials: nominatedMaterials,
-			sourcingMaterials: nominatedSourcingMaterials
+			recipientSourcingMaterials: nominatedSourcingMaterials
 		}) AS nominations
 		ORDER BY categoryRel.position
 

--- a/src/neo4j/cypher-queries/person/show/show-awards-subsequent-version-material.js
+++ b/src/neo4j/cypher-queries/person/show/show-awards-subsequent-version-material.js
@@ -259,7 +259,7 @@ export default () => `
 			entities: nominatedEntities,
 			productions: nominatedProductions,
 			materials: nominatedMaterials,
-			subsequentVersionMaterials: nominatedSubsequentVersionMaterials
+			recipientSubsequentVersionMaterials: nominatedSubsequentVersionMaterials
 		}) AS nominations
 		ORDER BY categoryRel.position
 

--- a/test-e2e/model-interaction/award-ceremonies-with-crediting-mat-collections-via-assocs.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-crediting-mat-collections-via-assocs.test.js
@@ -736,7 +736,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -779,7 +779,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -817,7 +817,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -882,7 +882,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -925,7 +925,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -963,7 +963,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -1028,7 +1028,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -1071,7 +1071,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -1109,7 +1109,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -1174,7 +1174,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -1217,7 +1217,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -1255,7 +1255,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -1320,7 +1320,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -1363,7 +1363,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -1401,7 +1401,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -1466,7 +1466,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -1509,7 +1509,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -1547,7 +1547,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -1612,7 +1612,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -1655,7 +1655,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -1693,7 +1693,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -1758,7 +1758,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -1801,7 +1801,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -1839,7 +1839,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -1904,7 +1904,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -1947,7 +1947,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -1985,7 +1985,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2078,7 +2078,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2121,7 +2121,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2177,7 +2177,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2220,7 +2220,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2258,7 +2258,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_PLUGH_PART_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2305,7 +2305,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2370,7 +2370,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2413,7 +2413,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2451,7 +2451,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_PLUGH_PART_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2498,7 +2498,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2563,7 +2563,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2606,7 +2606,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2662,7 +2662,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2705,7 +2705,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2743,7 +2743,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_PLUGH_PART_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2790,7 +2790,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2855,7 +2855,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2898,7 +2898,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2936,7 +2936,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_PLUGH_PART_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2983,7 +2983,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3048,7 +3048,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3091,7 +3091,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3147,7 +3147,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3190,7 +3190,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3228,7 +3228,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_PLUGH_PART_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3275,7 +3275,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3340,7 +3340,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3383,7 +3383,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3421,7 +3421,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_PLUGH_PART_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3468,7 +3468,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3561,7 +3561,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3617,7 +3617,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3673,7 +3673,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3716,7 +3716,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3754,7 +3754,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_PLUGH_PART_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3801,7 +3801,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_PLUGH_SECTION_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3844,7 +3844,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3909,7 +3909,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3965,7 +3965,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -4021,7 +4021,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -4064,7 +4064,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -4102,7 +4102,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_PLUGH_PART_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -4149,7 +4149,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_PLUGH_SECTION_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -4192,7 +4192,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -4257,7 +4257,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -4313,7 +4313,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -4369,7 +4369,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -4412,7 +4412,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -4450,7 +4450,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_PLUGH_PART_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -4497,7 +4497,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_PLUGH_SECTION_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -4540,7 +4540,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												subsequentVersionMaterials: [
+												recipientSubsequentVersionMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -4633,7 +4633,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
@@ -4676,7 +4676,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -4714,7 +4714,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -4779,7 +4779,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
@@ -4822,7 +4822,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -4860,7 +4860,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -4925,7 +4925,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
@@ -4968,7 +4968,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -5006,7 +5006,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -5071,7 +5071,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
@@ -5114,7 +5114,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -5152,7 +5152,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -5217,7 +5217,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
@@ -5260,7 +5260,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -5298,7 +5298,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -5363,7 +5363,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
@@ -5406,7 +5406,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -5444,7 +5444,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -5509,7 +5509,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
@@ -5552,7 +5552,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -5590,7 +5590,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -5655,7 +5655,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
@@ -5698,7 +5698,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -5736,7 +5736,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -5801,7 +5801,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
@@ -5844,7 +5844,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -5882,7 +5882,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -5975,7 +5975,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
@@ -6018,7 +6018,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -6074,7 +6074,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
@@ -6117,7 +6117,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -6155,7 +6155,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
@@ -6202,7 +6202,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -6267,7 +6267,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
@@ -6310,7 +6310,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -6348,7 +6348,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
@@ -6395,7 +6395,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -6460,7 +6460,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
@@ -6503,7 +6503,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -6559,7 +6559,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
@@ -6602,7 +6602,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -6640,7 +6640,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
@@ -6687,7 +6687,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -6752,7 +6752,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
@@ -6795,7 +6795,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -6833,7 +6833,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
@@ -6880,7 +6880,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -6945,7 +6945,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
@@ -6988,7 +6988,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -7044,7 +7044,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
@@ -7087,7 +7087,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -7125,7 +7125,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
@@ -7172,7 +7172,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -7237,7 +7237,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
@@ -7280,7 +7280,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -7318,7 +7318,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
@@ -7365,7 +7365,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -7458,7 +7458,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -7514,7 +7514,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -7570,7 +7570,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
@@ -7613,7 +7613,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -7651,7 +7651,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
@@ -7698,7 +7698,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_WIBBLE_SECTION_II_MATERIAL_UUID,
@@ -7741,7 +7741,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -7806,7 +7806,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -7862,7 +7862,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -7918,7 +7918,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
@@ -7961,7 +7961,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -7999,7 +7999,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
@@ -8046,7 +8046,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_WIBBLE_SECTION_II_MATERIAL_UUID,
@@ -8089,7 +8089,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -8154,7 +8154,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -8210,7 +8210,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -8266,7 +8266,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
@@ -8309,7 +8309,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -8347,7 +8347,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
@@ -8394,7 +8394,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: MID_WIBBLE_SECTION_II_MATERIAL_UUID,
@@ -8437,7 +8437,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 												entities: [],
 												productions: [],
 												materials: [],
-												sourcingMaterials: [
+												recipientSourcingMaterials: [
 													{
 														model: 'MATERIAL',
 														uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,

--- a/test-e2e/model-interaction/award-ceremonies-with-crediting-mats.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-crediting-mats.test.js
@@ -2993,7 +2993,7 @@ describe('Award ceremonies with crediting materials', () => {
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3064,7 +3064,7 @@ describe('Award ceremonies with crediting materials', () => {
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3138,7 +3138,7 @@ describe('Award ceremonies with crediting materials', () => {
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3209,7 +3209,7 @@ describe('Award ceremonies with crediting materials', () => {
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3284,7 +3284,7 @@ describe('Award ceremonies with crediting materials', () => {
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3355,7 +3355,7 @@ describe('Award ceremonies with crediting materials', () => {
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3442,7 +3442,7 @@ describe('Award ceremonies with crediting materials', () => {
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: WIBBLE_MATERIAL_UUID,
@@ -3513,7 +3513,7 @@ describe('Award ceremonies with crediting materials', () => {
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: WIBBLE_MATERIAL_UUID,
@@ -3599,7 +3599,7 @@ describe('Award ceremonies with crediting materials', () => {
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: WIBBLE_MATERIAL_UUID,
@@ -3670,7 +3670,7 @@ describe('Award ceremonies with crediting materials', () => {
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: WIBBLE_MATERIAL_UUID,
@@ -3756,7 +3756,7 @@ describe('Award ceremonies with crediting materials', () => {
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: WIBBLE_MATERIAL_UUID,
@@ -3827,7 +3827,7 @@ describe('Award ceremonies with crediting materials', () => {
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: WIBBLE_MATERIAL_UUID,
@@ -3973,7 +3973,7 @@ describe('Award ceremonies with crediting materials', () => {
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: XYZZY_MATERIAL_UUID,
@@ -4044,7 +4044,7 @@ describe('Award ceremonies with crediting materials', () => {
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: XYZZY_MATERIAL_UUID,
@@ -4119,7 +4119,7 @@ describe('Award ceremonies with crediting materials', () => {
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: XYZZY_MATERIAL_UUID,
@@ -4190,7 +4190,7 @@ describe('Award ceremonies with crediting materials', () => {
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: XYZZY_MATERIAL_UUID,
@@ -4279,7 +4279,7 @@ describe('Award ceremonies with crediting materials', () => {
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: HOGE_MATERIAL_UUID,
@@ -4336,7 +4336,7 @@ describe('Award ceremonies with crediting materials', () => {
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: HOGE_MATERIAL_UUID,
@@ -4425,7 +4425,7 @@ describe('Award ceremonies with crediting materials', () => {
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: HOGE_MATERIAL_UUID,
@@ -4482,7 +4482,7 @@ describe('Award ceremonies with crediting materials', () => {
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: HOGE_MATERIAL_UUID,

--- a/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-mats-via-assocs.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-mats-via-assocs.test.js
@@ -1891,7 +1891,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -1972,7 +1972,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2063,7 +2063,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2101,7 +2101,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 											entities: [],
 											productions: [],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_PLUGH_PART_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2187,7 +2187,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2280,7 +2280,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2361,7 +2361,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2455,7 +2455,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2493,7 +2493,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 											entities: [],
 											productions: [],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_PLUGH_PART_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2579,7 +2579,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2673,7 +2673,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2754,7 +2754,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2848,7 +2848,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2886,7 +2886,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 											entities: [],
 											productions: [],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_PLUGH_PART_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2972,7 +2972,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3064,7 +3064,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -3145,7 +3145,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -3236,7 +3236,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -3274,7 +3274,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 											entities: [],
 											productions: [],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
@@ -3360,7 +3360,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -3451,7 +3451,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -3532,7 +3532,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -3623,7 +3623,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -3661,7 +3661,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 											entities: [],
 											productions: [],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
@@ -3747,7 +3747,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -3838,7 +3838,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -3919,7 +3919,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -4010,7 +4010,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -4048,7 +4048,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 											entities: [],
 											productions: [],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
@@ -4134,7 +4134,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -4227,7 +4227,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_HOGE_MATERIAL_UUID,
@@ -4308,7 +4308,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_HOGE_PART_I_MATERIAL_UUID,
@@ -4402,7 +4402,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_HOGE_MATERIAL_UUID,
@@ -4440,7 +4440,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 											entities: [],
 											productions: [],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_HOGE_PART_II_MATERIAL_UUID,
@@ -4526,7 +4526,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_HOGE_PART_I_MATERIAL_UUID,
@@ -4620,7 +4620,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_HOGE_MATERIAL_UUID,
@@ -4701,7 +4701,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_HOGE_PART_I_MATERIAL_UUID,
@@ -4795,7 +4795,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_HOGE_MATERIAL_UUID,
@@ -4833,7 +4833,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 											entities: [],
 											productions: [],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_HOGE_PART_II_MATERIAL_UUID,
@@ -4919,7 +4919,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_HOGE_PART_I_MATERIAL_UUID,

--- a/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-mats.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-mats.test.js
@@ -2070,7 +2070,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2151,7 +2151,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2245,7 +2245,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2326,7 +2326,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -2418,7 +2418,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -2499,7 +2499,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_MATERIAL_UUID,
@@ -2590,7 +2590,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -2671,7 +2671,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_MATERIAL_UUID,
@@ -2764,7 +2764,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_HOGE_MATERIAL_UUID,
@@ -2845,7 +2845,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_HOGE_MATERIAL_UUID,
@@ -2939,7 +2939,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_HOGE_MATERIAL_UUID,
@@ -3020,7 +3020,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_HOGE_MATERIAL_UUID,

--- a/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-sub-mats-via-assocs.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-sub-mats-via-assocs.test.js
@@ -3637,7 +3637,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3713,7 +3713,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3802,7 +3802,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3907,7 +3907,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3983,7 +3983,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -4021,7 +4021,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 											entities: [],
 											productions: [],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_PLUGH_PART_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -4119,7 +4119,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -4224,7 +4224,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -4300,7 +4300,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -4338,7 +4338,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 											entities: [],
 											productions: [],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_PLUGH_PART_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -4385,7 +4385,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 											entities: [],
 											productions: [],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_PLUGH_SECTION_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -4479,7 +4479,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -4586,7 +4586,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -4662,7 +4662,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -4751,7 +4751,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -4859,7 +4859,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -4935,7 +4935,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -4973,7 +4973,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 											entities: [],
 											productions: [],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_PLUGH_PART_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -5071,7 +5071,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -5179,7 +5179,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -5255,7 +5255,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -5293,7 +5293,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 											entities: [],
 											productions: [],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_PLUGH_PART_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -5340,7 +5340,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 											entities: [],
 											productions: [],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_PLUGH_SECTION_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -5434,7 +5434,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -5542,7 +5542,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -5618,7 +5618,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -5707,7 +5707,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -5815,7 +5815,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -5891,7 +5891,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -5929,7 +5929,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 											entities: [],
 											productions: [],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_PLUGH_PART_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -6027,7 +6027,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -6135,7 +6135,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_PLUGH_SECTION_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -6211,7 +6211,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -6249,7 +6249,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 											entities: [],
 											productions: [],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_PLUGH_PART_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -6296,7 +6296,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 											entities: [],
 											productions: [],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_PLUGH_SECTION_II_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -6390,7 +6390,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_PLUGH_PART_I_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -6496,7 +6496,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
@@ -6572,7 +6572,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -6661,7 +6661,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -6766,7 +6766,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
@@ -6842,7 +6842,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -6880,7 +6880,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 											entities: [],
 											productions: [],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
@@ -6978,7 +6978,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -7083,7 +7083,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
@@ -7159,7 +7159,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -7197,7 +7197,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 											entities: [],
 											productions: [],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
@@ -7244,7 +7244,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 											entities: [],
 											productions: [],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_II_MATERIAL_UUID,
@@ -7338,7 +7338,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -7443,7 +7443,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
@@ -7519,7 +7519,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -7608,7 +7608,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -7713,7 +7713,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
@@ -7789,7 +7789,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -7827,7 +7827,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 											entities: [],
 											productions: [],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
@@ -7925,7 +7925,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -8030,7 +8030,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
@@ -8106,7 +8106,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -8144,7 +8144,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 											entities: [],
 											productions: [],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
@@ -8191,7 +8191,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 											entities: [],
 											productions: [],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_II_MATERIAL_UUID,
@@ -8285,7 +8285,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -8390,7 +8390,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
@@ -8466,7 +8466,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -8555,7 +8555,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -8660,7 +8660,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
@@ -8736,7 +8736,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -8774,7 +8774,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 											entities: [],
 											productions: [],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
@@ -8872,7 +8872,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -8977,7 +8977,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
@@ -9053,7 +9053,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -9091,7 +9091,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 											entities: [],
 											productions: [],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
@@ -9138,7 +9138,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 											entities: [],
 											productions: [],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_SECTION_II_MATERIAL_UUID,
@@ -9232,7 +9232,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
@@ -9339,7 +9339,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_HOGE_SECTION_I_MATERIAL_UUID,
@@ -9415,7 +9415,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_HOGE_MATERIAL_UUID,
@@ -9504,7 +9504,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_HOGE_PART_I_MATERIAL_UUID,
@@ -9612,7 +9612,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_HOGE_SECTION_I_MATERIAL_UUID,
@@ -9688,7 +9688,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_HOGE_MATERIAL_UUID,
@@ -9726,7 +9726,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 											entities: [],
 											productions: [],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_HOGE_PART_II_MATERIAL_UUID,
@@ -9824,7 +9824,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_HOGE_PART_I_MATERIAL_UUID,
@@ -9932,7 +9932,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_HOGE_SECTION_I_MATERIAL_UUID,
@@ -10008,7 +10008,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_HOGE_MATERIAL_UUID,
@@ -10046,7 +10046,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 											entities: [],
 											productions: [],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_HOGE_PART_II_MATERIAL_UUID,
@@ -10093,7 +10093,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 											entities: [],
 											productions: [],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_HOGE_SECTION_II_MATERIAL_UUID,
@@ -10187,7 +10187,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_HOGE_PART_I_MATERIAL_UUID,
@@ -10295,7 +10295,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_HOGE_SECTION_I_MATERIAL_UUID,
@@ -10371,7 +10371,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_HOGE_MATERIAL_UUID,
@@ -10460,7 +10460,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_HOGE_PART_I_MATERIAL_UUID,
@@ -10568,7 +10568,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_HOGE_SECTION_I_MATERIAL_UUID,
@@ -10644,7 +10644,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_HOGE_MATERIAL_UUID,
@@ -10682,7 +10682,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 											entities: [],
 											productions: [],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_HOGE_PART_II_MATERIAL_UUID,
@@ -10780,7 +10780,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_HOGE_PART_I_MATERIAL_UUID,
@@ -10888,7 +10888,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_HOGE_SECTION_I_MATERIAL_UUID,
@@ -10964,7 +10964,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_HOGE_MATERIAL_UUID,
@@ -11002,7 +11002,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 											entities: [],
 											productions: [],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_HOGE_PART_II_MATERIAL_UUID,
@@ -11049,7 +11049,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 											entities: [],
 											productions: [],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_HOGE_SECTION_II_MATERIAL_UUID,
@@ -11143,7 +11143,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_HOGE_PART_I_MATERIAL_UUID,

--- a/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-sub-mats.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-sub-mats.test.js
@@ -3173,7 +3173,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3249,7 +3249,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3338,7 +3338,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3446,7 +3446,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3522,7 +3522,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3611,7 +3611,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 												}
 											],
 											materials: [],
-											subsequentVersionMaterials: [
+											recipientSubsequentVersionMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_PLUGH_SUBSEQUENT_VERSION_MATERIAL_UUID,
@@ -3717,7 +3717,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_MATERIAL_UUID,
@@ -3793,7 +3793,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -3882,7 +3882,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_MATERIAL_UUID,
@@ -3987,7 +3987,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_WIBBLE_MATERIAL_UUID,
@@ -4063,7 +4063,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_WIBBLE_MATERIAL_UUID,
@@ -4152,7 +4152,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 												}
 											],
 											materials: [],
-											sourcingMaterials: [
+											recipientSourcingMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_WIBBLE_MATERIAL_UUID,
@@ -4259,7 +4259,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_HOGE_MATERIAL_UUID,
@@ -4335,7 +4335,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_HOGE_MATERIAL_UUID,
@@ -4424,7 +4424,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_HOGE_MATERIAL_UUID,
@@ -4532,7 +4532,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: MID_HOGE_MATERIAL_UUID,
@@ -4608,7 +4608,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUR_HOGE_MATERIAL_UUID,
@@ -4697,7 +4697,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 												}
 											],
 											materials: [],
-											rightsGrantorMaterials: [
+											recipientRightsGrantorMaterials: [
 												{
 													model: 'MATERIAL',
 													uuid: SUB_HOGE_MATERIAL_UUID,


### PR DESCRIPTION
This PR renames the below properties returned in the various awards show Cypher queries for companies, materials, and people.

This will provide consistency alongside the existing `recipientMaterial`/`recipientProduction` properties.

- `rightsGrantorMaterials` -> `recipientRightsGrantorMaterials`
- `sourcingMaterials` -> `recipientSourcingMaterials`
- `subsequentVersionMaterials` -> `recipientSubsequentVersionMaterials`