### PR TITLE
Enable multiple recipientMaterials + recipientProductions

### DIFF
--- a/src/neo4j/cypher-queries/production/show/show-awards.js
+++ b/src/neo4j/cypher-queries/production/show/show-awards.js
@@ -234,14 +234,25 @@ export default () => `
 				}
 			END
 		) AS nominatedMaterials
-		ORDER BY nomineeRel.nominationPosition
+		ORDER BY nomineeRel.nominationPosition, nomineeRel.productionPosition
+
+	WITH
+		nomineeRel.isWinner AS isWinner,
+		nomineeRel.customType AS customType,
+		category,
+		categoryRel,
+		ceremony,
+		nominatedEntities,
+		coNominatedProductions,
+		nominatedMaterials,
+		COLLECT(recipientProduction) AS recipientProductions
 
 	WITH category, categoryRel, ceremony,
 		COLLECT({
 			model: 'NOMINATION',
-			isWinner: COALESCE(nomineeRel.isWinner, false),
-			type: COALESCE(nomineeRel.customType, CASE WHEN nomineeRel.isWinner THEN 'Winner' ELSE 'Nomination' END),
-			recipientProduction: CASE WHEN recipientProduction IS NULL THEN null ELSE recipientProduction END,
+			isWinner: COALESCE(isWinner, false),
+			type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
+			recipientProductions: recipientProductions,
 			entities: nominatedEntities,
 			coProductions: coNominatedProductions,
 			materials: nominatedMaterials

--- a/test-e2e/model-interaction/award-ceremonies-with-sub-mats-sub-prods.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-sub-mats-sub-prods.test.js
@@ -1247,19 +1247,21 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientProduction: {
-												model: 'PRODUCTION',
-												uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-												name: 'Sur-Hoge',
-												startDate: '2019-05-01',
-												endDate: '2019-05-31',
-												venue: {
-													model: 'VENUE',
-													uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
-													name: 'Noël Coward Theatre',
-													surVenue: null
+											recipientProductions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sur-Hoge',
+													startDate: '2019-05-01',
+													endDate: '2019-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													}
 												}
-											},
+											],
 											entities: [
 												{
 													model: 'PERSON',
@@ -1342,7 +1344,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Nomination',
-											recipientProduction: null,
+											recipientProductions: [],
 											entities: [
 												{
 													model: 'PERSON',
@@ -1455,7 +1457,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientProduction: null,
+											recipientProductions: [],
 											entities: [
 												{
 													model: 'PERSON',
@@ -1538,19 +1540,21 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Nomination',
-											recipientProduction: {
-												model: 'PRODUCTION',
-												uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-												name: 'Sub-Hoge',
-												startDate: '2019-05-01',
-												endDate: '2019-05-31',
-												venue: {
-													model: 'VENUE',
-													uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
-													name: 'Noël Coward Theatre',
-													surVenue: null
+											recipientProductions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sub-Hoge',
+													startDate: '2019-05-01',
+													endDate: '2019-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													}
 												}
-											},
+											],
 											entities: [
 												{
 													model: 'PERSON',
@@ -1663,23 +1667,25 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientProduction: {
-												model: 'PRODUCTION',
-												uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-												name: 'Sur-Wibble',
-												startDate: '2019-06-01',
-												endDate: '2019-06-30',
-												venue: {
-													model: 'VENUE',
-													uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
-													name: 'Jerwood Theatre Upstairs',
-													surVenue: {
+											recipientProductions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sur-Wibble',
+													startDate: '2019-06-01',
+													endDate: '2019-06-30',
+													venue: {
 														model: 'VENUE',
-														uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
-														name: 'Royal Court Theatre'
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
 													}
 												}
-											},
+											],
 											entities: [
 												{
 													model: 'PERSON',
@@ -1758,7 +1764,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Nomination',
-											recipientProduction: null,
+											recipientProductions: [],
 											entities: [
 												{
 													model: 'PERSON',
@@ -1867,23 +1873,25 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientProduction: {
-												model: 'PRODUCTION',
-												uuid: SUB_WIBBLE_PART_II_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-												name: 'Sub-Wibble: Part II',
-												startDate: '2019-06-01',
-												endDate: '2019-06-30',
-												venue: {
-													model: 'VENUE',
-													uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
-													name: 'Jerwood Theatre Upstairs',
-													surVenue: {
+											recipientProductions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_WIBBLE_PART_II_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sub-Wibble: Part II',
+													startDate: '2019-06-01',
+													endDate: '2019-06-30',
+													venue: {
 														model: 'VENUE',
-														uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
-														name: 'Royal Court Theatre'
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
 													}
 												}
-											},
+											],
 											entities: [],
 											coProductions: [],
 											materials: [
@@ -1926,7 +1934,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientProduction: null,
+											recipientProductions: [],
 											entities: [
 												{
 													model: 'PERSON',
@@ -2005,23 +2013,25 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Nomination',
-											recipientProduction: {
-												model: 'PRODUCTION',
-												uuid: SUB_WIBBLE_PART_I_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-												name: 'Sub-Wibble: Part I',
-												startDate: '2019-06-01',
-												endDate: '2019-06-30',
-												venue: {
-													model: 'VENUE',
-													uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
-													name: 'Jerwood Theatre Upstairs',
-													surVenue: {
+											recipientProductions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_WIBBLE_PART_I_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sub-Wibble: Part I',
+													startDate: '2019-06-01',
+													endDate: '2019-06-30',
+													venue: {
 														model: 'VENUE',
-														uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
-														name: 'Royal Court Theatre'
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
 													}
 												}
-											},
+											],
 											entities: [
 												{
 													model: 'PERSON',
@@ -2130,13 +2140,15 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientMaterial: {
-												model: 'MATERIAL',
-												uuid: SUR_WIBBLE_MATERIAL_UUID,
-												name: 'Sur-Wibble',
-												format: 'collection of plays',
-												year: 2019
-											},
+											recipientMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_WIBBLE_MATERIAL_UUID,
+													name: 'Sur-Wibble',
+													format: 'collection of plays',
+													year: 2019
+												}
+											],
 											entities: [
 												{
 													model: 'PERSON',
@@ -2225,7 +2237,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Nomination',
-											recipientMaterial: null,
+											recipientMaterials: [],
 											entities: [
 												{
 													model: 'PERSON',
@@ -2344,13 +2356,15 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientMaterial: {
-												model: 'MATERIAL',
-												uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
-												name: 'Sub-Wibble: Part II',
-												format: 'play',
-												year: 2019
-											},
+											recipientMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
+													name: 'Sub-Wibble: Part II',
+													format: 'play',
+													year: 2019
+												}
+											],
 											entities: [],
 											productions: [
 												{
@@ -2403,7 +2417,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientMaterial: null,
+											recipientMaterials: [],
 											entities: [
 												{
 													model: 'PERSON',
@@ -2492,13 +2506,15 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Nomination',
-											recipientMaterial: {
-												model: 'MATERIAL',
-												uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
-												name: 'Sub-Wibble: Part I',
-												format: 'play',
-												year: 2019
-											},
+											recipientMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
+													name: 'Sub-Wibble: Part I',
+													format: 'play',
+													year: 2019
+												}
+											],
 											entities: [
 												{
 													model: 'PERSON',

--- a/test-e2e/model-interaction/award-ceremonies-with-sub-sub-mats-sub-sub-prods.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-sub-sub-mats-sub-sub-prods.test.js
@@ -1949,19 +1949,21 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientProduction: {
-												model: 'PRODUCTION',
-												uuid: MID_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-												name: 'Mid-Hoge',
-												startDate: '2019-05-01',
-												endDate: '2019-05-31',
-												venue: {
-													model: 'VENUE',
-													uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
-													name: 'Noël Coward Theatre',
-													surVenue: null
+											recipientProductions: [
+												{
+													model: 'PRODUCTION',
+													uuid: MID_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Mid-Hoge',
+													startDate: '2019-05-01',
+													endDate: '2019-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													}
 												}
-											},
+											],
 											entities: [
 												{
 													model: 'PERSON',
@@ -2059,19 +2061,21 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientProduction: {
-												model: 'PRODUCTION',
-												uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-												name: 'Sur-Hoge',
-												startDate: '2019-05-01',
-												endDate: '2019-05-31',
-												venue: {
-													model: 'VENUE',
-													uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
-													name: 'Noël Coward Theatre',
-													surVenue: null
+											recipientProductions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sur-Hoge',
+													startDate: '2019-05-01',
+													endDate: '2019-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													}
 												}
-											},
+											],
 											entities: [
 												{
 													model: 'PERSON',
@@ -2154,7 +2158,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Nomination',
-											recipientProduction: null,
+											recipientProductions: [],
 											entities: [
 												{
 													model: 'PERSON',
@@ -2279,7 +2283,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientProduction: null,
+											recipientProductions: [],
 											entities: [
 												{
 													model: 'PERSON',
@@ -2377,19 +2381,21 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientProduction: {
-												model: 'PRODUCTION',
-												uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-												name: 'Sur-Hoge',
-												startDate: '2019-05-01',
-												endDate: '2019-05-31',
-												venue: {
-													model: 'VENUE',
-													uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
-													name: 'Noël Coward Theatre',
-													surVenue: null
+											recipientProductions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sur-Hoge',
+													startDate: '2019-05-01',
+													endDate: '2019-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													}
 												}
-											},
+											],
 											entities: [
 												{
 													model: 'PERSON',
@@ -2472,19 +2478,21 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Nomination',
-											recipientProduction: {
-												model: 'PRODUCTION',
-												uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-												name: 'Sub-Hoge',
-												startDate: '2019-05-01',
-												endDate: '2019-05-31',
-												venue: {
-													model: 'VENUE',
-													uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
-													name: 'Noël Coward Theatre',
-													surVenue: null
+											recipientProductions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sub-Hoge',
+													startDate: '2019-05-01',
+													endDate: '2019-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													}
 												}
-											},
+											],
 											entities: [
 												{
 													model: 'PERSON',
@@ -2609,19 +2617,21 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientProduction: {
-												model: 'PRODUCTION',
-												uuid: MID_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-												name: 'Mid-Hoge',
-												startDate: '2019-05-01',
-												endDate: '2019-05-31',
-												venue: {
-													model: 'VENUE',
-													uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
-													name: 'Noël Coward Theatre',
-													surVenue: null
+											recipientProductions: [
+												{
+													model: 'PRODUCTION',
+													uuid: MID_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Mid-Hoge',
+													startDate: '2019-05-01',
+													endDate: '2019-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													}
 												}
-											},
+											],
 											entities: [
 												{
 													model: 'PERSON',
@@ -2719,7 +2729,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientProduction: null,
+											recipientProductions: [],
 											entities: [
 												{
 													model: 'PERSON',
@@ -2802,19 +2812,21 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Nomination',
-											recipientProduction: {
-												model: 'PRODUCTION',
-												uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID,
-												name: 'Sub-Hoge',
-												startDate: '2019-05-01',
-												endDate: '2019-05-31',
-												venue: {
-													model: 'VENUE',
-													uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
-													name: 'Noël Coward Theatre',
-													surVenue: null
+											recipientProductions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID,
+													name: 'Sub-Hoge',
+													startDate: '2019-05-01',
+													endDate: '2019-05-31',
+													venue: {
+														model: 'VENUE',
+														uuid: NOËL_COWARD_THEATRE_VENUE_UUID,
+														name: 'Noël Coward Theatre',
+														surVenue: null
+													}
 												}
-											},
+											],
 											entities: [
 												{
 													model: 'PERSON',
@@ -2939,23 +2951,25 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientProduction: {
-												model: 'PRODUCTION',
-												uuid: MID_WIBBLE_SECTION_I_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-												name: 'Mid-Wibble: Section I',
-												startDate: '2019-06-01',
-												endDate: '2019-06-30',
-												venue: {
-													model: 'VENUE',
-													uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
-													name: 'Jerwood Theatre Upstairs',
-													surVenue: {
+											recipientProductions: [
+												{
+													model: 'PRODUCTION',
+													uuid: MID_WIBBLE_SECTION_I_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Mid-Wibble: Section I',
+													startDate: '2019-06-01',
+													endDate: '2019-06-30',
+													venue: {
 														model: 'VENUE',
-														uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
-														name: 'Royal Court Theatre'
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
 													}
 												}
-											},
+											],
 											entities: [
 												{
 													model: 'PERSON',
@@ -3049,23 +3063,25 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientProduction: {
-												model: 'PRODUCTION',
-												uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-												name: 'Sur-Wibble',
-												startDate: '2019-06-01',
-												endDate: '2019-06-30',
-												venue: {
-													model: 'VENUE',
-													uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
-													name: 'Jerwood Theatre Upstairs',
-													surVenue: {
+											recipientProductions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sur-Wibble',
+													startDate: '2019-06-01',
+													endDate: '2019-06-30',
+													venue: {
 														model: 'VENUE',
-														uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
-														name: 'Royal Court Theatre'
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
 													}
 												}
-											},
+											],
 											entities: [
 												{
 													model: 'PERSON',
@@ -3144,7 +3160,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Nomination',
-											recipientProduction: null,
+											recipientProductions: [],
 											entities: [
 												{
 													model: 'PERSON',
@@ -3265,7 +3281,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientProduction: null,
+											recipientProductions: [],
 											entities: [
 												{
 													model: 'PERSON',
@@ -3359,23 +3375,25 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientProduction: {
-												model: 'PRODUCTION',
-												uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-												name: 'Sur-Wibble',
-												startDate: '2019-06-01',
-												endDate: '2019-06-30',
-												venue: {
-													model: 'VENUE',
-													uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
-													name: 'Jerwood Theatre Upstairs',
-													surVenue: {
+											recipientProductions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sur-Wibble',
+													startDate: '2019-06-01',
+													endDate: '2019-06-30',
+													venue: {
 														model: 'VENUE',
-														uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
-														name: 'Royal Court Theatre'
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
 													}
 												}
-											},
+											],
 											entities: [
 												{
 													model: 'PERSON',
@@ -3454,23 +3472,25 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Nomination',
-											recipientProduction: {
-												model: 'PRODUCTION',
-												uuid: SUB_WIBBLE_PART_I_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-												name: 'Sub-Wibble: Part I',
-												startDate: '2019-06-01',
-												endDate: '2019-06-30',
-												venue: {
-													model: 'VENUE',
-													uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
-													name: 'Jerwood Theatre Upstairs',
-													surVenue: {
+											recipientProductions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_WIBBLE_PART_I_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sub-Wibble: Part I',
+													startDate: '2019-06-01',
+													endDate: '2019-06-30',
+													venue: {
 														model: 'VENUE',
-														uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
-														name: 'Royal Court Theatre'
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
 													}
 												}
-											},
+											],
 											entities: [
 												{
 													model: 'PERSON',
@@ -3576,23 +3596,25 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Nomination',
-											recipientProduction: {
-												model: 'PRODUCTION',
-												uuid: SUB_WIBBLE_PART_II_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-												name: 'Sub-Wibble: Part II',
-												startDate: '2019-06-01',
-												endDate: '2019-06-30',
-												venue: {
-													model: 'VENUE',
-													uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
-													name: 'Jerwood Theatre Upstairs',
-													surVenue: {
+											recipientProductions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_WIBBLE_PART_II_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sub-Wibble: Part II',
+													startDate: '2019-06-01',
+													endDate: '2019-06-30',
+													venue: {
 														model: 'VENUE',
-														uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
-														name: 'Royal Court Theatre'
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
 													}
 												}
-											},
+											],
 											entities: [],
 											coProductions: [],
 											materials: [
@@ -3654,23 +3676,25 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientProduction: {
-												model: 'PRODUCTION',
-												uuid: MID_WIBBLE_SECTION_I_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-												name: 'Mid-Wibble: Section I',
-												startDate: '2019-06-01',
-												endDate: '2019-06-30',
-												venue: {
-													model: 'VENUE',
-													uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
-													name: 'Jerwood Theatre Upstairs',
-													surVenue: {
+											recipientProductions: [
+												{
+													model: 'PRODUCTION',
+													uuid: MID_WIBBLE_SECTION_I_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Mid-Wibble: Section I',
+													startDate: '2019-06-01',
+													endDate: '2019-06-30',
+													venue: {
 														model: 'VENUE',
-														uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
-														name: 'Royal Court Theatre'
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
 													}
 												}
-											},
+											],
 											entities: [
 												{
 													model: 'PERSON',
@@ -3764,7 +3788,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientProduction: null,
+											recipientProductions: [],
 											entities: [
 												{
 													model: 'PERSON',
@@ -3843,23 +3867,25 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Nomination',
-											recipientProduction: {
-												model: 'PRODUCTION',
-												uuid: SUB_WIBBLE_PART_I_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-												name: 'Sub-Wibble: Part I',
-												startDate: '2019-06-01',
-												endDate: '2019-06-30',
-												venue: {
-													model: 'VENUE',
-													uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
-													name: 'Jerwood Theatre Upstairs',
-													surVenue: {
+											recipientProductions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_WIBBLE_PART_I_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sub-Wibble: Part I',
+													startDate: '2019-06-01',
+													endDate: '2019-06-30',
+													venue: {
 														model: 'VENUE',
-														uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
-														name: 'Royal Court Theatre'
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
 													}
 												}
-											},
+											],
 											entities: [
 												{
 													model: 'PERSON',
@@ -3965,23 +3991,25 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Nomination',
-											recipientProduction: {
-												model: 'PRODUCTION',
-												uuid: SUB_WIBBLE_PART_II_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-												name: 'Sub-Wibble: Part II',
-												startDate: '2019-06-01',
-												endDate: '2019-06-30',
-												venue: {
-													model: 'VENUE',
-													uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
-													name: 'Jerwood Theatre Upstairs',
-													surVenue: {
+											recipientProductions: [
+												{
+													model: 'PRODUCTION',
+													uuid: SUB_WIBBLE_PART_II_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Sub-Wibble: Part II',
+													startDate: '2019-06-01',
+													endDate: '2019-06-30',
+													venue: {
 														model: 'VENUE',
-														uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
-														name: 'Royal Court Theatre'
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
 													}
 												}
-											},
+											],
 											entities: [],
 											coProductions: [],
 											materials: [
@@ -4028,23 +4056,25 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientProduction: {
-												model: 'PRODUCTION',
-												uuid: MID_WIBBLE_SECTION_II_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
-												name: 'Mid-Wibble: Section II',
-												startDate: '2019-06-01',
-												endDate: '2019-06-30',
-												venue: {
-													model: 'VENUE',
-													uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
-													name: 'Jerwood Theatre Upstairs',
-													surVenue: {
+											recipientProductions: [
+												{
+													model: 'PRODUCTION',
+													uuid: MID_WIBBLE_SECTION_II_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID,
+													name: 'Mid-Wibble: Section II',
+													startDate: '2019-06-01',
+													endDate: '2019-06-30',
+													venue: {
 														model: 'VENUE',
-														uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
-														name: 'Royal Court Theatre'
+														uuid: JERWOOD_THEATRE_UPSTAIRS_VENUE_UUID,
+														name: 'Jerwood Theatre Upstairs',
+														surVenue: {
+															model: 'VENUE',
+															uuid: ROYAL_COURT_THEATRE_VENUE_UUID,
+															name: 'Royal Court Theatre'
+														}
 													}
 												}
-											},
+											],
 											entities: [],
 											coProductions: [],
 											materials: [
@@ -4102,13 +4132,15 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientMaterial: {
-												model: 'MATERIAL',
-												uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
-												name: 'Mid-Wibble: Section I',
-												format: 'sub-collection of plays',
-												year: 2019
-											},
+											recipientMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+													name: 'Mid-Wibble: Section I',
+													format: 'sub-collection of plays',
+													year: 2019
+												}
+											],
 											entities: [
 												{
 													model: 'PERSON',
@@ -4212,13 +4244,15 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientMaterial: {
-												model: 'MATERIAL',
-												uuid: SUR_WIBBLE_MATERIAL_UUID,
-												name: 'Sur-Wibble',
-												format: 'collection of plays',
-												year: 2019
-											},
+											recipientMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_WIBBLE_MATERIAL_UUID,
+													name: 'Sur-Wibble',
+													format: 'collection of plays',
+													year: 2019
+												}
+											],
 											entities: [
 												{
 													model: 'PERSON',
@@ -4307,7 +4341,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Nomination',
-											recipientMaterial: null,
+											recipientMaterials: [],
 											entities: [
 												{
 													model: 'PERSON',
@@ -4438,7 +4472,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientMaterial: null,
+											recipientMaterials: [],
 											entities: [
 												{
 													model: 'PERSON',
@@ -4542,13 +4576,15 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientMaterial: {
-												model: 'MATERIAL',
-												uuid: SUR_WIBBLE_MATERIAL_UUID,
-												name: 'Sur-Wibble',
-												format: 'collection of plays',
-												year: 2019
-											},
+											recipientMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUR_WIBBLE_MATERIAL_UUID,
+													name: 'Sur-Wibble',
+													format: 'collection of plays',
+													year: 2019
+												}
+											],
 											entities: [
 												{
 													model: 'PERSON',
@@ -4637,13 +4673,15 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Nomination',
-											recipientMaterial: {
-												model: 'MATERIAL',
-												uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
-												name: 'Sub-Wibble: Part I',
-												format: 'play',
-												year: 2019
-											},
+											recipientMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
+													name: 'Sub-Wibble: Part I',
+													format: 'play',
+													year: 2019
+												}
+											],
 											entities: [
 												{
 													model: 'PERSON',
@@ -4759,13 +4797,15 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Nomination',
-											recipientMaterial: {
-												model: 'MATERIAL',
-												uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
-												name: 'Sub-Wibble: Part II',
-												format: 'play',
-												year: 2019
-											},
+											recipientMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
+													name: 'Sub-Wibble: Part II',
+													format: 'play',
+													year: 2019
+												}
+											],
 											entities: [],
 											productions: [
 												{
@@ -4837,13 +4877,15 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientMaterial: {
-												model: 'MATERIAL',
-												uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
-												name: 'Mid-Wibble: Section I',
-												format: 'sub-collection of plays',
-												year: 2019
-											},
+											recipientMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: MID_WIBBLE_SECTION_I_MATERIAL_UUID,
+													name: 'Mid-Wibble: Section I',
+													format: 'sub-collection of plays',
+													year: 2019
+												}
+											],
 											entities: [
 												{
 													model: 'PERSON',
@@ -4947,7 +4989,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientMaterial: null,
+											recipientMaterials: [],
 											entities: [
 												{
 													model: 'PERSON',
@@ -5036,13 +5078,15 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Nomination',
-											recipientMaterial: {
-												model: 'MATERIAL',
-												uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
-												name: 'Sub-Wibble: Part I',
-												format: 'play',
-												year: 2019
-											},
+											recipientMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_WIBBLE_PART_I_MATERIAL_UUID,
+													name: 'Sub-Wibble: Part I',
+													format: 'play',
+													year: 2019
+												}
+											],
 											entities: [
 												{
 													model: 'PERSON',
@@ -5158,13 +5202,15 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Nomination',
-											recipientMaterial: {
-												model: 'MATERIAL',
-												uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
-												name: 'Sub-Wibble: Part II',
-												format: 'play',
-												year: 2019
-											},
+											recipientMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: SUB_WIBBLE_PART_II_MATERIAL_UUID,
+													name: 'Sub-Wibble: Part II',
+													format: 'play',
+													year: 2019
+												}
+											],
 											entities: [],
 											productions: [
 												{
@@ -5221,13 +5267,15 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientMaterial: {
-												model: 'MATERIAL',
-												uuid: MID_WIBBLE_SECTION_II_MATERIAL_UUID,
-												name: 'Mid-Wibble: Section II',
-												format: 'sub-collection of plays',
-												year: 2019
-											},
+											recipientMaterials: [
+												{
+													model: 'MATERIAL',
+													uuid: MID_WIBBLE_SECTION_II_MATERIAL_UUID,
+													name: 'Mid-Wibble: Section II',
+													format: 'sub-collection of plays',
+													year: 2019
+												}
+											],
 											entities: [],
 											productions: [
 												{

--- a/test-e2e/model-interaction/award-ceremonies.test.js
+++ b/test-e2e/model-interaction/award-ceremonies.test.js
@@ -5773,7 +5773,7 @@ describe('Award ceremonies', () => {
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Finalist',
-											recipientProduction: null,
+											recipientProductions: [],
 											entities: [
 												{
 													model: 'COMPANY',
@@ -5847,7 +5847,7 @@ describe('Award ceremonies', () => {
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Finalist',
-											recipientProduction: null,
+											recipientProductions: [],
 											entities: [],
 											coProductions: [],
 											materials: []
@@ -5876,7 +5876,7 @@ describe('Award ceremonies', () => {
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Shortlisted',
-											recipientProduction: null,
+											recipientProductions: [],
 											entities: [
 												{
 													model: 'PERSON',
@@ -5928,7 +5928,7 @@ describe('Award ceremonies', () => {
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'First Place',
-											recipientProduction: null,
+											recipientProductions: [],
 											entities: [],
 											coProductions: [],
 											materials: []
@@ -5957,7 +5957,7 @@ describe('Award ceremonies', () => {
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientProduction: null,
+											recipientProductions: [],
 											entities: [
 												{
 													model: 'PERSON',
@@ -5996,7 +5996,7 @@ describe('Award ceremonies', () => {
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Nomination',
-											recipientProduction: null,
+											recipientProductions: [],
 											entities: [
 												{
 													model: 'COMPANY',
@@ -6085,7 +6085,7 @@ describe('Award ceremonies', () => {
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientProduction: null,
+											recipientProductions: [],
 											entities: [],
 											coProductions: [
 												{
@@ -6144,7 +6144,7 @@ describe('Award ceremonies', () => {
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Longlisted',
-											recipientProduction: null,
+											recipientProductions: [],
 											entities: [
 												{
 													model: 'PERSON',
@@ -6226,7 +6226,7 @@ describe('Award ceremonies', () => {
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Longlisted',
-											recipientProduction: null,
+											recipientProductions: [],
 											entities: [],
 											coProductions: [
 												{
@@ -6274,7 +6274,7 @@ describe('Award ceremonies', () => {
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Nomination',
-											recipientProduction: null,
+											recipientProductions: [],
 											entities: [
 												{
 													model: 'PERSON',
@@ -6334,7 +6334,7 @@ describe('Award ceremonies', () => {
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientProduction: null,
+											recipientProductions: [],
 											entities: [],
 											coProductions: [
 												{
@@ -6397,7 +6397,7 @@ describe('Award ceremonies', () => {
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Finalist',
-											recipientMaterial: null,
+											recipientMaterials: [],
 											entities: [
 												{
 													model: 'COMPANY',
@@ -6481,7 +6481,7 @@ describe('Award ceremonies', () => {
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Prize Recipient',
-											recipientMaterial: null,
+											recipientMaterials: [],
 											entities: [],
 											productions: [],
 											coMaterials: [
@@ -6519,7 +6519,7 @@ describe('Award ceremonies', () => {
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Shortlisted',
-											recipientMaterial: null,
+											recipientMaterials: [],
 											entities: [
 												{
 													model: 'PERSON',
@@ -6581,7 +6581,7 @@ describe('Award ceremonies', () => {
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Shortlisted',
-											recipientMaterial: null,
+											recipientMaterials: [],
 											entities: [],
 											productions: [],
 											coMaterials: []
@@ -6610,7 +6610,7 @@ describe('Award ceremonies', () => {
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'Winner',
-											recipientMaterial: null,
+											recipientMaterials: [],
 											entities: [
 												{
 													model: 'PERSON',
@@ -6658,7 +6658,7 @@ describe('Award ceremonies', () => {
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Nomination',
-											recipientMaterial: null,
+											recipientMaterials: [],
 											entities: [
 												{
 													model: 'COMPANY',
@@ -6756,7 +6756,7 @@ describe('Award ceremonies', () => {
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Nomination',
-											recipientMaterial: null,
+											recipientMaterials: [],
 											entities: [],
 											productions: [],
 											coMaterials: [
@@ -6809,7 +6809,7 @@ describe('Award ceremonies', () => {
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Longlisted',
-											recipientMaterial: null,
+											recipientMaterials: [],
 											entities: [
 												{
 													model: 'PERSON',
@@ -6897,7 +6897,7 @@ describe('Award ceremonies', () => {
 											model: 'NOMINATION',
 											isWinner: true,
 											type: 'First Place',
-											recipientMaterial: null,
+											recipientMaterials: [],
 											entities: [],
 											productions: [],
 											coMaterials: []
@@ -6926,7 +6926,7 @@ describe('Award ceremonies', () => {
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Nomination',
-											recipientMaterial: null,
+											recipientMaterials: [],
 											entities: [
 												{
 													model: 'PERSON',
@@ -6991,7 +6991,7 @@ describe('Award ceremonies', () => {
 											model: 'NOMINATION',
 											isWinner: false,
 											type: 'Nomination',
-											recipientMaterial: null,
+											recipientMaterials: [],
 											entities: [],
 											productions: [],
 											coMaterials: [


### PR DESCRIPTION
This PR applies changes to the material and production show awards Cypher queries to accommodate the (admittedly unlikely) scenario of there being multiple instances of `recipientMaterial` and `recipientProduction` respectively, e.g. a sur-instance might have two of its three sub-instances nominated for an award.

This results in the following property renames:
- `recipientMaterial` (object) -> `recipientMaterials` (array of objects)
- `recipientProduction` (object) -> `recipientProductions` (array of objects)