### PR TITLE
Revise Cypher model facet show queries to handle Not Found scenarios

### DIFF
--- a/src/neo4j/cypher-queries/company/show/show-awards-rights-grantor-material.js
+++ b/src/neo4j/cypher-queries/company/show/show-awards-rights-grantor-material.js
@@ -1,266 +1,273 @@
 export default () => `
 	MATCH (company:Company { uuid: $uuid })
 
-	OPTIONAL MATCH (company)
-		<-[:HAS_WRITING_ENTITY { creditType: 'RIGHTS_GRANTOR' }]
-		-(material:Material)-[:HAS_SUB_MATERIAL*0..2]-(nominatedRightsGrantorMaterial:Material)
-		<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
-		<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
-		WHERE
-			(material)-[:HAS_SUB_MATERIAL*0..2]->(nominatedRightsGrantorMaterial:Material) OR
-			(material)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedRightsGrantorMaterial:Material)
+	CALL {
+		WITH company
 
-	OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)
-		WHERE
-			(
-				(nominatedEntity:Person AND nominatedEntityRel.nominatedCompanyUuid IS NULL) OR
-				nominatedEntity:Company
-			) AND
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = nominatedEntityRel.nominationPosition
-			)
+		OPTIONAL MATCH (company)
+			<-[:HAS_WRITING_ENTITY { creditType: 'RIGHTS_GRANTOR' }]
+			-(material:Material)-[:HAS_SUB_MATERIAL*0..2]-(nominatedRightsGrantorMaterial:Material)
+			<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
+			<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
+			WHERE
+				(material)-[:HAS_SUB_MATERIAL*0..2]->(nominatedRightsGrantorMaterial:Material) OR
+				(material)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedRightsGrantorMaterial:Material)
 
-	WITH nominatedRightsGrantorMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntityRel,
-		COLLECT(nominatedEntity {
-			model: TOUPPER(HEAD(LABELS(nominatedEntity))),
-			.uuid,
-			.name,
-			nominatedMemberUuids: nominatedEntityRel.nominatedMemberUuids
-		}) AS nominatedEntities
+		OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)
+			WHERE
+				(
+					(nominatedEntity:Person AND nominatedEntityRel.nominatedCompanyUuid IS NULL) OR
+					nominatedEntity:Company
+				) AND
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = nominatedEntityRel.nominationPosition
+				)
 
-	UNWIND (CASE nominatedEntities WHEN [] THEN [null] ELSE nominatedEntities END) AS nominatedEntity
+		WITH nominatedRightsGrantorMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntityRel,
+			COLLECT(nominatedEntity {
+				model: TOUPPER(HEAD(LABELS(nominatedEntity))),
+				.uuid,
+				.name,
+				nominatedMemberUuids: nominatedEntityRel.nominatedMemberUuids
+			}) AS nominatedEntities
 
-		UNWIND (COALESCE(nominatedEntity.nominatedMemberUuids, [null])) AS nominatedMemberUuid
+		UNWIND (CASE nominatedEntities WHEN [] THEN [null] ELSE nominatedEntities END) AS nominatedEntity
 
-			OPTIONAL MATCH (category)-[nominatedMemberRel:HAS_NOMINEE]->
-				(nominatedMember:Person { uuid: nominatedMemberUuid })
-				WHERE
-					nominatedEntityRel.nominationPosition IS NULL OR
-					nominatedEntityRel.nominationPosition = nominatedMemberRel.nominationPosition
+			UNWIND (COALESCE(nominatedEntity.nominatedMemberUuids, [null])) AS nominatedMemberUuid
 
-			WITH
-				nominatedRightsGrantorMaterial,
-				nomineeRel,
-				category,
-				categoryRel,
-				ceremony,
-				nominatedEntityRel,
-				nominatedEntity,
-				nominatedMember
-				ORDER BY nominatedMemberRel.memberPosition
+				OPTIONAL MATCH (category)-[nominatedMemberRel:HAS_NOMINEE]->
+					(nominatedMember:Person { uuid: nominatedMemberUuid })
+					WHERE
+						nominatedEntityRel.nominationPosition IS NULL OR
+						nominatedEntityRel.nominationPosition = nominatedMemberRel.nominationPosition
 
-			WITH
-				nominatedRightsGrantorMaterial,
-				nomineeRel,
-				category,
-				categoryRel,
-				ceremony,
-				nominatedEntityRel,
-				nominatedEntity,
-				COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
+				WITH
+					nominatedRightsGrantorMaterial,
+					nomineeRel,
+					category,
+					categoryRel,
+					ceremony,
+					nominatedEntityRel,
+					nominatedEntity,
+					nominatedMember
+					ORDER BY nominatedMemberRel.memberPosition
 
-	WITH
-		nominatedRightsGrantorMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntityRel,
-		nominatedEntity,
-		nominatedMembers
-		ORDER BY nominatedEntityRel.nominationPosition, nominatedEntityRel.entityPosition
+				WITH
+					nominatedRightsGrantorMaterial,
+					nomineeRel,
+					category,
+					categoryRel,
+					ceremony,
+					nominatedEntityRel,
+					nominatedEntity,
+					COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
 
-	WITH nominatedRightsGrantorMaterial, nomineeRel, category, categoryRel, ceremony,
-		COLLECT(
-			CASE WHEN nominatedEntity IS NULL
-				THEN null
-				ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
-			END
-		) AS nominatedEntities
+		WITH
+			nominatedRightsGrantorMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntityRel,
+			nominatedEntity,
+			nominatedMembers
+			ORDER BY nominatedEntityRel.nominationPosition, nominatedEntityRel.entityPosition
 
-	WITH nominatedRightsGrantorMaterial, nomineeRel, category, categoryRel, ceremony,
-		[nominatedEntity IN nominatedEntities | CASE nominatedEntity.model WHEN 'COMPANY'
-			THEN nominatedEntity
-			ELSE nominatedEntity { .model, .uuid, .name }
-		END] AS nominatedEntities
+		WITH nominatedRightsGrantorMaterial, nomineeRel, category, categoryRel, ceremony,
+			COLLECT(
+				CASE WHEN nominatedEntity IS NULL
+					THEN null
+					ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
+				END
+			) AS nominatedEntities
 
-	OPTIONAL MATCH (category)-[nominatedProductionRel:HAS_NOMINEE]->(nominatedProduction:Production)
-		WHERE
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = nominatedProductionRel.nominationPosition
-			)
+		WITH nominatedRightsGrantorMaterial, nomineeRel, category, categoryRel, ceremony,
+			[nominatedEntity IN nominatedEntities | CASE nominatedEntity.model WHEN 'COMPANY'
+				THEN nominatedEntity
+				ELSE nominatedEntity { .model, .uuid, .name }
+			END] AS nominatedEntities
 
-	OPTIONAL MATCH (nominatedProduction)-[:PLAYS_AT]->(venue:Venue)
+		OPTIONAL MATCH (category)-[nominatedProductionRel:HAS_NOMINEE]->(nominatedProduction:Production)
+			WHERE
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = nominatedProductionRel.nominationPosition
+				)
 
-	OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
+		OPTIONAL MATCH (nominatedProduction)-[:PLAYS_AT]->(venue:Venue)
 
-	OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
+		OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
 
-	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+		OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
-	WITH
-		nominatedRightsGrantorMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductionRel,
-		nominatedProduction,
-		venue,
-		surVenue,
-		surProduction,
-		surSurProduction
-		ORDER BY nominatedProductionRel.productionPosition
+		OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
 
-	WITH nominatedRightsGrantorMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
-		COLLECT(
-			CASE WHEN nominatedProduction IS NULL
-				THEN null
-				ELSE nominatedProduction {
-					model: 'PRODUCTION',
-					.uuid,
-					.name,
-					.startDate,
-					.endDate,
-					venue: CASE WHEN venue IS NULL
-						THEN null
-						ELSE venue {
-							model: 'VENUE',
-							.uuid,
-							.name,
-							surVenue: CASE WHEN surVenue IS NULL
-								THEN null
-								ELSE surVenue { model: 'VENUE', .uuid, .name }
-							END
-						}
-					END,
-					surProduction: CASE WHEN surProduction IS NULL
-						THEN null
-						ELSE surProduction {
-							model: 'PRODUCTION',
-							.uuid,
-							.name,
-							surProduction: CASE WHEN surSurProduction IS NULL
-								THEN null
-								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
-							END
-						}
-					END
-				}
-			END
-		) AS nominatedProductions
+		WITH
+			nominatedRightsGrantorMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductionRel,
+			nominatedProduction,
+			venue,
+			surVenue,
+			surProduction,
+			surSurProduction
+			ORDER BY nominatedProductionRel.productionPosition
 
-	OPTIONAL MATCH (category)-[nominatedMaterialRel:HAS_NOMINEE]->(nominatedMaterial:Material)
-		WHERE
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = nominatedMaterialRel.nominationPosition
-			) AND
-			nominatedMaterialRel.uuid <> nominatedRightsGrantorMaterial.uuid
+		WITH nominatedRightsGrantorMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
+			COLLECT(
+				CASE WHEN nominatedProduction IS NULL
+					THEN null
+					ELSE nominatedProduction {
+						model: 'PRODUCTION',
+						.uuid,
+						.name,
+						.startDate,
+						.endDate,
+						venue: CASE WHEN venue IS NULL
+							THEN null
+							ELSE venue {
+								model: 'VENUE',
+								.uuid,
+								.name,
+								surVenue: CASE WHEN surVenue IS NULL
+									THEN null
+									ELSE surVenue { model: 'VENUE', .uuid, .name }
+								END
+							}
+						END,
+						surProduction: CASE WHEN surProduction IS NULL
+							THEN null
+							ELSE surProduction {
+								model: 'PRODUCTION',
+								.uuid,
+								.name,
+								surProduction: CASE WHEN surSurProduction IS NULL
+									THEN null
+									ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+								END
+							}
+						END
+					}
+				END
+			) AS nominatedProductions
 
-	OPTIONAL MATCH (nominatedMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSurMaterial:Material)
+		OPTIONAL MATCH (category)-[nominatedMaterialRel:HAS_NOMINEE]->(nominatedMaterial:Material)
+			WHERE
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = nominatedMaterialRel.nominationPosition
+				) AND
+				nominatedMaterialRel.uuid <> nominatedRightsGrantorMaterial.uuid
 
-	WITH
-		nominatedRightsGrantorMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductions,
-		nominatedMaterialRel,
-		nominatedMaterial,
-		nominatedSurMaterial
-		ORDER BY nominatedMaterialRel.materialPosition
+		OPTIONAL MATCH (nominatedMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSurMaterial:Material)
 
-	WITH
-		nominatedRightsGrantorMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductions,
-		COLLECT(
-			CASE WHEN nominatedMaterial IS NULL
-				THEN null
-				ELSE nominatedMaterial {
-					model: 'MATERIAL',
-					.uuid,
-					.name,
-					.format,
-					.year,
-					surMaterial: CASE WHEN nominatedSurMaterial IS NULL
-						THEN null
-						ELSE nominatedSurMaterial { model: 'MATERIAL', .uuid, .name }
-					END
-				}
-			END
-		) AS nominatedMaterials
-		ORDER BY nomineeRel.nominationPosition, nomineeRel.materialPosition
+		WITH
+			nominatedRightsGrantorMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductions,
+			nominatedMaterialRel,
+			nominatedMaterial,
+			nominatedSurMaterial
+			ORDER BY nominatedMaterialRel.materialPosition
 
-	OPTIONAL MATCH (nominatedRightsGrantorMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedRightsGrantorSurMaterial:Material)
+		WITH
+			nominatedRightsGrantorMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductions,
+			COLLECT(
+				CASE WHEN nominatedMaterial IS NULL
+					THEN null
+					ELSE nominatedMaterial {
+						model: 'MATERIAL',
+						.uuid,
+						.name,
+						.format,
+						.year,
+						surMaterial: CASE WHEN nominatedSurMaterial IS NULL
+							THEN null
+							ELSE nominatedSurMaterial { model: 'MATERIAL', .uuid, .name }
+						END
+					}
+				END
+			) AS nominatedMaterials
+			ORDER BY nomineeRel.nominationPosition, nomineeRel.materialPosition
 
-	OPTIONAL MATCH (nominatedRightsGrantorSurMaterial)
-		<-[:HAS_SUB_MATERIAL]-(nominatedRightsGrantorSurSurMaterial:Material)
+		OPTIONAL MATCH (nominatedRightsGrantorMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedRightsGrantorSurMaterial:Material)
 
-	WITH
-		nomineeRel.isWinner AS isWinner,
-		nomineeRel.customType AS customType,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductions,
-		nominatedMaterials,
-		COLLECT(
-			CASE WHEN nominatedRightsGrantorMaterial IS NULL
-				THEN null
-				ELSE nominatedRightsGrantorMaterial {
-					model: 'MATERIAL',
-					.uuid,
-					.name,
-					.format,
-					.year,
-					surMaterial: CASE WHEN nominatedRightsGrantorSurMaterial IS NULL
-						THEN null
-						ELSE nominatedRightsGrantorSurMaterial {
-							model: 'MATERIAL',
-							.uuid,
-							.name,
-							surMaterial: CASE WHEN nominatedRightsGrantorSurSurMaterial IS NULL
-								THEN null
-								ELSE nominatedRightsGrantorSurSurMaterial { model: 'MATERIAL', .uuid, .name }
-							END
-						}
-					END
-				}
-			END
-		) AS nominatedRightsGrantorMaterials
+		OPTIONAL MATCH (nominatedRightsGrantorSurMaterial)
+			<-[:HAS_SUB_MATERIAL]-(nominatedRightsGrantorSurSurMaterial:Material)
 
-	WITH category, categoryRel, ceremony,
-		COLLECT({
-			model: 'NOMINATION',
-			isWinner: COALESCE(isWinner, false),
-			type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
-			entities: nominatedEntities,
-			productions: nominatedProductions,
-			materials: nominatedMaterials,
-			recipientRightsGrantorMaterials: nominatedRightsGrantorMaterials
-		}) AS nominations
-		ORDER BY categoryRel.position
+		WITH
+			nomineeRel.isWinner AS isWinner,
+			nomineeRel.customType AS customType,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductions,
+			nominatedMaterials,
+			COLLECT(
+				CASE WHEN nominatedRightsGrantorMaterial IS NULL
+					THEN null
+					ELSE nominatedRightsGrantorMaterial {
+						model: 'MATERIAL',
+						.uuid,
+						.name,
+						.format,
+						.year,
+						surMaterial: CASE WHEN nominatedRightsGrantorSurMaterial IS NULL
+							THEN null
+							ELSE nominatedRightsGrantorSurMaterial {
+								model: 'MATERIAL',
+								.uuid,
+								.name,
+								surMaterial: CASE WHEN nominatedRightsGrantorSurSurMaterial IS NULL
+									THEN null
+									ELSE nominatedRightsGrantorSurSurMaterial { model: 'MATERIAL', .uuid, .name }
+								END
+							}
+						END
+					}
+				END
+			) AS nominatedRightsGrantorMaterials
 
-	WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
-		ORDER BY ceremony.name DESC
+		WITH category, categoryRel, ceremony,
+			COLLECT({
+				model: 'NOMINATION',
+				isWinner: COALESCE(isWinner, false),
+				type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
+				entities: nominatedEntities,
+				productions: nominatedProductions,
+				materials: nominatedMaterials,
+				recipientRightsGrantorMaterials: nominatedRightsGrantorMaterials
+			}) AS nominations
+			ORDER BY categoryRel.position
 
-	OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
+		WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
+			ORDER BY ceremony.name DESC
 
-	WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
-		ORDER BY award.name
+		OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
+
+		WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
+			ORDER BY award.name
+
+		RETURN
+			COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS rightsGrantorMaterialAwards
+	}
 
 	RETURN
-		COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS rightsGrantorMaterialAwards
+		rightsGrantorMaterialAwards
 `;

--- a/src/neo4j/cypher-queries/company/show/show-awards-sourcing-material.js
+++ b/src/neo4j/cypher-queries/company/show/show-awards-sourcing-material.js
@@ -1,280 +1,287 @@
 export default () => `
 	MATCH (company:Company { uuid: $uuid })
 
-	OPTIONAL MATCH path=(company)
-		<-[writingRel:HAS_WRITING_ENTITY]-(creditingMaterial:Material)
-			-[:HAS_SUB_MATERIAL*0..2]-(sourceMaterial:Material)
-		<-[:USES_SOURCE_MATERIAL*0..1]-(sourcingMaterial:Material)
-			-[:HAS_SUB_MATERIAL*0..2]-(nominatedSourcingMaterial:Material)
-		<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
-		<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
-		WHERE
-			(
-				writingRel.creditType = 'NON_SPECIFIC_SOURCE_MATERIAL' OR
-				ANY(rel IN RELATIONSHIPS(path) WHERE TYPE(rel) = 'USES_SOURCE_MATERIAL')
-			) AND (
+	CALL {
+		WITH company
+
+		OPTIONAL MATCH path=(company)
+			<-[writingRel:HAS_WRITING_ENTITY]-(creditingMaterial:Material)
+				-[:HAS_SUB_MATERIAL*0..2]-(sourceMaterial:Material)
+			<-[:USES_SOURCE_MATERIAL*0..1]-(sourcingMaterial:Material)
+				-[:HAS_SUB_MATERIAL*0..2]-(nominatedSourcingMaterial:Material)
+			<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
+			<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
+			WHERE
 				(
-					(creditingMaterial)-[:HAS_SUB_MATERIAL*0..2]->(sourceMaterial) AND
-					(sourcingMaterial)-[:HAS_SUB_MATERIAL*0..2]->(nominatedSourcingMaterial)
-				) OR (
-					(creditingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(sourceMaterial) AND
-					(sourcingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSourcingMaterial)
-				) OR (
-					(creditingMaterial)-[:HAS_SUB_MATERIAL*0..2]->(sourceMaterial) AND
-					(sourcingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSourcingMaterial)
+					writingRel.creditType = 'NON_SPECIFIC_SOURCE_MATERIAL' OR
+					ANY(rel IN RELATIONSHIPS(path) WHERE TYPE(rel) = 'USES_SOURCE_MATERIAL')
+				) AND (
+					(
+						(creditingMaterial)-[:HAS_SUB_MATERIAL*0..2]->(sourceMaterial) AND
+						(sourcingMaterial)-[:HAS_SUB_MATERIAL*0..2]->(nominatedSourcingMaterial)
+					) OR (
+						(creditingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(sourceMaterial) AND
+						(sourcingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSourcingMaterial)
+					) OR (
+						(creditingMaterial)-[:HAS_SUB_MATERIAL*0..2]->(sourceMaterial) AND
+						(sourcingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSourcingMaterial)
+					)
 				)
-			)
 
-	OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)
-		WHERE
-			(
-				(nominatedEntity:Person AND nominatedEntityRel.nominatedCompanyUuid IS NULL) OR
-				nominatedEntity:Company
-			) AND
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = nominatedEntityRel.nominationPosition
-			)
+		OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)
+			WHERE
+				(
+					(nominatedEntity:Person AND nominatedEntityRel.nominatedCompanyUuid IS NULL) OR
+					nominatedEntity:Company
+				) AND
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = nominatedEntityRel.nominationPosition
+				)
 
-	WITH nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntityRel,
-		COLLECT(nominatedEntity {
-			model: TOUPPER(HEAD(LABELS(nominatedEntity))),
-			.uuid,
-			.name,
-			nominatedMemberUuids: nominatedEntityRel.nominatedMemberUuids
-		}) AS nominatedEntities
+		WITH nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntityRel,
+			COLLECT(nominatedEntity {
+				model: TOUPPER(HEAD(LABELS(nominatedEntity))),
+				.uuid,
+				.name,
+				nominatedMemberUuids: nominatedEntityRel.nominatedMemberUuids
+			}) AS nominatedEntities
 
-	UNWIND (CASE nominatedEntities WHEN [] THEN [null] ELSE nominatedEntities END) AS nominatedEntity
+		UNWIND (CASE nominatedEntities WHEN [] THEN [null] ELSE nominatedEntities END) AS nominatedEntity
 
-		UNWIND (COALESCE(nominatedEntity.nominatedMemberUuids, [null])) AS nominatedMemberUuid
+			UNWIND (COALESCE(nominatedEntity.nominatedMemberUuids, [null])) AS nominatedMemberUuid
 
-			OPTIONAL MATCH (category)-[nominatedMemberRel:HAS_NOMINEE]->
-				(nominatedMember:Person { uuid: nominatedMemberUuid })
-				WHERE
-					nominatedEntityRel.nominationPosition IS NULL OR
-					nominatedEntityRel.nominationPosition = nominatedMemberRel.nominationPosition
+				OPTIONAL MATCH (category)-[nominatedMemberRel:HAS_NOMINEE]->
+					(nominatedMember:Person { uuid: nominatedMemberUuid })
+					WHERE
+						nominatedEntityRel.nominationPosition IS NULL OR
+						nominatedEntityRel.nominationPosition = nominatedMemberRel.nominationPosition
 
-			WITH
-				nominatedSourcingMaterial,
-				nomineeRel,
-				category,
-				categoryRel,
-				ceremony,
-				nominatedEntityRel,
-				nominatedEntity,
-				nominatedMember
-				ORDER BY nominatedMemberRel.memberPosition
+				WITH
+					nominatedSourcingMaterial,
+					nomineeRel,
+					category,
+					categoryRel,
+					ceremony,
+					nominatedEntityRel,
+					nominatedEntity,
+					nominatedMember
+					ORDER BY nominatedMemberRel.memberPosition
 
-			WITH
-				nominatedSourcingMaterial,
-				nomineeRel,
-				category,
-				categoryRel,
-				ceremony,
-				nominatedEntityRel,
-				nominatedEntity,
-				COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
+				WITH
+					nominatedSourcingMaterial,
+					nomineeRel,
+					category,
+					categoryRel,
+					ceremony,
+					nominatedEntityRel,
+					nominatedEntity,
+					COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
 
-	WITH
-		nominatedSourcingMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntityRel,
-		nominatedEntity,
-		nominatedMembers
-		ORDER BY nominatedEntityRel.nominationPosition, nominatedEntityRel.entityPosition
+		WITH
+			nominatedSourcingMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntityRel,
+			nominatedEntity,
+			nominatedMembers
+			ORDER BY nominatedEntityRel.nominationPosition, nominatedEntityRel.entityPosition
 
-	WITH nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony,
-		COLLECT(
-			CASE WHEN nominatedEntity IS NULL
-				THEN null
-				ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
-			END
-		) AS nominatedEntities
+		WITH nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony,
+			COLLECT(
+				CASE WHEN nominatedEntity IS NULL
+					THEN null
+					ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
+				END
+			) AS nominatedEntities
 
-	WITH nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony,
-		[nominatedEntity IN nominatedEntities | CASE nominatedEntity.model WHEN 'COMPANY'
-			THEN nominatedEntity
-			ELSE nominatedEntity { .model, .uuid, .name }
-		END] AS nominatedEntities
+		WITH nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony,
+			[nominatedEntity IN nominatedEntities | CASE nominatedEntity.model WHEN 'COMPANY'
+				THEN nominatedEntity
+				ELSE nominatedEntity { .model, .uuid, .name }
+			END] AS nominatedEntities
 
-	OPTIONAL MATCH (category)-[nominatedProductionRel:HAS_NOMINEE]->(nominatedProduction:Production)
-		WHERE
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = nominatedProductionRel.nominationPosition
-			)
+		OPTIONAL MATCH (category)-[nominatedProductionRel:HAS_NOMINEE]->(nominatedProduction:Production)
+			WHERE
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = nominatedProductionRel.nominationPosition
+				)
 
-	OPTIONAL MATCH (nominatedProduction)-[:PLAYS_AT]->(venue:Venue)
+		OPTIONAL MATCH (nominatedProduction)-[:PLAYS_AT]->(venue:Venue)
 
-	OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
+		OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
 
-	OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
+		OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
-	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+		OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
 
-	WITH
-		nominatedSourcingMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductionRel,
-		nominatedProduction,
-		venue,
-		surVenue,
-		surProduction,
-		surSurProduction
-		ORDER BY nominatedProductionRel.productionPosition
+		WITH
+			nominatedSourcingMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductionRel,
+			nominatedProduction,
+			venue,
+			surVenue,
+			surProduction,
+			surSurProduction
+			ORDER BY nominatedProductionRel.productionPosition
 
-	WITH nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
-		COLLECT(
-			CASE WHEN nominatedProduction IS NULL
-				THEN null
-				ELSE nominatedProduction {
-					model: 'PRODUCTION',
-					.uuid,
-					.name,
-					.startDate,
-					.endDate,
-					venue: CASE WHEN venue IS NULL
-						THEN null
-						ELSE venue {
-							model: 'VENUE',
-							.uuid,
-							.name,
-							surVenue: CASE WHEN surVenue IS NULL
-								THEN null
-								ELSE surVenue { model: 'VENUE', .uuid, .name }
-							END
-						}
-					END,
-					surProduction: CASE WHEN surProduction IS NULL
-						THEN null
-						ELSE surProduction {
-							model: 'PRODUCTION',
-							.uuid,
-							.name,
-							surProduction: CASE WHEN surSurProduction IS NULL
-								THEN null
-								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
-							END
-						}
-					END
-				}
-			END
-		) AS nominatedProductions
+		WITH nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
+			COLLECT(
+				CASE WHEN nominatedProduction IS NULL
+					THEN null
+					ELSE nominatedProduction {
+						model: 'PRODUCTION',
+						.uuid,
+						.name,
+						.startDate,
+						.endDate,
+						venue: CASE WHEN venue IS NULL
+							THEN null
+							ELSE venue {
+								model: 'VENUE',
+								.uuid,
+								.name,
+								surVenue: CASE WHEN surVenue IS NULL
+									THEN null
+									ELSE surVenue { model: 'VENUE', .uuid, .name }
+								END
+							}
+						END,
+						surProduction: CASE WHEN surProduction IS NULL
+							THEN null
+							ELSE surProduction {
+								model: 'PRODUCTION',
+								.uuid,
+								.name,
+								surProduction: CASE WHEN surSurProduction IS NULL
+									THEN null
+									ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+								END
+							}
+						END
+					}
+				END
+			) AS nominatedProductions
 
-	OPTIONAL MATCH (category)-[nominatedMaterialRel:HAS_NOMINEE]->(nominatedMaterial:Material)
-		WHERE
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = nominatedMaterialRel.nominationPosition
-			) AND
-			nominatedMaterialRel.uuid <> nominatedSourcingMaterial.uuid
+		OPTIONAL MATCH (category)-[nominatedMaterialRel:HAS_NOMINEE]->(nominatedMaterial:Material)
+			WHERE
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = nominatedMaterialRel.nominationPosition
+				) AND
+				nominatedMaterialRel.uuid <> nominatedSourcingMaterial.uuid
 
-	OPTIONAL MATCH (nominatedMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSurMaterial:Material)
+		OPTIONAL MATCH (nominatedMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSurMaterial:Material)
 
-	WITH
-		nominatedSourcingMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductions,
-		nominatedMaterialRel,
-		nominatedMaterial,
-		nominatedSurMaterial
-		ORDER BY nominatedMaterialRel.materialPosition
+		WITH
+			nominatedSourcingMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductions,
+			nominatedMaterialRel,
+			nominatedMaterial,
+			nominatedSurMaterial
+			ORDER BY nominatedMaterialRel.materialPosition
 
-	WITH
-		nominatedSourcingMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductions,
-		COLLECT(
-			CASE WHEN nominatedMaterial IS NULL
-				THEN null
-				ELSE nominatedMaterial {
-					model: 'MATERIAL',
-					.uuid,
-					.name,
-					.format,
-					.year,
-					surMaterial: CASE WHEN nominatedSurMaterial IS NULL
-						THEN null
-						ELSE nominatedSurMaterial { model: 'MATERIAL', .uuid, .name }
-					END
-				}
-			END
-		) AS nominatedMaterials
-		ORDER BY nomineeRel.nominationPosition, nomineeRel.materialPosition
+		WITH
+			nominatedSourcingMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductions,
+			COLLECT(
+				CASE WHEN nominatedMaterial IS NULL
+					THEN null
+					ELSE nominatedMaterial {
+						model: 'MATERIAL',
+						.uuid,
+						.name,
+						.format,
+						.year,
+						surMaterial: CASE WHEN nominatedSurMaterial IS NULL
+							THEN null
+							ELSE nominatedSurMaterial { model: 'MATERIAL', .uuid, .name }
+						END
+					}
+				END
+			) AS nominatedMaterials
+			ORDER BY nomineeRel.nominationPosition, nomineeRel.materialPosition
 
-	OPTIONAL MATCH (nominatedSourcingMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSourcingSurMaterial:Material)
+		OPTIONAL MATCH (nominatedSourcingMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSourcingSurMaterial:Material)
 
-	OPTIONAL MATCH (nominatedSourcingSurMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSourcingSurSurMaterial:Material)
+		OPTIONAL MATCH (nominatedSourcingSurMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSourcingSurSurMaterial:Material)
 
-	WITH
-		nomineeRel.isWinner AS isWinner,
-		nomineeRel.customType AS customType,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductions,
-		nominatedMaterials,
-		COLLECT(
-			CASE WHEN nominatedSourcingMaterial IS NULL
-				THEN null
-				ELSE nominatedSourcingMaterial {
-					model: 'MATERIAL',
-					.uuid,
-					.name,
-					.format,
-					.year,
-					surMaterial: CASE WHEN nominatedSourcingSurMaterial IS NULL
-						THEN null
-						ELSE nominatedSourcingSurMaterial {
-							model: 'MATERIAL',
-							.uuid,
-							.name,
-							surMaterial: CASE WHEN nominatedSourcingSurSurMaterial IS NULL
-								THEN null
-								ELSE nominatedSourcingSurSurMaterial { model: 'MATERIAL', .uuid, .name }
-							END
-						}
-					END
-				}
-			END
-		) AS nominatedSourcingMaterials
+		WITH
+			nomineeRel.isWinner AS isWinner,
+			nomineeRel.customType AS customType,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductions,
+			nominatedMaterials,
+			COLLECT(
+				CASE WHEN nominatedSourcingMaterial IS NULL
+					THEN null
+					ELSE nominatedSourcingMaterial {
+						model: 'MATERIAL',
+						.uuid,
+						.name,
+						.format,
+						.year,
+						surMaterial: CASE WHEN nominatedSourcingSurMaterial IS NULL
+							THEN null
+							ELSE nominatedSourcingSurMaterial {
+								model: 'MATERIAL',
+								.uuid,
+								.name,
+								surMaterial: CASE WHEN nominatedSourcingSurSurMaterial IS NULL
+									THEN null
+									ELSE nominatedSourcingSurSurMaterial { model: 'MATERIAL', .uuid, .name }
+								END
+							}
+						END
+					}
+				END
+			) AS nominatedSourcingMaterials
 
-	WITH category, categoryRel, ceremony,
-		COLLECT({
-			model: 'NOMINATION',
-			isWinner: COALESCE(isWinner, false),
-			type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
-			entities: nominatedEntities,
-			productions: nominatedProductions,
-			materials: nominatedMaterials,
-			recipientSourcingMaterials: nominatedSourcingMaterials
-		}) AS nominations
-		ORDER BY categoryRel.position
+		WITH category, categoryRel, ceremony,
+			COLLECT({
+				model: 'NOMINATION',
+				isWinner: COALESCE(isWinner, false),
+				type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
+				entities: nominatedEntities,
+				productions: nominatedProductions,
+				materials: nominatedMaterials,
+				recipientSourcingMaterials: nominatedSourcingMaterials
+			}) AS nominations
+			ORDER BY categoryRel.position
 
-	WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
-		ORDER BY ceremony.name DESC
+		WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
+			ORDER BY ceremony.name DESC
 
-	OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
+		OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
 
-	WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
-		ORDER BY award.name
+		WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
+			ORDER BY award.name
+
+		RETURN
+			COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS sourcingMaterialAwards
+	}
 
 	RETURN
-		COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS sourcingMaterialAwards
+		sourcingMaterialAwards
 `;

--- a/src/neo4j/cypher-queries/company/show/show-awards-subsequent-version-material.js
+++ b/src/neo4j/cypher-queries/company/show/show-awards-subsequent-version-material.js
@@ -1,277 +1,284 @@
 export default () => `
 	MATCH (company:Company { uuid: $uuid })
 
-	OPTIONAL MATCH (company)
-		<-[:HAS_WRITING_ENTITY]-(creditingMaterial:Material)-[:HAS_SUB_MATERIAL*0..2]-(originalVersionMaterial:Material)
-		<-[:SUBSEQUENT_VERSION_OF]-(subsequentVersionMaterial:Material)
-			-[:HAS_SUB_MATERIAL*0..2]-(nominatedSubsequentVersionMaterial:Material)
-		<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
-		<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
-		WHERE
-			(
-				(creditingMaterial)-[:HAS_SUB_MATERIAL*0..2]->(originalVersionMaterial) AND
-				(subsequentVersionMaterial)-[:HAS_SUB_MATERIAL*0..2]->(nominatedSubsequentVersionMaterial)
-			) OR (
-				(creditingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(originalVersionMaterial) AND
-				(subsequentVersionMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSubsequentVersionMaterial)
-			) OR (
-				(creditingMaterial)-[:HAS_SUB_MATERIAL*0..2]->(originalVersionMaterial) AND
-				(subsequentVersionMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSubsequentVersionMaterial)
-			)
+	CALL {
+		WITH company
 
-	OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)
-		WHERE
-			(
-				(nominatedEntity:Person AND nominatedEntityRel.nominatedCompanyUuid IS NULL) OR
-				nominatedEntity:Company
-			) AND
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = nominatedEntityRel.nominationPosition
-			)
+		OPTIONAL MATCH (company)
+			<-[:HAS_WRITING_ENTITY]-(creditingMaterial:Material)-[:HAS_SUB_MATERIAL*0..2]-(originalVersionMaterial:Material)
+			<-[:SUBSEQUENT_VERSION_OF]-(subsequentVersionMaterial:Material)
+				-[:HAS_SUB_MATERIAL*0..2]-(nominatedSubsequentVersionMaterial:Material)
+			<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
+			<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
+			WHERE
+				(
+					(creditingMaterial)-[:HAS_SUB_MATERIAL*0..2]->(originalVersionMaterial) AND
+					(subsequentVersionMaterial)-[:HAS_SUB_MATERIAL*0..2]->(nominatedSubsequentVersionMaterial)
+				) OR (
+					(creditingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(originalVersionMaterial) AND
+					(subsequentVersionMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSubsequentVersionMaterial)
+				) OR (
+					(creditingMaterial)-[:HAS_SUB_MATERIAL*0..2]->(originalVersionMaterial) AND
+					(subsequentVersionMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSubsequentVersionMaterial)
+				)
 
-	WITH nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntityRel,
-		COLLECT(nominatedEntity {
-			model: TOUPPER(HEAD(LABELS(nominatedEntity))),
-			.uuid,
-			.name,
-			nominatedMemberUuids: nominatedEntityRel.nominatedMemberUuids
-		}) AS nominatedEntities
+		OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)
+			WHERE
+				(
+					(nominatedEntity:Person AND nominatedEntityRel.nominatedCompanyUuid IS NULL) OR
+					nominatedEntity:Company
+				) AND
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = nominatedEntityRel.nominationPosition
+				)
 
-	UNWIND (CASE nominatedEntities WHEN [] THEN [null] ELSE nominatedEntities END) AS nominatedEntity
+		WITH nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntityRel,
+			COLLECT(nominatedEntity {
+				model: TOUPPER(HEAD(LABELS(nominatedEntity))),
+				.uuid,
+				.name,
+				nominatedMemberUuids: nominatedEntityRel.nominatedMemberUuids
+			}) AS nominatedEntities
 
-		UNWIND (COALESCE(nominatedEntity.nominatedMemberUuids, [null])) AS nominatedMemberUuid
+		UNWIND (CASE nominatedEntities WHEN [] THEN [null] ELSE nominatedEntities END) AS nominatedEntity
 
-			OPTIONAL MATCH (category)-[nominatedMemberRel:HAS_NOMINEE]->
-				(nominatedMember:Person { uuid: nominatedMemberUuid })
-				WHERE
-					nominatedEntityRel.nominationPosition IS NULL OR
-					nominatedEntityRel.nominationPosition = nominatedMemberRel.nominationPosition
+			UNWIND (COALESCE(nominatedEntity.nominatedMemberUuids, [null])) AS nominatedMemberUuid
 
-			WITH
-				nominatedSubsequentVersionMaterial,
-				nomineeRel,
-				category,
-				categoryRel,
-				ceremony,
-				nominatedEntityRel,
-				nominatedEntity,
-				nominatedMember
-				ORDER BY nominatedMemberRel.memberPosition
+				OPTIONAL MATCH (category)-[nominatedMemberRel:HAS_NOMINEE]->
+					(nominatedMember:Person { uuid: nominatedMemberUuid })
+					WHERE
+						nominatedEntityRel.nominationPosition IS NULL OR
+						nominatedEntityRel.nominationPosition = nominatedMemberRel.nominationPosition
 
-			WITH
-				nominatedSubsequentVersionMaterial,
-				nomineeRel,
-				category,
-				categoryRel,
-				ceremony,
-				nominatedEntityRel,
-				nominatedEntity,
-				COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
+				WITH
+					nominatedSubsequentVersionMaterial,
+					nomineeRel,
+					category,
+					categoryRel,
+					ceremony,
+					nominatedEntityRel,
+					nominatedEntity,
+					nominatedMember
+					ORDER BY nominatedMemberRel.memberPosition
 
-	WITH
-		nominatedSubsequentVersionMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntityRel,
-		nominatedEntity,
-		nominatedMembers
-		ORDER BY nominatedEntityRel.nominationPosition, nominatedEntityRel.entityPosition
+				WITH
+					nominatedSubsequentVersionMaterial,
+					nomineeRel,
+					category,
+					categoryRel,
+					ceremony,
+					nominatedEntityRel,
+					nominatedEntity,
+					COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
 
-	WITH nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony,
-		COLLECT(
-			CASE WHEN nominatedEntity IS NULL
-				THEN null
-				ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
-			END
-		) AS nominatedEntities
+		WITH
+			nominatedSubsequentVersionMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntityRel,
+			nominatedEntity,
+			nominatedMembers
+			ORDER BY nominatedEntityRel.nominationPosition, nominatedEntityRel.entityPosition
 
-	WITH nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony,
-		[nominatedEntity IN nominatedEntities | CASE nominatedEntity.model WHEN 'COMPANY'
-			THEN nominatedEntity
-			ELSE nominatedEntity { .model, .uuid, .name }
-		END] AS nominatedEntities
+		WITH nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony,
+			COLLECT(
+				CASE WHEN nominatedEntity IS NULL
+					THEN null
+					ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
+				END
+			) AS nominatedEntities
 
-	OPTIONAL MATCH (category)-[nominatedProductionRel:HAS_NOMINEE]->(nominatedProduction:Production)
-		WHERE
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = nominatedProductionRel.nominationPosition
-			)
+		WITH nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony,
+			[nominatedEntity IN nominatedEntities | CASE nominatedEntity.model WHEN 'COMPANY'
+				THEN nominatedEntity
+				ELSE nominatedEntity { .model, .uuid, .name }
+			END] AS nominatedEntities
 
-	OPTIONAL MATCH (nominatedProduction)-[:PLAYS_AT]->(venue:Venue)
+		OPTIONAL MATCH (category)-[nominatedProductionRel:HAS_NOMINEE]->(nominatedProduction:Production)
+			WHERE
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = nominatedProductionRel.nominationPosition
+				)
 
-	OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
+		OPTIONAL MATCH (nominatedProduction)-[:PLAYS_AT]->(venue:Venue)
 
-	OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
+		OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
 
-	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+		OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
-	WITH
-		nominatedSubsequentVersionMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductionRel,
-		nominatedProduction,
-		venue,
-		surVenue,
-		surProduction,
-		surSurProduction
-		ORDER BY nominatedProductionRel.productionPosition
+		OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
 
-	WITH nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
-		COLLECT(
-			CASE WHEN nominatedProduction IS NULL
-				THEN null
-				ELSE nominatedProduction {
-					model: 'PRODUCTION',
-					.uuid,
-					.name,
-					.startDate,
-					.endDate,
-					venue: CASE WHEN venue IS NULL
-						THEN null
-						ELSE venue {
-							model: 'VENUE',
-							.uuid,
-							.name,
-							surVenue: CASE WHEN surVenue IS NULL
-								THEN null
-								ELSE surVenue { model: 'VENUE', .uuid, .name }
-							END
-						}
-					END,
-					surProduction: CASE WHEN surProduction IS NULL
-						THEN null
-						ELSE surProduction {
-							model: 'PRODUCTION',
-							.uuid,
-							.name,
-							surProduction: CASE WHEN surSurProduction IS NULL
-								THEN null
-								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
-							END
-						}
-					END
-				}
-			END
-		) AS nominatedProductions
+		WITH
+			nominatedSubsequentVersionMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductionRel,
+			nominatedProduction,
+			venue,
+			surVenue,
+			surProduction,
+			surSurProduction
+			ORDER BY nominatedProductionRel.productionPosition
 
-	OPTIONAL MATCH (category)-[nominatedMaterialRel:HAS_NOMINEE]->(nominatedMaterial:Material)
-		WHERE
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = nominatedMaterialRel.nominationPosition
-			) AND
-			nominatedMaterialRel.uuid <> nominatedSubsequentVersionMaterial.uuid
+		WITH nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
+			COLLECT(
+				CASE WHEN nominatedProduction IS NULL
+					THEN null
+					ELSE nominatedProduction {
+						model: 'PRODUCTION',
+						.uuid,
+						.name,
+						.startDate,
+						.endDate,
+						venue: CASE WHEN venue IS NULL
+							THEN null
+							ELSE venue {
+								model: 'VENUE',
+								.uuid,
+								.name,
+								surVenue: CASE WHEN surVenue IS NULL
+									THEN null
+									ELSE surVenue { model: 'VENUE', .uuid, .name }
+								END
+							}
+						END,
+						surProduction: CASE WHEN surProduction IS NULL
+							THEN null
+							ELSE surProduction {
+								model: 'PRODUCTION',
+								.uuid,
+								.name,
+								surProduction: CASE WHEN surSurProduction IS NULL
+									THEN null
+									ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+								END
+							}
+						END
+					}
+				END
+			) AS nominatedProductions
 
-	OPTIONAL MATCH (nominatedMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSurMaterial:Material)
+		OPTIONAL MATCH (category)-[nominatedMaterialRel:HAS_NOMINEE]->(nominatedMaterial:Material)
+			WHERE
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = nominatedMaterialRel.nominationPosition
+				) AND
+				nominatedMaterialRel.uuid <> nominatedSubsequentVersionMaterial.uuid
 
-	WITH
-		nominatedSubsequentVersionMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductions,
-		nominatedMaterialRel,
-		nominatedMaterial,
-		nominatedSurMaterial
-		ORDER BY nominatedMaterialRel.materialPosition
+		OPTIONAL MATCH (nominatedMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSurMaterial:Material)
 
-	WITH
-		nominatedSubsequentVersionMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductions,
-		COLLECT(
-			CASE WHEN nominatedMaterial IS NULL
-				THEN null
-				ELSE nominatedMaterial {
-					model: 'MATERIAL',
-					.uuid,
-					.name,
-					.format,
-					.year,
-					surMaterial: CASE WHEN nominatedSurMaterial IS NULL
-						THEN null
-						ELSE nominatedSurMaterial { model: 'MATERIAL', .uuid, .name }
-					END
-				}
-			END
-		) AS nominatedMaterials
-		ORDER BY nomineeRel.nominationPosition, nomineeRel.materialPosition
+		WITH
+			nominatedSubsequentVersionMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductions,
+			nominatedMaterialRel,
+			nominatedMaterial,
+			nominatedSurMaterial
+			ORDER BY nominatedMaterialRel.materialPosition
 
-	OPTIONAL MATCH (nominatedSubsequentVersionMaterial)
-		<-[:HAS_SUB_MATERIAL]-(nominatedSubsequentVersionSurMaterial:Material)
+		WITH
+			nominatedSubsequentVersionMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductions,
+			COLLECT(
+				CASE WHEN nominatedMaterial IS NULL
+					THEN null
+					ELSE nominatedMaterial {
+						model: 'MATERIAL',
+						.uuid,
+						.name,
+						.format,
+						.year,
+						surMaterial: CASE WHEN nominatedSurMaterial IS NULL
+							THEN null
+							ELSE nominatedSurMaterial { model: 'MATERIAL', .uuid, .name }
+						END
+					}
+				END
+			) AS nominatedMaterials
+			ORDER BY nomineeRel.nominationPosition, nomineeRel.materialPosition
 
-	OPTIONAL MATCH (nominatedSubsequentVersionSurMaterial)
-		<-[:HAS_SUB_MATERIAL]-(nominatedSubsequentVersionSurSurMaterial:Material)
+		OPTIONAL MATCH (nominatedSubsequentVersionMaterial)
+			<-[:HAS_SUB_MATERIAL]-(nominatedSubsequentVersionSurMaterial:Material)
 
-	WITH
-		nomineeRel.isWinner AS isWinner,
-		nomineeRel.customType AS customType,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductions,
-		nominatedMaterials,
-		COLLECT(
-			CASE WHEN nominatedSubsequentVersionMaterial IS NULL
-				THEN null
-				ELSE nominatedSubsequentVersionMaterial {
-					model: 'MATERIAL',
-					.uuid,
-					.name,
-					.format,
-					.year,
-					surMaterial: CASE WHEN nominatedSubsequentVersionSurMaterial IS NULL
-						THEN null
-						ELSE nominatedSubsequentVersionSurMaterial {
-							model: 'MATERIAL',
-							.uuid,
-							.name,
-							surMaterial: CASE WHEN nominatedSubsequentVersionSurSurMaterial IS NULL
-								THEN null
-								ELSE nominatedSubsequentVersionSurSurMaterial { model: 'MATERIAL', .uuid, .name }
-							END
-						}
-					END
-				}
-			END
-		) AS nominatedSubsequentVersionMaterials
+		OPTIONAL MATCH (nominatedSubsequentVersionSurMaterial)
+			<-[:HAS_SUB_MATERIAL]-(nominatedSubsequentVersionSurSurMaterial:Material)
 
-	WITH category, categoryRel, ceremony,
-		COLLECT({
-			model: 'NOMINATION',
-			isWinner: COALESCE(isWinner, false),
-			type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
-			entities: nominatedEntities,
-			productions: nominatedProductions,
-			materials: nominatedMaterials,
-			recipientSubsequentVersionMaterials: nominatedSubsequentVersionMaterials
-		}) AS nominations
-		ORDER BY categoryRel.position
+		WITH
+			nomineeRel.isWinner AS isWinner,
+			nomineeRel.customType AS customType,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductions,
+			nominatedMaterials,
+			COLLECT(
+				CASE WHEN nominatedSubsequentVersionMaterial IS NULL
+					THEN null
+					ELSE nominatedSubsequentVersionMaterial {
+						model: 'MATERIAL',
+						.uuid,
+						.name,
+						.format,
+						.year,
+						surMaterial: CASE WHEN nominatedSubsequentVersionSurMaterial IS NULL
+							THEN null
+							ELSE nominatedSubsequentVersionSurMaterial {
+								model: 'MATERIAL',
+								.uuid,
+								.name,
+								surMaterial: CASE WHEN nominatedSubsequentVersionSurSurMaterial IS NULL
+									THEN null
+									ELSE nominatedSubsequentVersionSurSurMaterial { model: 'MATERIAL', .uuid, .name }
+								END
+							}
+						END
+					}
+				END
+			) AS nominatedSubsequentVersionMaterials
 
-	WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
-		ORDER BY ceremony.name DESC
+		WITH category, categoryRel, ceremony,
+			COLLECT({
+				model: 'NOMINATION',
+				isWinner: COALESCE(isWinner, false),
+				type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
+				entities: nominatedEntities,
+				productions: nominatedProductions,
+				materials: nominatedMaterials,
+				recipientSubsequentVersionMaterials: nominatedSubsequentVersionMaterials
+			}) AS nominations
+			ORDER BY categoryRel.position
 
-	OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
+		WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
+			ORDER BY ceremony.name DESC
 
-	WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
-		ORDER BY award.name
+		OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
+
+		WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
+			ORDER BY award.name
+
+		RETURN
+			COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS subsequentVersionMaterialAwards
+	}
 
 	RETURN
-		COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS subsequentVersionMaterialAwards
+		subsequentVersionMaterialAwards
 `;

--- a/src/neo4j/cypher-queries/company/show/show-awards.js
+++ b/src/neo4j/cypher-queries/company/show/show-awards.js
@@ -1,237 +1,244 @@
 export default () => `
 	MATCH (company:Company { uuid: $uuid })
 
-	OPTIONAL MATCH path=(company)
-		<-[:HAS_WRITING_ENTITY*0..1]-(creditingMaterial)-[:HAS_SUB_MATERIAL*0..2]-(nominatedMaterial)
-		<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
-		<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
-		WHERE
-			(NONE(rel IN RELATIONSHIPS(path)
-				WHERE COALESCE(rel.creditType IN ['NON_SPECIFIC_SOURCE_MATERIAL', 'RIGHTS_GRANTOR'], false)
-			)) AND
-			NOT EXISTS(
-				(company)
-				<-[:HAS_WRITING_ENTITY]-(:Material)
-				<-[:SUBSEQUENT_VERSION_OF]-(:Material)-[:HAS_SUB_MATERIAL*0..2]-(:Material)
-				<-[:HAS_NOMINEE]-(category)
-			) AND (
-				(creditingMaterial)-[:HAS_SUB_MATERIAL*0..2]->(nominatedMaterial) OR
-				(creditingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedMaterial)
-			)
+	CALL {
+		WITH company
 
-	WITH company, nomineeRel, category, categoryRel, ceremony
-
-	UNWIND (CASE WHEN nomineeRel IS NOT NULL AND nomineeRel.nominatedMemberUuids IS NOT NULL
-		THEN nomineeRel.nominatedMemberUuids
-		ELSE [null]
-	END) AS nominatedMemberUuid
-
-		OPTIONAL MATCH (category)-[nominatedMemberRel:HAS_NOMINEE]->
-			(nominatedMember:Person { uuid: nominatedMemberUuid })
+		OPTIONAL MATCH path=(company)
+			<-[:HAS_WRITING_ENTITY*0..1]-(creditingMaterial)-[:HAS_SUB_MATERIAL*0..2]-(nominatedMaterial)
+			<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
+			<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
 			WHERE
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = nominatedMemberRel.nominationPosition
+				(NONE(rel IN RELATIONSHIPS(path)
+					WHERE COALESCE(rel.creditType IN ['NON_SPECIFIC_SOURCE_MATERIAL', 'RIGHTS_GRANTOR'], false)
+				)) AND
+				NOT EXISTS(
+					(company)
+					<-[:HAS_WRITING_ENTITY]-(:Material)
+					<-[:SUBSEQUENT_VERSION_OF]-(:Material)-[:HAS_SUB_MATERIAL*0..2]-(:Material)
+					<-[:HAS_NOMINEE]-(category)
+				) AND (
+					(creditingMaterial)-[:HAS_SUB_MATERIAL*0..2]->(nominatedMaterial) OR
+					(creditingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedMaterial)
+				)
 
-		WITH company, nomineeRel, category, categoryRel, ceremony, nominatedMember
-			ORDER BY nominatedMemberRel.memberPosition
+		WITH company, nomineeRel, category, categoryRel, ceremony
 
-		WITH company, nomineeRel, category, categoryRel, ceremony,
-			COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
+		UNWIND (CASE WHEN nomineeRel IS NOT NULL AND nomineeRel.nominatedMemberUuids IS NOT NULL
+			THEN nomineeRel.nominatedMemberUuids
+			ELSE [null]
+		END) AS nominatedMemberUuid
 
-	OPTIONAL MATCH (category)-[coNominatedEntityRel:HAS_NOMINEE]->(coNominatedEntity:Person|Company)
-		WHERE
-			coNominatedEntityRel.nominatedCompanyUuid IS NULL AND
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = coNominatedEntityRel.nominationPosition
-			) AND
-			coNominatedEntity.uuid <> company.uuid
+			OPTIONAL MATCH (category)-[nominatedMemberRel:HAS_NOMINEE]->
+				(nominatedMember:Person { uuid: nominatedMemberUuid })
+				WHERE
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = nominatedMemberRel.nominationPosition
 
-	UNWIND (CASE WHEN coNominatedEntityRel IS NOT NULL AND coNominatedEntityRel.nominatedMemberUuids IS NOT NULL
-		THEN [uuid IN coNominatedEntityRel.nominatedMemberUuids]
-		ELSE [null]
-	END) AS coNominatedCompanyNominatedMemberUuid
+			WITH company, nomineeRel, category, categoryRel, ceremony, nominatedMember
+				ORDER BY nominatedMemberRel.memberPosition
 
-		OPTIONAL MATCH (category)-[coNominatedCompanyNominatedMemberRel:HAS_NOMINEE]->
-			(coNominatedCompanyNominatedMember:Person { uuid: coNominatedCompanyNominatedMemberUuid })
+			WITH company, nomineeRel, category, categoryRel, ceremony,
+				COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
+
+		OPTIONAL MATCH (category)-[coNominatedEntityRel:HAS_NOMINEE]->(coNominatedEntity:Person|Company)
 			WHERE
-				coNominatedEntityRel.nominationPosition IS NULL OR
-				coNominatedEntityRel.nominationPosition = coNominatedCompanyNominatedMemberRel.nominationPosition
+				coNominatedEntityRel.nominatedCompanyUuid IS NULL AND
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = coNominatedEntityRel.nominationPosition
+				) AND
+				coNominatedEntity.uuid <> company.uuid
+
+		UNWIND (CASE WHEN coNominatedEntityRel IS NOT NULL AND coNominatedEntityRel.nominatedMemberUuids IS NOT NULL
+			THEN [uuid IN coNominatedEntityRel.nominatedMemberUuids]
+			ELSE [null]
+		END) AS coNominatedCompanyNominatedMemberUuid
+
+			OPTIONAL MATCH (category)-[coNominatedCompanyNominatedMemberRel:HAS_NOMINEE]->
+				(coNominatedCompanyNominatedMember:Person { uuid: coNominatedCompanyNominatedMemberUuid })
+				WHERE
+					coNominatedEntityRel.nominationPosition IS NULL OR
+					coNominatedEntityRel.nominationPosition = coNominatedCompanyNominatedMemberRel.nominationPosition
+
+			WITH
+				nominatedMembers,
+				nomineeRel,
+				category,
+				categoryRel,
+				ceremony,
+				coNominatedEntityRel,
+				coNominatedEntity,
+				coNominatedCompanyNominatedMember
+				ORDER BY coNominatedCompanyNominatedMemberRel.memberPosition
+
+			WITH nominatedMembers, nomineeRel, category, categoryRel, ceremony, coNominatedEntityRel, coNominatedEntity,
+				COLLECT(coNominatedCompanyNominatedMember {
+					model: 'PERSON', .uuid, .name
+				}) AS coNominatedCompanyNominatedMembers
+				ORDER BY coNominatedEntityRel.entityPosition
+
+		WITH nominatedMembers, nomineeRel, category, categoryRel, ceremony,
+			COLLECT(
+				CASE WHEN coNominatedEntity IS NULL
+					THEN null
+					ELSE coNominatedEntity {
+						model: TOUPPER(HEAD(LABELS(coNominatedEntity))),
+						.uuid,
+						.name,
+						members: coNominatedCompanyNominatedMembers
+					}
+				END
+			) AS coNominatedEntities
+
+		WITH nominatedMembers, nomineeRel, category, categoryRel, ceremony,
+			[coNominatedEntity IN coNominatedEntities | CASE coNominatedEntity.model WHEN 'COMPANY'
+				THEN coNominatedEntity
+				ELSE coNominatedEntity { .model, .uuid, .name }
+			END] AS coNominatedEntities
+
+		OPTIONAL MATCH (category)-[nominatedProductionRel:HAS_NOMINEE]->(nominatedProduction:Production)
+			WHERE
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = nominatedProductionRel.nominationPosition
+				)
+
+		OPTIONAL MATCH (nominatedProduction)-[:PLAYS_AT]->(venue:Venue)
+
+		OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
+
+		OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
+
+		OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
 
 		WITH
-			nominatedMembers,
 			nomineeRel,
 			category,
 			categoryRel,
 			ceremony,
-			coNominatedEntityRel,
-			coNominatedEntity,
-			coNominatedCompanyNominatedMember
-			ORDER BY coNominatedCompanyNominatedMemberRel.memberPosition
+			nominatedMembers,
+			coNominatedEntities,
+			nominatedProductionRel,
+			nominatedProduction,
+			venue,
+			surVenue,
+			surProduction,
+			surSurProduction
+			ORDER BY nominatedProductionRel.productionPosition
 
-		WITH nominatedMembers, nomineeRel, category, categoryRel, ceremony, coNominatedEntityRel, coNominatedEntity,
-			COLLECT(coNominatedCompanyNominatedMember {
-				model: 'PERSON', .uuid, .name
-			}) AS coNominatedCompanyNominatedMembers
-			ORDER BY coNominatedEntityRel.entityPosition
+		WITH nomineeRel, category, categoryRel, ceremony, nominatedMembers, coNominatedEntities,
+			COLLECT(
+				CASE WHEN nominatedProduction IS NULL
+					THEN null
+					ELSE nominatedProduction {
+						model: 'PRODUCTION',
+						.uuid,
+						.name,
+						.startDate,
+						.endDate,
+						venue: CASE WHEN venue IS NULL
+							THEN null
+							ELSE venue {
+								model: 'VENUE',
+								.uuid,
+								.name,
+								surVenue: CASE WHEN surVenue IS NULL
+									THEN null
+									ELSE surVenue { model: 'VENUE', .uuid, .name }
+								END
+							}
+						END,
+						surProduction: CASE WHEN surProduction IS NULL
+							THEN null
+							ELSE surProduction {
+								model: 'PRODUCTION',
+								.uuid,
+								.name,
+								surProduction: CASE WHEN surSurProduction IS NULL
+									THEN null
+									ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+								END
+							}
+						END
+					}
+				END
+			) AS nominatedProductions
 
-	WITH nominatedMembers, nomineeRel, category, categoryRel, ceremony,
-		COLLECT(
-			CASE WHEN coNominatedEntity IS NULL
-				THEN null
-				ELSE coNominatedEntity {
-					model: TOUPPER(HEAD(LABELS(coNominatedEntity))),
-					.uuid,
-					.name,
-					members: coNominatedCompanyNominatedMembers
-				}
-			END
-		) AS coNominatedEntities
+		OPTIONAL MATCH (category)-[nominatedMaterialRel:HAS_NOMINEE]->(nominatedMaterial:Material)
+			WHERE
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = nominatedMaterialRel.nominationPosition
+				)
 
-	WITH nominatedMembers, nomineeRel, category, categoryRel, ceremony,
-		[coNominatedEntity IN coNominatedEntities | CASE coNominatedEntity.model WHEN 'COMPANY'
-			THEN coNominatedEntity
-			ELSE coNominatedEntity { .model, .uuid, .name }
-		END] AS coNominatedEntities
+		WITH
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedMembers,
+			coNominatedEntities,
+			nominatedProductions,
+			nominatedMaterialRel,
+			nominatedMaterial
+			ORDER BY nominatedMaterialRel.materialPosition
 
-	OPTIONAL MATCH (category)-[nominatedProductionRel:HAS_NOMINEE]->(nominatedProduction:Production)
-		WHERE
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = nominatedProductionRel.nominationPosition
-			)
+		OPTIONAL MATCH (nominatedMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSurMaterial:Material)
 
-	OPTIONAL MATCH (nominatedProduction)-[:PLAYS_AT]->(venue:Venue)
+		OPTIONAL MATCH (nominatedSurMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSurSurMaterial:Material)
 
-	OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
+		WITH nomineeRel, category, categoryRel, ceremony, nominatedMembers, coNominatedEntities, nominatedProductions,
+			COLLECT(
+				CASE WHEN nominatedMaterial IS NULL
+					THEN null
+					ELSE nominatedMaterial {
+						model: 'MATERIAL',
+						.uuid,
+						.name,
+						.format,
+						.year,
+						surMaterial: CASE WHEN nominatedSurMaterial IS NULL
+							THEN null
+							ELSE nominatedSurMaterial {
+								model: 'MATERIAL',
+								.uuid,
+								.name,
+								surMaterial: CASE WHEN nominatedSurSurMaterial IS NULL
+									THEN null
+									ELSE nominatedSurSurMaterial { model: 'MATERIAL', .uuid, .name }
+								END
+							}
+						END
+					}
+				END
+			) AS nominatedMaterials
+			ORDER BY nomineeRel.nominationPosition
 
-	OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
+		WITH category, categoryRel, ceremony,
+			COLLECT({
+				model: 'NOMINATION',
+				isWinner: COALESCE(nomineeRel.isWinner, false),
+				type: COALESCE(nomineeRel.customType, CASE WHEN nomineeRel.isWinner THEN 'Winner' ELSE 'Nomination' END),
+				members: nominatedMembers,
+				coEntities: coNominatedEntities,
+				productions: nominatedProductions,
+				materials: nominatedMaterials
+			}) AS nominations
+			ORDER BY categoryRel.position
 
-	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+		WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
+			ORDER BY ceremony.name DESC
 
-	WITH
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedMembers,
-		coNominatedEntities,
-		nominatedProductionRel,
-		nominatedProduction,
-		venue,
-		surVenue,
-		surProduction,
-		surSurProduction
-		ORDER BY nominatedProductionRel.productionPosition
+		OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
 
-	WITH nomineeRel, category, categoryRel, ceremony, nominatedMembers, coNominatedEntities,
-		COLLECT(
-			CASE WHEN nominatedProduction IS NULL
-				THEN null
-				ELSE nominatedProduction {
-					model: 'PRODUCTION',
-					.uuid,
-					.name,
-					.startDate,
-					.endDate,
-					venue: CASE WHEN venue IS NULL
-						THEN null
-						ELSE venue {
-							model: 'VENUE',
-							.uuid,
-							.name,
-							surVenue: CASE WHEN surVenue IS NULL
-								THEN null
-								ELSE surVenue { model: 'VENUE', .uuid, .name }
-							END
-						}
-					END,
-					surProduction: CASE WHEN surProduction IS NULL
-						THEN null
-						ELSE surProduction {
-							model: 'PRODUCTION',
-							.uuid,
-							.name,
-							surProduction: CASE WHEN surSurProduction IS NULL
-								THEN null
-								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
-							END
-						}
-					END
-				}
-			END
-		) AS nominatedProductions
+		WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
+			ORDER BY award.name
 
-	OPTIONAL MATCH (category)-[nominatedMaterialRel:HAS_NOMINEE]->(nominatedMaterial:Material)
-		WHERE
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = nominatedMaterialRel.nominationPosition
-			)
-
-	WITH
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedMembers,
-		coNominatedEntities,
-		nominatedProductions,
-		nominatedMaterialRel,
-		nominatedMaterial
-		ORDER BY nominatedMaterialRel.materialPosition
-
-	OPTIONAL MATCH (nominatedMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSurMaterial:Material)
-
-	OPTIONAL MATCH (nominatedSurMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSurSurMaterial:Material)
-
-	WITH nomineeRel, category, categoryRel, ceremony, nominatedMembers, coNominatedEntities, nominatedProductions,
-		COLLECT(
-			CASE WHEN nominatedMaterial IS NULL
-				THEN null
-				ELSE nominatedMaterial {
-					model: 'MATERIAL',
-					.uuid,
-					.name,
-					.format,
-					.year,
-					surMaterial: CASE WHEN nominatedSurMaterial IS NULL
-						THEN null
-						ELSE nominatedSurMaterial {
-							model: 'MATERIAL',
-							.uuid,
-							.name,
-							surMaterial: CASE WHEN nominatedSurSurMaterial IS NULL
-								THEN null
-								ELSE nominatedSurSurMaterial { model: 'MATERIAL', .uuid, .name }
-							END
-						}
-					END
-				}
-			END
-		) AS nominatedMaterials
-		ORDER BY nomineeRel.nominationPosition
-
-	WITH category, categoryRel, ceremony,
-		COLLECT({
-			model: 'NOMINATION',
-			isWinner: COALESCE(nomineeRel.isWinner, false),
-			type: COALESCE(nomineeRel.customType, CASE WHEN nomineeRel.isWinner THEN 'Winner' ELSE 'Nomination' END),
-			members: nominatedMembers,
-			coEntities: coNominatedEntities,
-			productions: nominatedProductions,
-			materials: nominatedMaterials
-		}) AS nominations
-		ORDER BY categoryRel.position
-
-	WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
-		ORDER BY ceremony.name DESC
-
-	OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
-
-	WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
-		ORDER BY award.name
+		RETURN
+			COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS awards
+	}
 
 	RETURN
-		COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS awards
+		awards
 `;

--- a/src/neo4j/cypher-queries/company/show/show-materials.js
+++ b/src/neo4j/cypher-queries/company/show/show-materials.js
@@ -1,213 +1,223 @@
 export default () => `
 	MATCH (company:Company { uuid: $uuid })
 
-	OPTIONAL MATCH (company)<-[:HAS_WRITING_ENTITY]-(:Material)<-[:USES_SOURCE_MATERIAL*0..1]-(material:Material)
-		WHERE NOT EXISTS(
-			(company)<-[:HAS_WRITING_ENTITY]-(:Material)<-[:USES_SOURCE_MATERIAL*0..1]-(:Material)
-			<-[:HAS_SUB_MATERIAL*1..2]-(material)
-		)
+	CALL {
+		WITH company
 
-	WITH company, COLLECT(DISTINCT(material)) AS materials
+		OPTIONAL MATCH (company)<-[:HAS_WRITING_ENTITY]-(:Material)<-[:USES_SOURCE_MATERIAL*0..1]-(material:Material)
+			WHERE NOT EXISTS(
+				(company)<-[:HAS_WRITING_ENTITY]-(:Material)<-[:USES_SOURCE_MATERIAL*0..1]-(:Material)
+				<-[:HAS_SUB_MATERIAL*1..2]-(material)
+			)
 
-	UNWIND (CASE materials WHEN [] THEN [null] ELSE materials END) AS material
+		WITH company, COLLECT(DISTINCT(material)) AS materials
 
-		OPTIONAL MATCH (company)<-[writerRel:HAS_WRITING_ENTITY]-(material)
+		UNWIND (CASE materials WHEN [] THEN [null] ELSE materials END) AS material
 
-		OPTIONAL MATCH (company)<-[:HAS_WRITING_ENTITY]-(:Material)
-			<-[subsequentVersionRel:SUBSEQUENT_VERSION_OF]-(material)
+			OPTIONAL MATCH (company)<-[writerRel:HAS_WRITING_ENTITY]-(material)
 
-		OPTIONAL MATCH (company)<-[:HAS_WRITING_ENTITY]-(:Material)
-			<-[sourcingMaterialRel:USES_SOURCE_MATERIAL]-(material)
+			OPTIONAL MATCH (company)<-[:HAS_WRITING_ENTITY]-(:Material)
+				<-[subsequentVersionRel:SUBSEQUENT_VERSION_OF]-(material)
 
-		OPTIONAL MATCH (material)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity:Person|Company|Material)
+			OPTIONAL MATCH (company)<-[:HAS_WRITING_ENTITY]-(:Material)
+				<-[sourcingMaterialRel:USES_SOURCE_MATERIAL]-(material)
 
-		OPTIONAL MATCH (entity:Material)<-[:HAS_SUB_MATERIAL]-(entitySurMaterial:Material)
+			OPTIONAL MATCH (material)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity:Person|Company|Material)
 
-		OPTIONAL MATCH (entitySurMaterial)<-[:HAS_SUB_MATERIAL]-(entitySurSurMaterial:Material)
+			OPTIONAL MATCH (entity:Material)<-[:HAS_SUB_MATERIAL]-(entitySurMaterial:Material)
 
-		OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->
-			(sourceMaterialWriter:Person|Company)
+			OPTIONAL MATCH (entitySurMaterial)<-[:HAS_SUB_MATERIAL]-(entitySurSurMaterial:Material)
 
-		WITH
-			material,
-			writerRel.creditType AS creditType,
-			CASE WHEN writerRel IS NULL THEN false ELSE true END AS hasDirectCredit,
-			CASE WHEN subsequentVersionRel IS NULL THEN false ELSE true END AS isSubsequentVersion,
-			CASE WHEN sourcingMaterialRel IS NULL THEN false ELSE true END AS isSourcingMaterial,
-			entityRel,
-			entity,
-			entitySurMaterial,
-			entitySurSurMaterial,
-			sourceMaterialWriterRel,
-			sourceMaterialWriter
-			ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriterRel.entityPosition
+			OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->
+				(sourceMaterialWriter:Person|Company)
 
-		WITH
-			material,
-			creditType,
-			hasDirectCredit,
-			isSubsequentVersion,
-			isSourcingMaterial,
-			entityRel,
-			entity,
-			entitySurMaterial,
-			entitySurSurMaterial,
-			sourceMaterialWriterRel.credit AS sourceMaterialWritingCreditName,
-			COLLECT(
-				CASE WHEN sourceMaterialWriter IS NULL
-					THEN null
-					ELSE sourceMaterialWriter { model: TOUPPER(HEAD(LABELS(sourceMaterialWriter))), .uuid, .name }
-				END
-			) AS sourceMaterialWriters
+			WITH
+				material,
+				writerRel.creditType AS creditType,
+				CASE WHEN writerRel IS NULL THEN false ELSE true END AS hasDirectCredit,
+				CASE WHEN subsequentVersionRel IS NULL THEN false ELSE true END AS isSubsequentVersion,
+				CASE WHEN sourcingMaterialRel IS NULL THEN false ELSE true END AS isSourcingMaterial,
+				entityRel,
+				entity,
+				entitySurMaterial,
+				entitySurSurMaterial,
+				sourceMaterialWriterRel,
+				sourceMaterialWriter
+				ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriterRel.entityPosition
 
-		WITH
-			material,
-			creditType,
-			hasDirectCredit,
-			isSubsequentVersion,
-			isSourcingMaterial,
-			entityRel,
-			entity,
-			entitySurMaterial,
-			entitySurSurMaterial,
-			COLLECT(
-				CASE SIZE(sourceMaterialWriters) WHEN 0
-					THEN null
-					ELSE {
-						model: 'WRITING_CREDIT',
-						name: COALESCE(sourceMaterialWritingCreditName, 'by'),
-						entities: sourceMaterialWriters
-					}
-				END
-			) AS sourceMaterialWritingCredits
-			ORDER BY entityRel.creditPosition, entityRel.entityPosition
+			WITH
+				material,
+				creditType,
+				hasDirectCredit,
+				isSubsequentVersion,
+				isSourcingMaterial,
+				entityRel,
+				entity,
+				entitySurMaterial,
+				entitySurSurMaterial,
+				sourceMaterialWriterRel.credit AS sourceMaterialWritingCreditName,
+				COLLECT(
+					CASE WHEN sourceMaterialWriter IS NULL
+						THEN null
+						ELSE sourceMaterialWriter { model: TOUPPER(HEAD(LABELS(sourceMaterialWriter))), .uuid, .name }
+					END
+				) AS sourceMaterialWriters
 
-		WITH
-			material,
-			creditType,
-			hasDirectCredit,
-			isSubsequentVersion,
-			isSourcingMaterial,
-			entityRel.credit AS writingCreditName,
-			COLLECT(
-				CASE WHEN entity IS NULL
-					THEN null
-					ELSE entity {
-						model: TOUPPER(HEAD(LABELS(entity))),
-						.uuid,
-						.name,
-						.format,
-						.year,
-						surMaterial: CASE WHEN entitySurMaterial IS NULL
-							THEN null
-							ELSE entitySurMaterial {
-								model: 'MATERIAL',
-								.uuid,
-								.name,
-								surMaterial: CASE WHEN entitySurSurMaterial IS NULL
-									THEN null
-									ELSE entitySurSurMaterial { model: 'MATERIAL', .uuid, .name }
-								END
-							}
-						END,
-						writingCredits: sourceMaterialWritingCredits
-					}
-				END
-			) AS entities
+			WITH
+				material,
+				creditType,
+				hasDirectCredit,
+				isSubsequentVersion,
+				isSourcingMaterial,
+				entityRel,
+				entity,
+				entitySurMaterial,
+				entitySurSurMaterial,
+				COLLECT(
+					CASE SIZE(sourceMaterialWriters) WHEN 0
+						THEN null
+						ELSE {
+							model: 'WRITING_CREDIT',
+							name: COALESCE(sourceMaterialWritingCreditName, 'by'),
+							entities: sourceMaterialWriters
+						}
+					END
+				) AS sourceMaterialWritingCredits
+				ORDER BY entityRel.creditPosition, entityRel.entityPosition
 
-		WITH
-			material,
-			creditType,
-			hasDirectCredit,
-			isSubsequentVersion,
-			isSourcingMaterial,
-			writingCreditName,
-			[entity IN entities | CASE entity.model WHEN 'MATERIAL'
-				THEN entity
-				ELSE entity { .model, .uuid, .name }
-			END] AS entities
+			WITH
+				material,
+				creditType,
+				hasDirectCredit,
+				isSubsequentVersion,
+				isSourcingMaterial,
+				entityRel.credit AS writingCreditName,
+				COLLECT(
+					CASE WHEN entity IS NULL
+						THEN null
+						ELSE entity {
+							model: TOUPPER(HEAD(LABELS(entity))),
+							.uuid,
+							.name,
+							.format,
+							.year,
+							surMaterial: CASE WHEN entitySurMaterial IS NULL
+								THEN null
+								ELSE entitySurMaterial {
+									model: 'MATERIAL',
+									.uuid,
+									.name,
+									surMaterial: CASE WHEN entitySurSurMaterial IS NULL
+										THEN null
+										ELSE entitySurSurMaterial { model: 'MATERIAL', .uuid, .name }
+									END
+								}
+							END,
+							writingCredits: sourceMaterialWritingCredits
+						}
+					END
+				) AS entities
 
-		OPTIONAL MATCH (material)<-[surMaterialRel:HAS_SUB_MATERIAL]-(surMaterial:Material)
+			WITH
+				material,
+				creditType,
+				hasDirectCredit,
+				isSubsequentVersion,
+				isSourcingMaterial,
+				writingCreditName,
+				[entity IN entities | CASE entity.model WHEN 'MATERIAL'
+					THEN entity
+					ELSE entity { .model, .uuid, .name }
+				END] AS entities
 
-		OPTIONAL MATCH (surMaterial)<-[surSurMaterialRel:HAS_SUB_MATERIAL]-(surSurMaterial:Material)
+			OPTIONAL MATCH (material)<-[surMaterialRel:HAS_SUB_MATERIAL]-(surMaterial:Material)
 
-		WITH
-			material,
-			creditType,
-			hasDirectCredit,
-			isSubsequentVersion,
-			isSourcingMaterial,
-			surMaterial,
-			surMaterialRel,
-			surSurMaterial,
-			surSurMaterialRel,
-			COLLECT(
-				CASE SIZE(entities) WHEN 0
-					THEN null
-					ELSE {
-						model: 'WRITING_CREDIT',
-						name: COALESCE(writingCreditName, 'by'),
-						entities: entities
-					}
-				END
-			) AS writingCredits
-			ORDER BY
-				material.year DESC,
-				COALESCE(surSurMaterial.name, surMaterial.name, material.name),
-				surSurMaterialRel.position DESC,
-				surMaterialRel.position DESC
+			OPTIONAL MATCH (surMaterial)<-[surSurMaterialRel:HAS_SUB_MATERIAL]-(surSurMaterial:Material)
 
-		WITH
-			COLLECT(
-				CASE WHEN material IS NULL
-					THEN null
-					ELSE material {
-						model: 'MATERIAL',
-						.uuid,
-						.name,
-						.format,
-						.year,
-						surMaterial: CASE WHEN surMaterial IS NULL
-							THEN null
-							ELSE surMaterial {
-								model: 'MATERIAL',
-								.uuid,
-								.name,
-								surMaterial: CASE WHEN surSurMaterial IS NULL
-									THEN null
-									ELSE surSurMaterial { model: 'MATERIAL', .uuid, .name }
-								END
-							}
-						END,
-						writingCredits,
-						creditType,
-						hasDirectCredit,
-						isSubsequentVersion,
-						isSourcingMaterial
-					}
-				END
-			) AS materials
+			WITH
+				material,
+				creditType,
+				hasDirectCredit,
+				isSubsequentVersion,
+				isSourcingMaterial,
+				surMaterial,
+				surMaterialRel,
+				surSurMaterial,
+				surSurMaterialRel,
+				COLLECT(
+					CASE SIZE(entities) WHEN 0
+						THEN null
+						ELSE {
+							model: 'WRITING_CREDIT',
+							name: COALESCE(writingCreditName, 'by'),
+							entities: entities
+						}
+					END
+				) AS writingCredits
+				ORDER BY
+					material.year DESC,
+					COALESCE(surSurMaterial.name, surMaterial.name, material.name),
+					surSurMaterialRel.position DESC,
+					surMaterialRel.position DESC
+
+			WITH
+				COLLECT(
+					CASE WHEN material IS NULL
+						THEN null
+						ELSE material {
+							model: 'MATERIAL',
+							.uuid,
+							.name,
+							.format,
+							.year,
+							surMaterial: CASE WHEN surMaterial IS NULL
+								THEN null
+								ELSE surMaterial {
+									model: 'MATERIAL',
+									.uuid,
+									.name,
+									surMaterial: CASE WHEN surSurMaterial IS NULL
+										THEN null
+										ELSE surSurMaterial { model: 'MATERIAL', .uuid, .name }
+									END
+								}
+							END,
+							writingCredits,
+							creditType,
+							hasDirectCredit,
+							isSubsequentVersion,
+							isSourcingMaterial
+						}
+					END
+				) AS materials
+
+		RETURN
+			[
+				material IN materials WHERE
+					material.hasDirectCredit AND
+					NOT material.isSubsequentVersion AND
+					material.creditType IS NULL |
+				material { .model, .uuid, .name, .format, .year, .writingCredits, .surMaterial }
+			] AS materials,
+			[
+				material IN materials WHERE material.isSubsequentVersion |
+				material { .model, .uuid, .name, .format, .year, .writingCredits, .surMaterial }
+			] AS subsequentVersionMaterials,
+			[
+				material IN materials WHERE
+					material.isSourcingMaterial OR
+					material.creditType = 'NON_SPECIFIC_SOURCE_MATERIAL' |
+				material { .model, .uuid, .name, .format, .year, .writingCredits, .surMaterial }
+			] AS sourcingMaterials,
+			[
+				material IN materials WHERE material.creditType = 'RIGHTS_GRANTOR' |
+				material { .model, .uuid, .name, .format, .year, .writingCredits, .surMaterial }
+			] AS rightsGrantorMaterials
+	}
 
 	RETURN
-		[
-			material IN materials WHERE
-				material.hasDirectCredit AND
-				NOT material.isSubsequentVersion AND
-				material.creditType IS NULL |
-			material { .model, .uuid, .name, .format, .year, .writingCredits, .surMaterial }
-		] AS materials,
-		[
-			material IN materials WHERE material.isSubsequentVersion |
-			material { .model, .uuid, .name, .format, .year, .writingCredits, .surMaterial }
-		] AS subsequentVersionMaterials,
-		[
-			material IN materials WHERE
-				material.isSourcingMaterial OR
-				material.creditType = 'NON_SPECIFIC_SOURCE_MATERIAL' |
-			material { .model, .uuid, .name, .format, .year, .writingCredits, .surMaterial }
-		] AS sourcingMaterials,
-		[
-			material IN materials WHERE material.creditType = 'RIGHTS_GRANTOR' |
-			material { .model, .uuid, .name, .format, .year, .writingCredits, .surMaterial }
-		] AS rightsGrantorMaterials
+		materials,
+		subsequentVersionMaterials,
+		sourcingMaterials,
+		rightsGrantorMaterials
 `;

--- a/src/neo4j/cypher-queries/material/show/show-awards-sourcing-material.js
+++ b/src/neo4j/cypher-queries/material/show/show-awards-sourcing-material.js
@@ -1,265 +1,272 @@
 export default () => `
 	MATCH (material:Material { uuid: $uuid })
 
-	OPTIONAL MATCH (material)-[:HAS_SUB_MATERIAL*0..2]-(sourceMaterial:Material)
-		<-[:USES_SOURCE_MATERIAL]-(sourcingMaterial:Material)
-			-[:HAS_SUB_MATERIAL*0..2]-(nominatedSourcingMaterial:Material)
-		<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
-		<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
-		WHERE
-			(
-				(material)-[:HAS_SUB_MATERIAL*0..2]->(sourceMaterial) AND
-				(sourcingMaterial)-[:HAS_SUB_MATERIAL*0..2]->(nominatedSourcingMaterial)
-			) OR (
-				(material)<-[:HAS_SUB_MATERIAL*0..2]-(sourceMaterial) AND
-				(sourcingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSourcingMaterial)
-			) OR (
-				(material)-[:HAS_SUB_MATERIAL*0..2]->(sourceMaterial) AND
-				(sourcingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSourcingMaterial)
-			)
+	CALL {
+		WITH material
 
-	OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)
-		WHERE
-			(
-				(nominatedEntity:Person AND nominatedEntityRel.nominatedCompanyUuid IS NULL) OR
-				nominatedEntity:Company
-			) AND
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = nominatedEntityRel.nominationPosition
-			)
+		OPTIONAL MATCH (material)-[:HAS_SUB_MATERIAL*0..2]-(sourceMaterial:Material)
+			<-[:USES_SOURCE_MATERIAL]-(sourcingMaterial:Material)
+				-[:HAS_SUB_MATERIAL*0..2]-(nominatedSourcingMaterial:Material)
+			<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
+			<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
+			WHERE
+				(
+					(material)-[:HAS_SUB_MATERIAL*0..2]->(sourceMaterial) AND
+					(sourcingMaterial)-[:HAS_SUB_MATERIAL*0..2]->(nominatedSourcingMaterial)
+				) OR (
+					(material)<-[:HAS_SUB_MATERIAL*0..2]-(sourceMaterial) AND
+					(sourcingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSourcingMaterial)
+				) OR (
+					(material)-[:HAS_SUB_MATERIAL*0..2]->(sourceMaterial) AND
+					(sourcingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSourcingMaterial)
+				)
 
-	WITH material, nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntityRel,
-		COLLECT(nominatedEntity {
-			model: TOUPPER(HEAD(LABELS(nominatedEntity))),
-			.uuid,
-			.name,
-			nominatedMemberUuids: nominatedEntityRel.nominatedMemberUuids
-		}) AS nominatedEntities
+		OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)
+			WHERE
+				(
+					(nominatedEntity:Person AND nominatedEntityRel.nominatedCompanyUuid IS NULL) OR
+					nominatedEntity:Company
+				) AND
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = nominatedEntityRel.nominationPosition
+				)
 
-	UNWIND (CASE nominatedEntities WHEN [] THEN [null] ELSE nominatedEntities END) AS nominatedEntity
+		WITH material, nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntityRel,
+			COLLECT(nominatedEntity {
+				model: TOUPPER(HEAD(LABELS(nominatedEntity))),
+				.uuid,
+				.name,
+				nominatedMemberUuids: nominatedEntityRel.nominatedMemberUuids
+			}) AS nominatedEntities
 
-		UNWIND (COALESCE(nominatedEntity.nominatedMemberUuids, [null])) AS nominatedMemberUuid
+		UNWIND (CASE nominatedEntities WHEN [] THEN [null] ELSE nominatedEntities END) AS nominatedEntity
 
-			OPTIONAL MATCH (category)-[nominatedMemberRel:HAS_NOMINEE]->
-				(nominatedMember:Person { uuid: nominatedMemberUuid })
-				WHERE
-					nominatedEntityRel.nominationPosition IS NULL OR
-					nominatedEntityRel.nominationPosition = nominatedMemberRel.nominationPosition
+			UNWIND (COALESCE(nominatedEntity.nominatedMemberUuids, [null])) AS nominatedMemberUuid
 
-			WITH
-				material,
-				nominatedSourcingMaterial,
-				nomineeRel,
-				category,
-				categoryRel,
-				ceremony,
-				nominatedEntityRel,
-				nominatedEntity,
-				nominatedMember
-				ORDER BY nominatedMemberRel.memberPosition
+				OPTIONAL MATCH (category)-[nominatedMemberRel:HAS_NOMINEE]->
+					(nominatedMember:Person { uuid: nominatedMemberUuid })
+					WHERE
+						nominatedEntityRel.nominationPosition IS NULL OR
+						nominatedEntityRel.nominationPosition = nominatedMemberRel.nominationPosition
 
-			WITH
-				material,
-				nominatedSourcingMaterial,
-				nomineeRel,
-				category,
-				categoryRel,
-				ceremony,
-				nominatedEntityRel,
-				nominatedEntity,
-				COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
+				WITH
+					material,
+					nominatedSourcingMaterial,
+					nomineeRel,
+					category,
+					categoryRel,
+					ceremony,
+					nominatedEntityRel,
+					nominatedEntity,
+					nominatedMember
+					ORDER BY nominatedMemberRel.memberPosition
 
-	WITH
-		material,
-		nominatedSourcingMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntityRel,
-		nominatedEntity,
-		nominatedMembers
-		ORDER BY nominatedEntityRel.nominationPosition, nominatedEntityRel.entityPosition
+				WITH
+					material,
+					nominatedSourcingMaterial,
+					nomineeRel,
+					category,
+					categoryRel,
+					ceremony,
+					nominatedEntityRel,
+					nominatedEntity,
+					COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
 
-	WITH material, nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony,
-		COLLECT(
-			CASE WHEN nominatedEntity IS NULL
-				THEN null
-				ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
-			END
-		) AS nominatedEntities
+		WITH
+			material,
+			nominatedSourcingMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntityRel,
+			nominatedEntity,
+			nominatedMembers
+			ORDER BY nominatedEntityRel.nominationPosition, nominatedEntityRel.entityPosition
 
-	WITH material, nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony,
-		[nominatedEntity IN nominatedEntities | CASE nominatedEntity.model WHEN 'COMPANY'
-			THEN nominatedEntity
-			ELSE nominatedEntity { .model, .uuid, .name }
-		END] AS nominatedEntities
+		WITH material, nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony,
+			COLLECT(
+				CASE WHEN nominatedEntity IS NULL
+					THEN null
+					ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
+				END
+			) AS nominatedEntities
 
-	OPTIONAL MATCH (category)-[nominatedProductionRel:HAS_NOMINEE]->(nominatedProduction:Production)
-		WHERE
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = nominatedProductionRel.nominationPosition
-			)
+		WITH material, nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony,
+			[nominatedEntity IN nominatedEntities | CASE nominatedEntity.model WHEN 'COMPANY'
+				THEN nominatedEntity
+				ELSE nominatedEntity { .model, .uuid, .name }
+			END] AS nominatedEntities
 
-	OPTIONAL MATCH (nominatedProduction)-[:PLAYS_AT]->(venue:Venue)
+		OPTIONAL MATCH (category)-[nominatedProductionRel:HAS_NOMINEE]->(nominatedProduction:Production)
+			WHERE
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = nominatedProductionRel.nominationPosition
+				)
 
-	OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
+		OPTIONAL MATCH (nominatedProduction)-[:PLAYS_AT]->(venue:Venue)
 
-	OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
+		OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
 
-	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+		OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
-	WITH
-		material,
-		nominatedSourcingMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductionRel,
-		nominatedProduction,
-		venue,
-		surVenue,
-		surProduction,
-		surSurProduction
-		ORDER BY nominatedProductionRel.productionPosition
+		OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
 
-	WITH material, nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
-		COLLECT(
-			CASE WHEN nominatedProduction IS NULL
-				THEN null
-				ELSE nominatedProduction {
-					model: 'PRODUCTION',
-					.uuid,
-					.name,
-					.startDate,
-					.endDate,
-					venue: CASE WHEN venue IS NULL
-						THEN null
-						ELSE venue {
-							model: 'VENUE',
-							.uuid,
-							.name,
-							surVenue: CASE WHEN surVenue IS NULL
-								THEN null
-								ELSE surVenue { model: 'VENUE', .uuid, .name }
-							END
-						}
-					END,
-					surProduction: CASE WHEN surProduction IS NULL
-						THEN null
-						ELSE surProduction {
-							model: 'PRODUCTION',
-							.uuid,
-							.name,
-							surProduction: CASE WHEN surSurProduction IS NULL
-								THEN null
-								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
-							END
-						}
-					END
-				}
-			END
-		) AS nominatedProductions
+		WITH
+			material,
+			nominatedSourcingMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductionRel,
+			nominatedProduction,
+			venue,
+			surVenue,
+			surProduction,
+			surSurProduction
+			ORDER BY nominatedProductionRel.productionPosition
 
-	OPTIONAL MATCH (category)-[nominatedMaterialRel:HAS_NOMINEE]->(nominatedMaterial:Material)
-		WHERE
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = nominatedMaterialRel.nominationPosition
-			) AND
-			nominatedMaterial.uuid <> nominatedSourcingMaterial.uuid AND
-			NOT EXISTS((material)<-[:USES_SOURCE_MATERIAL]-(nominatedMaterial))
+		WITH material, nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
+			COLLECT(
+				CASE WHEN nominatedProduction IS NULL
+					THEN null
+					ELSE nominatedProduction {
+						model: 'PRODUCTION',
+						.uuid,
+						.name,
+						.startDate,
+						.endDate,
+						venue: CASE WHEN venue IS NULL
+							THEN null
+							ELSE venue {
+								model: 'VENUE',
+								.uuid,
+								.name,
+								surVenue: CASE WHEN surVenue IS NULL
+									THEN null
+									ELSE surVenue { model: 'VENUE', .uuid, .name }
+								END
+							}
+						END,
+						surProduction: CASE WHEN surProduction IS NULL
+							THEN null
+							ELSE surProduction {
+								model: 'PRODUCTION',
+								.uuid,
+								.name,
+								surProduction: CASE WHEN surSurProduction IS NULL
+									THEN null
+									ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+								END
+							}
+						END
+					}
+				END
+			) AS nominatedProductions
 
-	WITH
-		nominatedSourcingMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductions,
-		nominatedMaterialRel,
-		nominatedMaterial
-		ORDER BY nominatedMaterialRel.materialPosition
+		OPTIONAL MATCH (category)-[nominatedMaterialRel:HAS_NOMINEE]->(nominatedMaterial:Material)
+			WHERE
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = nominatedMaterialRel.nominationPosition
+				) AND
+				nominatedMaterial.uuid <> nominatedSourcingMaterial.uuid AND
+				NOT EXISTS((material)<-[:USES_SOURCE_MATERIAL]-(nominatedMaterial))
 
-	WITH
-		nominatedSourcingMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductions,
-		COLLECT(
-			CASE WHEN nominatedMaterial IS NULL
-				THEN null
-				ELSE nominatedMaterial { model: 'MATERIAL', .uuid, .name, .format, .year }
-			END
-		) AS nominatedMaterials
-		ORDER BY nomineeRel.nominationPosition, nomineeRel.materialPosition
+		WITH
+			nominatedSourcingMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductions,
+			nominatedMaterialRel,
+			nominatedMaterial
+			ORDER BY nominatedMaterialRel.materialPosition
 
-	OPTIONAL MATCH (nominatedSourcingMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSourcingSurMaterial:Material)
+		WITH
+			nominatedSourcingMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductions,
+			COLLECT(
+				CASE WHEN nominatedMaterial IS NULL
+					THEN null
+					ELSE nominatedMaterial { model: 'MATERIAL', .uuid, .name, .format, .year }
+				END
+			) AS nominatedMaterials
+			ORDER BY nomineeRel.nominationPosition, nomineeRel.materialPosition
 
-	OPTIONAL MATCH (nominatedSourcingSurMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSourcingSurSurMaterial:Material)
+		OPTIONAL MATCH (nominatedSourcingMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSourcingSurMaterial:Material)
 
-	WITH
-		nomineeRel.isWinner AS isWinner,
-		nomineeRel.customType AS customType,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductions,
-		nominatedMaterials,
-		COLLECT(
-			CASE WHEN nominatedSourcingMaterial IS NULL
-				THEN null
-				ELSE nominatedSourcingMaterial {
-					model: 'MATERIAL',
-					.uuid,
-					.name,
-					.format,
-					.year,
-					surMaterial: CASE WHEN nominatedSourcingSurMaterial IS NULL
-						THEN null
-						ELSE nominatedSourcingSurMaterial {
-							model: 'MATERIAL',
-							.uuid,
-							.name,
-							surMaterial: CASE WHEN nominatedSourcingSurSurMaterial IS NULL
-								THEN null
-								ELSE nominatedSourcingSurSurMaterial { model: 'MATERIAL', .uuid, .name }
-							END
-						}
-					END
-				}
-			END
-		) AS nominatedSourcingMaterials
+		OPTIONAL MATCH (nominatedSourcingSurMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSourcingSurSurMaterial:Material)
 
-	WITH category, categoryRel, ceremony,
-		COLLECT({
-			model: 'NOMINATION',
-			isWinner: COALESCE(isWinner, false),
-			type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
-			entities: nominatedEntities,
-			productions: nominatedProductions,
-			materials: nominatedMaterials,
-			recipientSourcingMaterials: nominatedSourcingMaterials
-		}) AS nominations
-		ORDER BY categoryRel.position
+		WITH
+			nomineeRel.isWinner AS isWinner,
+			nomineeRel.customType AS customType,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductions,
+			nominatedMaterials,
+			COLLECT(
+				CASE WHEN nominatedSourcingMaterial IS NULL
+					THEN null
+					ELSE nominatedSourcingMaterial {
+						model: 'MATERIAL',
+						.uuid,
+						.name,
+						.format,
+						.year,
+						surMaterial: CASE WHEN nominatedSourcingSurMaterial IS NULL
+							THEN null
+							ELSE nominatedSourcingSurMaterial {
+								model: 'MATERIAL',
+								.uuid,
+								.name,
+								surMaterial: CASE WHEN nominatedSourcingSurSurMaterial IS NULL
+									THEN null
+									ELSE nominatedSourcingSurSurMaterial { model: 'MATERIAL', .uuid, .name }
+								END
+							}
+						END
+					}
+				END
+			) AS nominatedSourcingMaterials
 
-	WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
-		ORDER BY ceremony.name DESC
+		WITH category, categoryRel, ceremony,
+			COLLECT({
+				model: 'NOMINATION',
+				isWinner: COALESCE(isWinner, false),
+				type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
+				entities: nominatedEntities,
+				productions: nominatedProductions,
+				materials: nominatedMaterials,
+				recipientSourcingMaterials: nominatedSourcingMaterials
+			}) AS nominations
+			ORDER BY categoryRel.position
 
-	OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
+		WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
+			ORDER BY ceremony.name DESC
 
-	WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
-		ORDER BY award.name
+		OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
+
+		WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
+			ORDER BY award.name
+
+		RETURN
+			COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS sourcingMaterialAwards
+	}
 
 	RETURN
-		COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS sourcingMaterialAwards
+		sourcingMaterialAwards
 `;

--- a/src/neo4j/cypher-queries/material/show/show-awards-subsequent-version-material.js
+++ b/src/neo4j/cypher-queries/material/show/show-awards-subsequent-version-material.js
@@ -1,267 +1,274 @@
 export default () => `
 	MATCH (material:Material { uuid: $uuid })
 
-	OPTIONAL MATCH (material)-[:HAS_SUB_MATERIAL*0..2]-(originalVersionMaterial:Material)
-		<-[:SUBSEQUENT_VERSION_OF]-(subsequentVersionMaterial:Material)
-			-[:HAS_SUB_MATERIAL*0..2]-(nominatedSubsequentVersionMaterial:Material)
-		<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
-		<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
-		WHERE
-			(
-				(material)-[:HAS_SUB_MATERIAL*0..2]->(originalVersionMaterial) AND
-				(subsequentVersionMaterial)-[:HAS_SUB_MATERIAL*0..2]->(nominatedSubsequentVersionMaterial)
-			) OR (
-				(material)<-[:HAS_SUB_MATERIAL*0..2]-(originalVersionMaterial) AND
-				(subsequentVersionMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSubsequentVersionMaterial)
-			) OR (
-				(material)-[:HAS_SUB_MATERIAL*0..2]->(originalVersionMaterial) AND
-				(subsequentVersionMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSubsequentVersionMaterial)
-			)
+	CALL {
+		WITH material
 
-	OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)
-		WHERE
-			(
-				(nominatedEntity:Person AND nominatedEntityRel.nominatedCompanyUuid IS NULL) OR
-				nominatedEntity:Company
-			) AND
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = nominatedEntityRel.nominationPosition
-			)
+		OPTIONAL MATCH (material)-[:HAS_SUB_MATERIAL*0..2]-(originalVersionMaterial:Material)
+			<-[:SUBSEQUENT_VERSION_OF]-(subsequentVersionMaterial:Material)
+				-[:HAS_SUB_MATERIAL*0..2]-(nominatedSubsequentVersionMaterial:Material)
+			<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
+			<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
+			WHERE
+				(
+					(material)-[:HAS_SUB_MATERIAL*0..2]->(originalVersionMaterial) AND
+					(subsequentVersionMaterial)-[:HAS_SUB_MATERIAL*0..2]->(nominatedSubsequentVersionMaterial)
+				) OR (
+					(material)<-[:HAS_SUB_MATERIAL*0..2]-(originalVersionMaterial) AND
+					(subsequentVersionMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSubsequentVersionMaterial)
+				) OR (
+					(material)-[:HAS_SUB_MATERIAL*0..2]->(originalVersionMaterial) AND
+					(subsequentVersionMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSubsequentVersionMaterial)
+				)
 
-	WITH material, nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntityRel,
-		COLLECT(nominatedEntity {
-			model: TOUPPER(HEAD(LABELS(nominatedEntity))),
-			.uuid,
-			.name,
-			nominatedMemberUuids: nominatedEntityRel.nominatedMemberUuids
-		}) AS nominatedEntities
+		OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)
+			WHERE
+				(
+					(nominatedEntity:Person AND nominatedEntityRel.nominatedCompanyUuid IS NULL) OR
+					nominatedEntity:Company
+				) AND
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = nominatedEntityRel.nominationPosition
+				)
 
-	UNWIND (CASE nominatedEntities WHEN [] THEN [null] ELSE nominatedEntities END) AS nominatedEntity
+		WITH material, nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntityRel,
+			COLLECT(nominatedEntity {
+				model: TOUPPER(HEAD(LABELS(nominatedEntity))),
+				.uuid,
+				.name,
+				nominatedMemberUuids: nominatedEntityRel.nominatedMemberUuids
+			}) AS nominatedEntities
 
-		UNWIND (COALESCE(nominatedEntity.nominatedMemberUuids, [null])) AS nominatedMemberUuid
+		UNWIND (CASE nominatedEntities WHEN [] THEN [null] ELSE nominatedEntities END) AS nominatedEntity
 
-			OPTIONAL MATCH (category)-[nominatedMemberRel:HAS_NOMINEE]->
-				(nominatedMember:Person { uuid: nominatedMemberUuid })
-				WHERE
-					nominatedEntityRel.nominationPosition IS NULL OR
-					nominatedEntityRel.nominationPosition = nominatedMemberRel.nominationPosition
+			UNWIND (COALESCE(nominatedEntity.nominatedMemberUuids, [null])) AS nominatedMemberUuid
 
-			WITH
-				material,
-				nominatedSubsequentVersionMaterial,
-				nomineeRel,
-				category,
-				categoryRel,
-				ceremony,
-				nominatedEntityRel,
-				nominatedEntity,
-				nominatedMember
-				ORDER BY nominatedMemberRel.memberPosition
+				OPTIONAL MATCH (category)-[nominatedMemberRel:HAS_NOMINEE]->
+					(nominatedMember:Person { uuid: nominatedMemberUuid })
+					WHERE
+						nominatedEntityRel.nominationPosition IS NULL OR
+						nominatedEntityRel.nominationPosition = nominatedMemberRel.nominationPosition
 
-			WITH
-				material,
-				nominatedSubsequentVersionMaterial,
-				nomineeRel,
-				category,
-				categoryRel,
-				ceremony,
-				nominatedEntityRel,
-				nominatedEntity,
-				COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
+				WITH
+					material,
+					nominatedSubsequentVersionMaterial,
+					nomineeRel,
+					category,
+					categoryRel,
+					ceremony,
+					nominatedEntityRel,
+					nominatedEntity,
+					nominatedMember
+					ORDER BY nominatedMemberRel.memberPosition
 
-	WITH
-		material,
-		nominatedSubsequentVersionMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntityRel,
-		nominatedEntity,
-		nominatedMembers
-		ORDER BY nominatedEntityRel.nominationPosition, nominatedEntityRel.entityPosition
+				WITH
+					material,
+					nominatedSubsequentVersionMaterial,
+					nomineeRel,
+					category,
+					categoryRel,
+					ceremony,
+					nominatedEntityRel,
+					nominatedEntity,
+					COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
 
-	WITH material, nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony,
-		COLLECT(
-			CASE WHEN nominatedEntity IS NULL
-				THEN null
-				ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
-			END
-		) AS nominatedEntities
+		WITH
+			material,
+			nominatedSubsequentVersionMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntityRel,
+			nominatedEntity,
+			nominatedMembers
+			ORDER BY nominatedEntityRel.nominationPosition, nominatedEntityRel.entityPosition
 
-	WITH material, nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony,
-		[nominatedEntity IN nominatedEntities | CASE nominatedEntity.model WHEN 'COMPANY'
-			THEN nominatedEntity
-			ELSE nominatedEntity { .model, .uuid, .name }
-		END] AS nominatedEntities
+		WITH material, nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony,
+			COLLECT(
+				CASE WHEN nominatedEntity IS NULL
+					THEN null
+					ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
+				END
+			) AS nominatedEntities
 
-	OPTIONAL MATCH (category)-[nominatedProductionRel:HAS_NOMINEE]->(nominatedProduction:Production)
-		WHERE
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = nominatedProductionRel.nominationPosition
-			)
+		WITH material, nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony,
+			[nominatedEntity IN nominatedEntities | CASE nominatedEntity.model WHEN 'COMPANY'
+				THEN nominatedEntity
+				ELSE nominatedEntity { .model, .uuid, .name }
+			END] AS nominatedEntities
 
-	OPTIONAL MATCH (nominatedProduction)-[:PLAYS_AT]->(venue:Venue)
+		OPTIONAL MATCH (category)-[nominatedProductionRel:HAS_NOMINEE]->(nominatedProduction:Production)
+			WHERE
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = nominatedProductionRel.nominationPosition
+				)
 
-	OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
+		OPTIONAL MATCH (nominatedProduction)-[:PLAYS_AT]->(venue:Venue)
 
-	OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
+		OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
 
-	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+		OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
-	WITH
-		material,
-		nominatedSubsequentVersionMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductionRel,
-		nominatedProduction,
-		venue,
-		surVenue,
-		surProduction,
-		surSurProduction
-		ORDER BY nominatedProductionRel.productionPosition
+		OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
 
-	WITH material, nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
-		COLLECT(
-			CASE WHEN nominatedProduction IS NULL
-				THEN null
-				ELSE nominatedProduction {
-					model: 'PRODUCTION',
-					.uuid,
-					.name,
-					.startDate,
-					.endDate,
-					venue: CASE WHEN venue IS NULL
-						THEN null
-						ELSE venue {
-							model: 'VENUE',
-							.uuid,
-							.name,
-							surVenue: CASE WHEN surVenue IS NULL
-								THEN null
-								ELSE surVenue { model: 'VENUE', .uuid, .name }
-							END
-						}
-					END,
-					surProduction: CASE WHEN surProduction IS NULL
-						THEN null
-						ELSE surProduction {
-							model: 'PRODUCTION',
-							.uuid,
-							.name,
-							surProduction: CASE WHEN surSurProduction IS NULL
-								THEN null
-								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
-							END
-						}
-					END
-				}
-			END
-		) AS nominatedProductions
+		WITH
+			material,
+			nominatedSubsequentVersionMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductionRel,
+			nominatedProduction,
+			venue,
+			surVenue,
+			surProduction,
+			surSurProduction
+			ORDER BY nominatedProductionRel.productionPosition
 
-	OPTIONAL MATCH (category)-[nominatedMaterialRel:HAS_NOMINEE]->(nominatedMaterial:Material)
-		WHERE
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = nominatedMaterialRel.nominationPosition
-			) AND
-			nominatedMaterial.uuid <> nominatedSubsequentVersionMaterial.uuid AND
-			NOT EXISTS((material)<-[:SUBSEQUENT_VERSION_OF]-(nominatedMaterial))
+		WITH material, nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
+			COLLECT(
+				CASE WHEN nominatedProduction IS NULL
+					THEN null
+					ELSE nominatedProduction {
+						model: 'PRODUCTION',
+						.uuid,
+						.name,
+						.startDate,
+						.endDate,
+						venue: CASE WHEN venue IS NULL
+							THEN null
+							ELSE venue {
+								model: 'VENUE',
+								.uuid,
+								.name,
+								surVenue: CASE WHEN surVenue IS NULL
+									THEN null
+									ELSE surVenue { model: 'VENUE', .uuid, .name }
+								END
+							}
+						END,
+						surProduction: CASE WHEN surProduction IS NULL
+							THEN null
+							ELSE surProduction {
+								model: 'PRODUCTION',
+								.uuid,
+								.name,
+								surProduction: CASE WHEN surSurProduction IS NULL
+									THEN null
+									ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+								END
+							}
+						END
+					}
+				END
+			) AS nominatedProductions
 
-	WITH
-		nominatedSubsequentVersionMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductions,
-		nominatedMaterialRel,
-		nominatedMaterial
-		ORDER BY nominatedMaterialRel.materialPosition
+		OPTIONAL MATCH (category)-[nominatedMaterialRel:HAS_NOMINEE]->(nominatedMaterial:Material)
+			WHERE
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = nominatedMaterialRel.nominationPosition
+				) AND
+				nominatedMaterial.uuid <> nominatedSubsequentVersionMaterial.uuid AND
+				NOT EXISTS((material)<-[:SUBSEQUENT_VERSION_OF]-(nominatedMaterial))
 
-	WITH
-		nominatedSubsequentVersionMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductions,
-		COLLECT(
-			CASE WHEN nominatedMaterial IS NULL
-				THEN null
-				ELSE nominatedMaterial { model: 'MATERIAL', .uuid, .name, .format, .year }
-			END
-		) AS nominatedMaterials
-		ORDER BY nomineeRel.nominationPosition, nomineeRel.materialPosition
+		WITH
+			nominatedSubsequentVersionMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductions,
+			nominatedMaterialRel,
+			nominatedMaterial
+			ORDER BY nominatedMaterialRel.materialPosition
 
-	OPTIONAL MATCH (nominatedSubsequentVersionMaterial)
-		<-[:HAS_SUB_MATERIAL]-(nominatedSubsequentVersionSurMaterial:Material)
+		WITH
+			nominatedSubsequentVersionMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductions,
+			COLLECT(
+				CASE WHEN nominatedMaterial IS NULL
+					THEN null
+					ELSE nominatedMaterial { model: 'MATERIAL', .uuid, .name, .format, .year }
+				END
+			) AS nominatedMaterials
+			ORDER BY nomineeRel.nominationPosition, nomineeRel.materialPosition
 
-	OPTIONAL MATCH (nominatedSubsequentVersionSurMaterial)
-		<-[:HAS_SUB_MATERIAL]-(nominatedSubsequentVersionSurSurMaterial:Material)
+		OPTIONAL MATCH (nominatedSubsequentVersionMaterial)
+			<-[:HAS_SUB_MATERIAL]-(nominatedSubsequentVersionSurMaterial:Material)
 
-	WITH
-		nomineeRel.isWinner AS isWinner,
-		nomineeRel.customType AS customType,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductions,
-		nominatedMaterials,
-		COLLECT(
-			CASE WHEN nominatedSubsequentVersionMaterial IS NULL
-				THEN null
-				ELSE nominatedSubsequentVersionMaterial {
-					model: 'MATERIAL',
-					.uuid,
-					.name,
-					.format,
-					.year,
-					surMaterial: CASE WHEN nominatedSubsequentVersionSurMaterial IS NULL
-						THEN null
-						ELSE nominatedSubsequentVersionSurMaterial {
-							model: 'MATERIAL',
-							.uuid,
-							.name,
-							surMaterial: CASE WHEN nominatedSubsequentVersionSurSurMaterial IS NULL
-								THEN null
-								ELSE nominatedSubsequentVersionSurSurMaterial { model: 'MATERIAL', .uuid, .name }
-							END
-						}
-					END
-				}
-			END
-		) AS nominatedSubsequentVersionMaterials
+		OPTIONAL MATCH (nominatedSubsequentVersionSurMaterial)
+			<-[:HAS_SUB_MATERIAL]-(nominatedSubsequentVersionSurSurMaterial:Material)
 
-	WITH category, categoryRel, ceremony,
-		COLLECT({
-			model: 'NOMINATION',
-			isWinner: COALESCE(isWinner, false),
-			type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
-			entities: nominatedEntities,
-			productions: nominatedProductions,
-			materials: nominatedMaterials,
-			recipientSubsequentVersionMaterials: nominatedSubsequentVersionMaterials
-		}) AS nominations
-		ORDER BY categoryRel.position
+		WITH
+			nomineeRel.isWinner AS isWinner,
+			nomineeRel.customType AS customType,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductions,
+			nominatedMaterials,
+			COLLECT(
+				CASE WHEN nominatedSubsequentVersionMaterial IS NULL
+					THEN null
+					ELSE nominatedSubsequentVersionMaterial {
+						model: 'MATERIAL',
+						.uuid,
+						.name,
+						.format,
+						.year,
+						surMaterial: CASE WHEN nominatedSubsequentVersionSurMaterial IS NULL
+							THEN null
+							ELSE nominatedSubsequentVersionSurMaterial {
+								model: 'MATERIAL',
+								.uuid,
+								.name,
+								surMaterial: CASE WHEN nominatedSubsequentVersionSurSurMaterial IS NULL
+									THEN null
+									ELSE nominatedSubsequentVersionSurSurMaterial { model: 'MATERIAL', .uuid, .name }
+								END
+							}
+						END
+					}
+				END
+			) AS nominatedSubsequentVersionMaterials
 
-	WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
-		ORDER BY ceremony.name DESC
+		WITH category, categoryRel, ceremony,
+			COLLECT({
+				model: 'NOMINATION',
+				isWinner: COALESCE(isWinner, false),
+				type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
+				entities: nominatedEntities,
+				productions: nominatedProductions,
+				materials: nominatedMaterials,
+				recipientSubsequentVersionMaterials: nominatedSubsequentVersionMaterials
+			}) AS nominations
+			ORDER BY categoryRel.position
 
-	OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
+		WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
+			ORDER BY ceremony.name DESC
 
-	WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
-		ORDER BY award.name
+		OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
+
+		WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
+			ORDER BY award.name
+
+		RETURN
+			COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS subsequentVersionMaterialAwards
+	}
 
 	RETURN
-		COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS subsequentVersionMaterialAwards
+		subsequentVersionMaterialAwards
 `;

--- a/src/neo4j/cypher-queries/material/show/show-awards.js
+++ b/src/neo4j/cypher-queries/material/show/show-awards.js
@@ -1,254 +1,261 @@
 export default () => `
 	MATCH (material:Material { uuid: $uuid })
 
-	OPTIONAL MATCH (material)-[:HAS_SUB_MATERIAL*0..2]-(nominatedMaterial:Material)
-		<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
-		<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
- 		WHERE (
-			(material)-[:HAS_SUB_MATERIAL*0..2]->(nominatedMaterial) OR
-			(material)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedMaterial)
-		)
+	CALL {
+		WITH material
 
-	OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)
-		WHERE
-			(
-				(nominatedEntity:Person AND nominatedEntityRel.nominatedCompanyUuid IS NULL) OR
-				nominatedEntity:Company
-			) AND
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = nominatedEntityRel.nominationPosition
+		OPTIONAL MATCH (material)-[:HAS_SUB_MATERIAL*0..2]-(nominatedMaterial:Material)
+			<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
+			<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
+	 		WHERE (
+				(material)-[:HAS_SUB_MATERIAL*0..2]->(nominatedMaterial) OR
+				(material)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedMaterial)
 			)
 
-	WITH
-		material,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntityRel,
-		CASE WHEN material <> nominatedMaterial
-			THEN nominatedMaterial { model: 'MATERIAL', .uuid, .name, .format, .year }
-			ELSE null
-		END AS recipientMaterial,
-		COLLECT(nominatedEntity {
-			model: TOUPPER(HEAD(LABELS(nominatedEntity))),
-			.uuid,
-			.name,
-			nominatedMemberUuids: nominatedEntityRel.nominatedMemberUuids
-		}) AS nominatedEntities
+		OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)
+			WHERE
+				(
+					(nominatedEntity:Person AND nominatedEntityRel.nominatedCompanyUuid IS NULL) OR
+					nominatedEntity:Company
+				) AND
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = nominatedEntityRel.nominationPosition
+				)
 
-	UNWIND (CASE nominatedEntities WHEN [] THEN [null] ELSE nominatedEntities END) AS nominatedEntity
+		WITH
+			material,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntityRel,
+			CASE WHEN material <> nominatedMaterial
+				THEN nominatedMaterial { model: 'MATERIAL', .uuid, .name, .format, .year }
+				ELSE null
+			END AS recipientMaterial,
+			COLLECT(nominatedEntity {
+				model: TOUPPER(HEAD(LABELS(nominatedEntity))),
+				.uuid,
+				.name,
+				nominatedMemberUuids: nominatedEntityRel.nominatedMemberUuids
+			}) AS nominatedEntities
 
-		UNWIND (COALESCE(nominatedEntity.nominatedMemberUuids, [null])) AS nominatedMemberUuid
+		UNWIND (CASE nominatedEntities WHEN [] THEN [null] ELSE nominatedEntities END) AS nominatedEntity
 
-			OPTIONAL MATCH (category)-[nominatedMemberRel:HAS_NOMINEE]->
-				(nominatedMember:Person { uuid: nominatedMemberUuid })
-				WHERE
-					nominatedEntityRel.nominationPosition IS NULL OR
-					nominatedEntityRel.nominationPosition = nominatedMemberRel.nominationPosition
+			UNWIND (COALESCE(nominatedEntity.nominatedMemberUuids, [null])) AS nominatedMemberUuid
 
-			WITH
-				material,
-				recipientMaterial,
-				nomineeRel,
-				category,
-				categoryRel,
-				ceremony,
-				nominatedEntityRel,
-				nominatedEntity,
-				nominatedMember
-				ORDER BY nominatedMemberRel.memberPosition
+				OPTIONAL MATCH (category)-[nominatedMemberRel:HAS_NOMINEE]->
+					(nominatedMember:Person { uuid: nominatedMemberUuid })
+					WHERE
+						nominatedEntityRel.nominationPosition IS NULL OR
+						nominatedEntityRel.nominationPosition = nominatedMemberRel.nominationPosition
 
-			WITH
-				material,
-				recipientMaterial,
-				nomineeRel,
-				category,
-				categoryRel,
-				ceremony,
-				nominatedEntityRel,
-				nominatedEntity,
-				COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
+				WITH
+					material,
+					recipientMaterial,
+					nomineeRel,
+					category,
+					categoryRel,
+					ceremony,
+					nominatedEntityRel,
+					nominatedEntity,
+					nominatedMember
+					ORDER BY nominatedMemberRel.memberPosition
 
-	WITH
-		material,
-		recipientMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntityRel,
-		nominatedEntity,
-		nominatedMembers
-		ORDER BY nominatedEntityRel.nominationPosition, nominatedEntityRel.entityPosition
+				WITH
+					material,
+					recipientMaterial,
+					nomineeRel,
+					category,
+					categoryRel,
+					ceremony,
+					nominatedEntityRel,
+					nominatedEntity,
+					COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
 
-	WITH material, recipientMaterial, nomineeRel, category, categoryRel, ceremony,
-		COLLECT(
-			CASE WHEN nominatedEntity IS NULL
-				THEN null
-				ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
-			END
-		) AS nominatedEntities
+		WITH
+			material,
+			recipientMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntityRel,
+			nominatedEntity,
+			nominatedMembers
+			ORDER BY nominatedEntityRel.nominationPosition, nominatedEntityRel.entityPosition
 
-	WITH material, recipientMaterial, nomineeRel, category, categoryRel, ceremony,
-		[nominatedEntity IN nominatedEntities | CASE nominatedEntity.model WHEN 'COMPANY'
-			THEN nominatedEntity
-			ELSE nominatedEntity { .model, .uuid, .name }
-		END] AS nominatedEntities
+		WITH material, recipientMaterial, nomineeRel, category, categoryRel, ceremony,
+			COLLECT(
+				CASE WHEN nominatedEntity IS NULL
+					THEN null
+					ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
+				END
+			) AS nominatedEntities
 
-	OPTIONAL MATCH (category)-[nominatedProductionRel:HAS_NOMINEE]->(nominatedProduction:Production)
-		WHERE
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = nominatedProductionRel.nominationPosition
-			)
+		WITH material, recipientMaterial, nomineeRel, category, categoryRel, ceremony,
+			[nominatedEntity IN nominatedEntities | CASE nominatedEntity.model WHEN 'COMPANY'
+				THEN nominatedEntity
+				ELSE nominatedEntity { .model, .uuid, .name }
+			END] AS nominatedEntities
 
-	OPTIONAL MATCH (nominatedProduction)-[:PLAYS_AT]->(venue:Venue)
+		OPTIONAL MATCH (category)-[nominatedProductionRel:HAS_NOMINEE]->(nominatedProduction:Production)
+			WHERE
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = nominatedProductionRel.nominationPosition
+				)
 
-	OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
+		OPTIONAL MATCH (nominatedProduction)-[:PLAYS_AT]->(venue:Venue)
 
-	OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
+		OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
 
-	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+		OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
-	WITH
-		material,
-		recipientMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductionRel,
-		nominatedProduction,
-		venue,
-		surVenue,
-		surProduction,
-		surSurProduction
-		ORDER BY nominatedProductionRel.productionPosition
+		OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
 
-	WITH material, recipientMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
-		COLLECT(
-			CASE WHEN nominatedProduction IS NULL
-				THEN null
-				ELSE nominatedProduction {
-					model: 'PRODUCTION',
-					.uuid,
-					.name,
-					.startDate,
-					.endDate,
-					venue: CASE WHEN venue IS NULL
-						THEN null
-						ELSE venue {
-							model: 'VENUE',
-							.uuid,
-							.name,
-							surVenue: CASE WHEN surVenue IS NULL
-								THEN null
-								ELSE surVenue { model: 'VENUE', .uuid, .name }
-							END
-						}
-					END,
-					surProduction: CASE WHEN surProduction IS NULL
-						THEN null
-						ELSE surProduction {
-							model: 'PRODUCTION',
-							.uuid,
-							.name,
-							surProduction: CASE WHEN surSurProduction IS NULL
-								THEN null
-								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
-							END
-						}
-					END
-				}
-			END
-		) AS nominatedProductions
+		WITH
+			material,
+			recipientMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductionRel,
+			nominatedProduction,
+			venue,
+			surVenue,
+			surProduction,
+			surSurProduction
+			ORDER BY nominatedProductionRel.productionPosition
 
-	OPTIONAL MATCH (category)-[coNominatedMaterialRel:HAS_NOMINEE]->(coNominatedMaterial:Material)
-		WHERE
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = coNominatedMaterialRel.nominationPosition
-			) AND
-			coNominatedMaterial.uuid <> material.uuid AND
-			NOT EXISTS((material)-[:HAS_SUB_MATERIAL*1..2]-(coNominatedMaterial))
+		WITH material, recipientMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
+			COLLECT(
+				CASE WHEN nominatedProduction IS NULL
+					THEN null
+					ELSE nominatedProduction {
+						model: 'PRODUCTION',
+						.uuid,
+						.name,
+						.startDate,
+						.endDate,
+						venue: CASE WHEN venue IS NULL
+							THEN null
+							ELSE venue {
+								model: 'VENUE',
+								.uuid,
+								.name,
+								surVenue: CASE WHEN surVenue IS NULL
+									THEN null
+									ELSE surVenue { model: 'VENUE', .uuid, .name }
+								END
+							}
+						END,
+						surProduction: CASE WHEN surProduction IS NULL
+							THEN null
+							ELSE surProduction {
+								model: 'PRODUCTION',
+								.uuid,
+								.name,
+								surProduction: CASE WHEN surSurProduction IS NULL
+									THEN null
+									ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+								END
+							}
+						END
+					}
+				END
+			) AS nominatedProductions
 
-	WITH
-		recipientMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductions,
-		coNominatedMaterialRel,
-		coNominatedMaterial
-		ORDER BY coNominatedMaterialRel.materialPosition
+		OPTIONAL MATCH (category)-[coNominatedMaterialRel:HAS_NOMINEE]->(coNominatedMaterial:Material)
+			WHERE
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = coNominatedMaterialRel.nominationPosition
+				) AND
+				coNominatedMaterial.uuid <> material.uuid AND
+				NOT EXISTS((material)-[:HAS_SUB_MATERIAL*1..2]-(coNominatedMaterial))
 
-	OPTIONAL MATCH (coNominatedMaterial)<-[:HAS_SUB_MATERIAL]-(coNominatedMaterialSurMaterial:Material)
+		WITH
+			recipientMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductions,
+			coNominatedMaterialRel,
+			coNominatedMaterial
+			ORDER BY coNominatedMaterialRel.materialPosition
 
-	OPTIONAL MATCH (coNominatedMaterialSurMaterial)<-[:HAS_SUB_MATERIAL]-(coNominatedMaterialSurSurMaterial:Material)
+		OPTIONAL MATCH (coNominatedMaterial)<-[:HAS_SUB_MATERIAL]-(coNominatedMaterialSurMaterial:Material)
 
-	WITH recipientMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities, nominatedProductions,
-		COLLECT(
-			CASE WHEN coNominatedMaterial IS NULL
-				THEN null
-				ELSE coNominatedMaterial {
-					model: 'MATERIAL',
-					.uuid,
-					.name,
-					.format,
-					.year,
-					surMaterial: CASE WHEN coNominatedMaterialSurMaterial IS NULL
-						THEN null
-						ELSE coNominatedMaterialSurMaterial {
-							model: 'MATERIAL',
-							.uuid,
-							.name,
-							surMaterial: CASE WHEN coNominatedMaterialSurSurMaterial IS NULL
-								THEN null
-								ELSE coNominatedMaterialSurSurMaterial { model: 'MATERIAL', .uuid, .name }
-							END
-						}
-					END
-				}
-			END
-		) AS coNominatedMaterials
-		ORDER BY nomineeRel.nominationPosition, nomineeRel.materialPosition
+		OPTIONAL MATCH (coNominatedMaterialSurMaterial)<-[:HAS_SUB_MATERIAL]-(coNominatedMaterialSurSurMaterial:Material)
 
-	WITH
-		nomineeRel.isWinner AS isWinner,
-		nomineeRel.customType AS customType,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductions,
-		coNominatedMaterials,
-		COLLECT(recipientMaterial) AS recipientMaterials
+		WITH recipientMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities, nominatedProductions,
+			COLLECT(
+				CASE WHEN coNominatedMaterial IS NULL
+					THEN null
+					ELSE coNominatedMaterial {
+						model: 'MATERIAL',
+						.uuid,
+						.name,
+						.format,
+						.year,
+						surMaterial: CASE WHEN coNominatedMaterialSurMaterial IS NULL
+							THEN null
+							ELSE coNominatedMaterialSurMaterial {
+								model: 'MATERIAL',
+								.uuid,
+								.name,
+								surMaterial: CASE WHEN coNominatedMaterialSurSurMaterial IS NULL
+									THEN null
+									ELSE coNominatedMaterialSurSurMaterial { model: 'MATERIAL', .uuid, .name }
+								END
+							}
+						END
+					}
+				END
+			) AS coNominatedMaterials
+			ORDER BY nomineeRel.nominationPosition, nomineeRel.materialPosition
 
-	WITH category, categoryRel, ceremony,
-		COLLECT({
-			model: 'NOMINATION',
-			isWinner: COALESCE(isWinner, false),
-			type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
-			recipientMaterials: recipientMaterials,
-			entities: nominatedEntities,
-			productions: nominatedProductions,
-			coMaterials: coNominatedMaterials
-		}) AS nominations
-		ORDER BY categoryRel.position
+		WITH
+			nomineeRel.isWinner AS isWinner,
+			nomineeRel.customType AS customType,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductions,
+			coNominatedMaterials,
+			COLLECT(recipientMaterial) AS recipientMaterials
 
-	WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
-		ORDER BY ceremony.name DESC
+		WITH category, categoryRel, ceremony,
+			COLLECT({
+				model: 'NOMINATION',
+				isWinner: COALESCE(isWinner, false),
+				type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
+				recipientMaterials: recipientMaterials,
+				entities: nominatedEntities,
+				productions: nominatedProductions,
+				coMaterials: coNominatedMaterials
+			}) AS nominations
+			ORDER BY categoryRel.position
 
-	OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
+		WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
+			ORDER BY ceremony.name DESC
 
-	WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
-		ORDER BY award.name
+		OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
+
+		WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
+			ORDER BY award.name
+
+		RETURN
+			COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS awards
+	}
 
 	RETURN
-		COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS awards
+		awards
 `;

--- a/src/neo4j/cypher-queries/material/show/show-materials.js
+++ b/src/neo4j/cypher-queries/material/show/show-materials.js
@@ -1,197 +1,205 @@
 export default () => `
 	MATCH (material:Material { uuid: $uuid })
 
-	OPTIONAL MATCH (material)<-[:SUBSEQUENT_VERSION_OF]-(subsequentVersionMaterial)
-		WHERE NOT EXISTS(
-			(material)<-[:SUBSEQUENT_VERSION_OF]-(:Material)<-[:HAS_SUB_MATERIAL*1..2]-(subsequentVersionMaterial)
-		)
+	CALL {
+		WITH material
 
-	OPTIONAL MATCH (material)<-[:USES_SOURCE_MATERIAL]-(sourcingMaterial:Material)
-		WHERE NOT EXISTS(
-			(material)<-[:USES_SOURCE_MATERIAL]-(:Material)<-[:HAS_SUB_MATERIAL*1..2]-(sourcingMaterial)
-		)
+		OPTIONAL MATCH (material)<-[:SUBSEQUENT_VERSION_OF]-(subsequentVersionMaterial)
+			WHERE NOT EXISTS(
+				(material)<-[:SUBSEQUENT_VERSION_OF]-(:Material)<-[:HAS_SUB_MATERIAL*1..2]-(subsequentVersionMaterial)
+			)
 
-	WITH
-		material,
-		COLLECT(subsequentVersionMaterial) AS subsequentVersionMaterials,
-		COLLECT(sourcingMaterial) AS sourcingMaterials
-
-	WITH
-		material,
-		[material] + subsequentVersionMaterials + sourcingMaterials AS relatedMaterials
-
-	UNWIND (CASE relatedMaterials WHEN [] THEN [null] ELSE relatedMaterials END) AS relatedMaterial
-
-		OPTIONAL MATCH (relatedMaterial)-[subsequentVersionRel:SUBSEQUENT_VERSION_OF]->(material)
-
-		OPTIONAL MATCH (relatedMaterial)-[sourcingMaterialRel:USES_SOURCE_MATERIAL]->(material)
-
-		OPTIONAL MATCH (relatedMaterial)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->
-			(entity:Person|Company|Material)
-
-		OPTIONAL MATCH (entity)<-[originalVersionWritingEntityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]-(material)
-
-		OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->
-			(sourceMaterialWriter:Person|Company)
-
-		OPTIONAL MATCH (entity:Material)<-[:HAS_SUB_MATERIAL]-(entitySurMaterial:Material)
-
-		OPTIONAL MATCH (entitySurMaterial)<-[:HAS_SUB_MATERIAL]-(entitySurSurMaterial:Material)
+		OPTIONAL MATCH (material)<-[:USES_SOURCE_MATERIAL]-(sourcingMaterial:Material)
+			WHERE NOT EXISTS(
+				(material)<-[:USES_SOURCE_MATERIAL]-(:Material)<-[:HAS_SUB_MATERIAL*1..2]-(sourcingMaterial)
+			)
 
 		WITH
 			material,
-			relatedMaterial,
-			CASE WHEN subsequentVersionRel IS NULL THEN false ELSE true END AS isSubsequentVersion,
-			CASE WHEN sourcingMaterialRel IS NULL THEN false ELSE true END AS isSourcingMaterial,
-			entityRel,
-			entity,
-			entitySurMaterial,
-			entitySurSurMaterial,
-			CASE WHEN originalVersionWritingEntityRel IS NULL THEN false ELSE true END AS isOriginalVersionWritingEntity,
-			sourceMaterialWriterRel,
-			sourceMaterialWriter
-			ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriterRel.entityPosition
+			COLLECT(subsequentVersionMaterial) AS subsequentVersionMaterials,
+			COLLECT(sourcingMaterial) AS sourcingMaterials
 
 		WITH
 			material,
-			relatedMaterial,
-			isSubsequentVersion,
-			isSourcingMaterial,
-			entityRel,
-			entity,
-			entitySurMaterial,
-			entitySurSurMaterial,
-			isOriginalVersionWritingEntity,
-			sourceMaterialWriterRel.credit AS sourceMaterialWritingCreditName,
-			COLLECT(
-				CASE WHEN sourceMaterialWriter IS NULL
-					THEN null
-					ELSE sourceMaterialWriter { model: TOUPPER(HEAD(LABELS(sourceMaterialWriter))), .uuid, .name }
-				END
-			) AS sourceMaterialWriters
+			[material] + subsequentVersionMaterials + sourcingMaterials AS relatedMaterials
 
-		WITH
-			material,
-			relatedMaterial,
-			isSubsequentVersion,
-			isSourcingMaterial,
-			entityRel,
-			entity,
-			entitySurMaterial,
-			entitySurSurMaterial,
-			isOriginalVersionWritingEntity,
-			COLLECT(
-				CASE SIZE(sourceMaterialWriters) WHEN 0
-					THEN null
-					ELSE {
-						model: 'WRITING_CREDIT',
-						name: COALESCE(sourceMaterialWritingCreditName, 'by'),
-						entities: sourceMaterialWriters
-					}
-				END
-			) AS sourceMaterialWritingCredits
-			ORDER BY entityRel.creditPosition, entityRel.entityPosition
+		UNWIND (CASE relatedMaterials WHEN [] THEN [null] ELSE relatedMaterials END) AS relatedMaterial
 
-		WITH
-			material,
-			relatedMaterial,
-			isSubsequentVersion,
-			isSourcingMaterial,
-			entityRel.credit AS writingCreditName,
-			COLLECT(
-				CASE WHEN entity IS NULL OR (isSubsequentVersion AND isOriginalVersionWritingEntity)
-					THEN null
-					ELSE entity {
-						model: TOUPPER(HEAD(LABELS(entity))),
-						.uuid,
-						.name,
-						.format,
-						.year,
-						surMaterial: CASE WHEN entitySurMaterial IS NULL
-							THEN null
-							ELSE entitySurMaterial {
-								model: 'MATERIAL',
-								.uuid,
-								.name,
-								surMaterial: CASE WHEN entitySurSurMaterial IS NULL
-									THEN null
-									ELSE entitySurSurMaterial { model: 'MATERIAL', .uuid, .name }
-								END
-							}
-						END,
-						writingCredits: sourceMaterialWritingCredits
-					}
-				END
-			) AS entities
+			OPTIONAL MATCH (relatedMaterial)-[subsequentVersionRel:SUBSEQUENT_VERSION_OF]->(material)
 
-		WITH
-			material,
-			relatedMaterial,
-			isSubsequentVersion,
-			isSourcingMaterial,
-			writingCreditName,
-			[entity IN entities | CASE entity.model WHEN 'MATERIAL'
-				THEN entity
-				ELSE entity { .model, .uuid, .name }
-			END] AS entities
+			OPTIONAL MATCH (relatedMaterial)-[sourcingMaterialRel:USES_SOURCE_MATERIAL]->(material)
 
-		WITH
-			material,
-			relatedMaterial,
-			isSubsequentVersion,
-			isSourcingMaterial,
-			COLLECT(
-				CASE SIZE(entities) WHEN 0
-					THEN null
-					ELSE {
-						model: 'WRITING_CREDIT',
-						name: COALESCE(writingCreditName, 'by'),
-						entities: entities
-					}
-				END
-			) AS writingCredits
-			ORDER BY relatedMaterial.year DESC, relatedMaterial.name
+			OPTIONAL MATCH (relatedMaterial)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->
+				(entity:Person|Company|Material)
 
-		OPTIONAL MATCH (relatedMaterial)<-[:HAS_SUB_MATERIAL]-(surMaterial:Material)
+			OPTIONAL MATCH (entity)<-[originalVersionWritingEntityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]-(material)
 
-		OPTIONAL MATCH (surMaterial)<-[:HAS_SUB_MATERIAL]-(surSurMaterial:Material)
+			OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->
+				(sourceMaterialWriter:Person|Company)
 
-		WITH material,
-			COLLECT(
-				CASE WHEN relatedMaterial IS NULL
-					THEN null
-					ELSE relatedMaterial {
-						model: 'MATERIAL',
-						.uuid,
-						.name,
-						.format,
-						.year,
-						surMaterial: CASE WHEN surMaterial IS NULL
-							THEN null
-							ELSE surMaterial {
-								model: 'MATERIAL',
-								.uuid,
-								.name,
-								surMaterial: CASE WHEN surSurMaterial IS NULL
-									THEN null
-									ELSE surSurMaterial { model: 'MATERIAL', .uuid, .name }
-								END
-							}
-						END,
-						writingCredits,
-						isSubsequentVersion,
-						isSourcingMaterial
-					}
-				END
-			) AS relatedMaterials
+			OPTIONAL MATCH (entity:Material)<-[:HAS_SUB_MATERIAL]-(entitySurMaterial:Material)
+
+			OPTIONAL MATCH (entitySurMaterial)<-[:HAS_SUB_MATERIAL]-(entitySurSurMaterial:Material)
+
+			WITH
+				material,
+				relatedMaterial,
+				CASE WHEN subsequentVersionRel IS NULL THEN false ELSE true END AS isSubsequentVersion,
+				CASE WHEN sourcingMaterialRel IS NULL THEN false ELSE true END AS isSourcingMaterial,
+				entityRel,
+				entity,
+				entitySurMaterial,
+				entitySurSurMaterial,
+				CASE WHEN originalVersionWritingEntityRel IS NULL THEN false ELSE true END AS isOriginalVersionWritingEntity,
+				sourceMaterialWriterRel,
+				sourceMaterialWriter
+				ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriterRel.entityPosition
+
+			WITH
+				material,
+				relatedMaterial,
+				isSubsequentVersion,
+				isSourcingMaterial,
+				entityRel,
+				entity,
+				entitySurMaterial,
+				entitySurSurMaterial,
+				isOriginalVersionWritingEntity,
+				sourceMaterialWriterRel.credit AS sourceMaterialWritingCreditName,
+				COLLECT(
+					CASE WHEN sourceMaterialWriter IS NULL
+						THEN null
+						ELSE sourceMaterialWriter { model: TOUPPER(HEAD(LABELS(sourceMaterialWriter))), .uuid, .name }
+					END
+				) AS sourceMaterialWriters
+
+			WITH
+				material,
+				relatedMaterial,
+				isSubsequentVersion,
+				isSourcingMaterial,
+				entityRel,
+				entity,
+				entitySurMaterial,
+				entitySurSurMaterial,
+				isOriginalVersionWritingEntity,
+				COLLECT(
+					CASE SIZE(sourceMaterialWriters) WHEN 0
+						THEN null
+						ELSE {
+							model: 'WRITING_CREDIT',
+							name: COALESCE(sourceMaterialWritingCreditName, 'by'),
+							entities: sourceMaterialWriters
+						}
+					END
+				) AS sourceMaterialWritingCredits
+				ORDER BY entityRel.creditPosition, entityRel.entityPosition
+
+			WITH
+				material,
+				relatedMaterial,
+				isSubsequentVersion,
+				isSourcingMaterial,
+				entityRel.credit AS writingCreditName,
+				COLLECT(
+					CASE WHEN entity IS NULL OR (isSubsequentVersion AND isOriginalVersionWritingEntity)
+						THEN null
+						ELSE entity {
+							model: TOUPPER(HEAD(LABELS(entity))),
+							.uuid,
+							.name,
+							.format,
+							.year,
+							surMaterial: CASE WHEN entitySurMaterial IS NULL
+								THEN null
+								ELSE entitySurMaterial {
+									model: 'MATERIAL',
+									.uuid,
+									.name,
+									surMaterial: CASE WHEN entitySurSurMaterial IS NULL
+										THEN null
+										ELSE entitySurSurMaterial { model: 'MATERIAL', .uuid, .name }
+									END
+								}
+							END,
+							writingCredits: sourceMaterialWritingCredits
+						}
+					END
+				) AS entities
+
+			WITH
+				material,
+				relatedMaterial,
+				isSubsequentVersion,
+				isSourcingMaterial,
+				writingCreditName,
+				[entity IN entities | CASE entity.model WHEN 'MATERIAL'
+					THEN entity
+					ELSE entity { .model, .uuid, .name }
+				END] AS entities
+
+			WITH
+				material,
+				relatedMaterial,
+				isSubsequentVersion,
+				isSourcingMaterial,
+				COLLECT(
+					CASE SIZE(entities) WHEN 0
+						THEN null
+						ELSE {
+							model: 'WRITING_CREDIT',
+							name: COALESCE(writingCreditName, 'by'),
+							entities: entities
+						}
+					END
+				) AS writingCredits
+				ORDER BY relatedMaterial.year DESC, relatedMaterial.name
+
+			OPTIONAL MATCH (relatedMaterial)<-[:HAS_SUB_MATERIAL]-(surMaterial:Material)
+
+			OPTIONAL MATCH (surMaterial)<-[:HAS_SUB_MATERIAL]-(surSurMaterial:Material)
+
+			WITH material,
+				COLLECT(
+					CASE WHEN relatedMaterial IS NULL
+						THEN null
+						ELSE relatedMaterial {
+							model: 'MATERIAL',
+							.uuid,
+							.name,
+							.format,
+							.year,
+							surMaterial: CASE WHEN surMaterial IS NULL
+								THEN null
+								ELSE surMaterial {
+									model: 'MATERIAL',
+									.uuid,
+									.name,
+									surMaterial: CASE WHEN surSurMaterial IS NULL
+										THEN null
+										ELSE surSurMaterial { model: 'MATERIAL', .uuid, .name }
+									END
+								}
+							END,
+							writingCredits,
+							isSubsequentVersion,
+							isSourcingMaterial
+						}
+					END
+				) AS relatedMaterials
+
+		RETURN
+			[
+				relatedMaterial IN relatedMaterials WHERE relatedMaterial.isSubsequentVersion |
+				relatedMaterial { .model, .uuid, .name, .format, .year, .surMaterial, .writingCredits }
+			] AS subsequentVersionMaterials,
+			[
+				relatedMaterial IN relatedMaterials WHERE relatedMaterial.isSourcingMaterial |
+				relatedMaterial { .model, .uuid, .name, .format, .year, .surMaterial, .writingCredits }
+			] AS sourcingMaterials
+	}
 
 	RETURN
-		[
-			relatedMaterial IN relatedMaterials WHERE relatedMaterial.isSubsequentVersion |
-			relatedMaterial { .model, .uuid, .name, .format, .year, .surMaterial, .writingCredits }
-		] AS subsequentVersionMaterials,
-		[
-			relatedMaterial IN relatedMaterials WHERE relatedMaterial.isSourcingMaterial |
-			relatedMaterial { .model, .uuid, .name, .format, .year, .surMaterial, .writingCredits }
-		] AS sourcingMaterials
+		subsequentVersionMaterials,
+		sourcingMaterials
 `;

--- a/src/neo4j/cypher-queries/material/show/show-productions.js
+++ b/src/neo4j/cypher-queries/material/show/show-productions.js
@@ -1,89 +1,97 @@
 export default () => `
 	MATCH (material:Material { uuid: $uuid })
 
-	OPTIONAL MATCH (material)<-[:USES_SOURCE_MATERIAL*0..1]-(:Material)<-[:PRODUCTION_OF]-(production:Production)
-		WHERE NOT EXISTS(
-			(material)<-[:USES_SOURCE_MATERIAL]-(:Material)
-			<-[:HAS_SUB_MATERIAL*1..2]-(:Material)<-[:PRODUCTION_OF]-(production:Production)
-		)
+	CALL {
+		WITH material
 
-	WITH material, COLLECT(production) AS productions
+		OPTIONAL MATCH (material)<-[:USES_SOURCE_MATERIAL*0..1]-(:Material)<-[:PRODUCTION_OF]-(production:Production)
+			WHERE NOT EXISTS(
+				(material)<-[:USES_SOURCE_MATERIAL]-(:Material)
+				<-[:HAS_SUB_MATERIAL*1..2]-(:Material)<-[:PRODUCTION_OF]-(production:Production)
+			)
 
-	UNWIND (CASE productions WHEN [] THEN [null] ELSE productions END) AS production
+		WITH material, COLLECT(production) AS productions
 
-		OPTIONAL MATCH (production)-[:PLAYS_AT]->(venue:Venue)
+		UNWIND (CASE productions WHEN [] THEN [null] ELSE productions END) AS production
 
-		OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
+			OPTIONAL MATCH (production)-[:PLAYS_AT]->(venue:Venue)
 
-		OPTIONAL MATCH (production)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
+			OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
 
-		OPTIONAL MATCH (surProduction)<-[surSurProductionRel:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+			OPTIONAL MATCH (production)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
-		OPTIONAL MATCH (material)<-[:USES_SOURCE_MATERIAL]-(:Material)<-[sourcingMaterialRel:PRODUCTION_OF]-(production)
+			OPTIONAL MATCH (surProduction)<-[surSurProductionRel:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
 
-		WITH
-			production,
-			venue,
-			surVenue,
-			surProduction,
-			surProductionRel,
-			surSurProduction,
-			surSurProductionRel,
-			CASE WHEN sourcingMaterialRel IS NULL THEN false ELSE true END AS usesSourcingMaterial
-			ORDER BY
-				production.startDate DESC,
-				COALESCE(surSurProduction.name, surProduction.name, production.name),
-				COALESCE(surSurProductionRel.position, surProductionRel.position, -1) DESC,
-				COALESCE(surSurProductionRel.position, -1) DESC,
-				COALESCE(surProductionRel.position, -1) DESC,
-				venue.name
+			OPTIONAL MATCH (material)<-[:USES_SOURCE_MATERIAL]-(:Material)<-[sourcingMaterialRel:PRODUCTION_OF]-(production)
 
-		WITH
-			COLLECT(
-				CASE WHEN production IS NULL
-					THEN null
-					ELSE production {
-						model: 'PRODUCTION',
-						.uuid,
-						.name,
-						.startDate,
-						.endDate,
-						usesSourcingMaterial,
-						venue: CASE WHEN venue IS NULL
-							THEN null
-							ELSE venue {
-								model: 'VENUE',
-								.uuid,
-								.name,
-								surVenue: CASE WHEN surVenue IS NULL
-									THEN null
-									ELSE surVenue { model: 'VENUE', .uuid, .name }
-								END
-							}
-						END,
-						surProduction: CASE WHEN surProduction IS NULL
-							THEN null
-							ELSE surProduction {
-								model: 'PRODUCTION',
-								.uuid,
-								.name,
-								surProduction: CASE WHEN surSurProduction IS NULL
-									THEN null
-									ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
-								END
-							}
-						END
-					}
-				END
-			) AS productions
+			WITH
+				production,
+				venue,
+				surVenue,
+				surProduction,
+				surProductionRel,
+				surSurProduction,
+				surSurProductionRel,
+				CASE WHEN sourcingMaterialRel IS NULL THEN false ELSE true END AS usesSourcingMaterial
+				ORDER BY
+					production.startDate DESC,
+					COALESCE(surSurProduction.name, surProduction.name, production.name),
+					COALESCE(surSurProductionRel.position, surProductionRel.position, -1) DESC,
+					COALESCE(surSurProductionRel.position, -1) DESC,
+					COALESCE(surProductionRel.position, -1) DESC,
+					venue.name
+
+			WITH
+				COLLECT(
+					CASE WHEN production IS NULL
+						THEN null
+						ELSE production {
+							model: 'PRODUCTION',
+							.uuid,
+							.name,
+							.startDate,
+							.endDate,
+							usesSourcingMaterial,
+							venue: CASE WHEN venue IS NULL
+								THEN null
+								ELSE venue {
+									model: 'VENUE',
+									.uuid,
+									.name,
+									surVenue: CASE WHEN surVenue IS NULL
+										THEN null
+										ELSE surVenue { model: 'VENUE', .uuid, .name }
+									END
+								}
+							END,
+							surProduction: CASE WHEN surProduction IS NULL
+								THEN null
+								ELSE surProduction {
+									model: 'PRODUCTION',
+									.uuid,
+									.name,
+									surProduction: CASE WHEN surSurProduction IS NULL
+										THEN null
+										ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+									END
+								}
+							END
+						}
+					END
+				) AS productions
+
+		RETURN
+			[
+				production IN productions WHERE NOT production.usesSourcingMaterial |
+				production { .model, .uuid, .name, .startDate, .endDate, .venue, .surProduction }
+			] AS productions,
+			[
+				production IN productions WHERE production.usesSourcingMaterial |
+				production { .model, .uuid, .name, .startDate, .endDate, .venue, .surProduction }
+			] AS sourcingMaterialProductions
+	}
 
 	RETURN
-		[
-			production IN productions WHERE NOT production.usesSourcingMaterial |
-			production { .model, .uuid, .name, .startDate, .endDate, .venue, .surProduction }
-		] AS productions,
-		[
-			production IN productions WHERE production.usesSourcingMaterial |
-			production { .model, .uuid, .name, .startDate, .endDate, .venue, .surProduction }
-		] AS sourcingMaterialProductions
+		productions,
+		sourcingMaterialProductions
 `;

--- a/src/neo4j/cypher-queries/person/show/show-awards-rights-grantor-material.js
+++ b/src/neo4j/cypher-queries/person/show/show-awards-rights-grantor-material.js
@@ -1,266 +1,273 @@
 export default () => `
 	MATCH (person:Person { uuid: $uuid })
 
-	OPTIONAL MATCH (person)
-		<-[:HAS_WRITING_ENTITY { creditType: 'RIGHTS_GRANTOR' }]
-		-(material:Material)-[:HAS_SUB_MATERIAL*0..2]-(nominatedRightsGrantorMaterial:Material)
-		<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
-		<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
-		WHERE
-			(material)-[:HAS_SUB_MATERIAL*0..2]->(nominatedRightsGrantorMaterial:Material) OR
-			(material)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedRightsGrantorMaterial:Material)
+	CALL {
+		WITH person
 
-	OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)
-		WHERE
-			(
-				(nominatedEntity:Person AND nominatedEntityRel.nominatedCompanyUuid IS NULL) OR
-				nominatedEntity:Company
-			) AND
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = nominatedEntityRel.nominationPosition
-			)
+		OPTIONAL MATCH (person)
+			<-[:HAS_WRITING_ENTITY { creditType: 'RIGHTS_GRANTOR' }]
+			-(material:Material)-[:HAS_SUB_MATERIAL*0..2]-(nominatedRightsGrantorMaterial:Material)
+			<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
+			<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
+			WHERE
+				(material)-[:HAS_SUB_MATERIAL*0..2]->(nominatedRightsGrantorMaterial:Material) OR
+				(material)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedRightsGrantorMaterial:Material)
 
-	WITH nominatedRightsGrantorMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntityRel,
-		COLLECT(nominatedEntity {
-			model: TOUPPER(HEAD(LABELS(nominatedEntity))),
-			.uuid,
-			.name,
-			nominatedMemberUuids: nominatedEntityRel.nominatedMemberUuids
-		}) AS nominatedEntities
+		OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)
+			WHERE
+				(
+					(nominatedEntity:Person AND nominatedEntityRel.nominatedCompanyUuid IS NULL) OR
+					nominatedEntity:Company
+				) AND
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = nominatedEntityRel.nominationPosition
+				)
 
-	UNWIND (CASE nominatedEntities WHEN [] THEN [null] ELSE nominatedEntities END) AS nominatedEntity
+		WITH nominatedRightsGrantorMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntityRel,
+			COLLECT(nominatedEntity {
+				model: TOUPPER(HEAD(LABELS(nominatedEntity))),
+				.uuid,
+				.name,
+				nominatedMemberUuids: nominatedEntityRel.nominatedMemberUuids
+			}) AS nominatedEntities
 
-		UNWIND (COALESCE(nominatedEntity.nominatedMemberUuids, [null])) AS nominatedMemberUuid
+		UNWIND (CASE nominatedEntities WHEN [] THEN [null] ELSE nominatedEntities END) AS nominatedEntity
 
-			OPTIONAL MATCH (category)-[nominatedMemberRel:HAS_NOMINEE]->
-				(nominatedMember:Person { uuid: nominatedMemberUuid })
-				WHERE
-					nominatedEntityRel.nominationPosition IS NULL OR
-					nominatedEntityRel.nominationPosition = nominatedMemberRel.nominationPosition
+			UNWIND (COALESCE(nominatedEntity.nominatedMemberUuids, [null])) AS nominatedMemberUuid
 
-			WITH
-				nominatedRightsGrantorMaterial,
-				nomineeRel,
-				category,
-				categoryRel,
-				ceremony,
-				nominatedEntityRel,
-				nominatedEntity,
-				nominatedMember
-				ORDER BY nominatedMemberRel.memberPosition
+				OPTIONAL MATCH (category)-[nominatedMemberRel:HAS_NOMINEE]->
+					(nominatedMember:Person { uuid: nominatedMemberUuid })
+					WHERE
+						nominatedEntityRel.nominationPosition IS NULL OR
+						nominatedEntityRel.nominationPosition = nominatedMemberRel.nominationPosition
 
-			WITH
-				nominatedRightsGrantorMaterial,
-				nomineeRel,
-				category,
-				categoryRel,
-				ceremony,
-				nominatedEntityRel,
-				nominatedEntity,
-				COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
+				WITH
+					nominatedRightsGrantorMaterial,
+					nomineeRel,
+					category,
+					categoryRel,
+					ceremony,
+					nominatedEntityRel,
+					nominatedEntity,
+					nominatedMember
+					ORDER BY nominatedMemberRel.memberPosition
 
-	WITH
-		nominatedRightsGrantorMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntityRel,
-		nominatedEntity,
-		nominatedMembers
-		ORDER BY nominatedEntityRel.nominationPosition, nominatedEntityRel.entityPosition
+				WITH
+					nominatedRightsGrantorMaterial,
+					nomineeRel,
+					category,
+					categoryRel,
+					ceremony,
+					nominatedEntityRel,
+					nominatedEntity,
+					COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
 
-	WITH nominatedRightsGrantorMaterial, nomineeRel, category, categoryRel, ceremony,
-		COLLECT(
-			CASE WHEN nominatedEntity IS NULL
-				THEN null
-				ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
-			END
-		) AS nominatedEntities
+		WITH
+			nominatedRightsGrantorMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntityRel,
+			nominatedEntity,
+			nominatedMembers
+			ORDER BY nominatedEntityRel.nominationPosition, nominatedEntityRel.entityPosition
 
-	WITH nominatedRightsGrantorMaterial, nomineeRel, category, categoryRel, ceremony,
-		[nominatedEntity IN nominatedEntities | CASE nominatedEntity.model WHEN 'COMPANY'
-			THEN nominatedEntity
-			ELSE nominatedEntity { .model, .uuid, .name }
-		END] AS nominatedEntities
+		WITH nominatedRightsGrantorMaterial, nomineeRel, category, categoryRel, ceremony,
+			COLLECT(
+				CASE WHEN nominatedEntity IS NULL
+					THEN null
+					ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
+				END
+			) AS nominatedEntities
 
-	OPTIONAL MATCH (category)-[nominatedProductionRel:HAS_NOMINEE]->(nominatedProduction:Production)
-		WHERE
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = nominatedProductionRel.nominationPosition
-			)
+		WITH nominatedRightsGrantorMaterial, nomineeRel, category, categoryRel, ceremony,
+			[nominatedEntity IN nominatedEntities | CASE nominatedEntity.model WHEN 'COMPANY'
+				THEN nominatedEntity
+				ELSE nominatedEntity { .model, .uuid, .name }
+			END] AS nominatedEntities
 
-	OPTIONAL MATCH (nominatedProduction)-[:PLAYS_AT]->(venue:Venue)
+		OPTIONAL MATCH (category)-[nominatedProductionRel:HAS_NOMINEE]->(nominatedProduction:Production)
+			WHERE
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = nominatedProductionRel.nominationPosition
+				)
 
-	OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
+		OPTIONAL MATCH (nominatedProduction)-[:PLAYS_AT]->(venue:Venue)
 
-	OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
+		OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
 
-	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+		OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
-	WITH
-		nominatedRightsGrantorMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductionRel,
-		nominatedProduction,
-		venue,
-		surVenue,
-		surProduction,
-		surSurProduction
-		ORDER BY nominatedProductionRel.productionPosition
+		OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
 
-	WITH nominatedRightsGrantorMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
-		COLLECT(
-			CASE WHEN nominatedProduction IS NULL
-				THEN null
-				ELSE nominatedProduction {
-					model: 'PRODUCTION',
-					.uuid,
-					.name,
-					.startDate,
-					.endDate,
-					venue: CASE WHEN venue IS NULL
-						THEN null
-						ELSE venue {
-							model: 'VENUE',
-							.uuid,
-							.name,
-							surVenue: CASE WHEN surVenue IS NULL
-								THEN null
-								ELSE surVenue { model: 'VENUE', .uuid, .name }
-							END
-						}
-					END,
-					surProduction: CASE WHEN surProduction IS NULL
-						THEN null
-						ELSE surProduction {
-							model: 'PRODUCTION',
-							.uuid,
-							.name,
-							surProduction: CASE WHEN surSurProduction IS NULL
-								THEN null
-								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
-							END
-						}
-					END
-				}
-			END
-		) AS nominatedProductions
+		WITH
+			nominatedRightsGrantorMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductionRel,
+			nominatedProduction,
+			venue,
+			surVenue,
+			surProduction,
+			surSurProduction
+			ORDER BY nominatedProductionRel.productionPosition
 
-	OPTIONAL MATCH (category)-[nominatedMaterialRel:HAS_NOMINEE]->(nominatedMaterial:Material)
-		WHERE
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = nominatedMaterialRel.nominationPosition
-			) AND
-			nominatedMaterialRel.uuid <> nominatedRightsGrantorMaterial.uuid
+		WITH nominatedRightsGrantorMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
+			COLLECT(
+				CASE WHEN nominatedProduction IS NULL
+					THEN null
+					ELSE nominatedProduction {
+						model: 'PRODUCTION',
+						.uuid,
+						.name,
+						.startDate,
+						.endDate,
+						venue: CASE WHEN venue IS NULL
+							THEN null
+							ELSE venue {
+								model: 'VENUE',
+								.uuid,
+								.name,
+								surVenue: CASE WHEN surVenue IS NULL
+									THEN null
+									ELSE surVenue { model: 'VENUE', .uuid, .name }
+								END
+							}
+						END,
+						surProduction: CASE WHEN surProduction IS NULL
+							THEN null
+							ELSE surProduction {
+								model: 'PRODUCTION',
+								.uuid,
+								.name,
+								surProduction: CASE WHEN surSurProduction IS NULL
+									THEN null
+									ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+								END
+							}
+						END
+					}
+				END
+			) AS nominatedProductions
 
-	OPTIONAL MATCH (nominatedMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSurMaterial:Material)
+		OPTIONAL MATCH (category)-[nominatedMaterialRel:HAS_NOMINEE]->(nominatedMaterial:Material)
+			WHERE
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = nominatedMaterialRel.nominationPosition
+				) AND
+				nominatedMaterialRel.uuid <> nominatedRightsGrantorMaterial.uuid
 
-	WITH
-		nominatedRightsGrantorMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductions,
-		nominatedMaterialRel,
-		nominatedMaterial,
-		nominatedSurMaterial
-		ORDER BY nominatedMaterialRel.materialPosition
+		OPTIONAL MATCH (nominatedMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSurMaterial:Material)
 
-	WITH
-		nominatedRightsGrantorMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductions,
-		COLLECT(
-			CASE WHEN nominatedMaterial IS NULL
-				THEN null
-				ELSE nominatedMaterial {
-					model: 'MATERIAL',
-					.uuid,
-					.name,
-					.format,
-					.year,
-					surMaterial: CASE WHEN nominatedSurMaterial IS NULL
-						THEN null
-						ELSE nominatedSurMaterial { model: 'MATERIAL', .uuid, .name }
-					END
-				}
-			END
-		) AS nominatedMaterials
-		ORDER BY nomineeRel.nominationPosition, nomineeRel.materialPosition
+		WITH
+			nominatedRightsGrantorMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductions,
+			nominatedMaterialRel,
+			nominatedMaterial,
+			nominatedSurMaterial
+			ORDER BY nominatedMaterialRel.materialPosition
 
-	OPTIONAL MATCH (nominatedRightsGrantorMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedRightsGrantorSurMaterial:Material)
+		WITH
+			nominatedRightsGrantorMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductions,
+			COLLECT(
+				CASE WHEN nominatedMaterial IS NULL
+					THEN null
+					ELSE nominatedMaterial {
+						model: 'MATERIAL',
+						.uuid,
+						.name,
+						.format,
+						.year,
+						surMaterial: CASE WHEN nominatedSurMaterial IS NULL
+							THEN null
+							ELSE nominatedSurMaterial { model: 'MATERIAL', .uuid, .name }
+						END
+					}
+				END
+			) AS nominatedMaterials
+			ORDER BY nomineeRel.nominationPosition, nomineeRel.materialPosition
 
-	OPTIONAL MATCH (nominatedRightsGrantorSurMaterial)
-		<-[:HAS_SUB_MATERIAL]-(nominatedRightsGrantorSurSurMaterial:Material)
+		OPTIONAL MATCH (nominatedRightsGrantorMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedRightsGrantorSurMaterial:Material)
 
-	WITH
-		nomineeRel.isWinner AS isWinner,
-		nomineeRel.customType AS customType,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductions,
-		nominatedMaterials,
-		COLLECT(
-			CASE WHEN nominatedRightsGrantorMaterial IS NULL
-				THEN null
-				ELSE nominatedRightsGrantorMaterial {
-					model: 'MATERIAL',
-					.uuid,
-					.name,
-					.format,
-					.year,
-					surMaterial: CASE WHEN nominatedRightsGrantorSurMaterial IS NULL
-						THEN null
-						ELSE nominatedRightsGrantorSurMaterial {
-							model: 'MATERIAL',
-							.uuid,
-							.name,
-							surMaterial: CASE WHEN nominatedRightsGrantorSurSurMaterial IS NULL
-								THEN null
-								ELSE nominatedRightsGrantorSurSurMaterial { model: 'MATERIAL', .uuid, .name }
-							END
-						}
-					END
-				}
-			END
-		) AS nominatedRightsGrantorMaterials
+		OPTIONAL MATCH (nominatedRightsGrantorSurMaterial)
+			<-[:HAS_SUB_MATERIAL]-(nominatedRightsGrantorSurSurMaterial:Material)
 
-	WITH category, categoryRel, ceremony,
-		COLLECT({
-			model: 'NOMINATION',
-			isWinner: COALESCE(isWinner, false),
-			type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
-			entities: nominatedEntities,
-			productions: nominatedProductions,
-			materials: nominatedMaterials,
-			recipientRightsGrantorMaterials: nominatedRightsGrantorMaterials
-		}) AS nominations
-		ORDER BY categoryRel.position
+		WITH
+			nomineeRel.isWinner AS isWinner,
+			nomineeRel.customType AS customType,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductions,
+			nominatedMaterials,
+			COLLECT(
+				CASE WHEN nominatedRightsGrantorMaterial IS NULL
+					THEN null
+					ELSE nominatedRightsGrantorMaterial {
+						model: 'MATERIAL',
+						.uuid,
+						.name,
+						.format,
+						.year,
+						surMaterial: CASE WHEN nominatedRightsGrantorSurMaterial IS NULL
+							THEN null
+							ELSE nominatedRightsGrantorSurMaterial {
+								model: 'MATERIAL',
+								.uuid,
+								.name,
+								surMaterial: CASE WHEN nominatedRightsGrantorSurSurMaterial IS NULL
+									THEN null
+									ELSE nominatedRightsGrantorSurSurMaterial { model: 'MATERIAL', .uuid, .name }
+								END
+							}
+						END
+					}
+				END
+			) AS nominatedRightsGrantorMaterials
 
-	WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
-		ORDER BY ceremony.name DESC
+		WITH category, categoryRel, ceremony,
+			COLLECT({
+				model: 'NOMINATION',
+				isWinner: COALESCE(isWinner, false),
+				type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
+				entities: nominatedEntities,
+				productions: nominatedProductions,
+				materials: nominatedMaterials,
+				recipientRightsGrantorMaterials: nominatedRightsGrantorMaterials
+			}) AS nominations
+			ORDER BY categoryRel.position
 
-	OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
+		WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
+			ORDER BY ceremony.name DESC
 
-	WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
-		ORDER BY award.name
+		OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
+
+		WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
+			ORDER BY award.name
+
+		RETURN
+			COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS rightsGrantorMaterialAwards
+	}
 
 	RETURN
-		COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS rightsGrantorMaterialAwards
+		rightsGrantorMaterialAwards
 `;

--- a/src/neo4j/cypher-queries/person/show/show-awards-sourcing-material.js
+++ b/src/neo4j/cypher-queries/person/show/show-awards-sourcing-material.js
@@ -1,280 +1,287 @@
 export default () => `
 	MATCH (person:Person { uuid: $uuid })
 
-	OPTIONAL MATCH path=(person)
-		<-[writingRel:HAS_WRITING_ENTITY]-(creditingMaterial:Material)
-			-[:HAS_SUB_MATERIAL*0..2]-(sourceMaterial:Material)
-		<-[:USES_SOURCE_MATERIAL*0..1]-(sourcingMaterial:Material)
-			-[:HAS_SUB_MATERIAL*0..2]-(nominatedSourcingMaterial:Material)
-		<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
-		<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
-		WHERE
-			(
-				writingRel.creditType = 'NON_SPECIFIC_SOURCE_MATERIAL' OR
-				ANY(rel IN RELATIONSHIPS(path) WHERE TYPE(rel) = 'USES_SOURCE_MATERIAL')
-			) AND (
+	CALL {
+		WITH person
+
+		OPTIONAL MATCH path=(person)
+			<-[writingRel:HAS_WRITING_ENTITY]-(creditingMaterial:Material)
+				-[:HAS_SUB_MATERIAL*0..2]-(sourceMaterial:Material)
+			<-[:USES_SOURCE_MATERIAL*0..1]-(sourcingMaterial:Material)
+				-[:HAS_SUB_MATERIAL*0..2]-(nominatedSourcingMaterial:Material)
+			<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
+			<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
+			WHERE
 				(
-					(creditingMaterial)-[:HAS_SUB_MATERIAL*0..2]->(sourceMaterial) AND
-					(sourcingMaterial)-[:HAS_SUB_MATERIAL*0..2]->(nominatedSourcingMaterial)
-				) OR (
-					(creditingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(sourceMaterial) AND
-					(sourcingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSourcingMaterial)
-				) OR (
-					(creditingMaterial)-[:HAS_SUB_MATERIAL*0..2]->(sourceMaterial) AND
-					(sourcingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSourcingMaterial)
+					writingRel.creditType = 'NON_SPECIFIC_SOURCE_MATERIAL' OR
+					ANY(rel IN RELATIONSHIPS(path) WHERE TYPE(rel) = 'USES_SOURCE_MATERIAL')
+				) AND (
+					(
+						(creditingMaterial)-[:HAS_SUB_MATERIAL*0..2]->(sourceMaterial) AND
+						(sourcingMaterial)-[:HAS_SUB_MATERIAL*0..2]->(nominatedSourcingMaterial)
+					) OR (
+						(creditingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(sourceMaterial) AND
+						(sourcingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSourcingMaterial)
+					) OR (
+						(creditingMaterial)-[:HAS_SUB_MATERIAL*0..2]->(sourceMaterial) AND
+						(sourcingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSourcingMaterial)
+					)
 				)
-			)
 
-	OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)
-		WHERE
-			(
-				(nominatedEntity:Person AND nominatedEntityRel.nominatedCompanyUuid IS NULL) OR
-				nominatedEntity:Company
-			) AND
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = nominatedEntityRel.nominationPosition
-			)
+		OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)
+			WHERE
+				(
+					(nominatedEntity:Person AND nominatedEntityRel.nominatedCompanyUuid IS NULL) OR
+					nominatedEntity:Company
+				) AND
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = nominatedEntityRel.nominationPosition
+				)
 
-	WITH nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntityRel,
-		COLLECT(nominatedEntity {
-			model: TOUPPER(HEAD(LABELS(nominatedEntity))),
-			.uuid,
-			.name,
-			nominatedMemberUuids: nominatedEntityRel.nominatedMemberUuids
-		}) AS nominatedEntities
+		WITH nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntityRel,
+			COLLECT(nominatedEntity {
+				model: TOUPPER(HEAD(LABELS(nominatedEntity))),
+				.uuid,
+				.name,
+				nominatedMemberUuids: nominatedEntityRel.nominatedMemberUuids
+			}) AS nominatedEntities
 
-	UNWIND (CASE nominatedEntities WHEN [] THEN [null] ELSE nominatedEntities END) AS nominatedEntity
+		UNWIND (CASE nominatedEntities WHEN [] THEN [null] ELSE nominatedEntities END) AS nominatedEntity
 
-		UNWIND (COALESCE(nominatedEntity.nominatedMemberUuids, [null])) AS nominatedMemberUuid
+			UNWIND (COALESCE(nominatedEntity.nominatedMemberUuids, [null])) AS nominatedMemberUuid
 
-			OPTIONAL MATCH (category)-[nominatedMemberRel:HAS_NOMINEE]->
-				(nominatedMember:Person { uuid: nominatedMemberUuid })
-				WHERE
-					nominatedEntityRel.nominationPosition IS NULL OR
-					nominatedEntityRel.nominationPosition = nominatedMemberRel.nominationPosition
+				OPTIONAL MATCH (category)-[nominatedMemberRel:HAS_NOMINEE]->
+					(nominatedMember:Person { uuid: nominatedMemberUuid })
+					WHERE
+						nominatedEntityRel.nominationPosition IS NULL OR
+						nominatedEntityRel.nominationPosition = nominatedMemberRel.nominationPosition
 
-			WITH
-				nominatedSourcingMaterial,
-				nomineeRel,
-				category,
-				categoryRel,
-				ceremony,
-				nominatedEntityRel,
-				nominatedEntity,
-				nominatedMember
-				ORDER BY nominatedMemberRel.memberPosition
+				WITH
+					nominatedSourcingMaterial,
+					nomineeRel,
+					category,
+					categoryRel,
+					ceremony,
+					nominatedEntityRel,
+					nominatedEntity,
+					nominatedMember
+					ORDER BY nominatedMemberRel.memberPosition
 
-			WITH
-				nominatedSourcingMaterial,
-				nomineeRel,
-				category,
-				categoryRel,
-				ceremony,
-				nominatedEntityRel,
-				nominatedEntity,
-				COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
+				WITH
+					nominatedSourcingMaterial,
+					nomineeRel,
+					category,
+					categoryRel,
+					ceremony,
+					nominatedEntityRel,
+					nominatedEntity,
+					COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
 
-	WITH
-		nominatedSourcingMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntityRel,
-		nominatedEntity,
-		nominatedMembers
-		ORDER BY nominatedEntityRel.nominationPosition, nominatedEntityRel.entityPosition
+		WITH
+			nominatedSourcingMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntityRel,
+			nominatedEntity,
+			nominatedMembers
+			ORDER BY nominatedEntityRel.nominationPosition, nominatedEntityRel.entityPosition
 
-	WITH nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony,
-		COLLECT(
-			CASE WHEN nominatedEntity IS NULL
-				THEN null
-				ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
-			END
-		) AS nominatedEntities
+		WITH nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony,
+			COLLECT(
+				CASE WHEN nominatedEntity IS NULL
+					THEN null
+					ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
+				END
+			) AS nominatedEntities
 
-	WITH nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony,
-		[nominatedEntity IN nominatedEntities | CASE nominatedEntity.model WHEN 'COMPANY'
-			THEN nominatedEntity
-			ELSE nominatedEntity { .model, .uuid, .name }
-		END] AS nominatedEntities
+		WITH nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony,
+			[nominatedEntity IN nominatedEntities | CASE nominatedEntity.model WHEN 'COMPANY'
+				THEN nominatedEntity
+				ELSE nominatedEntity { .model, .uuid, .name }
+			END] AS nominatedEntities
 
-	OPTIONAL MATCH (category)-[nominatedProductionRel:HAS_NOMINEE]->(nominatedProduction:Production)
-		WHERE
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = nominatedProductionRel.nominationPosition
-			)
+		OPTIONAL MATCH (category)-[nominatedProductionRel:HAS_NOMINEE]->(nominatedProduction:Production)
+			WHERE
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = nominatedProductionRel.nominationPosition
+				)
 
-	OPTIONAL MATCH (nominatedProduction)-[:PLAYS_AT]->(venue:Venue)
+		OPTIONAL MATCH (nominatedProduction)-[:PLAYS_AT]->(venue:Venue)
 
-	OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
+		OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
 
-	OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
+		OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
-	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+		OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
 
-	WITH
-		nominatedSourcingMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductionRel,
-		nominatedProduction,
-		venue,
-		surVenue,
-		surProduction,
-		surSurProduction
-		ORDER BY nominatedProductionRel.productionPosition
+		WITH
+			nominatedSourcingMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductionRel,
+			nominatedProduction,
+			venue,
+			surVenue,
+			surProduction,
+			surSurProduction
+			ORDER BY nominatedProductionRel.productionPosition
 
-	WITH nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
-		COLLECT(
-			CASE WHEN nominatedProduction IS NULL
-				THEN null
-				ELSE nominatedProduction {
-					model: 'PRODUCTION',
-					.uuid,
-					.name,
-					.startDate,
-					.endDate,
-					venue: CASE WHEN venue IS NULL
-						THEN null
-						ELSE venue {
-							model: 'VENUE',
-							.uuid,
-							.name,
-							surVenue: CASE WHEN surVenue IS NULL
-								THEN null
-								ELSE surVenue { model: 'VENUE', .uuid, .name }
-							END
-						}
-					END,
-					surProduction: CASE WHEN surProduction IS NULL
-						THEN null
-						ELSE surProduction {
-							model: 'PRODUCTION',
-							.uuid,
-							.name,
-							surProduction: CASE WHEN surSurProduction IS NULL
-								THEN null
-								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
-							END
-						}
-					END
-				}
-			END
-		) AS nominatedProductions
+		WITH nominatedSourcingMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
+			COLLECT(
+				CASE WHEN nominatedProduction IS NULL
+					THEN null
+					ELSE nominatedProduction {
+						model: 'PRODUCTION',
+						.uuid,
+						.name,
+						.startDate,
+						.endDate,
+						venue: CASE WHEN venue IS NULL
+							THEN null
+							ELSE venue {
+								model: 'VENUE',
+								.uuid,
+								.name,
+								surVenue: CASE WHEN surVenue IS NULL
+									THEN null
+									ELSE surVenue { model: 'VENUE', .uuid, .name }
+								END
+							}
+						END,
+						surProduction: CASE WHEN surProduction IS NULL
+							THEN null
+							ELSE surProduction {
+								model: 'PRODUCTION',
+								.uuid,
+								.name,
+								surProduction: CASE WHEN surSurProduction IS NULL
+									THEN null
+									ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+								END
+							}
+						END
+					}
+				END
+			) AS nominatedProductions
 
-	OPTIONAL MATCH (category)-[nominatedMaterialRel:HAS_NOMINEE]->(nominatedMaterial:Material)
-		WHERE
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = nominatedMaterialRel.nominationPosition
-			) AND
-			nominatedMaterialRel.uuid <> nominatedSourcingMaterial.uuid
+		OPTIONAL MATCH (category)-[nominatedMaterialRel:HAS_NOMINEE]->(nominatedMaterial:Material)
+			WHERE
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = nominatedMaterialRel.nominationPosition
+				) AND
+				nominatedMaterialRel.uuid <> nominatedSourcingMaterial.uuid
 
-	OPTIONAL MATCH (nominatedMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSurMaterial:Material)
+		OPTIONAL MATCH (nominatedMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSurMaterial:Material)
 
-	WITH
-		nominatedSourcingMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductions,
-		nominatedMaterialRel,
-		nominatedMaterial,
-		nominatedSurMaterial
-		ORDER BY nominatedMaterialRel.materialPosition
+		WITH
+			nominatedSourcingMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductions,
+			nominatedMaterialRel,
+			nominatedMaterial,
+			nominatedSurMaterial
+			ORDER BY nominatedMaterialRel.materialPosition
 
-	WITH
-		nominatedSourcingMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductions,
-		COLLECT(
-			CASE WHEN nominatedMaterial IS NULL
-				THEN null
-				ELSE nominatedMaterial {
-					model: 'MATERIAL',
-					.uuid,
-					.name,
-					.format,
-					.year,
-					surMaterial: CASE WHEN nominatedSurMaterial IS NULL
-						THEN null
-						ELSE nominatedSurMaterial { model: 'MATERIAL', .uuid, .name }
-					END
-				}
-			END
-		) AS nominatedMaterials
-		ORDER BY nomineeRel.nominationPosition, nomineeRel.materialPosition
+		WITH
+			nominatedSourcingMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductions,
+			COLLECT(
+				CASE WHEN nominatedMaterial IS NULL
+					THEN null
+					ELSE nominatedMaterial {
+						model: 'MATERIAL',
+						.uuid,
+						.name,
+						.format,
+						.year,
+						surMaterial: CASE WHEN nominatedSurMaterial IS NULL
+							THEN null
+							ELSE nominatedSurMaterial { model: 'MATERIAL', .uuid, .name }
+						END
+					}
+				END
+			) AS nominatedMaterials
+			ORDER BY nomineeRel.nominationPosition, nomineeRel.materialPosition
 
-	OPTIONAL MATCH (nominatedSourcingMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSourcingSurMaterial:Material)
+		OPTIONAL MATCH (nominatedSourcingMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSourcingSurMaterial:Material)
 
-	OPTIONAL MATCH (nominatedSourcingSurMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSourcingSurSurMaterial:Material)
+		OPTIONAL MATCH (nominatedSourcingSurMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSourcingSurSurMaterial:Material)
 
-	WITH
-		nomineeRel.isWinner AS isWinner,
-		nomineeRel.customType AS customType,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductions,
-		nominatedMaterials,
-		COLLECT(
-			CASE WHEN nominatedSourcingMaterial IS NULL
-				THEN null
-				ELSE nominatedSourcingMaterial {
-					model: 'MATERIAL',
-					.uuid,
-					.name,
-					.format,
-					.year,
-					surMaterial: CASE WHEN nominatedSourcingSurMaterial IS NULL
-						THEN null
-						ELSE nominatedSourcingSurMaterial {
-							model: 'MATERIAL',
-							.uuid,
-							.name,
-							surMaterial: CASE WHEN nominatedSourcingSurSurMaterial IS NULL
-								THEN null
-								ELSE nominatedSourcingSurSurMaterial { model: 'MATERIAL', .uuid, .name }
-							END
-						}
-					END
-				}
-			END
-		) AS nominatedSourcingMaterials
+		WITH
+			nomineeRel.isWinner AS isWinner,
+			nomineeRel.customType AS customType,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductions,
+			nominatedMaterials,
+			COLLECT(
+				CASE WHEN nominatedSourcingMaterial IS NULL
+					THEN null
+					ELSE nominatedSourcingMaterial {
+						model: 'MATERIAL',
+						.uuid,
+						.name,
+						.format,
+						.year,
+						surMaterial: CASE WHEN nominatedSourcingSurMaterial IS NULL
+							THEN null
+							ELSE nominatedSourcingSurMaterial {
+								model: 'MATERIAL',
+								.uuid,
+								.name,
+								surMaterial: CASE WHEN nominatedSourcingSurSurMaterial IS NULL
+									THEN null
+									ELSE nominatedSourcingSurSurMaterial { model: 'MATERIAL', .uuid, .name }
+								END
+							}
+						END
+					}
+				END
+			) AS nominatedSourcingMaterials
 
-	WITH category, categoryRel, ceremony,
-		COLLECT({
-			model: 'NOMINATION',
-			isWinner: COALESCE(isWinner, false),
-			type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
-			entities: nominatedEntities,
-			productions: nominatedProductions,
-			materials: nominatedMaterials,
-			recipientSourcingMaterials: nominatedSourcingMaterials
-		}) AS nominations
-		ORDER BY categoryRel.position
+		WITH category, categoryRel, ceremony,
+			COLLECT({
+				model: 'NOMINATION',
+				isWinner: COALESCE(isWinner, false),
+				type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
+				entities: nominatedEntities,
+				productions: nominatedProductions,
+				materials: nominatedMaterials,
+				recipientSourcingMaterials: nominatedSourcingMaterials
+			}) AS nominations
+			ORDER BY categoryRel.position
 
-	WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
-		ORDER BY ceremony.name DESC
+		WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
+			ORDER BY ceremony.name DESC
 
-	OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
+		OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
 
-	WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
-		ORDER BY award.name
+		WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
+			ORDER BY award.name
+
+		RETURN
+			COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS sourcingMaterialAwards
+	}
 
 	RETURN
-		COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS sourcingMaterialAwards
+		sourcingMaterialAwards
 `;

--- a/src/neo4j/cypher-queries/person/show/show-awards-subsequent-version-material.js
+++ b/src/neo4j/cypher-queries/person/show/show-awards-subsequent-version-material.js
@@ -1,276 +1,283 @@
 export default () => `
 	MATCH (person:Person { uuid: $uuid })
 
-	OPTIONAL MATCH (person)
-		<-[:HAS_WRITING_ENTITY]-(creditingMaterial:Material)-[:HAS_SUB_MATERIAL*0..2]-(originalVersionMaterial:Material)
-		<-[:SUBSEQUENT_VERSION_OF]-(subsequentVersionMaterial:Material)
-			-[:HAS_SUB_MATERIAL*0..2]-(nominatedSubsequentVersionMaterial:Material)
-		<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
-		<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
-		WHERE
-			(
-				(creditingMaterial)-[:HAS_SUB_MATERIAL*0..2]->(originalVersionMaterial) AND
-				(subsequentVersionMaterial)-[:HAS_SUB_MATERIAL*0..2]->(nominatedSubsequentVersionMaterial)
-			) OR (
-				(creditingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(originalVersionMaterial) AND
-				(subsequentVersionMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSubsequentVersionMaterial)
-			) OR (
-				(creditingMaterial)-[:HAS_SUB_MATERIAL*0..2]->(originalVersionMaterial) AND
-				(subsequentVersionMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSubsequentVersionMaterial)
-			)
+	CALL {
+		WITH person
 
-	OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)
-		WHERE
-			(
-				(nominatedEntity:Person AND nominatedEntityRel.nominatedCompanyUuid IS NULL) OR
-				nominatedEntity:Company
-			) AND
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = nominatedEntityRel.nominationPosition
-			)
+		OPTIONAL MATCH (person)
+			<-[:HAS_WRITING_ENTITY]-(creditingMaterial:Material)-[:HAS_SUB_MATERIAL*0..2]-(originalVersionMaterial:Material)
+			<-[:SUBSEQUENT_VERSION_OF]-(subsequentVersionMaterial:Material)
+				-[:HAS_SUB_MATERIAL*0..2]-(nominatedSubsequentVersionMaterial:Material)
+			<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
+			<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
+			WHERE
+				(
+					(creditingMaterial)-[:HAS_SUB_MATERIAL*0..2]->(originalVersionMaterial) AND
+					(subsequentVersionMaterial)-[:HAS_SUB_MATERIAL*0..2]->(nominatedSubsequentVersionMaterial)
+				) OR (
+					(creditingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(originalVersionMaterial) AND
+					(subsequentVersionMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSubsequentVersionMaterial)
+				) OR (
+					(creditingMaterial)-[:HAS_SUB_MATERIAL*0..2]->(originalVersionMaterial) AND
+					(subsequentVersionMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedSubsequentVersionMaterial)
+				)
 
-	WITH nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntityRel,
-		COLLECT(nominatedEntity {
-			model: TOUPPER(HEAD(LABELS(nominatedEntity))),
-			.uuid,
-			.name,
-			nominatedMemberUuids: nominatedEntityRel.nominatedMemberUuids
-		}) AS nominatedEntities
+		OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)
+			WHERE
+				(
+					(nominatedEntity:Person AND nominatedEntityRel.nominatedCompanyUuid IS NULL) OR
+					nominatedEntity:Company
+				) AND
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = nominatedEntityRel.nominationPosition
+				)
 
-	UNWIND (CASE nominatedEntities WHEN [] THEN [null] ELSE nominatedEntities END) AS nominatedEntity
+		WITH nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntityRel,
+			COLLECT(nominatedEntity {
+				model: TOUPPER(HEAD(LABELS(nominatedEntity))),
+				.uuid,
+				.name,
+				nominatedMemberUuids: nominatedEntityRel.nominatedMemberUuids
+			}) AS nominatedEntities
 
-		UNWIND (COALESCE(nominatedEntity.nominatedMemberUuids, [null])) AS nominatedMemberUuid
+		UNWIND (CASE nominatedEntities WHEN [] THEN [null] ELSE nominatedEntities END) AS nominatedEntity
 
-			OPTIONAL MATCH (category)-[nominatedMemberRel:HAS_NOMINEE]->
-				(nominatedMember:Person { uuid: nominatedMemberUuid })
-				WHERE
-					nominatedEntityRel.nominationPosition IS NULL OR
-					nominatedEntityRel.nominationPosition = nominatedMemberRel.nominationPosition
+			UNWIND (COALESCE(nominatedEntity.nominatedMemberUuids, [null])) AS nominatedMemberUuid
 
-			WITH
-				nominatedSubsequentVersionMaterial,
-				nomineeRel,
-				category,
-				categoryRel,
-				ceremony,
-				nominatedEntityRel,
-				nominatedEntity,
-				nominatedMember
-				ORDER BY nominatedMemberRel.memberPosition
+				OPTIONAL MATCH (category)-[nominatedMemberRel:HAS_NOMINEE]->
+					(nominatedMember:Person { uuid: nominatedMemberUuid })
+					WHERE
+						nominatedEntityRel.nominationPosition IS NULL OR
+						nominatedEntityRel.nominationPosition = nominatedMemberRel.nominationPosition
 
-			WITH
-				nominatedSubsequentVersionMaterial,
-				nomineeRel,
-				category,
-				categoryRel,
-				ceremony,
-				nominatedEntityRel,
-				nominatedEntity,
-				COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
+				WITH
+					nominatedSubsequentVersionMaterial,
+					nomineeRel,
+					category,
+					categoryRel,
+					ceremony,
+					nominatedEntityRel,
+					nominatedEntity,
+					nominatedMember
+					ORDER BY nominatedMemberRel.memberPosition
 
-	WITH
-		nominatedSubsequentVersionMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntityRel,
-		nominatedEntity,
-		nominatedMembers
-		ORDER BY nominatedEntityRel.nominationPosition, nominatedEntityRel.entityPosition
+				WITH
+					nominatedSubsequentVersionMaterial,
+					nomineeRel,
+					category,
+					categoryRel,
+					ceremony,
+					nominatedEntityRel,
+					nominatedEntity,
+					COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
 
-	WITH nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony,
-		COLLECT(
-			CASE WHEN nominatedEntity IS NULL
-				THEN null
-				ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
-			END
-		) AS nominatedEntities
+		WITH
+			nominatedSubsequentVersionMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntityRel,
+			nominatedEntity,
+			nominatedMembers
+			ORDER BY nominatedEntityRel.nominationPosition, nominatedEntityRel.entityPosition
 
-	WITH nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony,
-		[nominatedEntity IN nominatedEntities | CASE nominatedEntity.model WHEN 'COMPANY'
-			THEN nominatedEntity
-			ELSE nominatedEntity { .model, .uuid, .name }
-		END] AS nominatedEntities
+		WITH nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony,
+			COLLECT(
+				CASE WHEN nominatedEntity IS NULL
+					THEN null
+					ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
+				END
+			) AS nominatedEntities
 
-	OPTIONAL MATCH (category)-[nominatedProductionRel:HAS_NOMINEE]->(nominatedProduction:Production)
-		WHERE
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = nominatedProductionRel.nominationPosition
-			)
+		WITH nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony,
+			[nominatedEntity IN nominatedEntities | CASE nominatedEntity.model WHEN 'COMPANY'
+				THEN nominatedEntity
+				ELSE nominatedEntity { .model, .uuid, .name }
+			END] AS nominatedEntities
 
-	OPTIONAL MATCH (nominatedProduction)-[:PLAYS_AT]->(venue:Venue)
+		OPTIONAL MATCH (category)-[nominatedProductionRel:HAS_NOMINEE]->(nominatedProduction:Production)
+			WHERE
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = nominatedProductionRel.nominationPosition
+				)
 
-	OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
+		OPTIONAL MATCH (nominatedProduction)-[:PLAYS_AT]->(venue:Venue)
 
-	OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
+		OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
 
-	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+		OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
-	WITH
-		nominatedSubsequentVersionMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductionRel,
-		nominatedProduction,
-		venue,
-		surVenue,
-		surProduction,
-		surSurProduction
-		ORDER BY nominatedProductionRel.productionPosition
+		OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
 
-	WITH nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
-		COLLECT(
-			CASE WHEN nominatedProduction IS NULL
-				THEN null
-				ELSE nominatedProduction {
-					model: 'PRODUCTION',
-					.uuid,
-					.name,
-					.startDate,
-					.endDate,
-					venue: CASE WHEN venue IS NULL
-						THEN null
-						ELSE venue {
-							model: 'VENUE',
-							.uuid,
-							.name,
-							surVenue: CASE WHEN surVenue IS NULL
-								THEN null
-								ELSE surVenue { model: 'VENUE', .uuid, .name }
-							END
-						}
-					END,
-					surProduction: CASE WHEN surProduction IS NULL
-						THEN null
-						ELSE surProduction {
-							model: 'PRODUCTION',
-							.uuid,
-							.name,
-							surProduction: CASE WHEN surSurProduction IS NULL
-								THEN null
-								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
-							END
-						}
-					END
-				}
-			END
-		) AS nominatedProductions
+		WITH
+			nominatedSubsequentVersionMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductionRel,
+			nominatedProduction,
+			venue,
+			surVenue,
+			surProduction,
+			surSurProduction
+			ORDER BY nominatedProductionRel.productionPosition
 
-	OPTIONAL MATCH (category)-[nominatedMaterialRel:HAS_NOMINEE]->(nominatedMaterial:Material)
-		WHERE
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = nominatedMaterialRel.nominationPosition
-			) AND
-			nominatedMaterialRel.uuid <> nominatedSubsequentVersionMaterial.uuid
+		WITH nominatedSubsequentVersionMaterial, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
+			COLLECT(
+				CASE WHEN nominatedProduction IS NULL
+					THEN null
+					ELSE nominatedProduction {
+						model: 'PRODUCTION',
+						.uuid,
+						.name,
+						.startDate,
+						.endDate,
+						venue: CASE WHEN venue IS NULL
+							THEN null
+							ELSE venue {
+								model: 'VENUE',
+								.uuid,
+								.name,
+								surVenue: CASE WHEN surVenue IS NULL
+									THEN null
+									ELSE surVenue { model: 'VENUE', .uuid, .name }
+								END
+							}
+						END,
+						surProduction: CASE WHEN surProduction IS NULL
+							THEN null
+							ELSE surProduction {
+								model: 'PRODUCTION',
+								.uuid,
+								.name,
+								surProduction: CASE WHEN surSurProduction IS NULL
+									THEN null
+									ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+								END
+							}
+						END
+					}
+				END
+			) AS nominatedProductions
 
-	OPTIONAL MATCH (nominatedMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSurMaterial:Material)
+		OPTIONAL MATCH (category)-[nominatedMaterialRel:HAS_NOMINEE]->(nominatedMaterial:Material)
+			WHERE
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = nominatedMaterialRel.nominationPosition
+				) AND
+				nominatedMaterialRel.uuid <> nominatedSubsequentVersionMaterial.uuid
 
-	WITH
-		nominatedSubsequentVersionMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductions,
-		nominatedMaterialRel,
-		nominatedMaterial,
-		nominatedSurMaterial
-		ORDER BY nominatedMaterialRel.materialPosition
+		OPTIONAL MATCH (nominatedMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSurMaterial:Material)
 
-	WITH
-		nominatedSubsequentVersionMaterial,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductions,
-		COLLECT(
-			CASE WHEN nominatedMaterial IS NULL
-				THEN null
-				ELSE nominatedMaterial {
-					model: 'MATERIAL',
-					.uuid,
-					.name,
-					.format,
-					.year,
-					surMaterial: CASE WHEN nominatedSurMaterial IS NULL
-						THEN null
-						ELSE nominatedSurMaterial { model: 'MATERIAL', .uuid, .name }
-					END
-				}
-			END
-		) AS nominatedMaterials
-		ORDER BY nomineeRel.nominationPosition, nomineeRel.materialPosition
+		WITH
+			nominatedSubsequentVersionMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductions,
+			nominatedMaterialRel,
+			nominatedMaterial,
+			nominatedSurMaterial
+			ORDER BY nominatedMaterialRel.materialPosition
 
-	OPTIONAL MATCH (nominatedSubsequentVersionMaterial)
-		<-[:HAS_SUB_MATERIAL]-(nominatedSubsequentVersionSurMaterial:Material)
+		WITH
+			nominatedSubsequentVersionMaterial,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductions,
+			COLLECT(
+				CASE WHEN nominatedMaterial IS NULL
+					THEN null
+					ELSE nominatedMaterial {
+						model: 'MATERIAL',
+						.uuid,
+						.name,
+						.format,
+						.year,
+						surMaterial: CASE WHEN nominatedSurMaterial IS NULL
+							THEN null
+							ELSE nominatedSurMaterial { model: 'MATERIAL', .uuid, .name }
+						END
+					}
+				END
+			) AS nominatedMaterials
+			ORDER BY nomineeRel.nominationPosition, nomineeRel.materialPosition
 
-	OPTIONAL MATCH (nominatedSubsequentVersionSurMaterial)
-		<-[:HAS_SUB_MATERIAL]-(nominatedSubsequentVersionSurSurMaterial:Material)
+		OPTIONAL MATCH (nominatedSubsequentVersionMaterial)
+			<-[:HAS_SUB_MATERIAL]-(nominatedSubsequentVersionSurMaterial:Material)
 
-	WITH
-		nomineeRel.isWinner AS isWinner,
-		nomineeRel.customType AS customType,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		nominatedProductions,
-		nominatedMaterials,
-		COLLECT(
-			CASE WHEN nominatedSubsequentVersionMaterial IS NULL
-				THEN null
-				ELSE nominatedSubsequentVersionMaterial {
-					model: 'MATERIAL',
-					.uuid,
-					.name,
-					.format,
-					.year,
-					surMaterial: CASE WHEN nominatedSubsequentVersionSurMaterial IS NULL
-						THEN null
-						ELSE nominatedSubsequentVersionSurMaterial {
-							model: 'MATERIAL',
-							.uuid,
-							.name,
-							surMaterial: CASE WHEN nominatedSubsequentVersionSurSurMaterial IS NULL
-								THEN null
-								ELSE nominatedSubsequentVersionSurSurMaterial { model: 'MATERIAL', .uuid, .name }
-							END
-						}
-					END
-				}
-			END
-		) AS nominatedSubsequentVersionMaterials
+		OPTIONAL MATCH (nominatedSubsequentVersionSurMaterial)
+			<-[:HAS_SUB_MATERIAL]-(nominatedSubsequentVersionSurSurMaterial:Material)
 
-	WITH category, categoryRel, ceremony,
-		COLLECT({
-			model: 'NOMINATION',
-			isWinner: COALESCE(isWinner, false),
-			type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
-			entities: nominatedEntities,
-			productions: nominatedProductions,
-			materials: nominatedMaterials,
-			recipientSubsequentVersionMaterials: nominatedSubsequentVersionMaterials
-		}) AS nominations
-		ORDER BY categoryRel.position
+		WITH
+			nomineeRel.isWinner AS isWinner,
+			nomineeRel.customType AS customType,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			nominatedProductions,
+			nominatedMaterials,
+			COLLECT(
+				CASE WHEN nominatedSubsequentVersionMaterial IS NULL
+					THEN null
+					ELSE nominatedSubsequentVersionMaterial {
+						model: 'MATERIAL',
+						.uuid,
+						.name,
+						.format,
+						.year,
+						surMaterial: CASE WHEN nominatedSubsequentVersionSurMaterial IS NULL
+							THEN null
+							ELSE nominatedSubsequentVersionSurMaterial {
+								model: 'MATERIAL',
+								.uuid,
+								.name,
+								surMaterial: CASE WHEN nominatedSubsequentVersionSurSurMaterial IS NULL
+									THEN null
+									ELSE nominatedSubsequentVersionSurSurMaterial { model: 'MATERIAL', .uuid, .name }
+								END
+							}
+						END
+					}
+				END
+			) AS nominatedSubsequentVersionMaterials
 
-	WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
-		ORDER BY ceremony.name DESC
+		WITH category, categoryRel, ceremony,
+			COLLECT({
+				model: 'NOMINATION',
+				isWinner: COALESCE(isWinner, false),
+				type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
+				entities: nominatedEntities,
+				productions: nominatedProductions,
+				materials: nominatedMaterials,
+				recipientSubsequentVersionMaterials: nominatedSubsequentVersionMaterials
+			}) AS nominations
+			ORDER BY categoryRel.position
 
-	OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
+		WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
+			ORDER BY ceremony.name DESC
 
-	WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
-		ORDER BY award.name
+		OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
+
+		WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
+			ORDER BY award.name
+
+		RETURN
+			COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS subsequentVersionMaterialAwards
+	}
 
 	RETURN
-		COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS subsequentVersionMaterialAwards
+		subsequentVersionMaterialAwards
 `;

--- a/src/neo4j/cypher-queries/person/show/show-awards.js
+++ b/src/neo4j/cypher-queries/person/show/show-awards.js
@@ -1,91 +1,152 @@
 export default () => `
 	MATCH (person:Person { uuid: $uuid })
 
-	OPTIONAL MATCH path=(person)
-		<-[:HAS_WRITING_ENTITY*0..1]-(creditingMaterial)-[:HAS_SUB_MATERIAL*0..2]-(nominatedMaterial)
-		<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
-		<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
-		WHERE
-			(NONE(rel IN RELATIONSHIPS(path)
-				WHERE COALESCE(rel.creditType IN ['NON_SPECIFIC_SOURCE_MATERIAL', 'RIGHTS_GRANTOR'], false)
-			)) AND
-			NOT EXISTS(
-				(person)
-				<-[:HAS_WRITING_ENTITY]-(:Material)
-				<-[:SUBSEQUENT_VERSION_OF]-(:Material)-[:HAS_SUB_MATERIAL*0..2]-(:Material)
-				<-[:HAS_NOMINEE]-(category)
-			) AND (
-				(creditingMaterial)-[:HAS_SUB_MATERIAL*0..2]->(nominatedMaterial) OR
-				(creditingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedMaterial)
-			)
+	CALL {
+		WITH person
 
-	WITH person, nomineeRel, category, categoryRel, ceremony
-
-	OPTIONAL MATCH (category)-[nominatedCompanyRel:HAS_NOMINEE]->
-		(nominatedEmployerCompany:Company { uuid: nomineeRel.nominatedCompanyUuid })
-		WHERE
-			nomineeRel.nominationPosition IS NULL OR
-			nomineeRel.nominationPosition = nominatedCompanyRel.nominationPosition
-
-	UNWIND (CASE WHEN nominatedCompanyRel IS NOT NULL AND nominatedCompanyRel.nominatedMemberUuids IS NOT NULL
-		THEN [uuid IN nominatedCompanyRel.nominatedMemberUuids]
-		ELSE [null]
-	END) AS coNominatedMemberUuid
-
-		OPTIONAL MATCH (category)-[coNominatedMemberRel:HAS_NOMINEE]->
-			(coNominatedMember:Person { uuid: coNominatedMemberUuid })
+		OPTIONAL MATCH path=(person)
+			<-[:HAS_WRITING_ENTITY*0..1]-(creditingMaterial)-[:HAS_SUB_MATERIAL*0..2]-(nominatedMaterial)
+			<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
+			<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
 			WHERE
-				coNominatedMember.uuid <> person.uuid AND
-				(
-					nominatedCompanyRel.nominationPosition IS NULL OR
-					nominatedCompanyRel.nominationPosition = coNominatedMemberRel.nominationPosition
+				(NONE(rel IN RELATIONSHIPS(path)
+					WHERE COALESCE(rel.creditType IN ['NON_SPECIFIC_SOURCE_MATERIAL', 'RIGHTS_GRANTOR'], false)
+				)) AND
+				NOT EXISTS(
+					(person)
+					<-[:HAS_WRITING_ENTITY]-(:Material)
+					<-[:SUBSEQUENT_VERSION_OF]-(:Material)-[:HAS_SUB_MATERIAL*0..2]-(:Material)
+					<-[:HAS_NOMINEE]-(category)
+				) AND (
+					(creditingMaterial)-[:HAS_SUB_MATERIAL*0..2]->(nominatedMaterial) OR
+					(creditingMaterial)<-[:HAS_SUB_MATERIAL*0..2]-(nominatedMaterial)
 				)
+
+		WITH person, nomineeRel, category, categoryRel, ceremony
+
+		OPTIONAL MATCH (category)-[nominatedCompanyRel:HAS_NOMINEE]->
+			(nominatedEmployerCompany:Company { uuid: nomineeRel.nominatedCompanyUuid })
+			WHERE
+				nomineeRel.nominationPosition IS NULL OR
+				nomineeRel.nominationPosition = nominatedCompanyRel.nominationPosition
+
+		UNWIND (CASE WHEN nominatedCompanyRel IS NOT NULL AND nominatedCompanyRel.nominatedMemberUuids IS NOT NULL
+			THEN [uuid IN nominatedCompanyRel.nominatedMemberUuids]
+			ELSE [null]
+		END) AS coNominatedMemberUuid
+
+			OPTIONAL MATCH (category)-[coNominatedMemberRel:HAS_NOMINEE]->
+				(coNominatedMember:Person { uuid: coNominatedMemberUuid })
+				WHERE
+					coNominatedMember.uuid <> person.uuid AND
+					(
+						nominatedCompanyRel.nominationPosition IS NULL OR
+						nominatedCompanyRel.nominationPosition = coNominatedMemberRel.nominationPosition
+					)
+
+			WITH
+				person,
+				nomineeRel,
+				nominatedCompanyRel,
+				nominatedEmployerCompany,
+				category,
+				categoryRel,
+				ceremony,
+				coNominatedMember
+				ORDER BY coNominatedMemberRel.memberPosition
+
+			WITH person, nomineeRel, nominatedCompanyRel, nominatedEmployerCompany, category, categoryRel, ceremony,
+				COLLECT(coNominatedMember { model: 'PERSON', .uuid, .name }) AS coNominatedMembers
 
 		WITH
 			person,
-			nomineeRel,
-			nominatedCompanyRel,
-			nominatedEmployerCompany,
 			category,
 			categoryRel,
 			ceremony,
-			coNominatedMember
-			ORDER BY coNominatedMemberRel.memberPosition
+			CASE WHEN nominatedEmployerCompany IS NULL
+				THEN null
+				ELSE nominatedEmployerCompany { model: 'COMPANY', .uuid, .name, coMembers: coNominatedMembers }
+			END AS nominatedEmployerCompany,
+			COALESCE(nominatedEmployerCompany, person) AS entity,
+			COALESCE(nominatedCompanyRel, nomineeRel) AS entityRel
 
-		WITH person, nomineeRel, nominatedCompanyRel, nominatedEmployerCompany, category, categoryRel, ceremony,
-			COLLECT(coNominatedMember { model: 'PERSON', .uuid, .name }) AS coNominatedMembers
-
-	WITH
-		person,
-		category,
-		categoryRel,
-		ceremony,
-		CASE WHEN nominatedEmployerCompany IS NULL
-			THEN null
-			ELSE nominatedEmployerCompany { model: 'COMPANY', .uuid, .name, coMembers: coNominatedMembers }
-		END AS nominatedEmployerCompany,
-		COALESCE(nominatedEmployerCompany, person) AS entity,
-		COALESCE(nominatedCompanyRel, nomineeRel) AS entityRel
-
-	OPTIONAL MATCH (category)-[coNominatedEntityRel:HAS_NOMINEE]->(coNominatedEntity:Person|Company)
-		WHERE
-			coNominatedEntityRel.nominatedCompanyUuid IS NULL AND
-			(
-				entityRel.nominationPosition IS NULL OR
-				entityRel.nominationPosition = coNominatedEntityRel.nominationPosition
-			) AND
-			coNominatedEntity.uuid <> entity.uuid
-
-	UNWIND (CASE WHEN coNominatedEntityRel IS NOT NULL AND coNominatedEntityRel.nominatedMemberUuids IS NOT NULL
-		THEN [uuid IN coNominatedEntityRel.nominatedMemberUuids]
-		ELSE [null]
-	END) AS coNominatedCompanyNominatedMemberUuid
-
-		OPTIONAL MATCH (category)-[coNominatedCompanyNominatedMemberRel:HAS_NOMINEE]->
-			(coNominatedCompanyNominatedMember:Person { uuid: coNominatedCompanyNominatedMemberUuid })
+		OPTIONAL MATCH (category)-[coNominatedEntityRel:HAS_NOMINEE]->(coNominatedEntity:Person|Company)
 			WHERE
-				coNominatedEntityRel.nominationPosition IS NULL OR
-				coNominatedEntityRel.nominationPosition = coNominatedCompanyNominatedMemberRel.nominationPosition
+				coNominatedEntityRel.nominatedCompanyUuid IS NULL AND
+				(
+					entityRel.nominationPosition IS NULL OR
+					entityRel.nominationPosition = coNominatedEntityRel.nominationPosition
+				) AND
+				coNominatedEntity.uuid <> entity.uuid
+
+		UNWIND (CASE WHEN coNominatedEntityRel IS NOT NULL AND coNominatedEntityRel.nominatedMemberUuids IS NOT NULL
+			THEN [uuid IN coNominatedEntityRel.nominatedMemberUuids]
+			ELSE [null]
+		END) AS coNominatedCompanyNominatedMemberUuid
+
+			OPTIONAL MATCH (category)-[coNominatedCompanyNominatedMemberRel:HAS_NOMINEE]->
+				(coNominatedCompanyNominatedMember:Person { uuid: coNominatedCompanyNominatedMemberUuid })
+				WHERE
+					coNominatedEntityRel.nominationPosition IS NULL OR
+					coNominatedEntityRel.nominationPosition = coNominatedCompanyNominatedMemberRel.nominationPosition
+
+			WITH
+				entityRel,
+				nominatedEmployerCompany,
+				category,
+				categoryRel,
+				ceremony,
+				coNominatedEntityRel,
+				coNominatedEntity,
+				coNominatedCompanyNominatedMember
+				ORDER BY coNominatedCompanyNominatedMemberRel.memberPosition
+
+			WITH
+				entityRel,
+				nominatedEmployerCompany,
+				category,
+				categoryRel,
+				ceremony,
+				coNominatedEntityRel,
+				coNominatedEntity,
+				COLLECT(coNominatedCompanyNominatedMember {
+					model: 'PERSON', .uuid, .name
+				}) AS coNominatedCompanyNominatedMembers
+				ORDER BY coNominatedEntityRel.entityPosition
+
+		WITH entityRel, nominatedEmployerCompany, category, categoryRel, ceremony,
+			COLLECT(
+				CASE WHEN coNominatedEntity IS NULL
+					THEN null
+					ELSE coNominatedEntity {
+						model: TOUPPER(HEAD(LABELS(coNominatedEntity))),
+						.uuid,
+						.name,
+						members: coNominatedCompanyNominatedMembers
+					}
+				END
+			) AS coNominatedEntities
+
+		WITH entityRel, nominatedEmployerCompany, category, categoryRel, ceremony,
+			[coNominatedEntity IN coNominatedEntities | CASE coNominatedEntity.model WHEN 'COMPANY'
+				THEN coNominatedEntity
+				ELSE coNominatedEntity { .model, .uuid, .name }
+			END] AS coNominatedEntities
+
+		OPTIONAL MATCH (category)-[nominatedProductionRel:HAS_NOMINEE]->(nominatedProduction:Production)
+			WHERE
+				(
+					entityRel.nominationPosition IS NULL OR
+					entityRel.nominationPosition = nominatedProductionRel.nominationPosition
+				)
+
+		OPTIONAL MATCH (nominatedProduction)-[:PLAYS_AT]->(venue:Venue)
+
+		OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
+
+		OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
+
+		OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
 
 		WITH
 			entityRel,
@@ -93,10 +154,59 @@ export default () => `
 			category,
 			categoryRel,
 			ceremony,
-			coNominatedEntityRel,
-			coNominatedEntity,
-			coNominatedCompanyNominatedMember
-			ORDER BY coNominatedCompanyNominatedMemberRel.memberPosition
+			coNominatedEntities,
+			nominatedProductionRel,
+			nominatedProduction,
+			venue,
+			surVenue,
+			surProduction,
+			surSurProduction
+			ORDER BY nominatedProductionRel.productionPosition
+
+		WITH entityRel, nominatedEmployerCompany, category, categoryRel, ceremony, coNominatedEntities,
+			COLLECT(
+				CASE WHEN nominatedProduction IS NULL
+					THEN null
+					ELSE nominatedProduction {
+						model: 'PRODUCTION',
+						.uuid,
+						.name,
+						.startDate,
+						.endDate,
+						venue: CASE WHEN venue IS NULL
+							THEN null
+							ELSE venue {
+								model: 'VENUE',
+								.uuid,
+								.name,
+								surVenue: CASE WHEN surVenue IS NULL
+									THEN null
+									ELSE surVenue { model: 'VENUE', .uuid, .name }
+								END
+							}
+						END,
+						surProduction: CASE WHEN surProduction IS NULL
+							THEN null
+							ELSE surProduction {
+								model: 'PRODUCTION',
+								.uuid,
+								.name,
+								surProduction: CASE WHEN surSurProduction IS NULL
+									THEN null
+									ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+								END
+							}
+						END
+					}
+				END
+			) AS nominatedProductions
+
+		OPTIONAL MATCH (category)-[nominatedMaterialRel:HAS_NOMINEE]->(nominatedMaterial:Material)
+			WHERE
+				(
+					entityRel.nominationPosition IS NULL OR
+					entityRel.nominationPosition = nominatedMaterialRel.nominationPosition
+				)
 
 		WITH
 			entityRel,
@@ -104,177 +214,74 @@ export default () => `
 			category,
 			categoryRel,
 			ceremony,
-			coNominatedEntityRel,
-			coNominatedEntity,
-			COLLECT(coNominatedCompanyNominatedMember {
-				model: 'PERSON', .uuid, .name
-			}) AS coNominatedCompanyNominatedMembers
-			ORDER BY coNominatedEntityRel.entityPosition
+			coNominatedEntities,
+			nominatedProductions,
+			nominatedMaterialRel,
+			nominatedMaterial
+			ORDER BY nominatedMaterialRel.materialPosition
 
-	WITH entityRel, nominatedEmployerCompany, category, categoryRel, ceremony,
-		COLLECT(
-			CASE WHEN coNominatedEntity IS NULL
-				THEN null
-				ELSE coNominatedEntity {
-					model: TOUPPER(HEAD(LABELS(coNominatedEntity))),
-					.uuid,
-					.name,
-					members: coNominatedCompanyNominatedMembers
-				}
-			END
-		) AS coNominatedEntities
+		OPTIONAL MATCH (nominatedMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSurMaterial:Material)
 
-	WITH entityRel, nominatedEmployerCompany, category, categoryRel, ceremony,
-		[coNominatedEntity IN coNominatedEntities | CASE coNominatedEntity.model WHEN 'COMPANY'
-			THEN coNominatedEntity
-			ELSE coNominatedEntity { .model, .uuid, .name }
-		END] AS coNominatedEntities
+		OPTIONAL MATCH (nominatedSurMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSurSurMaterial:Material)
 
-	OPTIONAL MATCH (category)-[nominatedProductionRel:HAS_NOMINEE]->(nominatedProduction:Production)
-		WHERE
-			(
-				entityRel.nominationPosition IS NULL OR
-				entityRel.nominationPosition = nominatedProductionRel.nominationPosition
-			)
+		WITH
+			entityRel,
+			nominatedEmployerCompany,
+			category,
+			categoryRel,
+			ceremony,
+			coNominatedEntities,
+			nominatedProductions,
+			COLLECT(
+				CASE WHEN nominatedMaterial IS NULL
+					THEN null
+					ELSE nominatedMaterial {
+						model: 'MATERIAL',
+						.uuid,
+						.name,
+						.format,
+						.year,
+						surMaterial: CASE WHEN nominatedSurMaterial IS NULL
+							THEN null
+							ELSE nominatedSurMaterial {
+								model: 'MATERIAL',
+								.uuid,
+								.name,
+								surMaterial: CASE WHEN nominatedSurSurMaterial IS NULL
+									THEN null
+									ELSE nominatedSurSurMaterial { model: 'MATERIAL', .uuid, .name }
+								END
+							}
+						END
+					}
+				END
+			) AS nominatedMaterials
+			ORDER BY entityRel.nominationPosition
 
-	OPTIONAL MATCH (nominatedProduction)-[:PLAYS_AT]->(venue:Venue)
+		WITH category, categoryRel, ceremony,
+			COLLECT({
+				model: 'NOMINATION',
+				isWinner: COALESCE(entityRel.isWinner, false),
+				type: COALESCE(entityRel.customType, CASE WHEN entityRel.isWinner THEN 'Winner' ELSE 'Nomination' END),
+				employerCompany: nominatedEmployerCompany,
+				coEntities: coNominatedEntities,
+				productions: nominatedProductions,
+				materials: nominatedMaterials
+			}) AS nominations
+			ORDER BY categoryRel.position
 
-	OPTIONAL MATCH (venue)<-[:HAS_SUB_VENUE]-(surVenue:Venue)
+		WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
+			ORDER BY ceremony.name DESC
 
-	OPTIONAL MATCH (nominatedProduction)<-[:HAS_SUB_PRODUCTION]-(surProduction:Production)
+		OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
 
-	OPTIONAL MATCH (surProduction)<-[:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+		WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
+			ORDER BY award.name
 
-	WITH
-		entityRel,
-		nominatedEmployerCompany,
-		category,
-		categoryRel,
-		ceremony,
-		coNominatedEntities,
-		nominatedProductionRel,
-		nominatedProduction,
-		venue,
-		surVenue,
-		surProduction,
-		surSurProduction
-		ORDER BY nominatedProductionRel.productionPosition
-
-	WITH entityRel, nominatedEmployerCompany, category, categoryRel, ceremony, coNominatedEntities,
-		COLLECT(
-			CASE WHEN nominatedProduction IS NULL
-				THEN null
-				ELSE nominatedProduction {
-					model: 'PRODUCTION',
-					.uuid,
-					.name,
-					.startDate,
-					.endDate,
-					venue: CASE WHEN venue IS NULL
-						THEN null
-						ELSE venue {
-							model: 'VENUE',
-							.uuid,
-							.name,
-							surVenue: CASE WHEN surVenue IS NULL
-								THEN null
-								ELSE surVenue { model: 'VENUE', .uuid, .name }
-							END
-						}
-					END,
-					surProduction: CASE WHEN surProduction IS NULL
-						THEN null
-						ELSE surProduction {
-							model: 'PRODUCTION',
-							.uuid,
-							.name,
-							surProduction: CASE WHEN surSurProduction IS NULL
-								THEN null
-								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
-							END
-						}
-					END
-				}
-			END
-		) AS nominatedProductions
-
-	OPTIONAL MATCH (category)-[nominatedMaterialRel:HAS_NOMINEE]->(nominatedMaterial:Material)
-		WHERE
-			(
-				entityRel.nominationPosition IS NULL OR
-				entityRel.nominationPosition = nominatedMaterialRel.nominationPosition
-			)
-
-	WITH
-		entityRel,
-		nominatedEmployerCompany,
-		category,
-		categoryRel,
-		ceremony,
-		coNominatedEntities,
-		nominatedProductions,
-		nominatedMaterialRel,
-		nominatedMaterial
-		ORDER BY nominatedMaterialRel.materialPosition
-
-	OPTIONAL MATCH (nominatedMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSurMaterial:Material)
-
-	OPTIONAL MATCH (nominatedSurMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSurSurMaterial:Material)
-
-	WITH
-		entityRel,
-		nominatedEmployerCompany,
-		category,
-		categoryRel,
-		ceremony,
-		coNominatedEntities,
-		nominatedProductions,
-		COLLECT(
-			CASE WHEN nominatedMaterial IS NULL
-				THEN null
-				ELSE nominatedMaterial {
-					model: 'MATERIAL',
-					.uuid,
-					.name,
-					.format,
-					.year,
-					surMaterial: CASE WHEN nominatedSurMaterial IS NULL
-						THEN null
-						ELSE nominatedSurMaterial {
-							model: 'MATERIAL',
-							.uuid,
-							.name,
-							surMaterial: CASE WHEN nominatedSurSurMaterial IS NULL
-								THEN null
-								ELSE nominatedSurSurMaterial { model: 'MATERIAL', .uuid, .name }
-							END
-						}
-					END
-				}
-			END
-		) AS nominatedMaterials
-		ORDER BY entityRel.nominationPosition
-
-	WITH category, categoryRel, ceremony,
-		COLLECT({
-			model: 'NOMINATION',
-			isWinner: COALESCE(entityRel.isWinner, false),
-			type: COALESCE(entityRel.customType, CASE WHEN entityRel.isWinner THEN 'Winner' ELSE 'Nomination' END),
-			employerCompany: nominatedEmployerCompany,
-			coEntities: coNominatedEntities,
-			productions: nominatedProductions,
-			materials: nominatedMaterials
-		}) AS nominations
-		ORDER BY categoryRel.position
-
-	WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
-		ORDER BY ceremony.name DESC
-
-	OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
-
-	WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
-		ORDER BY award.name
+		RETURN
+			COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS awards
+	}
 
 	RETURN
-		COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS awards
+		awards
 `;

--- a/src/neo4j/cypher-queries/person/show/show-materials.js
+++ b/src/neo4j/cypher-queries/person/show/show-materials.js
@@ -1,213 +1,223 @@
 export default () => `
 	MATCH (person:Person { uuid: $uuid })
 
-	OPTIONAL MATCH (person)<-[:HAS_WRITING_ENTITY]-(:Material)<-[:USES_SOURCE_MATERIAL*0..1]-(material:Material)
-		WHERE NOT EXISTS(
-			(person)<-[:HAS_WRITING_ENTITY]-(:Material)<-[:USES_SOURCE_MATERIAL*0..1]-(:Material)
-			<-[:HAS_SUB_MATERIAL*1..2]-(material)
-		)
+	CALL {
+		WITH person
 
-	WITH person, COLLECT(DISTINCT(material)) AS materials
+		OPTIONAL MATCH (person)<-[:HAS_WRITING_ENTITY]-(:Material)<-[:USES_SOURCE_MATERIAL*0..1]-(material:Material)
+			WHERE NOT EXISTS(
+				(person)<-[:HAS_WRITING_ENTITY]-(:Material)<-[:USES_SOURCE_MATERIAL*0..1]-(:Material)
+				<-[:HAS_SUB_MATERIAL*1..2]-(material)
+			)
 
-	UNWIND (CASE materials WHEN [] THEN [null] ELSE materials END) AS material
+		WITH person, COLLECT(DISTINCT(material)) AS materials
 
-		OPTIONAL MATCH (person)<-[writerRel:HAS_WRITING_ENTITY]-(material)
+		UNWIND (CASE materials WHEN [] THEN [null] ELSE materials END) AS material
 
-		OPTIONAL MATCH (person)<-[:HAS_WRITING_ENTITY]-(:Material)
-			<-[subsequentVersionRel:SUBSEQUENT_VERSION_OF]-(material)
+			OPTIONAL MATCH (person)<-[writerRel:HAS_WRITING_ENTITY]-(material)
 
-		OPTIONAL MATCH (person)<-[:HAS_WRITING_ENTITY]-(:Material)
-			<-[sourcingMaterialRel:USES_SOURCE_MATERIAL]-(material)
+			OPTIONAL MATCH (person)<-[:HAS_WRITING_ENTITY]-(:Material)
+				<-[subsequentVersionRel:SUBSEQUENT_VERSION_OF]-(material)
 
-		OPTIONAL MATCH (material)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity:Person|Company|Material)
+			OPTIONAL MATCH (person)<-[:HAS_WRITING_ENTITY]-(:Material)
+				<-[sourcingMaterialRel:USES_SOURCE_MATERIAL]-(material)
 
-		OPTIONAL MATCH (entity:Material)<-[:HAS_SUB_MATERIAL]-(entitySurMaterial:Material)
+			OPTIONAL MATCH (material)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity:Person|Company|Material)
 
-		OPTIONAL MATCH (entitySurMaterial)<-[:HAS_SUB_MATERIAL]-(entitySurSurMaterial:Material)
+			OPTIONAL MATCH (entity:Material)<-[:HAS_SUB_MATERIAL]-(entitySurMaterial:Material)
 
-		OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->
-			(sourceMaterialWriter:Person|Company)
+			OPTIONAL MATCH (entitySurMaterial)<-[:HAS_SUB_MATERIAL]-(entitySurSurMaterial:Material)
 
-		WITH
-			material,
-			writerRel.creditType AS creditType,
-			CASE WHEN writerRel IS NULL THEN false ELSE true END AS hasDirectCredit,
-			CASE WHEN subsequentVersionRel IS NULL THEN false ELSE true END AS isSubsequentVersion,
-			CASE WHEN sourcingMaterialRel IS NULL THEN false ELSE true END AS isSourcingMaterial,
-			entityRel,
-			entity,
-			entitySurMaterial,
-			entitySurSurMaterial,
-			sourceMaterialWriterRel,
-			sourceMaterialWriter
-			ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriterRel.entityPosition
+			OPTIONAL MATCH (entity:Material)-[sourceMaterialWriterRel:HAS_WRITING_ENTITY]->
+				(sourceMaterialWriter:Person|Company)
 
-		WITH
-			material,
-			creditType,
-			hasDirectCredit,
-			isSubsequentVersion,
-			isSourcingMaterial,
-			entityRel,
-			entity,
-			entitySurMaterial,
-			entitySurSurMaterial,
-			sourceMaterialWriterRel.credit AS sourceMaterialWritingCreditName,
-			COLLECT(
-				CASE WHEN sourceMaterialWriter IS NULL
-					THEN null
-					ELSE sourceMaterialWriter { model: TOUPPER(HEAD(LABELS(sourceMaterialWriter))), .uuid, .name }
-				END
-			) AS sourceMaterialWriters
+			WITH
+				material,
+				writerRel.creditType AS creditType,
+				CASE WHEN writerRel IS NULL THEN false ELSE true END AS hasDirectCredit,
+				CASE WHEN subsequentVersionRel IS NULL THEN false ELSE true END AS isSubsequentVersion,
+				CASE WHEN sourcingMaterialRel IS NULL THEN false ELSE true END AS isSourcingMaterial,
+				entityRel,
+				entity,
+				entitySurMaterial,
+				entitySurSurMaterial,
+				sourceMaterialWriterRel,
+				sourceMaterialWriter
+				ORDER BY sourceMaterialWriterRel.creditPosition, sourceMaterialWriterRel.entityPosition
 
-		WITH
-			material,
-			creditType,
-			hasDirectCredit,
-			isSubsequentVersion,
-			isSourcingMaterial,
-			entityRel,
-			entity,
-			entitySurMaterial,
-			entitySurSurMaterial,
-			COLLECT(
-				CASE SIZE(sourceMaterialWriters) WHEN 0
-					THEN null
-					ELSE {
-						model: 'WRITING_CREDIT',
-						name: COALESCE(sourceMaterialWritingCreditName, 'by'),
-						entities: sourceMaterialWriters
-					}
-				END
-			) AS sourceMaterialWritingCredits
-			ORDER BY entityRel.creditPosition, entityRel.entityPosition
+			WITH
+				material,
+				creditType,
+				hasDirectCredit,
+				isSubsequentVersion,
+				isSourcingMaterial,
+				entityRel,
+				entity,
+				entitySurMaterial,
+				entitySurSurMaterial,
+				sourceMaterialWriterRel.credit AS sourceMaterialWritingCreditName,
+				COLLECT(
+					CASE WHEN sourceMaterialWriter IS NULL
+						THEN null
+						ELSE sourceMaterialWriter { model: TOUPPER(HEAD(LABELS(sourceMaterialWriter))), .uuid, .name }
+					END
+				) AS sourceMaterialWriters
 
-		WITH
-			material,
-			creditType,
-			hasDirectCredit,
-			isSubsequentVersion,
-			isSourcingMaterial,
-			entityRel.credit AS writingCreditName,
-			COLLECT(
-				CASE WHEN entity IS NULL
-					THEN null
-					ELSE entity {
-						model: TOUPPER(HEAD(LABELS(entity))),
-						.uuid,
-						.name,
-						.format,
-						.year,
-						surMaterial: CASE WHEN entitySurMaterial IS NULL
-							THEN null
-							ELSE entitySurMaterial {
-								model: 'MATERIAL',
-								.uuid,
-								.name,
-								surMaterial: CASE WHEN entitySurSurMaterial IS NULL
-									THEN null
-									ELSE entitySurSurMaterial { model: 'MATERIAL', .uuid, .name }
-								END
-							}
-						END,
-						writingCredits: sourceMaterialWritingCredits
-					}
-				END
-			) AS entities
+			WITH
+				material,
+				creditType,
+				hasDirectCredit,
+				isSubsequentVersion,
+				isSourcingMaterial,
+				entityRel,
+				entity,
+				entitySurMaterial,
+				entitySurSurMaterial,
+				COLLECT(
+					CASE SIZE(sourceMaterialWriters) WHEN 0
+						THEN null
+						ELSE {
+							model: 'WRITING_CREDIT',
+							name: COALESCE(sourceMaterialWritingCreditName, 'by'),
+							entities: sourceMaterialWriters
+						}
+					END
+				) AS sourceMaterialWritingCredits
+				ORDER BY entityRel.creditPosition, entityRel.entityPosition
 
-		WITH
-			material,
-			creditType,
-			hasDirectCredit,
-			isSubsequentVersion,
-			isSourcingMaterial,
-			writingCreditName,
-			[entity IN entities | CASE entity.model WHEN 'MATERIAL'
-				THEN entity
-				ELSE entity { .model, .uuid, .name }
-			END] AS entities
+			WITH
+				material,
+				creditType,
+				hasDirectCredit,
+				isSubsequentVersion,
+				isSourcingMaterial,
+				entityRel.credit AS writingCreditName,
+				COLLECT(
+					CASE WHEN entity IS NULL
+						THEN null
+						ELSE entity {
+							model: TOUPPER(HEAD(LABELS(entity))),
+							.uuid,
+							.name,
+							.format,
+							.year,
+							surMaterial: CASE WHEN entitySurMaterial IS NULL
+								THEN null
+								ELSE entitySurMaterial {
+									model: 'MATERIAL',
+									.uuid,
+									.name,
+									surMaterial: CASE WHEN entitySurSurMaterial IS NULL
+										THEN null
+										ELSE entitySurSurMaterial { model: 'MATERIAL', .uuid, .name }
+									END
+								}
+							END,
+							writingCredits: sourceMaterialWritingCredits
+						}
+					END
+				) AS entities
 
-		OPTIONAL MATCH (material)<-[surMaterialRel:HAS_SUB_MATERIAL]-(surMaterial:Material)
+			WITH
+				material,
+				creditType,
+				hasDirectCredit,
+				isSubsequentVersion,
+				isSourcingMaterial,
+				writingCreditName,
+				[entity IN entities | CASE entity.model WHEN 'MATERIAL'
+					THEN entity
+					ELSE entity { .model, .uuid, .name }
+				END] AS entities
 
-		OPTIONAL MATCH (surMaterial)<-[surSurMaterialRel:HAS_SUB_MATERIAL]-(surSurMaterial:Material)
+			OPTIONAL MATCH (material)<-[surMaterialRel:HAS_SUB_MATERIAL]-(surMaterial:Material)
 
-		WITH
-			material,
-			creditType,
-			hasDirectCredit,
-			isSubsequentVersion,
-			isSourcingMaterial,
-			surMaterial,
-			surMaterialRel,
-			surSurMaterial,
-			surSurMaterialRel,
-			COLLECT(
-				CASE SIZE(entities) WHEN 0
-					THEN null
-					ELSE {
-						model: 'WRITING_CREDIT',
-						name: COALESCE(writingCreditName, 'by'),
-						entities: entities
-					}
-				END
-			) AS writingCredits
-			ORDER BY
-				material.year DESC,
-				COALESCE(surSurMaterial.name, surMaterial.name, material.name),
-				surSurMaterialRel.position DESC,
-				surMaterialRel.position DESC
+			OPTIONAL MATCH (surMaterial)<-[surSurMaterialRel:HAS_SUB_MATERIAL]-(surSurMaterial:Material)
 
-		WITH
-			COLLECT(
-				CASE WHEN material IS NULL
-					THEN null
-					ELSE material {
-						model: 'MATERIAL',
-						.uuid,
-						.name,
-						.format,
-						.year,
-						surMaterial: CASE WHEN surMaterial IS NULL
-							THEN null
-							ELSE surMaterial {
-								model: 'MATERIAL',
-								.uuid,
-								.name,
-								surMaterial: CASE WHEN surSurMaterial IS NULL
-									THEN null
-									ELSE surSurMaterial { model: 'MATERIAL', .uuid, .name }
-								END
-							}
-						END,
-						writingCredits,
-						creditType,
-						hasDirectCredit,
-						isSubsequentVersion,
-						isSourcingMaterial
-					}
-				END
-			) AS materials
+			WITH
+				material,
+				creditType,
+				hasDirectCredit,
+				isSubsequentVersion,
+				isSourcingMaterial,
+				surMaterial,
+				surMaterialRel,
+				surSurMaterial,
+				surSurMaterialRel,
+				COLLECT(
+					CASE SIZE(entities) WHEN 0
+						THEN null
+						ELSE {
+							model: 'WRITING_CREDIT',
+							name: COALESCE(writingCreditName, 'by'),
+							entities: entities
+						}
+					END
+				) AS writingCredits
+				ORDER BY
+					material.year DESC,
+					COALESCE(surSurMaterial.name, surMaterial.name, material.name),
+					surSurMaterialRel.position DESC,
+					surMaterialRel.position DESC
+
+			WITH
+				COLLECT(
+					CASE WHEN material IS NULL
+						THEN null
+						ELSE material {
+							model: 'MATERIAL',
+							.uuid,
+							.name,
+							.format,
+							.year,
+							surMaterial: CASE WHEN surMaterial IS NULL
+								THEN null
+								ELSE surMaterial {
+									model: 'MATERIAL',
+									.uuid,
+									.name,
+									surMaterial: CASE WHEN surSurMaterial IS NULL
+										THEN null
+										ELSE surSurMaterial { model: 'MATERIAL', .uuid, .name }
+									END
+								}
+							END,
+							writingCredits,
+							creditType,
+							hasDirectCredit,
+							isSubsequentVersion,
+							isSourcingMaterial
+						}
+					END
+				) AS materials
+
+		RETURN
+			[
+				material IN materials WHERE
+					material.hasDirectCredit AND
+					NOT material.isSubsequentVersion AND
+					material.creditType IS NULL |
+				material { .model, .uuid, .name, .format, .year, .writingCredits, .surMaterial }
+			] AS materials,
+			[
+				material IN materials WHERE material.isSubsequentVersion |
+				material { .model, .uuid, .name, .format, .year, .writingCredits, .surMaterial }
+			] AS subsequentVersionMaterials,
+			[
+				material IN materials WHERE
+					material.isSourcingMaterial OR
+					material.creditType = 'NON_SPECIFIC_SOURCE_MATERIAL' |
+				material { .model, .uuid, .name, .format, .year, .writingCredits, .surMaterial }
+			] AS sourcingMaterials,
+			[
+				material IN materials WHERE material.creditType = 'RIGHTS_GRANTOR' |
+				material { .model, .uuid, .name, .format, .year, .writingCredits, .surMaterial }
+			] AS rightsGrantorMaterials
+	}
 
 	RETURN
-		[
-			material IN materials WHERE
-				material.hasDirectCredit AND
-				NOT material.isSubsequentVersion AND
-				material.creditType IS NULL |
-			material { .model, .uuid, .name, .format, .year, .writingCredits, .surMaterial }
-		] AS materials,
-		[
-			material IN materials WHERE material.isSubsequentVersion |
-			material { .model, .uuid, .name, .format, .year, .writingCredits, .surMaterial }
-		] AS subsequentVersionMaterials,
-		[
-			material IN materials WHERE
-				material.isSourcingMaterial OR
-				material.creditType = 'NON_SPECIFIC_SOURCE_MATERIAL' |
-			material { .model, .uuid, .name, .format, .year, .writingCredits, .surMaterial }
-		] AS sourcingMaterials,
-		[
-			material IN materials WHERE material.creditType = 'RIGHTS_GRANTOR' |
-			material { .model, .uuid, .name, .format, .year, .writingCredits, .surMaterial }
-		] AS rightsGrantorMaterials
+		materials,
+		subsequentVersionMaterials,
+		sourcingMaterials,
+		rightsGrantorMaterials
 `;

--- a/src/neo4j/cypher-queries/production/show/show-awards.js
+++ b/src/neo4j/cypher-queries/production/show/show-awards.js
@@ -1,272 +1,286 @@
 export default () => `
 	MATCH (production:Production { uuid: $uuid })
 
-	OPTIONAL MATCH (production)-[:HAS_SUB_PRODUCTION*0..2]-(nominatedProduction:Production)
-		<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
-		<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
- 		WHERE (
-			(production)-[:HAS_SUB_PRODUCTION*0..2]->(nominatedProduction) OR
-			(production)<-[:HAS_SUB_PRODUCTION*0..2]-(nominatedProduction)
-		)
+	CALL {
+		WITH production
 
-	OPTIONAL MATCH (nominatedProduction)-[:PLAYS_AT]->(nominatedProductionVenue:Venue)
-
-	OPTIONAL MATCH (nominatedProductionVenue)<-[:HAS_SUB_VENUE]-(nominatedProductionSurVenue:Venue)
-
-	OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)
-		WHERE
-			(
-				(nominatedEntity:Person AND nominatedEntityRel.nominatedCompanyUuid IS NULL) OR
-				nominatedEntity:Company
-			) AND
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = nominatedEntityRel.nominationPosition
+		OPTIONAL MATCH (production)-[:HAS_SUB_PRODUCTION*0..2]-(nominatedProduction:Production)
+			<-[nomineeRel:HAS_NOMINEE]-(category:AwardCeremonyCategory)
+			<-[categoryRel:PRESENTS_CATEGORY]-(ceremony:AwardCeremony)
+	 		WHERE (
+				(production)-[:HAS_SUB_PRODUCTION*0..2]->(nominatedProduction) OR
+				(production)<-[:HAS_SUB_PRODUCTION*0..2]-(nominatedProduction)
 			)
 
-	WITH production, nomineeRel, category, categoryRel, ceremony, nominatedEntityRel,
-		CASE WHEN production <> nominatedProduction
-			THEN nominatedProduction {
-				model: 'PRODUCTION',
-				.uuid,
-				.name,
-				.startDate,
-				.endDate,
-				venue: CASE WHEN nominatedProductionVenue IS NULL
-					THEN null
-					ELSE nominatedProductionVenue {
-						model: 'VENUE',
-						.uuid,
-						.name,
-						surVenue: CASE WHEN nominatedProductionSurVenue IS NULL
-							THEN null
-							ELSE nominatedProductionSurVenue { model: 'VENUE', .uuid, .name }
-						END
-					}
-				END
-			}
-			ELSE null
-		END AS recipientProduction,
-		COLLECT(nominatedEntity {
-			model: TOUPPER(HEAD(LABELS(nominatedEntity))),
-			.uuid,
-			.name,
-			nominatedMemberUuids: nominatedEntityRel.nominatedMemberUuids
-		}) AS nominatedEntities
+		OPTIONAL MATCH (nominatedProduction)-[:PLAYS_AT]->(nominatedProductionVenue:Venue)
 
-	UNWIND (CASE nominatedEntities WHEN [] THEN [null] ELSE nominatedEntities END) AS nominatedEntity
+		OPTIONAL MATCH (nominatedProductionVenue)<-[:HAS_SUB_VENUE]-(nominatedProductionSurVenue:Venue)
 
-		UNWIND (COALESCE(nominatedEntity.nominatedMemberUuids, [null])) AS nominatedMemberUuid
+		OPTIONAL MATCH (category)-[nominatedEntityRel:HAS_NOMINEE]->(nominatedEntity)
+			WHERE
+				(
+					(nominatedEntity:Person AND nominatedEntityRel.nominatedCompanyUuid IS NULL) OR
+					nominatedEntity:Company
+				) AND
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = nominatedEntityRel.nominationPosition
+				)
 
-			OPTIONAL MATCH (category)-[nominatedMemberRel:HAS_NOMINEE]->
-				(nominatedMember:Person { uuid: nominatedMemberUuid })
-				WHERE
-					nominatedEntityRel.nominationPosition IS NULL OR
-					nominatedEntityRel.nominationPosition = nominatedMemberRel.nominationPosition
-
-			WITH
-				production,
-				recipientProduction,
-				nomineeRel,
-				category,
-				categoryRel,
-				ceremony,
-				nominatedEntityRel,
-				nominatedEntity,
-				nominatedMember
-				ORDER BY nominatedMemberRel.memberPosition
-
-			WITH
-				production,
-				recipientProduction,
-				nomineeRel,
-				category,
-				categoryRel,
-				ceremony,
-				nominatedEntityRel,
-				nominatedEntity,
-				COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
-
-	WITH
-		production,
-		recipientProduction,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntityRel,
-		nominatedEntity,
-		nominatedMembers
-		ORDER BY nominatedEntityRel.nominationPosition, nominatedEntityRel.entityPosition
-
-	WITH production, recipientProduction, nomineeRel, category, categoryRel, ceremony,
-		COLLECT(
-			CASE WHEN nominatedEntity IS NULL
-				THEN null
-				ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
-			END
-		) AS nominatedEntities
-
-	WITH production, recipientProduction, nomineeRel, category, categoryRel, ceremony,
-		[nominatedEntity IN nominatedEntities | CASE nominatedEntity.model WHEN 'COMPANY'
-			THEN nominatedEntity
-			ELSE nominatedEntity { .model, .uuid, .name }
-		END] AS nominatedEntities
-
-	OPTIONAL MATCH (category)-[coNominatedProductionRel:HAS_NOMINEE]->(coNominatedProduction:Production)
-		WHERE
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = coNominatedProductionRel.nominationPosition
-			) AND
-			coNominatedProduction.uuid <> production.uuid AND
-			NOT EXISTS((production)-[:HAS_SUB_PRODUCTION*1..2]-(coNominatedProduction))
-
-	OPTIONAL MATCH (coNominatedProduction)-[:PLAYS_AT]->(coNominatedProductionVenue:Venue)
-
-	OPTIONAL MATCH (coNominatedProductionVenue)<-[:HAS_SUB_VENUE]-(coNominatedProductionSurVenue:Venue)
-
-	OPTIONAL MATCH (coNominatedProduction)<-[:HAS_SUB_PRODUCTION]-(coNominatedProductionSurProduction:Production)
-
-	OPTIONAL MATCH (coNominatedProductionSurProduction)
-		<-[:HAS_SUB_PRODUCTION]-(coNominatedProductionSurSurProduction:Production)
-
-	WITH
-		recipientProduction,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		coNominatedProductionRel,
-		coNominatedProduction,
-		coNominatedProductionVenue,
-		coNominatedProductionSurVenue,
-		coNominatedProductionSurProduction,
-		coNominatedProductionSurSurProduction
-		ORDER BY coNominatedProductionRel.productionPosition
-
-	WITH recipientProduction, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
-		COLLECT(
-			CASE WHEN coNominatedProduction IS NULL
-				THEN null
-				ELSE coNominatedProduction {
+		WITH production, nomineeRel, category, categoryRel, ceremony, nominatedEntityRel,
+			CASE WHEN production <> nominatedProduction
+				THEN nominatedProduction {
 					model: 'PRODUCTION',
 					.uuid,
 					.name,
 					.startDate,
 					.endDate,
-					venue: CASE WHEN coNominatedProductionVenue IS NULL
+					venue: CASE WHEN nominatedProductionVenue IS NULL
 						THEN null
-						ELSE coNominatedProductionVenue {
+						ELSE nominatedProductionVenue {
 							model: 'VENUE',
 							.uuid,
 							.name,
-							surVenue: CASE WHEN coNominatedProductionSurVenue IS NULL
+							surVenue: CASE WHEN nominatedProductionSurVenue IS NULL
 								THEN null
-								ELSE coNominatedProductionSurVenue { model: 'VENUE', .uuid, .name }
-							END
-						}
-					END,
-					surProduction: CASE WHEN coNominatedProductionSurProduction IS NULL
-						THEN null
-						ELSE coNominatedProductionSurProduction {
-							model: 'PRODUCTION',
-							.uuid,
-							.name,
-							surProduction: CASE WHEN coNominatedProductionSurSurProduction IS NULL
-								THEN null
-								ELSE coNominatedProductionSurSurProduction{ model: 'PRODUCTION', .uuid, .name }
+								ELSE nominatedProductionSurVenue { model: 'VENUE', .uuid, .name }
 							END
 						}
 					END
 				}
-			END
-		) AS coNominatedProductions
+				ELSE null
+			END AS recipientProduction,
+			COLLECT(nominatedEntity {
+				model: TOUPPER(HEAD(LABELS(nominatedEntity))),
+				.uuid,
+				.name,
+				nominatedMemberUuids: nominatedEntityRel.nominatedMemberUuids
+			}) AS nominatedEntities
 
-	OPTIONAL MATCH (category)-[nominatedMaterialRel:HAS_NOMINEE]->(nominatedMaterial:Material)
-		WHERE
-			(
-				nomineeRel.nominationPosition IS NULL OR
-				nomineeRel.nominationPosition = nominatedMaterialRel.nominationPosition
-			)
+		UNWIND (CASE nominatedEntities WHEN [] THEN [null] ELSE nominatedEntities END) AS nominatedEntity
 
-	OPTIONAL MATCH (nominatedMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSurMaterial:Material)
+			UNWIND (COALESCE(nominatedEntity.nominatedMemberUuids, [null])) AS nominatedMemberUuid
 
-	OPTIONAL MATCH (nominatedSurMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSurSurMaterial:Material)
+				OPTIONAL MATCH (category)-[nominatedMemberRel:HAS_NOMINEE]->
+					(nominatedMember:Person { uuid: nominatedMemberUuid })
+					WHERE
+						nominatedEntityRel.nominationPosition IS NULL OR
+						nominatedEntityRel.nominationPosition = nominatedMemberRel.nominationPosition
 
-	WITH
-		recipientProduction,
-		nomineeRel,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		coNominatedProductions,
-		nominatedMaterialRel,
-		nominatedMaterial,
-		nominatedSurMaterial,
-		nominatedSurSurMaterial
-		ORDER BY nominatedMaterialRel.materialPosition
+				WITH
+					production,
+					recipientProduction,
+					nomineeRel,
+					category,
+					categoryRel,
+					ceremony,
+					nominatedEntityRel,
+					nominatedEntity,
+					nominatedMember
+					ORDER BY nominatedMemberRel.memberPosition
 
-	WITH recipientProduction, nomineeRel, category, categoryRel, ceremony, nominatedEntities, coNominatedProductions,
-		COLLECT(
-			CASE WHEN nominatedMaterial IS NULL
-				THEN null
-				ELSE nominatedMaterial {
-					model: 'MATERIAL',
-					.uuid,
-					.name,
-					.format,
-					.year,
-					surMaterial: CASE WHEN nominatedSurMaterial IS NULL
-						THEN null
-						ELSE nominatedSurMaterial {
-							model: 'MATERIAL',
-							.uuid,
-							.name,
-							surMaterial: CASE WHEN nominatedSurSurMaterial IS NULL
-								THEN null
-								ELSE nominatedSurSurMaterial { model: 'MATERIAL', .uuid, .name }
-							END
-						}
-					END
-				}
-			END
-		) AS nominatedMaterials
-		ORDER BY nomineeRel.nominationPosition, nomineeRel.productionPosition
+				WITH
+					production,
+					recipientProduction,
+					nomineeRel,
+					category,
+					categoryRel,
+					ceremony,
+					nominatedEntityRel,
+					nominatedEntity,
+					COLLECT(nominatedMember { model: 'PERSON', .uuid, .name }) AS nominatedMembers
 
-	WITH
-		nomineeRel.isWinner AS isWinner,
-		nomineeRel.customType AS customType,
-		category,
-		categoryRel,
-		ceremony,
-		nominatedEntities,
-		coNominatedProductions,
-		nominatedMaterials,
-		COLLECT(recipientProduction) AS recipientProductions
+		WITH
+			production,
+			recipientProduction,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntityRel,
+			nominatedEntity,
+			nominatedMembers
+			ORDER BY nominatedEntityRel.nominationPosition, nominatedEntityRel.entityPosition
 
-	WITH category, categoryRel, ceremony,
-		COLLECT({
-			model: 'NOMINATION',
-			isWinner: COALESCE(isWinner, false),
-			type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
-			recipientProductions: recipientProductions,
-			entities: nominatedEntities,
-			coProductions: coNominatedProductions,
-			materials: nominatedMaterials
-		}) AS nominations
-		ORDER BY categoryRel.position
+		WITH production, recipientProduction, nomineeRel, category, categoryRel, ceremony,
+			COLLECT(
+				CASE WHEN nominatedEntity IS NULL
+					THEN null
+					ELSE nominatedEntity { .model, .uuid, .name, members: nominatedMembers }
+				END
+			) AS nominatedEntities
 
-	WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
-		ORDER BY ceremony.name DESC
+		WITH production, recipientProduction, nomineeRel, category, categoryRel, ceremony,
+			[nominatedEntity IN nominatedEntities | CASE nominatedEntity.model WHEN 'COMPANY'
+				THEN nominatedEntity
+				ELSE nominatedEntity { .model, .uuid, .name }
+			END] AS nominatedEntities
 
-	OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
+		OPTIONAL MATCH (category)-[coNominatedProductionRel:HAS_NOMINEE]->(coNominatedProduction:Production)
+			WHERE
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = coNominatedProductionRel.nominationPosition
+				) AND
+				coNominatedProduction.uuid <> production.uuid AND
+				NOT EXISTS((production)-[:HAS_SUB_PRODUCTION*1..2]-(coNominatedProduction))
 
-	WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
-		ORDER BY award.name
+		OPTIONAL MATCH (coNominatedProduction)-[:PLAYS_AT]->(coNominatedProductionVenue:Venue)
+
+		OPTIONAL MATCH (coNominatedProductionVenue)<-[:HAS_SUB_VENUE]-(coNominatedProductionSurVenue:Venue)
+
+		OPTIONAL MATCH (coNominatedProduction)<-[:HAS_SUB_PRODUCTION]-(coNominatedProductionSurProduction:Production)
+
+		OPTIONAL MATCH (coNominatedProductionSurProduction)
+			<-[:HAS_SUB_PRODUCTION]-(coNominatedProductionSurSurProduction:Production)
+
+		WITH
+			recipientProduction,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			coNominatedProductionRel,
+			coNominatedProduction,
+			coNominatedProductionVenue,
+			coNominatedProductionSurVenue,
+			coNominatedProductionSurProduction,
+			coNominatedProductionSurSurProduction
+			ORDER BY coNominatedProductionRel.productionPosition
+
+		WITH recipientProduction, nomineeRel, category, categoryRel, ceremony, nominatedEntities,
+			COLLECT(
+				CASE WHEN coNominatedProduction IS NULL
+					THEN null
+					ELSE coNominatedProduction {
+						model: 'PRODUCTION',
+						.uuid,
+						.name,
+						.startDate,
+						.endDate,
+						venue: CASE WHEN coNominatedProductionVenue IS NULL
+							THEN null
+							ELSE coNominatedProductionVenue {
+								model: 'VENUE',
+								.uuid,
+								.name,
+								surVenue: CASE WHEN coNominatedProductionSurVenue IS NULL
+									THEN null
+									ELSE coNominatedProductionSurVenue { model: 'VENUE', .uuid, .name }
+								END
+							}
+						END,
+						surProduction: CASE WHEN coNominatedProductionSurProduction IS NULL
+							THEN null
+							ELSE coNominatedProductionSurProduction {
+								model: 'PRODUCTION',
+								.uuid,
+								.name,
+								surProduction: CASE WHEN coNominatedProductionSurSurProduction IS NULL
+									THEN null
+									ELSE coNominatedProductionSurSurProduction{ model: 'PRODUCTION', .uuid, .name }
+								END
+							}
+						END
+					}
+				END
+			) AS coNominatedProductions
+
+		OPTIONAL MATCH (category)-[nominatedMaterialRel:HAS_NOMINEE]->(nominatedMaterial:Material)
+			WHERE
+				(
+					nomineeRel.nominationPosition IS NULL OR
+					nomineeRel.nominationPosition = nominatedMaterialRel.nominationPosition
+				)
+
+		OPTIONAL MATCH (nominatedMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSurMaterial:Material)
+
+		OPTIONAL MATCH (nominatedSurMaterial)<-[:HAS_SUB_MATERIAL]-(nominatedSurSurMaterial:Material)
+
+		WITH
+			recipientProduction,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			coNominatedProductions,
+			nominatedMaterialRel,
+			nominatedMaterial,
+			nominatedSurMaterial,
+			nominatedSurSurMaterial
+			ORDER BY nominatedMaterialRel.materialPosition
+
+		WITH
+			recipientProduction,
+			nomineeRel,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			coNominatedProductions,
+			COLLECT(
+				CASE WHEN nominatedMaterial IS NULL
+					THEN null
+					ELSE nominatedMaterial {
+						model: 'MATERIAL',
+						.uuid,
+						.name,
+						.format,
+						.year,
+						surMaterial: CASE WHEN nominatedSurMaterial IS NULL
+							THEN null
+							ELSE nominatedSurMaterial {
+								model: 'MATERIAL',
+								.uuid,
+								.name,
+								surMaterial: CASE WHEN nominatedSurSurMaterial IS NULL
+									THEN null
+									ELSE nominatedSurSurMaterial { model: 'MATERIAL', .uuid, .name }
+								END
+							}
+						END
+					}
+				END
+			) AS nominatedMaterials
+			ORDER BY nomineeRel.nominationPosition, nomineeRel.productionPosition
+
+		WITH
+			nomineeRel.isWinner AS isWinner,
+			nomineeRel.customType AS customType,
+			category,
+			categoryRel,
+			ceremony,
+			nominatedEntities,
+			coNominatedProductions,
+			nominatedMaterials,
+			COLLECT(recipientProduction) AS recipientProductions
+
+		WITH category, categoryRel, ceremony,
+			COLLECT({
+				model: 'NOMINATION',
+				isWinner: COALESCE(isWinner, false),
+				type: COALESCE(customType, CASE WHEN isWinner THEN 'Winner' ELSE 'Nomination' END),
+				recipientProductions: recipientProductions,
+				entities: nominatedEntities,
+				coProductions: coNominatedProductions,
+				materials: nominatedMaterials
+			}) AS nominations
+			ORDER BY categoryRel.position
+
+		WITH ceremony, COLLECT(category { model: 'AWARD_CEREMONY_CATEGORY', .name, nominations }) AS categories
+			ORDER BY ceremony.name DESC
+
+		OPTIONAL MATCH (ceremony)<-[:PRESENTED_AT]-(award:Award)
+
+		WITH award, COLLECT(ceremony { model: 'AWARD_CEREMONY', .uuid, .name, categories }) AS ceremonies
+			ORDER BY award.name
+
+		RETURN
+			COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS awards
+	}
 
 	RETURN
-		COLLECT(award { model: 'AWARD', .uuid, .name, ceremonies }) AS awards
+		awards
 `;

--- a/src/neo4j/cypher-queries/venue/show/show-productions.js
+++ b/src/neo4j/cypher-queries/venue/show/show-productions.js
@@ -1,58 +1,65 @@
 export default () => `
 	MATCH (venue:Venue { uuid: $uuid })
 
-	OPTIONAL MATCH (venue)-[:HAS_SUB_VENUE*0..1]->
-		(venueLinkedToProduction:Venue)<-[:PLAYS_AT]-(production:Production)
-		WHERE NOT EXISTS(
-			(venue)-[:HAS_SUB_VENUE*0..1]->(venueLinkedToProduction)
-			<-[:PLAYS_AT]-(:Production)<-[:HAS_SUB_PRODUCTION*1..2]-(production)
-		)
+	CALL {
+		WITH venue
 
-	OPTIONAL MATCH (production)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
+		OPTIONAL MATCH (venue)-[:HAS_SUB_VENUE*0..1]->
+			(venueLinkedToProduction:Venue)<-[:PLAYS_AT]-(production:Production)
+			WHERE NOT EXISTS(
+				(venue)-[:HAS_SUB_VENUE*0..1]->(venueLinkedToProduction)
+				<-[:PLAYS_AT]-(:Production)<-[:HAS_SUB_PRODUCTION*1..2]-(production)
+			)
 
-	OPTIONAL MATCH (surProduction)<-[surSurProductionRel:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+		OPTIONAL MATCH (production)<-[surProductionRel:HAS_SUB_PRODUCTION]-(surProduction:Production)
 
-	WITH
-		venue,
-		venueLinkedToProduction,
-		production,
-		surProduction,
-		surProductionRel,
-		surSurProduction,
-		surSurProductionRel
-		ORDER BY
-			production.startDate DESC,
-			COALESCE(surSurProduction.name, surProduction.name, production.name),
-			surSurProductionRel.position DESC,
-			surProductionRel.position DESC
+		OPTIONAL MATCH (surProduction)<-[surSurProductionRel:HAS_SUB_PRODUCTION]-(surSurProduction:Production)
+
+		WITH
+			venue,
+			venueLinkedToProduction,
+			production,
+			surProduction,
+			surProductionRel,
+			surSurProduction,
+			surSurProductionRel
+			ORDER BY
+				production.startDate DESC,
+				COALESCE(surSurProduction.name, surProduction.name, production.name),
+				surSurProductionRel.position DESC,
+				surProductionRel.position DESC
+
+		RETURN
+			COLLECT(
+				CASE WHEN production IS NULL
+					THEN null
+					ELSE production {
+						model: 'PRODUCTION',
+						.uuid,
+						.name,
+						.startDate,
+						.endDate,
+						subVenue: CASE WHEN venue <> venueLinkedToProduction
+							THEN venueLinkedToProduction { model: 'VENUE', .uuid, .name }
+							ELSE null
+						END,
+						surProduction: CASE WHEN surProduction IS NULL
+							THEN null
+							ELSE surProduction {
+								model: 'PRODUCTION',
+								.uuid,
+								.name,
+								surProduction: CASE WHEN surSurProduction IS NULL
+									THEN null
+									ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
+								END
+							}
+						END
+					}
+				END
+			) AS productions
+	}
 
 	RETURN
-		COLLECT(
-			CASE WHEN production IS NULL
-				THEN null
-				ELSE production {
-					model: 'PRODUCTION',
-					.uuid,
-					.name,
-					.startDate,
-					.endDate,
-					subVenue: CASE WHEN venue <> venueLinkedToProduction
-						THEN venueLinkedToProduction { model: 'VENUE', .uuid, .name }
-						ELSE null
-					END,
-					surProduction: CASE WHEN surProduction IS NULL
-						THEN null
-						ELSE surProduction {
-							model: 'PRODUCTION',
-							.uuid,
-							.name,
-							surProduction: CASE WHEN surSurProduction IS NULL
-								THEN null
-								ELSE surSurProduction { model: 'PRODUCTION', .uuid, .name }
-							END
-						}
-					END
-				}
-			END
-		) AS productions
+		productions
 `;


### PR DESCRIPTION
This previous PR https://github.com/andygout/theatrebase-api/pull/518 extracted the show queries for models into multiple smaller queries, e.g. material includes:
- 1 x show query for its most direct properties (e.g. `writingCredits`, `originalVersionMaterial`, `surMaterial`, `subMaterials`, `characterGroups`)
- multiple other show queries each covering one of its various facets:
  - `sourcingMaterialAwards`
  - `subsequentVersionMaterialAwards`
  - `awards`
  - `productions` and `sourcingMaterialProductions`

This change required that the show queries used a `Promise.all()`.

However, the facet queries did not include in their `RETURN` statement any part of the subject instance's identifier, i.e. the one identified in the opening `MATCH` statement and which relies on the `$uuid` param. In the above examples, `material` would be the identifier.

E.g.

#### `src/neo4j/cypher-queries/material/show/show.js`
```cypher
RETURN
	'MATERIAL' AS model,
	material.uuid AS uuid,
	material.name AS name,
	material.differentiator AS differentiator,
	material.format AS format,
	material.year AS year,
	subjectMaterial.writingCredits AS writingCredits,
	subjectMaterial.originalVersionMaterial AS originalVersionMaterial,
	surMaterial,
	subMaterials,
	subjectMaterial.characterGroups AS characterGroups
```

#### `src/neo4j/cypher-queries/material/show/show-awards.js`
N.B. `material` is not included in this statement as it is above.
```cypher
RETURN
	awards
```

---

This creates a key difference when querying a non-existent instance, where the [`resultObjects`](https://github.com/andygout/theatrebase-api/blob/b9cc086e3c289e6fd387dbdb1e196d84471d852f/src/neo4j/query.js#L19) (in [`src/neo4j/query.js`](https://github.com/andygout/theatrebase-api/blob/b9cc086e3c289e6fd387dbdb1e196d84471d852f/src/neo4j/query.js)) are as follows:

#### `src/neo4j/cypher-queries/material/show/show.js`
```json
[]
```

#### `src/neo4j/cypher-queries/material/show/show-awards.js`
```json
[
	{
		"awards": []
	}
]
```

This means that the facet queries' `resultObjects` will always have length and consequently will never result in a Not Found error, which is based upon this [conditional](https://github.com/andygout/theatrebase-api/blob/b9cc086e3c289e6fd387dbdb1e196d84471d852f/src/neo4j/query.js#L21):
```js
if (!resultObjects.length && !isOptionalResult) throw new Error('Not Found');
```

Admittedly, while the `Promise.all()` contains the show query for the instance's most direct properties (i.e. `show.js`), in the scenario of a non-existent instance this will always throw the Not Found error, causing the whole `Promise.all()` group to fail on that basis.

> It rejects when any of the input's promises rejects, with this first rejection reason.

> **Asynchronously rejected**, when any of the promises in the given `iterable` rejects. The rejection reason is the rejection reason of the first promise that was rejected.

This is not as performant as it could be: if all queries are able to throw the Not Found error then it would occur on the first query to throw it, rather than always having to wait for the model's `show.js` query to respond.

It also means the Not Found logic will not work if these facet queries are eventually run independently of the main `show.js` query, e.g. separate endpoints are used for each of them to be run individually.

For these reasons, this PR revises the facet Cypher queries so that if the instance is non-existent then they too, like `show.js`, will also have `[]` as their `resultObjects` value and be able to throw the Not Found error.

One approach for achieving this was to pass the subject instance's identifier down the query in the `WITH` statements and including one of its aspects in the `RETURN` statement, e.g. `material.uuid AS uuid`, which would be repeated in the `show.js` file though the property (`uuid`) would be de-duplicated by `Object.assign({}, ...showQueryResponses);`, which is performed upon the collective responses of the `Promise.all()`.

However, it was noted that the queries in `src/neo4j/cypher-queries/character/show/show-materials.js` and `src/neo4j/cypher-queries/character/show/show-productions.js` already had the desired behaviour through using subqueries with `CALL` blocks (which were implemented in this PR https://github.com/andygout/theatrebase-api/pull/570). This solution was applied as it meant avoiding passing an identifier all the way down the query whose return value would only be de-duplicated and whose purpose would consequently be opaque.

### References:
- [MDN Web Docs: Promise.all()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all)