### PR TITLE
Remove unnecessary uuid stubs from uniqueness-in-db E2E tests

### DIFF
--- a/test-e2e/uniqueness-in-db/award-ceremonies-api.test.js
+++ b/test-e2e/uniqueness-in-db/award-ceremonies-api.test.js
@@ -2,7 +2,6 @@ import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
 
-import * as getRandomUuidModule from '../../src/lib/get-random-uuid';
 import app from '../../src/app';
 import { countNodesWithLabel, createNode, purgeDatabase } from '../test-helpers/neo4j';
 
@@ -31,10 +30,6 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 		};
 
 		before(async () => {
-
-			let uuidCallCount = 0;
-
-			sandbox.stub(getRandomUuidModule, 'getRandomUuid').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -151,10 +146,6 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 		};
 
 		before(async () => {
-
-			let uuidCallCount = 0;
-
-			sandbox.stub(getRandomUuidModule, 'getRandomUuid').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -332,10 +323,6 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 
 		before(async () => {
 
-			let uuidCallCount = 0;
-
-			sandbox.stub(getRandomUuidModule, 'getRandomUuid').callsFake(() => (uuidCallCount++).toString());
-
 			await purgeDatabase();
 
 			await createNode({
@@ -499,10 +486,6 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 		};
 
 		before(async () => {
-
-			let uuidCallCount = 0;
-
-			sandbox.stub(getRandomUuidModule, 'getRandomUuid').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 

--- a/test-e2e/uniqueness-in-db/materials-api.test.js
+++ b/test-e2e/uniqueness-in-db/materials-api.test.js
@@ -435,10 +435,6 @@ describe('Uniqueness in database: Materials API', () => {
 
 		before(async () => {
 
-			let uuidCallCount = 0;
-
-			sandbox.stub(getRandomUuidModule, 'getRandomUuid').callsFake(() => (uuidCallCount++).toString());
-
 			await purgeDatabase();
 
 			await createNode({
@@ -558,10 +554,6 @@ describe('Uniqueness in database: Materials API', () => {
 		};
 
 		before(async () => {
-
-			let uuidCallCount = 0;
-
-			sandbox.stub(getRandomUuidModule, 'getRandomUuid').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -702,10 +694,6 @@ describe('Uniqueness in database: Materials API', () => {
 		};
 
 		before(async () => {
-
-			let uuidCallCount = 0;
-
-			sandbox.stub(getRandomUuidModule, 'getRandomUuid').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -850,10 +838,6 @@ describe('Uniqueness in database: Materials API', () => {
 		};
 
 		before(async () => {
-
-			let uuidCallCount = 0;
-
-			sandbox.stub(getRandomUuidModule, 'getRandomUuid').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -1003,10 +987,6 @@ describe('Uniqueness in database: Materials API', () => {
 
 		before(async () => {
 
-			let uuidCallCount = 0;
-
-			sandbox.stub(getRandomUuidModule, 'getRandomUuid').callsFake(() => (uuidCallCount++).toString());
-
 			await purgeDatabase();
 
 			await createNode({
@@ -1134,10 +1114,6 @@ describe('Uniqueness in database: Materials API', () => {
 		};
 
 		before(async () => {
-
-			let uuidCallCount = 0;
-
-			sandbox.stub(getRandomUuidModule, 'getRandomUuid').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 

--- a/test-e2e/uniqueness-in-db/productions-api.test.js
+++ b/test-e2e/uniqueness-in-db/productions-api.test.js
@@ -2,7 +2,6 @@ import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { createSandbox } from 'sinon';
 
-import * as getRandomUuidModule from '../../src/lib/get-random-uuid';
 import app from '../../src/app';
 import { countNodesWithLabel, createNode, purgeDatabase } from '../test-helpers/neo4j';
 
@@ -31,10 +30,6 @@ describe('Uniqueness in database: Productions API', () => {
 		};
 
 		before(async () => {
-
-			let uuidCallCount = 0;
-
-			sandbox.stub(getRandomUuidModule, 'getRandomUuid').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -152,10 +147,6 @@ describe('Uniqueness in database: Productions API', () => {
 
 		before(async () => {
 
-			let uuidCallCount = 0;
-
-			sandbox.stub(getRandomUuidModule, 'getRandomUuid').callsFake(() => (uuidCallCount++).toString());
-
 			await purgeDatabase();
 
 			await createNode({
@@ -272,10 +263,6 @@ describe('Uniqueness in database: Productions API', () => {
 
 		before(async () => {
 
-			let uuidCallCount = 0;
-
-			sandbox.stub(getRandomUuidModule, 'getRandomUuid').callsFake(() => (uuidCallCount++).toString());
-
 			await purgeDatabase();
 
 			await createNode({
@@ -391,10 +378,6 @@ describe('Uniqueness in database: Productions API', () => {
 		};
 
 		before(async () => {
-
-			let uuidCallCount = 0;
-
-			sandbox.stub(getRandomUuidModule, 'getRandomUuid').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -556,10 +539,6 @@ describe('Uniqueness in database: Productions API', () => {
 
 		before(async () => {
 
-			let uuidCallCount = 0;
-
-			sandbox.stub(getRandomUuidModule, 'getRandomUuid').callsFake(() => (uuidCallCount++).toString());
-
 			await purgeDatabase();
 
 			await createNode({
@@ -707,10 +686,6 @@ describe('Uniqueness in database: Productions API', () => {
 		};
 
 		before(async () => {
-
-			let uuidCallCount = 0;
-
-			sandbox.stub(getRandomUuidModule, 'getRandomUuid').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -902,10 +877,6 @@ describe('Uniqueness in database: Productions API', () => {
 
 		before(async () => {
 
-			let uuidCallCount = 0;
-
-			sandbox.stub(getRandomUuidModule, 'getRandomUuid').callsFake(() => (uuidCallCount++).toString());
-
 			await purgeDatabase();
 
 			await createNode({
@@ -1029,10 +1000,6 @@ describe('Uniqueness in database: Productions API', () => {
 		};
 
 		before(async () => {
-
-			let uuidCallCount = 0;
-
-			sandbox.stub(getRandomUuidModule, 'getRandomUuid').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -1194,10 +1161,6 @@ describe('Uniqueness in database: Productions API', () => {
 
 		before(async () => {
 
-			let uuidCallCount = 0;
-
-			sandbox.stub(getRandomUuidModule, 'getRandomUuid').callsFake(() => (uuidCallCount++).toString());
-
 			await purgeDatabase();
 
 			await createNode({
@@ -1345,10 +1308,6 @@ describe('Uniqueness in database: Productions API', () => {
 		};
 
 		before(async () => {
-
-			let uuidCallCount = 0;
-
-			sandbox.stub(getRandomUuidModule, 'getRandomUuid').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 
@@ -1518,10 +1477,6 @@ describe('Uniqueness in database: Productions API', () => {
 
 		before(async () => {
 
-			let uuidCallCount = 0;
-
-			sandbox.stub(getRandomUuidModule, 'getRandomUuid').callsFake(() => (uuidCallCount++).toString());
-
 			await purgeDatabase();
 
 			await createNode({
@@ -1682,10 +1637,6 @@ describe('Uniqueness in database: Productions API', () => {
 
 		before(async () => {
 
-			let uuidCallCount = 0;
-
-			sandbox.stub(getRandomUuidModule, 'getRandomUuid').callsFake(() => (uuidCallCount++).toString());
-
 			await purgeDatabase();
 
 			await createNode({
@@ -1833,10 +1784,6 @@ describe('Uniqueness in database: Productions API', () => {
 		};
 
 		before(async () => {
-
-			let uuidCallCount = 0;
-
-			sandbox.stub(getRandomUuidModule, 'getRandomUuid').callsFake(() => (uuidCallCount++).toString());
 
 			await purgeDatabase();
 

--- a/test-e2e/uniqueness-in-db/venue-api.test.js
+++ b/test-e2e/uniqueness-in-db/venue-api.test.js
@@ -251,10 +251,6 @@ describe('Uniqueness in database: Venues API', () => {
 
 		before(async () => {
 
-			let uuidCallCount = 0;
-
-			sandbox.stub(getRandomUuidModule, 'getRandomUuid').callsFake(() => (uuidCallCount++).toString());
-
 			await purgeDatabase();
 
 			await createNode({


### PR DESCRIPTION
This PR removes the stubs for the `getRandomUuid()` function (in the Prepare As Params module) from the `uniqueness-in-db` end-to-end tests where the code does not touch this function.