### PR TITLE
Add pause in database seeding performFetch function

### DIFF
--- a/db-seeding/seed-db.js
+++ b/db-seeding/seed-db.js
@@ -11,7 +11,11 @@ const PLURALISED_MODEL_TO_EMOJI_MAP = {
 	'materials': '📖',
 	'productions': '🎭',
 	'venues': '🏛️'
-}
+};
+
+const PAUSE_DURATION_IN_MILLISECONDS = 1000;
+
+const pause = duration => new Promise(resolve => setTimeout(resolve, duration));
 
 async function performFetch (url, instance, modelEmoji, filenamePathSlug) {
 
@@ -22,6 +26,8 @@ async function performFetch (url, instance, modelEmoji, filenamePathSlug) {
 		method: 'POST',
 		body: JSON.stringify(instance)
 	}
+
+	await pause(PAUSE_DURATION_IN_MILLISECONDS);
 
 	const response = await fetch(url, settings);
 


### PR DESCRIPTION
When seeding the amount of seeds that now exist, I have often experienced that the process hangs, my laptop starts to heat up, and the fans get very loud trying to counter this.

When observing Activity Monitor, it shows a large amount of Java usage, which indicates that my local instance of Neo4j is having issues.

The usage of [directly](https://www.npmjs.com/package/directly) should mean that only one promise is made at a time, but there are clearly issues.

This PR adds a pause to the `performFetch()` function when seeding the database so that before every fetch request to add another seed to the Neo4j database there is a pause of 1 second, which, though making the database seeding process a fair amount longer, seems to have prevented the issue over repeated attempts.