### PR TITLE
Add festival festival series

### DIFF
--- a/src/models/Festival.js
+++ b/src/models/Festival.js
@@ -1,17 +1,34 @@
-import Entity from './Entity';
+import FestivalBase from './FestivalBase';
+import { FestivalSeries } from '.';
 import { MODELS } from '../utils/constants';
 
-export default class Festival extends Entity {
+export default class Festival extends FestivalBase {
 
 	constructor (props = {}) {
 
 		super(props);
+
+		const { festivalSeries } = props;
+
+		this.festivalSeries = new FestivalSeries(festivalSeries);
 
 	}
 
 	get model () {
 
 		return MODELS.FESTIVAL;
+
+	}
+
+	runInputValidations () {
+
+		this.validateName({ isRequired: true });
+
+		this.validateDifferentiator();
+
+		this.festivalSeries.validateName({ isRequired: false });
+
+		this.festivalSeries.validateDifferentiator();
 
 	}
 

--- a/src/models/FestivalBase.js
+++ b/src/models/FestivalBase.js
@@ -1,0 +1,18 @@
+import Entity from './Entity';
+import { MODELS } from '../utils/constants';
+
+export default class FestivalBase extends Entity {
+
+	constructor (props = {}) {
+
+		super(props);
+
+	}
+
+	get model () {
+
+		return MODELS.FESTIVAL;
+
+	}
+
+}

--- a/src/models/Production.js
+++ b/src/models/Production.js
@@ -9,7 +9,7 @@ import {
 	CastMember,
 	CreativeCredit,
 	CrewCredit,
-	Festival,
+	FestivalBase,
 	MaterialBase,
 	ProducerCredit,
 	Season,
@@ -51,7 +51,7 @@ export default class Production extends Entity {
 
 		this.season = new Season(season);
 
-		this.festival = new Festival(festival);
+		this.festival = new FestivalBase(festival);
 
 		this.subProductions = subProductions
 			? subProductions.map(subProduction => new SubProductionIdentifier(subProduction))

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -10,6 +10,7 @@ import CompanyWithMembers from './CompanyWithMembers';
 import CreativeCredit from './CreativeCredit';
 import CrewCredit from './CrewCredit';
 import Festival from './Festival';
+import FestivalBase from './FestivalBase';
 import FestivalSeries from './FestivalSeries';
 import Material from './Material';
 import MaterialBase from './MaterialBase';
@@ -41,6 +42,7 @@ export {
 	CreativeCredit,
 	CrewCredit,
 	Festival,
+	FestivalBase,
 	FestivalSeries,
 	Material,
 	MaterialBase,

--- a/src/neo4j/cypher-queries/festival-series/show.js
+++ b/src/neo4j/cypher-queries/festival-series/show.js
@@ -1,8 +1,20 @@
 export default () => [`
 	MATCH (festivalSeries:FestivalSeries { uuid: $uuid })
+
+	OPTIONAL MATCH (festivalSeries)<-[:PART_OF_FESTIVAL_SERIES]-(festival:Festival)
+
+	WITH festivalSeries, festival
+		ORDER BY festival.name DESC
+
 	RETURN
 		'FESTIVAL_SERIES' AS model,
 		festivalSeries.uuid AS uuid,
 		festivalSeries.name AS name,
-		festivalSeries.differentiator AS differentiator
+		festivalSeries.differentiator AS differentiator,
+		COLLECT(
+			CASE WHEN festival IS NULL
+				THEN null
+				ELSE festival { model: 'FESTIVAL', .uuid, .name }
+			END
+		) AS festivals
 `];

--- a/src/neo4j/cypher-queries/festival/create-update.js
+++ b/src/neo4j/cypher-queries/festival/create-update.js
@@ -1,0 +1,59 @@
+import { getEditQuery } from '.';
+import { ACTIONS } from '../../../utils/constants';
+
+const getCreateUpdateQuery = action => {
+
+	const createUpdateQueryOpeningMap = {
+		[ACTIONS.CREATE]: `
+			CREATE (festival:Festival { uuid: $uuid, name: $name, differentiator: $differentiator })
+		`,
+		[ACTIONS.UPDATE]: `
+			MATCH (festival:Festival { uuid: $uuid })
+
+			OPTIONAL MATCH (festival)-[festivalSeriesRel:PART_OF_FESTIVAL_SERIES]->(:FestivalSeries)
+
+			DELETE festivalSeriesRel
+
+			WITH DISTINCT festival
+
+			SET
+				festival.name = $name,
+				festival.differentiator = $differentiator
+		`
+	};
+
+	return `
+		${createUpdateQueryOpeningMap[action]}
+
+		WITH festival
+
+		OPTIONAL MATCH (existingFestivalSeries:FestivalSeries { name: $festivalSeries.name })
+			WHERE
+				($festivalSeries.differentiator IS NULL AND existingFestivalSeries.differentiator IS NULL) OR
+				$festivalSeries.differentiator = existingFestivalSeries.differentiator
+
+		FOREACH (item IN CASE WHEN $festivalSeries.name IS NULL THEN [] ELSE [1] END |
+			MERGE (festivalSeries:FestivalSeries {
+				uuid: COALESCE(existingFestivalSeries.uuid, $festivalSeries.uuid),
+				name: $festivalSeries.name
+			})
+				ON CREATE SET festivalSeries.differentiator = $festivalSeries.differentiator
+
+			CREATE (festival)-[:PART_OF_FESTIVAL_SERIES]->(festivalSeries)
+		)
+
+		WITH DISTINCT festival
+
+		${getEditQuery()}
+	`;
+
+};
+
+const getCreateQuery = () => getCreateUpdateQuery(ACTIONS.CREATE);
+
+const getUpdateQuery = () => getCreateUpdateQuery(ACTIONS.UPDATE);
+
+export {
+	getCreateQuery,
+	getUpdateQuery
+};

--- a/src/neo4j/cypher-queries/festival/edit.js
+++ b/src/neo4j/cypher-queries/festival/edit.js
@@ -1,0 +1,16 @@
+export default () => `
+	MATCH (festival:Festival { uuid: $uuid })
+
+	OPTIONAL MATCH (festival)-[:PART_OF_FESTIVAL_SERIES]->(festivalSeries:FestivalSeries)
+
+	WITH festival, festivalSeries
+
+	RETURN
+		festival.uuid AS uuid,
+		festival.name AS name,
+		festival.differentiator AS differentiator,
+		{
+			name: COALESCE(festivalSeries.name, ''),
+			differentiator: COALESCE(festivalSeries.differentiator, '')
+		} AS festivalSeries
+`;

--- a/src/neo4j/cypher-queries/festival/index.js
+++ b/src/neo4j/cypher-queries/festival/index.js
@@ -1,5 +1,12 @@
+import { getCreateQuery, getUpdateQuery } from './create-update';
+import getEditQuery from './edit';
+import getListQuery from './list';
 import getShowQueries from './show';
 
 export {
-	getShowQueries
+	getCreateQuery,
+	getEditQuery,
+	getUpdateQuery,
+	getShowQueries,
+	getListQuery
 };

--- a/src/neo4j/cypher-queries/festival/list.js
+++ b/src/neo4j/cypher-queries/festival/list.js
@@ -1,0 +1,19 @@
+export default () => `
+	MATCH (festival:Festival)
+
+	OPTIONAL MATCH (festival)-[:PART_OF_FESTIVAL_SERIES]->(festivalSeries:FestivalSeries)
+
+	RETURN
+		'FESTIVAL' AS model,
+		festival.uuid AS uuid,
+		festival.name AS name,
+		CASE WHEN festivalSeries IS NULL
+			THEN null
+			ELSE festivalSeries { model: 'FESTIVAL_SERIES', .uuid, .name }
+		END AS festivalSeries
+
+	ORDER BY
+		festival.name DESC, festivalSeries.name
+
+	LIMIT 1000
+`;

--- a/src/neo4j/cypher-queries/festival/show/show.js
+++ b/src/neo4j/cypher-queries/festival/show/show.js
@@ -1,9 +1,22 @@
 export default () => `
 	MATCH (festival:Festival { uuid: $uuid })
 
+	CALL {
+		WITH festival
+
+		OPTIONAL MATCH (festival)-[:PART_OF_FESTIVAL_SERIES]->(festivalSeries:FestivalSeries)
+
+		RETURN
+			CASE WHEN festivalSeries IS NULL
+				THEN null
+				ELSE festivalSeries { model: 'FESTIVAL_SERIES', .uuid, .name }
+			END AS festivalSeries
+	}
+
 	RETURN
 		'FESTIVAL' AS model,
 		festival.uuid AS uuid,
 		festival.name AS name,
-		festival.differentiator AS differentiator
+		festival.differentiator AS differentiator,
+		festivalSeries
 `;

--- a/src/neo4j/cypher-queries/index.js
+++ b/src/neo4j/cypher-queries/index.js
@@ -8,7 +8,13 @@ import {
 } from './award-ceremony';
 import { getShowQueries as getCharacterShowQueries } from './character';
 import { getShowQueries as getCompanyShowQueries } from './company';
-import { getShowQueries as getFestivalShowQueries } from './festival';
+import {
+	getCreateQuery as getFestivalCreateQuery,
+	getEditQuery as getFestivalEditQuery,
+	getUpdateQuery as getFestivalUpdateQuery,
+	getShowQueries as getFestivalShowQueries,
+	getListQuery as getFestivalListQuery
+} from './festival';
 import { getShowQueries as getFestivalSeriesShowQueries } from './festival-series';
 import {
 	getCreateQuery as getMaterialCreateQuery,
@@ -52,6 +58,7 @@ import { MODELS } from '../../utils/constants';
 
 const getCreateQueries = {
 	[MODELS.AWARD_CEREMONY]: getAwardCeremonyCreateQuery,
+	[MODELS.FESTIVAL]: getFestivalCreateQuery,
 	[MODELS.MATERIAL]: getMaterialCreateQuery,
 	[MODELS.PRODUCTION]: getProductionCreateQuery,
 	[MODELS.VENUE]: getVenueCreateQuery
@@ -59,6 +66,7 @@ const getCreateQueries = {
 
 const getEditQueries = {
 	[MODELS.AWARD_CEREMONY]: getAwardCeremonyEditQuery,
+	[MODELS.FESTIVAL]: getFestivalEditQuery,
 	[MODELS.MATERIAL]: getMaterialEditQuery,
 	[MODELS.PRODUCTION]: getProductionEditQuery,
 	[MODELS.VENUE]: getVenueEditQuery
@@ -66,6 +74,7 @@ const getEditQueries = {
 
 const getUpdateQueries = {
 	[MODELS.AWARD_CEREMONY]: getAwardCeremonyUpdateQuery,
+	[MODELS.FESTIVAL]: getFestivalUpdateQuery,
 	[MODELS.MATERIAL]: getMaterialUpdateQuery,
 	[MODELS.PRODUCTION]: getProductionUpdateQuery,
 	[MODELS.VENUE]: getVenueUpdateQuery
@@ -87,6 +96,7 @@ const getShowQueries = {
 
 const getListQueries = {
 	[MODELS.AWARD_CEREMONY]: getAwardCeremonyListQuery,
+	[MODELS.FESTIVAL]: getFestivalListQuery,
 	[MODELS.MATERIAL]: getMaterialListQuery,
 	[MODELS.PRODUCTION]: getProductionListQuery,
 	[MODELS.VENUE]: getVenueListQuery

--- a/src/neo4j/cypher-queries/production/show/show.js
+++ b/src/neo4j/cypher-queries/production/show/show.js
@@ -213,6 +213,8 @@ export default () => `
 
 		OPTIONAL MATCH (collectionProduction)-[:PART_OF_FESTIVAL]->(festival:Festival)
 
+		OPTIONAL MATCH (festival)-[:PART_OF_FESTIVAL_SERIES]->(festivalSeries:FestivalSeries)
+
 		WITH
 			production,
 			collectionProduction,
@@ -224,7 +226,11 @@ export default () => `
 				ELSE festival {
 					model: 'FESTIVAL',
 					.uuid,
-					.name
+					.name,
+					festivalSeries: CASE WHEN festivalSeries IS NULL
+						THEN null
+						ELSE festivalSeries { model: 'FESTIVAL_SERIES', .uuid, .name }
+					END
 				}
 			END AS festival
 

--- a/test-e2e/crud/festival-serieses-api.test.js
+++ b/test-e2e/crud/festival-serieses-api.test.js
@@ -127,7 +127,8 @@ describe('CRUD (Create, Read, Update, Delete): Festival Serieses API', () => {
 				model: 'FESTIVAL_SERIES',
 				uuid: FESTIVAL_SERIES_UUID,
 				name: 'Connections',
-				differentiator: null
+				differentiator: null,
+				festivals: []
 			};
 
 			expect(response).to.have.status(200);

--- a/test-e2e/crud/festivals-api.test.js
+++ b/test-e2e/crud/festivals-api.test.js
@@ -24,7 +24,13 @@ describe('CRUD (Create, Read, Update, Delete): Festivals API', () => {
 				model: 'FESTIVAL',
 				name: '',
 				differentiator: '',
-				errors: {}
+				errors: {},
+				festivalSeries: {
+					model: 'FESTIVAL_SERIES',
+					name: '',
+					differentiator: '',
+					errors: {}
+				}
 			};
 
 			expect(response).to.have.status(200);
@@ -67,7 +73,13 @@ describe('CRUD (Create, Read, Update, Delete): Festivals API', () => {
 				uuid: FESTIVAL_UUID,
 				name: 'The Complete Works',
 				differentiator: '',
-				errors: {}
+				errors: {},
+				festivalSeries: {
+					model: 'FESTIVAL_SERIES',
+					name: '',
+					differentiator: '',
+					errors: {}
+				}
 			};
 
 			expect(response).to.have.status(200);
@@ -86,7 +98,13 @@ describe('CRUD (Create, Read, Update, Delete): Festivals API', () => {
 				uuid: FESTIVAL_UUID,
 				name: 'The Complete Works',
 				differentiator: '',
-				errors: {}
+				errors: {},
+				festivalSeries: {
+					model: 'FESTIVAL_SERIES',
+					name: '',
+					differentiator: '',
+					errors: {}
+				}
 			};
 
 			expect(response).to.have.status(200);
@@ -109,7 +127,13 @@ describe('CRUD (Create, Read, Update, Delete): Festivals API', () => {
 				uuid: FESTIVAL_UUID,
 				name: 'Globe to Globe',
 				differentiator: '',
-				errors: {}
+				errors: {},
+				festivalSeries: {
+					model: 'FESTIVAL_SERIES',
+					name: '',
+					differentiator: '',
+					errors: {}
+				}
 			};
 
 			expect(response).to.have.status(200);
@@ -128,6 +152,7 @@ describe('CRUD (Create, Read, Update, Delete): Festivals API', () => {
 				uuid: FESTIVAL_UUID,
 				name: 'Globe to Globe',
 				differentiator: null,
+				festivalSeries: null,
 				productions: []
 			};
 
@@ -147,7 +172,269 @@ describe('CRUD (Create, Read, Update, Delete): Festivals API', () => {
 				model: 'FESTIVAL',
 				name: 'Globe to Globe',
 				differentiator: '',
-				errors: {}
+				errors: {},
+				festivalSeries: {
+					model: 'FESTIVAL_SERIES',
+					name: '',
+					differentiator: '',
+					errors: {}
+				}
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Festival')).to.equal(0);
+
+		});
+
+	});
+
+	describe('CRUD with full range of attributes assigned values', () => {
+
+		const FESTIVAL_UUID = '2008_1_FESTIVAL_UUID';
+		const EDINBURGH_INTERNATIONAL_FESTIVAL_FESTIVAL_SERIES_UUID = 'EDINBURGH_INTERNATIONAL_FESTIVAL_1_FESTIVAL_SERIES_UUID';
+		const CONNECTIONS_FESTIVAL_SERIES_UUID = 'CONNECTIONS_1_FESTIVAL_SERIES_UUID';
+
+		before(async () => {
+
+			const stubUuidCounts = {};
+
+			sandbox.stub(getRandomUuidModule, 'getRandomUuid').callsFake(arg => getStubUuid(arg, stubUuidCounts));
+
+			await purgeDatabase();
+
+		});
+
+		after(() => {
+
+			sandbox.restore();
+
+		});
+
+		it('creates festival', async () => {
+
+			expect(await countNodesWithLabel('Festival')).to.equal(0);
+
+			const response = await chai.request(app)
+				.post('/festivals')
+				.send({
+					name: '2008',
+					differentiator: '1',
+					festivalSeries: {
+						name: 'Edinburgh International Festival',
+						differentiator: '1'
+					}
+				});
+
+			const expectedResponseBody = {
+				model: 'FESTIVAL',
+				uuid: FESTIVAL_UUID,
+				name: '2008',
+				differentiator: '1',
+				errors: {},
+				festivalSeries: {
+					model: 'FESTIVAL_SERIES',
+					name: 'Edinburgh International Festival',
+					differentiator: '1',
+					errors: {}
+				}
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Festival')).to.equal(1);
+
+		});
+
+		it('shows festival (post-creation)', async () => {
+
+			const response = await chai.request(app)
+				.get(`/festivals/${FESTIVAL_UUID}`);
+
+			const expectedResponseBody = {
+				model: 'FESTIVAL',
+				uuid: FESTIVAL_UUID,
+				name: '2008',
+				differentiator: '1',
+				festivalSeries: {
+					model: 'FESTIVAL_SERIES',
+					uuid: EDINBURGH_INTERNATIONAL_FESTIVAL_FESTIVAL_SERIES_UUID,
+					name: 'Edinburgh International Festival'
+				},
+				productions: []
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+
+		});
+
+		it('gets data required to edit specific festival', async () => {
+
+			const response = await chai.request(app)
+				.get(`/festivals/${FESTIVAL_UUID}/edit`);
+
+			const expectedResponseBody = {
+				model: 'FESTIVAL',
+				uuid: FESTIVAL_UUID,
+				name: '2008',
+				differentiator: '1',
+				errors: {},
+				festivalSeries: {
+					model: 'FESTIVAL_SERIES',
+					name: 'Edinburgh International Festival',
+					differentiator: '1',
+					errors: {}
+				}
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+
+		});
+
+		it('updates festival (with existing data)', async () => {
+
+			expect(await countNodesWithLabel('Festival')).to.equal(1);
+
+			const response = await chai.request(app)
+				.put(`/festivals/${FESTIVAL_UUID}`)
+				.send({
+					name: '2008',
+					differentiator: '1',
+					festivalSeries: {
+						name: 'Edinburgh International Festival',
+						differentiator: '1'
+					}
+				});
+
+			const expectedResponseBody = {
+				model: 'FESTIVAL',
+				uuid: FESTIVAL_UUID,
+				name: '2008',
+				differentiator: '1',
+				errors: {},
+				festivalSeries: {
+					model: 'FESTIVAL_SERIES',
+					name: 'Edinburgh International Festival',
+					differentiator: '1',
+					errors: {}
+				}
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Festival')).to.equal(1);
+
+		});
+
+		it('updates festival (with new data)', async () => {
+
+			expect(await countNodesWithLabel('Festival')).to.equal(1);
+
+			const response = await chai.request(app)
+				.put(`/festivals/${FESTIVAL_UUID}`)
+				.send({
+					name: '2009',
+					differentiator: '1',
+					festivalSeries: {
+						name: 'Connections',
+						differentiator: '1'
+					}
+				});
+
+			const expectedResponseBody = {
+				model: 'FESTIVAL',
+				uuid: FESTIVAL_UUID,
+				name: '2009',
+				differentiator: '1',
+				errors: {},
+				festivalSeries: {
+					model: 'FESTIVAL_SERIES',
+					name: 'Connections',
+					differentiator: '1',
+					errors: {}
+				}
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Festival')).to.equal(1);
+
+		});
+
+		it('shows festival (post-update)', async () => {
+
+			const response = await chai.request(app)
+				.get(`/festivals/${FESTIVAL_UUID}`);
+
+			const expectedResponseBody = {
+				model: 'FESTIVAL',
+				uuid: FESTIVAL_UUID,
+				name: '2009',
+				differentiator: '1',
+				festivalSeries: {
+					model: 'FESTIVAL_SERIES',
+					uuid: CONNECTIONS_FESTIVAL_SERIES_UUID,
+					name: 'Connections'
+				},
+				productions: []
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+
+		});
+
+		it('updates festival to remove all associations prior to deletion', async () => {
+
+			expect(await countNodesWithLabel('Festival')).to.equal(1);
+
+			const response = await chai.request(app)
+				.put(`/festivals/${FESTIVAL_UUID}`)
+				.send({
+					name: '2009',
+					differentiator: '1'
+				});
+
+			const expectedResponseBody = {
+				model: 'FESTIVAL',
+				uuid: FESTIVAL_UUID,
+				name: '2009',
+				differentiator: '1',
+				errors: {},
+				festivalSeries: {
+					model: 'FESTIVAL_SERIES',
+					name: '',
+					differentiator: '',
+					errors: {}
+				}
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Festival')).to.equal(1);
+
+		});
+
+		it('deletes festival', async () => {
+
+			expect(await countNodesWithLabel('Festival')).to.equal(1);
+
+			const response = await chai.request(app)
+				.delete(`/festivals/${FESTIVAL_UUID}`);
+
+			const expectedResponseBody = {
+				model: 'FESTIVAL',
+				name: '2009',
+				differentiator: '1',
+				errors: {},
+				festivalSeries: {
+					model: 'FESTIVAL_SERIES',
+					name: '',
+					differentiator: '',
+					errors: {}
+				}
 			};
 
 			expect(response).to.have.status(200);
@@ -198,7 +485,7 @@ describe('CRUD (Create, Read, Update, Delete): Festivals API', () => {
 
 		});
 
-		it('lists all festivals ordered by name', async () => {
+		it('lists all festivals ordered by name in descending order (and then by festival series name)', async () => {
 
 			const response = await chai.request(app)
 				.get('/festivals');
@@ -206,18 +493,21 @@ describe('CRUD (Create, Read, Update, Delete): Festivals API', () => {
 			const expectedResponseBody = [
 				{
 					model: 'FESTIVAL',
-					uuid: GLOBE_TO_GLOBE_FESTIVAL_UUID,
-					name: 'Globe to Globe'
+					uuid: THE_COMPLETE_WORKS_FESTIVAL_UUID,
+					name: 'The Complete Works',
+					festivalSeries: null
 				},
 				{
 					model: 'FESTIVAL',
 					uuid: SHAKESPEARE_400_ARTS_FESTIVAL_UUID,
-					name: 'Shakespeare 400 Arts Festival'
+					name: 'Shakespeare 400 Arts Festival',
+					festivalSeries: null
 				},
 				{
 					model: 'FESTIVAL',
-					uuid: THE_COMPLETE_WORKS_FESTIVAL_UUID,
-					name: 'The Complete Works'
+					uuid: GLOBE_TO_GLOBE_FESTIVAL_UUID,
+					name: 'Globe to Globe',
+					festivalSeries: null
 				}
 			];
 

--- a/test-e2e/crud/productions-api.test.js
+++ b/test-e2e/crud/productions-api.test.js
@@ -1718,7 +1718,8 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 				festival: {
 					model: 'FESTIVAL',
 					uuid: THE_COMPLETE_WORKS_FESTIVAL_UUID,
-					name: 'The Complete Works'
+					name: 'The Complete Works',
+					festivalSeries: null
 				},
 				surProduction: null,
 				subProductions: [
@@ -4750,7 +4751,8 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 				festival: {
 					model: 'FESTIVAL',
 					uuid: GLOBE_TO_GLOBE_FESTIVAL_UUID,
-					name: 'Globe to Globe'
+					name: 'Globe to Globe',
+					festivalSeries: null
 				},
 				surProduction: null,
 				subProductions: [

--- a/test-e2e/instance-validation-failures/festival-serieses-api.test.js
+++ b/test-e2e/instance-validation-failures/festival-serieses-api.test.js
@@ -2,7 +2,13 @@ import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 
 import app from '../../src/app';
-import { countNodesWithLabel, createNode, isNodeExistent, purgeDatabase } from '../test-helpers/neo4j';
+import {
+	countNodesWithLabel,
+	createNode,
+	createRelationship,
+	isNodeExistent,
+	purgeDatabase
+} from '../test-helpers/neo4j';
 
 describe('Instance validation failures: Festival Serieses API', () => {
 
@@ -190,6 +196,69 @@ describe('Instance validation failures: Festival Serieses API', () => {
 					name: 'Connections',
 					uuid: CONNECTIONS_FESTIVAL_SERIES_UUID
 				})).to.be.true;
+
+			});
+
+		});
+
+	});
+
+	describe('attempt to delete instance', () => {
+
+		const EDINBURGH_INTERNATIONAL_FESTIVAL_FESTIVAL_SERIES_UUID = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+		const TWO_THOUSAND_AND_EIGHT_FESTIVAL_UUID = 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy';
+
+		before(async () => {
+
+			await purgeDatabase();
+
+			await createNode({
+				label: 'FestivalSeries',
+				uuid: EDINBURGH_INTERNATIONAL_FESTIVAL_FESTIVAL_SERIES_UUID,
+				name: 'Edinburgh International Festival'
+			});
+
+			await createNode({
+				label: 'Festival',
+				uuid: TWO_THOUSAND_AND_EIGHT_FESTIVAL_UUID,
+				name: '2008'
+			});
+
+			await createRelationship({
+				sourceLabel: 'Festival',
+				sourceUuid: TWO_THOUSAND_AND_EIGHT_FESTIVAL_UUID,
+				destinationLabel: 'FestivalSeries',
+				destinationUuid: EDINBURGH_INTERNATIONAL_FESTIVAL_FESTIVAL_SERIES_UUID,
+				relationshipName: 'PART_OF_FESTIVAL_SERIES'
+			});
+
+		});
+
+		context('instance has associations', () => {
+
+			it('returns instance with appropriate errors attached', async () => {
+
+				expect(await countNodesWithLabel('FestivalSeries')).to.equal(1);
+
+				const response = await chai.request(app)
+					.delete(`/festival-serieses/${EDINBURGH_INTERNATIONAL_FESTIVAL_FESTIVAL_SERIES_UUID}`);
+
+				const expectedResponseBody = {
+					model: 'FESTIVAL_SERIES',
+					uuid: EDINBURGH_INTERNATIONAL_FESTIVAL_FESTIVAL_SERIES_UUID,
+					name: 'Edinburgh International Festival',
+					differentiator: null,
+					hasErrors: true,
+					errors: {
+						associations: [
+							'Festival'
+						]
+					}
+				};
+
+				expect(response).to.have.status(200);
+				expect(response.body).to.deep.equal(expectedResponseBody);
+				expect(await countNodesWithLabel('FestivalSeries')).to.equal(1);
 
 			});
 

--- a/test-e2e/instance-validation-failures/festivals-api.test.js
+++ b/test-e2e/instance-validation-failures/festivals-api.test.js
@@ -51,6 +51,12 @@ describe('Instance validation failures: Festivals API', () => {
 						name: [
 							'Value is too short'
 						]
+					},
+					festivalSeries: {
+						model: 'FESTIVAL_SERIES',
+						name: '',
+						differentiator: '',
+						errors: {}
 					}
 				};
 
@@ -86,6 +92,12 @@ describe('Instance validation failures: Festivals API', () => {
 						differentiator: [
 							'Name and differentiator combination already exists'
 						]
+					},
+					festivalSeries: {
+						model: 'FESTIVAL_SERIES',
+						name: '',
+						differentiator: '',
+						errors: {}
 					}
 				};
 
@@ -144,6 +156,12 @@ describe('Instance validation failures: Festivals API', () => {
 						name: [
 							'Value is too short'
 						]
+					},
+					festivalSeries: {
+						model: 'FESTIVAL_SERIES',
+						name: '',
+						differentiator: '',
+						errors: {}
 					}
 				};
 
@@ -185,6 +203,12 @@ describe('Instance validation failures: Festivals API', () => {
 						differentiator: [
 							'Name and differentiator combination already exists'
 						]
+					},
+					festivalSeries: {
+						model: 'FESTIVAL_SERIES',
+						name: '',
+						differentiator: '',
+						errors: {}
 					}
 				};
 
@@ -253,6 +277,12 @@ describe('Instance validation failures: Festivals API', () => {
 						associations: [
 							'Production'
 						]
+					},
+					festivalSeries: {
+						model: 'FESTIVAL_SERIES',
+						name: '',
+						differentiator: '',
+						errors: {}
 					}
 				};
 

--- a/test-e2e/model-interaction/festival-series-with-festivals.test.js
+++ b/test-e2e/model-interaction/festival-series-with-festivals.test.js
@@ -1,0 +1,335 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import { createSandbox } from 'sinon';
+
+import * as getRandomUuidModule from '../../src/lib/get-random-uuid';
+import app from '../../src/app';
+import { purgeDatabase } from '../test-helpers/neo4j';
+import { getStubUuid } from '../test-helpers';
+
+describe('Festival series with festivals', () => {
+
+	chai.use(chaiHttp);
+
+	const EDINBURGH_INTERNATIONAL_FESTIVAL_2008_FESTIVAL_UUID = '2008_EDINBURGH_INTERNATIONAL_FESTIVAL_FESTIVAL_UUID';
+	const EDINBURGH_INTERNATIONAL_FESTIVAL_FESTIVAL_SERIES_UUID = 'EDINBURGH_INTERNATIONAL_FESTIVAL_FESTIVAL_SERIES_UUID';
+	const EDINBURGH_INTERNATIONAL_FESTIVAL_2009_FESTIVAL_UUID = '2009_EDINBURGH_INTERNATIONAL_FESTIVAL_FESTIVAL_UUID';
+	const EDINBURGH_INTERNATIONAL_FESTIVAL_2010_FESTIVAL_UUID = '2010_EDINBURGH_INTERNATIONAL_FESTIVAL_FESTIVAL_UUID';
+	const HIGHTIDE_FESTIVAL_2008_FESTIVAL_UUID = '2008_HIGHTIDE_FESTIVAL_FESTIVAL_UUID';
+	const HIGHTIDE_FESTIVAL_FESTIVAL_SERIES_UUID = 'HIGHTIDE_FESTIVAL_FESTIVAL_SERIES_UUID';
+	const HIGHTIDE_FESTIVAL_2009_FESTIVAL_UUID = '2009_HIGHTIDE_FESTIVAL_FESTIVAL_UUID';
+	const HIGHTIDE_FESTIVAL_2010_FESTIVAL_UUID = '2010_HIGHTIDE_FESTIVAL_FESTIVAL_UUID';
+	const CONNECTIONS_2008_FESTIVAL_UUID = '2008_CONNECTIONS_FESTIVAL_UUID';
+	const CONNECTIONS_FESTIVAL_SERIES_UUID = 'CONNECTIONS_FESTIVAL_SERIES_UUID';
+	const CONNECTIONS_2009_FESTIVAL_UUID = '2009_CONNECTIONS_FESTIVAL_UUID';
+	const CONNECTIONS_2010_FESTIVAL_UUID = '2010_CONNECTIONS_FESTIVAL_UUID';
+	const THE_COMPLETE_WORKS_FESTIVAL_UUID = 'THE_COMPLETE_WORKS_FESTIVAL_UUID';
+	const GLOBE_TO_GLOBE_FESTIVAL_UUID = 'GLOBE_TO_GLOBE_FESTIVAL_UUID';
+
+	let edinburghInternationalFestivalFestivalSeries;
+
+	const sandbox = createSandbox();
+
+	before(async () => {
+
+		const stubUuidCounts = {};
+
+		sandbox.stub(getRandomUuidModule, 'getRandomUuid').callsFake(arg => getStubUuid(arg, stubUuidCounts));
+
+		await purgeDatabase();
+
+		await chai.request(app)
+			.post('/festivals')
+			.send({
+				name: '2008',
+				differentiator: 'Edinburgh International Festival',
+				festivalSeries: {
+					name: 'Edinburgh International Festival'
+				}
+			});
+
+		await chai.request(app)
+			.post('/festivals')
+			.send({
+				name: '2009',
+				differentiator: 'Edinburgh International Festival',
+				festivalSeries: {
+					name: 'Edinburgh International Festival'
+				}
+			});
+
+		await chai.request(app)
+			.post('/festivals')
+			.send({
+				name: '2010',
+				differentiator: 'Edinburgh International Festival',
+				festivalSeries: {
+					name: 'Edinburgh International Festival'
+				}
+			});
+
+		await chai.request(app)
+			.post('/festivals')
+			.send({
+				name: '2008',
+				differentiator: 'HighTide Festival',
+				festivalSeries: {
+					name: 'HighTide Festival'
+				}
+			});
+
+		await chai.request(app)
+			.post('/festivals')
+			.send({
+				name: '2009',
+				differentiator: 'HighTide Festival',
+				festivalSeries: {
+					name: 'HighTide Festival'
+				}
+			});
+
+		await chai.request(app)
+			.post('/festivals')
+			.send({
+				name: '2010',
+				differentiator: 'HighTide Festival',
+				festivalSeries: {
+					name: 'HighTide Festival'
+				}
+			});
+
+		await chai.request(app)
+			.post('/festivals')
+			.send({
+				name: '2008',
+				differentiator: 'Connections',
+				festivalSeries: {
+					name: 'Connections'
+				}
+			});
+
+		await chai.request(app)
+			.post('/festivals')
+			.send({
+				name: '2009',
+				differentiator: 'Connections',
+				festivalSeries: {
+					name: 'Connections'
+				}
+			});
+
+		await chai.request(app)
+			.post('/festivals')
+			.send({
+				name: '2010',
+				differentiator: 'Connections',
+				festivalSeries: {
+					name: 'Connections'
+				}
+			});
+
+		await chai.request(app)
+			.post('/festivals')
+			.send({
+				name: 'The Complete Works'
+			});
+
+		await chai.request(app)
+			.post('/festivals')
+			.send({
+				name: 'Globe to Globe'
+			});
+
+		edinburghInternationalFestivalFestivalSeries = await chai.request(app)
+			.get(`/festival-serieses/${EDINBURGH_INTERNATIONAL_FESTIVAL_FESTIVAL_SERIES_UUID}`);
+
+	});
+
+	after(() => {
+
+		sandbox.restore();
+
+	});
+
+	describe('Edinburgh International Festival (festival series)', () => {
+
+		it('includes its festivals', () => {
+
+			const expectedFestivals = [
+				{
+					model: 'FESTIVAL',
+					uuid: EDINBURGH_INTERNATIONAL_FESTIVAL_2010_FESTIVAL_UUID,
+					name: '2010'
+				},
+				{
+					model: 'FESTIVAL',
+					uuid: EDINBURGH_INTERNATIONAL_FESTIVAL_2009_FESTIVAL_UUID,
+					name: '2009'
+				},
+				{
+					model: 'FESTIVAL',
+					uuid: EDINBURGH_INTERNATIONAL_FESTIVAL_2008_FESTIVAL_UUID,
+					name: '2008'
+				}
+			];
+
+			const { festivals } = edinburghInternationalFestivalFestivalSeries.body;
+
+			expect(festivals).to.deep.equal(expectedFestivals);
+
+		});
+
+	});
+
+	describe('festival serieses list', () => {
+
+		it('includes festival series', async () => {
+
+			const response = await chai.request(app)
+				.get('/festival-serieses');
+
+			const expectedResponseBody = [
+				{
+					model: 'FESTIVAL_SERIES',
+					uuid: CONNECTIONS_FESTIVAL_SERIES_UUID,
+					name: 'Connections'
+				},
+				{
+					model: 'FESTIVAL_SERIES',
+					uuid: EDINBURGH_INTERNATIONAL_FESTIVAL_FESTIVAL_SERIES_UUID,
+					name: 'Edinburgh International Festival'
+				},
+				{
+					model: 'FESTIVAL_SERIES',
+					uuid: HIGHTIDE_FESTIVAL_FESTIVAL_SERIES_UUID,
+					name: 'HighTide Festival'
+				}
+			];
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+
+		});
+
+	});
+
+	describe('festivals list', () => {
+
+		it('includes festivals and (if applicable) corresponding festival series', async () => {
+
+			const response = await chai.request(app)
+				.get('/festivals');
+
+			const expectedResponseBody = [
+				{
+					model: 'FESTIVAL',
+					uuid: THE_COMPLETE_WORKS_FESTIVAL_UUID,
+					name: 'The Complete Works',
+					festivalSeries: null
+				},
+				{
+					model: 'FESTIVAL',
+					uuid: GLOBE_TO_GLOBE_FESTIVAL_UUID,
+					name: 'Globe to Globe',
+					festivalSeries: null
+				},
+				{
+					model: 'FESTIVAL',
+					uuid: CONNECTIONS_2010_FESTIVAL_UUID,
+					name: '2010',
+					festivalSeries: {
+						model: 'FESTIVAL_SERIES',
+						uuid: CONNECTIONS_FESTIVAL_SERIES_UUID,
+						name: 'Connections'
+					}
+				},
+				{
+					model: 'FESTIVAL',
+					uuid: EDINBURGH_INTERNATIONAL_FESTIVAL_2010_FESTIVAL_UUID,
+					name: '2010',
+					festivalSeries: {
+						model: 'FESTIVAL_SERIES',
+						uuid: EDINBURGH_INTERNATIONAL_FESTIVAL_FESTIVAL_SERIES_UUID,
+						name: 'Edinburgh International Festival'
+					}
+				},
+				{
+					model: 'FESTIVAL',
+					uuid: HIGHTIDE_FESTIVAL_2010_FESTIVAL_UUID,
+					name: '2010',
+					festivalSeries: {
+						model: 'FESTIVAL_SERIES',
+						uuid: HIGHTIDE_FESTIVAL_FESTIVAL_SERIES_UUID,
+						name: 'HighTide Festival'
+					}
+				},
+				{
+					model: 'FESTIVAL',
+					uuid: CONNECTIONS_2009_FESTIVAL_UUID,
+					name: '2009',
+					festivalSeries: {
+						model: 'FESTIVAL_SERIES',
+						uuid: CONNECTIONS_FESTIVAL_SERIES_UUID,
+						name: 'Connections'
+					}
+				},
+				{
+					model: 'FESTIVAL',
+					uuid: EDINBURGH_INTERNATIONAL_FESTIVAL_2009_FESTIVAL_UUID,
+					name: '2009',
+					festivalSeries: {
+						model: 'FESTIVAL_SERIES',
+						uuid: EDINBURGH_INTERNATIONAL_FESTIVAL_FESTIVAL_SERIES_UUID,
+						name: 'Edinburgh International Festival'
+					}
+				},
+				{
+					model: 'FESTIVAL',
+					uuid: HIGHTIDE_FESTIVAL_2009_FESTIVAL_UUID,
+					name: '2009',
+					festivalSeries: {
+						model: 'FESTIVAL_SERIES',
+						uuid: HIGHTIDE_FESTIVAL_FESTIVAL_SERIES_UUID,
+						name: 'HighTide Festival'
+					}
+				},
+				{
+					model: 'FESTIVAL',
+					uuid: CONNECTIONS_2008_FESTIVAL_UUID,
+					name: '2008',
+					festivalSeries: {
+						model: 'FESTIVAL_SERIES',
+						uuid: CONNECTIONS_FESTIVAL_SERIES_UUID,
+						name: 'Connections'
+					}
+				},
+				{
+					model: 'FESTIVAL',
+					uuid: EDINBURGH_INTERNATIONAL_FESTIVAL_2008_FESTIVAL_UUID,
+					name: '2008',
+					festivalSeries: {
+						model: 'FESTIVAL_SERIES',
+						uuid: EDINBURGH_INTERNATIONAL_FESTIVAL_FESTIVAL_SERIES_UUID,
+						name: 'Edinburgh International Festival'
+					}
+				},
+				{
+					model: 'FESTIVAL',
+					uuid: HIGHTIDE_FESTIVAL_2008_FESTIVAL_UUID,
+					name: '2008',
+					festivalSeries: {
+						model: 'FESTIVAL_SERIES',
+						uuid: HIGHTIDE_FESTIVAL_FESTIVAL_SERIES_UUID,
+						name: 'HighTide Festival'
+					}
+				}
+			];
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+
+		});
+
+	});
+
+});

--- a/test-e2e/model-interaction/festival-with-prods.test.js
+++ b/test-e2e/model-interaction/festival-with-prods.test.js
@@ -17,11 +17,15 @@ describe('Festival with multiple productions', () => {
 	const ANTONY_AND_CLEOPATRA_SWAN_THEATRE_PRODUCTION_UUID = 'ANTONY_AND_CLEOPATRA_PRODUCTION_UUID';
 	const SWAN_THEATRE_VENUE_UUID = 'SWAN_THEATRE_VENUE_UUID';
 	const JULIUS_CAESAR_ROYAL_SHAKESPEARE_THEATRE_PRODUCTION_UUID = 'JULIUS_CAESAR_PRODUCTION_UUID';
+	const EDINBURGH_INTERNATIONAL_FESTIVAL_2006_FESTIVAL_UUID = '2006_FESTIVAL_UUID';
+	const EDINBURGH_INTERNATIONAL_FESTIVAL_FESTIVAL_SERIES_UUID = 'EDINBURGH_INTERNATIONAL_FESTIVAL_FESTIVAL_SERIES_UUID';
+	const TROILUS_AND_CRESSIDA_KINGS_THEATRE_PRODUCTION_UUID = 'TROILUS_AND_CRESSIDA_PRODUCTION_UUID';
 
 	let theCompleteWorksFestival;
 	let romeoAndJulietRoyalShakespeareProduction;
 	let antonyAndCleopatraSwanProduction;
 	let juliusCaesarRoyalShakespeareProduction;
+	let troilusAndCressidaKingsProduction;
 
 	const sandbox = createSandbox();
 
@@ -78,6 +82,29 @@ describe('Festival with multiple productions', () => {
 				}
 			});
 
+		await chai.request(app)
+			.post('/festivals')
+			.send({
+				name: '2006',
+				festivalSeries: {
+					name: 'Edinburgh International Festival'
+				}
+			});
+
+		await chai.request(app)
+			.post('/productions')
+			.send({
+				name: 'Troilus and Cressida',
+				startDate: '2006-08-14',
+				endDate: '2006-08-26',
+				venue: {
+					name: 'King\'s Theatre'
+				},
+				festival: {
+					name: '2006'
+				}
+			});
+
 		theCompleteWorksFestival = await chai.request(app)
 			.get(`/festivals/${THE_COMPLETE_WORKS_FESTIVAL_UUID}`);
 
@@ -89,6 +116,9 @@ describe('Festival with multiple productions', () => {
 
 		juliusCaesarRoyalShakespeareProduction = await chai.request(app)
 			.get(`/productions/${JULIUS_CAESAR_ROYAL_SHAKESPEARE_THEATRE_PRODUCTION_UUID}`);
+
+		troilusAndCressidaKingsProduction = await chai.request(app)
+			.get(`/productions/${TROILUS_AND_CRESSIDA_KINGS_THEATRE_PRODUCTION_UUID}`);
 
 	});
 
@@ -162,7 +192,8 @@ describe('Festival with multiple productions', () => {
 			const expectedFestival = {
 				model: 'FESTIVAL',
 				uuid: THE_COMPLETE_WORKS_FESTIVAL_UUID,
-				name: 'The Complete Works'
+				name: 'The Complete Works',
+				festivalSeries: null
 			};
 
 			const { festival } = romeoAndJulietRoyalShakespeareProduction.body;
@@ -180,7 +211,8 @@ describe('Festival with multiple productions', () => {
 			const expectedFestival = {
 				model: 'FESTIVAL',
 				uuid: THE_COMPLETE_WORKS_FESTIVAL_UUID,
-				name: 'The Complete Works'
+				name: 'The Complete Works',
+				festivalSeries: null
 			};
 
 			const { festival } = antonyAndCleopatraSwanProduction.body;
@@ -198,10 +230,34 @@ describe('Festival with multiple productions', () => {
 			const expectedFestival = {
 				model: 'FESTIVAL',
 				uuid: THE_COMPLETE_WORKS_FESTIVAL_UUID,
-				name: 'The Complete Works'
+				name: 'The Complete Works',
+				festivalSeries: null
 			};
 
 			const { festival } = juliusCaesarRoyalShakespeareProduction.body;
+
+			expect(festival).to.deep.equal(expectedFestival);
+
+		});
+
+	});
+
+	describe('Troilus and Cressida at King\'s Theatre (production)', () => {
+
+		it('attributes festival as The Complete Works', () => {
+
+			const expectedFestival = {
+				model: 'FESTIVAL',
+				uuid: EDINBURGH_INTERNATIONAL_FESTIVAL_2006_FESTIVAL_UUID,
+				name: '2006',
+				festivalSeries: {
+					model: 'FESTIVAL_SERIES',
+					uuid: EDINBURGH_INTERNATIONAL_FESTIVAL_FESTIVAL_SERIES_UUID,
+					name: 'Edinburgh International Festival'
+				}
+			};
+
+			const { festival } = troilusAndCressidaKingsProduction.body;
 
 			expect(festival).to.deep.equal(expectedFestival);
 

--- a/test-e2e/model-interaction/prod-with-sub-prods.test.js
+++ b/test-e2e/model-interaction/prod-with-sub-prods.test.js
@@ -13,6 +13,8 @@ describe('Production with sub-productions', () => {
 
 	const NATIONAL_THEATRE_VENUE_UUID = 'NATIONAL_THEATRE_VENUE_UUID';
 	const OLIVIER_THEATRE_VENUE_UUID = 'OLIVIER_THEATRE_VENUE_UUID';
+	const STOPPARD_FESTIVAL_2002_FESTIVAL_UUID = '2002_FESTIVAL_UUID';
+	const STOPPARD_FESTIVAL_FESTIVAL_SERIES_UUID = 'STOPPARD_FESTIVAL_FESTIVAL_SERIES_UUID';
 	const VOYAGE_MATERIAL_UUID = 'VOYAGE_MATERIAL_UUID';
 	const TOM_STOPPARD_JR_PERSON_UUID = 'TOM_STOPPARD_JR_PERSON_UUID';
 	const THE_SUB_STRÄUSSLER_GROUP_COMPANY_UUID = 'THE_SUB_STRAUSSLER_GROUP_COMPANY_UUID';
@@ -25,7 +27,6 @@ describe('Production with sub-productions', () => {
 	const ALEXANDER_HERZEN_SR_CHARACTER_UUID = 'ALEXANDER_HERZEN_SR_CHARACTER_UUID';
 	const VOYAGE_OLIVIER_PRODUCTION_UUID = 'VOYAGE_PRODUCTION_UUID';
 	const STOPPARD_SEASON_UUID = 'STOPPARD_SEASON_SEASON_UUID';
-	const STOPPARD_FESTIVAL_UUID = 'STOPPARD_FESTIVAL_FESTIVAL_UUID';
 	const TREVOR_NUNN_JR_PERSON_UUID = 'TREVOR_NUNN_JR_PERSON_UUID';
 	const SUB_NATIONAL_THEATRE_COMPANY_UUID = 'SUB_NATIONAL_THEATRE_COMPANY_COMPANY_UUID';
 	const NICK_STARR_JR_PERSON_UUID = 'NICK_STARR_JR_PERSON_UUID';
@@ -51,6 +52,7 @@ describe('Production with sub-productions', () => {
 	const SUE_MILLIN_SR_PERSON_UUID = 'SUE_MILLIN_SR_PERSON_UUID';
 	const VOYAGE_VIVIAN_BEAUMONT_PRODUCTION_UUID = 'VOYAGE_2_PRODUCTION_UUID';
 	const VIVIAN_BEAUMONT_THEATRE_VENUE_UUID = 'VIVIAN_BEAUMONT_THEATRE_VENUE_UUID';
+	const PRE_REVOLUTION_RUSSIA_FESTIVAL_FESTIVAL_UUID = 'PRE_REVOLUTION_RUSSIA_FESTIVAL_FESTIVAL_UUID';
 	const SHIPWRECK_VIVIAN_BEAUMONT_PRODUCTION_UUID = 'SHIPWRECK_2_PRODUCTION_UUID';
 	const SALVAGE_VIVIAN_BEAUMONT_PRODUCTION_UUID = 'SALVAGE_2_PRODUCTION_UUID';
 	const THE_COAST_OF_UTOPIA_VIVIAN_BEAUMONT_PRODUCTION_UUID = 'THE_COAST_OF_UTOPIA_2_PRODUCTION_UUID';
@@ -64,7 +66,7 @@ describe('Production with sub-productions', () => {
 	let nationalTheatreVenue;
 	let olivierTheatreVenue;
 	let stoppardSeason;
-	let stoppardFestival;
+	let stoppardFestival2002;
 	let trevorNunnJrPerson;
 	let subNationalTheatreCompany;
 	let nickStarrJrPerson;
@@ -96,6 +98,15 @@ describe('Production with sub-productions', () => {
 						name: 'Olivier Theatre'
 					}
 				]
+			});
+
+		await chai.request(app)
+			.post('/festivals')
+			.send({
+				name: '2002',
+				festivalSeries: {
+					name: 'Stoppard Festival'
+				}
 			});
 
 		await chai.request(app)
@@ -246,7 +257,7 @@ describe('Production with sub-productions', () => {
 					name: 'Stoppard Season'
 				},
 				festival: {
-					name: 'Stoppard Festival'
+					name: '2002'
 				},
 				producerCredits: [
 					{
@@ -333,7 +344,7 @@ describe('Production with sub-productions', () => {
 					name: 'Stoppard Season'
 				},
 				festival: {
-					name: 'Stoppard Festival'
+					name: '2002'
 				},
 				producerCredits: [
 					{
@@ -420,7 +431,7 @@ describe('Production with sub-productions', () => {
 					name: 'Stoppard Season'
 				},
 				festival: {
-					name: 'Stoppard Festival'
+					name: '2002'
 				},
 				producerCredits: [
 					{
@@ -507,7 +518,7 @@ describe('Production with sub-productions', () => {
 					name: 'Stoppard Season'
 				},
 				festival: {
-					name: 'Stoppard Festival'
+					name: '2002'
 				},
 				subProductions: [
 					{
@@ -600,6 +611,9 @@ describe('Production with sub-productions', () => {
 				},
 				venue: {
 					name: 'Vivian Beaumont Theatre'
+				},
+				festival: {
+					name: 'Pre-Revolution Russia Festival'
 				}
 			});
 
@@ -615,6 +629,9 @@ describe('Production with sub-productions', () => {
 				},
 				venue: {
 					name: 'Vivian Beaumont Theatre'
+				},
+				festival: {
+					name: 'Pre-Revolution Russia Festival'
 				}
 			});
 
@@ -630,6 +647,9 @@ describe('Production with sub-productions', () => {
 				},
 				venue: {
 					name: 'Vivian Beaumont Theatre'
+				},
+				festival: {
+					name: 'Pre-Revolution Russia Festival'
 				}
 			});
 
@@ -644,6 +664,9 @@ describe('Production with sub-productions', () => {
 				},
 				venue: {
 					name: 'Vivian Beaumont Theatre'
+				},
+				festival: {
+					name: 'Pre-Revolution Russia Festival'
 				},
 				subProductions: [
 					{
@@ -685,8 +708,8 @@ describe('Production with sub-productions', () => {
 		stoppardSeason = await chai.request(app)
 			.get(`/seasons/${STOPPARD_SEASON_UUID}`);
 
-		stoppardFestival = await chai.request(app)
-			.get(`/festivals/${STOPPARD_FESTIVAL_UUID}`);
+		stoppardFestival2002 = await chai.request(app)
+			.get(`/festivals/${STOPPARD_FESTIVAL_2002_FESTIVAL_UUID}`);
 
 		trevorNunnJrPerson = await chai.request(app)
 			.get(`/people/${TREVOR_NUNN_JR_PERSON_UUID}`);
@@ -789,8 +812,13 @@ describe('Production with sub-productions', () => {
 					},
 					festival: {
 						model: 'FESTIVAL',
-						uuid: STOPPARD_FESTIVAL_UUID,
-						name: 'Stoppard Festival'
+						uuid: STOPPARD_FESTIVAL_2002_FESTIVAL_UUID,
+						name: '2002',
+						festivalSeries: {
+							model: 'FESTIVAL_SERIES',
+							uuid: STOPPARD_FESTIVAL_FESTIVAL_SERIES_UUID,
+							name: 'Stoppard Festival'
+						}
 					},
 					subProductions: [],
 					producerCredits: [
@@ -940,8 +968,13 @@ describe('Production with sub-productions', () => {
 					},
 					festival: {
 						model: 'FESTIVAL',
-						uuid: STOPPARD_FESTIVAL_UUID,
-						name: 'Stoppard Festival'
+						uuid: STOPPARD_FESTIVAL_2002_FESTIVAL_UUID,
+						name: '2002',
+						festivalSeries: {
+							model: 'FESTIVAL_SERIES',
+							uuid: STOPPARD_FESTIVAL_FESTIVAL_SERIES_UUID,
+							name: 'Stoppard Festival'
+						}
 					},
 					subProductions: [],
 					producerCredits: [
@@ -1091,8 +1124,13 @@ describe('Production with sub-productions', () => {
 					},
 					festival: {
 						model: 'FESTIVAL',
-						uuid: STOPPARD_FESTIVAL_UUID,
-						name: 'Stoppard Festival'
+						uuid: STOPPARD_FESTIVAL_2002_FESTIVAL_UUID,
+						name: '2002',
+						festivalSeries: {
+							model: 'FESTIVAL_SERIES',
+							uuid: STOPPARD_FESTIVAL_FESTIVAL_SERIES_UUID,
+							name: 'Stoppard Festival'
+						}
 					},
 					subProductions: [],
 					producerCredits: [
@@ -1251,8 +1289,13 @@ describe('Production with sub-productions', () => {
 				},
 				festival: {
 					model: 'FESTIVAL',
-					uuid: STOPPARD_FESTIVAL_UUID,
-					name: 'Stoppard Festival'
+					uuid: STOPPARD_FESTIVAL_2002_FESTIVAL_UUID,
+					name: '2002',
+					festivalSeries: {
+						model: 'FESTIVAL_SERIES',
+						uuid: STOPPARD_FESTIVAL_FESTIVAL_SERIES_UUID,
+						name: 'Stoppard Festival'
+					}
 				},
 				surProduction: null,
 				producerCredits: [
@@ -1406,7 +1449,12 @@ describe('Production with sub-productions', () => {
 						surVenue: null
 					},
 					season: null,
-					festival: null,
+					festival: {
+						model: 'FESTIVAL',
+						uuid: PRE_REVOLUTION_RUSSIA_FESTIVAL_FESTIVAL_UUID,
+						name: 'Pre-Revolution Russia Festival',
+						festivalSeries: null
+					},
 					subProductions: [],
 					producerCredits: [],
 					cast: [],
@@ -1458,7 +1506,12 @@ describe('Production with sub-productions', () => {
 						surVenue: null
 					},
 					season: null,
-					festival: null,
+					festival: {
+						model: 'FESTIVAL',
+						uuid: PRE_REVOLUTION_RUSSIA_FESTIVAL_FESTIVAL_UUID,
+						name: 'Pre-Revolution Russia Festival',
+						festivalSeries: null
+					},
 					subProductions: [],
 					producerCredits: [],
 					cast: [],
@@ -1510,7 +1563,12 @@ describe('Production with sub-productions', () => {
 						surVenue: null
 					},
 					season: null,
-					festival: null,
+					festival: {
+						model: 'FESTIVAL',
+						uuid: PRE_REVOLUTION_RUSSIA_FESTIVAL_FESTIVAL_UUID,
+						name: 'Pre-Revolution Russia Festival',
+						festivalSeries: null
+					},
 					subProductions: [],
 					producerCredits: [],
 					cast: [],
@@ -1571,7 +1629,12 @@ describe('Production with sub-productions', () => {
 					surVenue: null
 				},
 				season: null,
-				festival: null,
+				festival: {
+					model: 'FESTIVAL',
+					uuid: PRE_REVOLUTION_RUSSIA_FESTIVAL_FESTIVAL_UUID,
+					name: 'Pre-Revolution Russia Festival',
+					festivalSeries: null
+				},
 				surProduction: null,
 				producerCredits: [],
 				cast: [],
@@ -1901,7 +1964,7 @@ describe('Production with sub-productions', () => {
 
 	});
 
-	describe('Stoppard Festival (festival)', () => {
+	describe('Stoppard Festival 2002 (festival)', () => {
 
 		it('includes productions in this festival and, where applicable, corresponding sur-productions; will exclude sur-productions when included via sub-production association', () => {
 
@@ -1977,7 +2040,7 @@ describe('Production with sub-productions', () => {
 				}
 			];
 
-			const { productions } = stoppardFestival.body;
+			const { productions } = stoppardFestival2002.body;
 
 			expect(productions).to.deep.equal(expectedProductions);
 

--- a/test-e2e/model-interaction/prod-with-sub-sub-prods.test.js
+++ b/test-e2e/model-interaction/prod-with-sub-sub-prods.test.js
@@ -13,6 +13,8 @@ describe('Production with sub-sub-productions', () => {
 
 	const BERKELEY_REPERTORY_THEATRE_VENUE_UUID = 'BERKELEY_REPERTORY_THEATRE_VENUE_UUID';
 	const RODA_THEATRE_VENUE_UUID = 'RODA_THEATRE_VENUE_UUID';
+	const AFGHAN_HISTORY_FESTIVAL_2009_FESTIVAL_UUID = '2009_FESTIVAL_UUID';
+	const AFGHAN_HISTORY_FESTIVAL_FESTIVAL_SERIES_UUID = 'AFGHAN_HISTORY_FESTIVAL_FESTIVAL_SERIES_UUID';
 	const BUGLES_AT_THE_GATES_OF_JALALABAD_MATERIAL_UUID = 'BUGLES_AT_THE_GATES_OF_JALALABAD_MATERIAL_UUID';
 	const FERDINAND_FOO_JR_PERSON_UUID = 'FERDINAND_FOO_JR_PERSON_UUID';
 	const SUB_INKISTS_LTD_COMPANY_UUID = 'SUB_INKISTS_LTD_COMPANY_UUID';
@@ -37,7 +39,6 @@ describe('Production with sub-sub-productions', () => {
 	const BAR_SR_CHARACTER_UUID = 'BAR_SR_CHARACTER_UUID';
 	const BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID = 'BUGLES_AT_THE_GATES_OF_JALALABAD_PRODUCTION_UUID';
 	const AFGHAN_HISTORY_SEASON_UUID = 'AFGHAN_HISTORY_SEASON_SEASON_UUID';
-	const AFGHAN_HISTORY_FESTIVAL_UUID = 'AFGHAN_HISTORY_FESTIVAL_FESTIVAL_UUID';
 	const NICOLAS_KENT_JR_PERSON_UUID = 'NICOLAS_KENT_JR_PERSON_UUID';
 	const SUB_TRICYCLE_THEATRE_COMPANY_UUID = 'SUB_TRICYCLE_THEATRE_COMPANY_COMPANY_UUID';
 	const ZOË_INGENHAAG_JR_PERSON_UUID = 'ZOE_INGENHAAG_JR_PERSON_UUID';
@@ -82,6 +83,7 @@ describe('Production with sub-sub-productions', () => {
 	const CHARLOTTE_PADGHAM_SR_PERSON_UUID = 'CHARLOTTE_PADGHAM_SR_PERSON_UUID';
 	const BUGLES_AT_THE_GATES_OF_JALALABAD_TRICYCLE_PRODUCTION_UUID = 'BUGLES_AT_THE_GATES_OF_JALALABAD_2_PRODUCTION_UUID';
 	const TRICYCLE_THEATRE_VENUE_UUID = 'TRICYCLE_THEATRE_VENUE_UUID';
+	const WORLD_POLITICS_FESTIVAL_FESTIVAL_UUID = 'WORLD_POLITICS_FESTIVAL_FESTIVAL_UUID';
 	const DURANDS_LINE_TRICYCLE_PRODUCTION_UUID = 'DURANDS_LINE_2_PRODUCTION_UUID';
 	const CAMPAIGN_TRICYCLE_PRODUCTION_UUID = 'CAMPAIGN_2_PRODUCTION_UUID';
 	const PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID = 'PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_2_PRODUCTION_UUID';
@@ -107,7 +109,7 @@ describe('Production with sub-sub-productions', () => {
 	let berkeleyRepertoryTheatreVenue;
 	let rodaTheatreVenue;
 	let afghanHistorySeason;
-	let afghanHistoryFestival;
+	let afghanHistoryFestival2009;
 	let nicolasKentJrPerson;
 	let subTricycleTheatreCompany;
 	let zoëIngenhaagJrPerson;
@@ -139,6 +141,15 @@ describe('Production with sub-sub-productions', () => {
 						name: 'Roda Theatre'
 					}
 				]
+			});
+
+		await chai.request(app)
+			.post('/festivals')
+			.send({
+				name: '2009',
+				festivalSeries: {
+					name: 'Afghan History Festival'
+				}
 			});
 
 		await chai.request(app)
@@ -592,7 +603,7 @@ describe('Production with sub-sub-productions', () => {
 					name: 'Afghan History Season'
 				},
 				festival: {
-					name: 'Afghan History Festival'
+					name: '2009'
 				},
 				producerCredits: [
 					{
@@ -679,7 +690,7 @@ describe('Production with sub-sub-productions', () => {
 					name: 'Afghan History Season'
 				},
 				festival: {
-					name: 'Afghan History Festival'
+					name: '2009'
 				},
 				producerCredits: [
 					{
@@ -766,7 +777,7 @@ describe('Production with sub-sub-productions', () => {
 					name: 'Afghan History Season'
 				},
 				festival: {
-					name: 'Afghan History Festival'
+					name: '2009'
 				},
 				producerCredits: [
 					{
@@ -853,7 +864,7 @@ describe('Production with sub-sub-productions', () => {
 					name: 'Afghan History Season'
 				},
 				festival: {
-					name: 'Afghan History Festival'
+					name: '2009'
 				},
 				subProductions: [
 					{
@@ -951,7 +962,7 @@ describe('Production with sub-sub-productions', () => {
 					name: 'Afghan History Season'
 				},
 				festival: {
-					name: 'Afghan History Festival'
+					name: '2009'
 				},
 				producerCredits: [
 					{
@@ -1038,7 +1049,7 @@ describe('Production with sub-sub-productions', () => {
 					name: 'Afghan History Season'
 				},
 				festival: {
-					name: 'Afghan History Festival'
+					name: '2009'
 				},
 				producerCredits: [
 					{
@@ -1125,7 +1136,7 @@ describe('Production with sub-sub-productions', () => {
 					name: 'Afghan History Season'
 				},
 				festival: {
-					name: 'Afghan History Festival'
+					name: '2009'
 				},
 				producerCredits: [
 					{
@@ -1212,7 +1223,7 @@ describe('Production with sub-sub-productions', () => {
 					name: 'Afghan History Season'
 				},
 				festival: {
-					name: 'Afghan History Festival'
+					name: '2009'
 				},
 				subProductions: [
 					{
@@ -1310,7 +1321,7 @@ describe('Production with sub-sub-productions', () => {
 					name: 'Afghan History Season'
 				},
 				festival: {
-					name: 'Afghan History Festival'
+					name: '2009'
 				},
 				producerCredits: [
 					{
@@ -1397,7 +1408,7 @@ describe('Production with sub-sub-productions', () => {
 					name: 'Afghan History Season'
 				},
 				festival: {
-					name: 'Afghan History Festival'
+					name: '2009'
 				},
 				producerCredits: [
 					{
@@ -1484,7 +1495,7 @@ describe('Production with sub-sub-productions', () => {
 					name: 'Afghan History Season'
 				},
 				festival: {
-					name: 'Afghan History Festival'
+					name: '2009'
 				},
 				producerCredits: [
 					{
@@ -1571,7 +1582,7 @@ describe('Production with sub-sub-productions', () => {
 					name: 'Afghan History Season'
 				},
 				festival: {
-					name: 'Afghan History Festival'
+					name: '2009'
 				},
 				subProductions: [
 					{
@@ -1669,7 +1680,7 @@ describe('Production with sub-sub-productions', () => {
 					name: 'Afghan History Season'
 				},
 				festival: {
-					name: 'Afghan History Festival'
+					name: '2009'
 				},
 				subProductions: [
 					{
@@ -1762,6 +1773,9 @@ describe('Production with sub-sub-productions', () => {
 				},
 				venue: {
 					name: 'Tricycle Theatre'
+				},
+				festival: {
+					name: 'World Politics Festival'
 				}
 			});
 
@@ -1777,6 +1791,9 @@ describe('Production with sub-sub-productions', () => {
 				},
 				venue: {
 					name: 'Tricycle Theatre'
+				},
+				festival: {
+					name: 'World Politics Festival'
 				}
 			});
 
@@ -1792,6 +1809,9 @@ describe('Production with sub-sub-productions', () => {
 				},
 				venue: {
 					name: 'Tricycle Theatre'
+				},
+				festival: {
+					name: 'World Politics Festival'
 				}
 			});
 
@@ -1807,6 +1827,9 @@ describe('Production with sub-sub-productions', () => {
 				},
 				venue: {
 					name: 'Tricycle Theatre'
+				},
+				festival: {
+					name: 'World Politics Festival'
 				},
 				subProductions: [
 					{
@@ -1833,6 +1856,9 @@ describe('Production with sub-sub-productions', () => {
 				},
 				venue: {
 					name: 'Tricycle Theatre'
+				},
+				festival: {
+					name: 'World Politics Festival'
 				}
 			});
 
@@ -1848,6 +1874,9 @@ describe('Production with sub-sub-productions', () => {
 				},
 				venue: {
 					name: 'Tricycle Theatre'
+				},
+				festival: {
+					name: 'World Politics Festival'
 				}
 			});
 
@@ -1863,6 +1892,9 @@ describe('Production with sub-sub-productions', () => {
 				},
 				venue: {
 					name: 'Tricycle Theatre'
+				},
+				festival: {
+					name: 'World Politics Festival'
 				}
 			});
 
@@ -1878,6 +1910,9 @@ describe('Production with sub-sub-productions', () => {
 				},
 				venue: {
 					name: 'Tricycle Theatre'
+				},
+				festival: {
+					name: 'World Politics Festival'
 				},
 				subProductions: [
 					{
@@ -1904,6 +1939,9 @@ describe('Production with sub-sub-productions', () => {
 				},
 				venue: {
 					name: 'Tricycle Theatre'
+				},
+				festival: {
+					name: 'World Politics Festival'
 				}
 			});
 
@@ -1919,6 +1957,9 @@ describe('Production with sub-sub-productions', () => {
 				},
 				venue: {
 					name: 'Tricycle Theatre'
+				},
+				festival: {
+					name: 'World Politics Festival'
 				}
 			});
 
@@ -1934,6 +1975,9 @@ describe('Production with sub-sub-productions', () => {
 				},
 				venue: {
 					name: 'Tricycle Theatre'
+				},
+				festival: {
+					name: 'World Politics Festival'
 				}
 			});
 
@@ -1949,6 +1993,9 @@ describe('Production with sub-sub-productions', () => {
 				},
 				venue: {
 					name: 'Tricycle Theatre'
+				},
+				festival: {
+					name: 'World Politics Festival'
 				},
 				subProductions: [
 					{
@@ -1975,6 +2022,9 @@ describe('Production with sub-sub-productions', () => {
 				},
 				venue: {
 					name: 'Tricycle Theatre'
+				},
+				festival: {
+					name: 'World Politics Festival'
 				},
 				subProductions: [
 					{
@@ -2025,8 +2075,8 @@ describe('Production with sub-sub-productions', () => {
 		afghanHistorySeason = await chai.request(app)
 			.get(`/seasons/${AFGHAN_HISTORY_SEASON_UUID}`);
 
-		afghanHistoryFestival = await chai.request(app)
-			.get(`/festivals/${AFGHAN_HISTORY_FESTIVAL_UUID}`);
+		afghanHistoryFestival2009 = await chai.request(app)
+			.get(`/festivals/${AFGHAN_HISTORY_FESTIVAL_2009_FESTIVAL_UUID}`);
 
 		nicolasKentJrPerson = await chai.request(app)
 			.get(`/people/${NICOLAS_KENT_JR_PERSON_UUID}`);
@@ -2129,8 +2179,13 @@ describe('Production with sub-sub-productions', () => {
 					},
 					festival: {
 						model: 'FESTIVAL',
-						uuid: AFGHAN_HISTORY_FESTIVAL_UUID,
-						name: 'Afghan History Festival'
+						uuid: AFGHAN_HISTORY_FESTIVAL_2009_FESTIVAL_UUID,
+						name: '2009',
+						festivalSeries: {
+							model: 'FESTIVAL_SERIES',
+							uuid: AFGHAN_HISTORY_FESTIVAL_FESTIVAL_SERIES_UUID,
+							name: 'Afghan History Festival'
+						}
 					},
 					subProductions: [
 						{
@@ -2192,8 +2247,13 @@ describe('Production with sub-sub-productions', () => {
 							},
 							festival: {
 								model: 'FESTIVAL',
-								uuid: AFGHAN_HISTORY_FESTIVAL_UUID,
-								name: 'Afghan History Festival'
+								uuid: AFGHAN_HISTORY_FESTIVAL_2009_FESTIVAL_UUID,
+								name: '2009',
+								festivalSeries: {
+									model: 'FESTIVAL_SERIES',
+									uuid: AFGHAN_HISTORY_FESTIVAL_FESTIVAL_SERIES_UUID,
+									name: 'Afghan History Festival'
+								}
 							},
 							producerCredits: [
 								{
@@ -2346,8 +2406,13 @@ describe('Production with sub-sub-productions', () => {
 							},
 							festival: {
 								model: 'FESTIVAL',
-								uuid: AFGHAN_HISTORY_FESTIVAL_UUID,
-								name: 'Afghan History Festival'
+								uuid: AFGHAN_HISTORY_FESTIVAL_2009_FESTIVAL_UUID,
+								name: '2009',
+								festivalSeries: {
+									model: 'FESTIVAL_SERIES',
+									uuid: AFGHAN_HISTORY_FESTIVAL_FESTIVAL_SERIES_UUID,
+									name: 'Afghan History Festival'
+								}
 							},
 							producerCredits: [
 								{
@@ -2500,8 +2565,13 @@ describe('Production with sub-sub-productions', () => {
 							},
 							festival: {
 								model: 'FESTIVAL',
-								uuid: AFGHAN_HISTORY_FESTIVAL_UUID,
-								name: 'Afghan History Festival'
+								uuid: AFGHAN_HISTORY_FESTIVAL_2009_FESTIVAL_UUID,
+								name: '2009',
+								festivalSeries: {
+									model: 'FESTIVAL_SERIES',
+									uuid: AFGHAN_HISTORY_FESTIVAL_FESTIVAL_SERIES_UUID,
+									name: 'Afghan History Festival'
+								}
 							},
 							producerCredits: [
 								{
@@ -2743,8 +2813,13 @@ describe('Production with sub-sub-productions', () => {
 					},
 					festival: {
 						model: 'FESTIVAL',
-						uuid: AFGHAN_HISTORY_FESTIVAL_UUID,
-						name: 'Afghan History Festival'
+						uuid: AFGHAN_HISTORY_FESTIVAL_2009_FESTIVAL_UUID,
+						name: '2009',
+						festivalSeries: {
+							model: 'FESTIVAL_SERIES',
+							uuid: AFGHAN_HISTORY_FESTIVAL_FESTIVAL_SERIES_UUID,
+							name: 'Afghan History Festival'
+						}
 					},
 					subProductions: [
 						{
@@ -2806,8 +2881,13 @@ describe('Production with sub-sub-productions', () => {
 							},
 							festival: {
 								model: 'FESTIVAL',
-								uuid: AFGHAN_HISTORY_FESTIVAL_UUID,
-								name: 'Afghan History Festival'
+								uuid: AFGHAN_HISTORY_FESTIVAL_2009_FESTIVAL_UUID,
+								name: '2009',
+								festivalSeries: {
+									model: 'FESTIVAL_SERIES',
+									uuid: AFGHAN_HISTORY_FESTIVAL_FESTIVAL_SERIES_UUID,
+									name: 'Afghan History Festival'
+								}
 							},
 							producerCredits: [
 								{
@@ -2960,8 +3040,13 @@ describe('Production with sub-sub-productions', () => {
 							},
 							festival: {
 								model: 'FESTIVAL',
-								uuid: AFGHAN_HISTORY_FESTIVAL_UUID,
-								name: 'Afghan History Festival'
+								uuid: AFGHAN_HISTORY_FESTIVAL_2009_FESTIVAL_UUID,
+								name: '2009',
+								festivalSeries: {
+									model: 'FESTIVAL_SERIES',
+									uuid: AFGHAN_HISTORY_FESTIVAL_FESTIVAL_SERIES_UUID,
+									name: 'Afghan History Festival'
+								}
 							},
 							producerCredits: [
 								{
@@ -3114,8 +3199,13 @@ describe('Production with sub-sub-productions', () => {
 							},
 							festival: {
 								model: 'FESTIVAL',
-								uuid: AFGHAN_HISTORY_FESTIVAL_UUID,
-								name: 'Afghan History Festival'
+								uuid: AFGHAN_HISTORY_FESTIVAL_2009_FESTIVAL_UUID,
+								name: '2009',
+								festivalSeries: {
+									model: 'FESTIVAL_SERIES',
+									uuid: AFGHAN_HISTORY_FESTIVAL_FESTIVAL_SERIES_UUID,
+									name: 'Afghan History Festival'
+								}
 							},
 							producerCredits: [
 								{
@@ -3357,8 +3447,13 @@ describe('Production with sub-sub-productions', () => {
 					},
 					festival: {
 						model: 'FESTIVAL',
-						uuid: AFGHAN_HISTORY_FESTIVAL_UUID,
-						name: 'Afghan History Festival'
+						uuid: AFGHAN_HISTORY_FESTIVAL_2009_FESTIVAL_UUID,
+						name: '2009',
+						festivalSeries: {
+							model: 'FESTIVAL_SERIES',
+							uuid: AFGHAN_HISTORY_FESTIVAL_FESTIVAL_SERIES_UUID,
+							name: 'Afghan History Festival'
+						}
 					},
 					subProductions: [
 						{
@@ -3420,8 +3515,13 @@ describe('Production with sub-sub-productions', () => {
 							},
 							festival: {
 								model: 'FESTIVAL',
-								uuid: AFGHAN_HISTORY_FESTIVAL_UUID,
-								name: 'Afghan History Festival'
+								uuid: AFGHAN_HISTORY_FESTIVAL_2009_FESTIVAL_UUID,
+								name: '2009',
+								festivalSeries: {
+									model: 'FESTIVAL_SERIES',
+									uuid: AFGHAN_HISTORY_FESTIVAL_FESTIVAL_SERIES_UUID,
+									name: 'Afghan History Festival'
+								}
 							},
 							producerCredits: [
 								{
@@ -3574,8 +3674,13 @@ describe('Production with sub-sub-productions', () => {
 							},
 							festival: {
 								model: 'FESTIVAL',
-								uuid: AFGHAN_HISTORY_FESTIVAL_UUID,
-								name: 'Afghan History Festival'
+								uuid: AFGHAN_HISTORY_FESTIVAL_2009_FESTIVAL_UUID,
+								name: '2009',
+								festivalSeries: {
+									model: 'FESTIVAL_SERIES',
+									uuid: AFGHAN_HISTORY_FESTIVAL_FESTIVAL_SERIES_UUID,
+									name: 'Afghan History Festival'
+								}
 							},
 							producerCredits: [
 								{
@@ -3728,8 +3833,13 @@ describe('Production with sub-sub-productions', () => {
 							},
 							festival: {
 								model: 'FESTIVAL',
-								uuid: AFGHAN_HISTORY_FESTIVAL_UUID,
-								name: 'Afghan History Festival'
+								uuid: AFGHAN_HISTORY_FESTIVAL_2009_FESTIVAL_UUID,
+								name: '2009',
+								festivalSeries: {
+									model: 'FESTIVAL_SERIES',
+									uuid: AFGHAN_HISTORY_FESTIVAL_FESTIVAL_SERIES_UUID,
+									name: 'Afghan History Festival'
+								}
 							},
 							producerCredits: [
 								{
@@ -3980,8 +4090,13 @@ describe('Production with sub-sub-productions', () => {
 				},
 				festival: {
 					model: 'FESTIVAL',
-					uuid: AFGHAN_HISTORY_FESTIVAL_UUID,
-					name: 'Afghan History Festival'
+					uuid: AFGHAN_HISTORY_FESTIVAL_2009_FESTIVAL_UUID,
+					name: '2009',
+					festivalSeries: {
+						model: 'FESTIVAL_SERIES',
+						uuid: AFGHAN_HISTORY_FESTIVAL_FESTIVAL_SERIES_UUID,
+						name: 'Afghan History Festival'
+					}
 				},
 				surProduction: null,
 				producerCredits: [
@@ -4145,8 +4260,13 @@ describe('Production with sub-sub-productions', () => {
 					},
 					festival: {
 						model: 'FESTIVAL',
-						uuid: AFGHAN_HISTORY_FESTIVAL_UUID,
-						name: 'Afghan History Festival'
+						uuid: AFGHAN_HISTORY_FESTIVAL_2009_FESTIVAL_UUID,
+						name: '2009',
+						festivalSeries: {
+							model: 'FESTIVAL_SERIES',
+							uuid: AFGHAN_HISTORY_FESTIVAL_FESTIVAL_SERIES_UUID,
+							name: 'Afghan History Festival'
+						}
 					},
 					subProductions: [],
 					producerCredits: [
@@ -4300,8 +4420,13 @@ describe('Production with sub-sub-productions', () => {
 					},
 					festival: {
 						model: 'FESTIVAL',
-						uuid: AFGHAN_HISTORY_FESTIVAL_UUID,
-						name: 'Afghan History Festival'
+						uuid: AFGHAN_HISTORY_FESTIVAL_2009_FESTIVAL_UUID,
+						name: '2009',
+						festivalSeries: {
+							model: 'FESTIVAL_SERIES',
+							uuid: AFGHAN_HISTORY_FESTIVAL_FESTIVAL_SERIES_UUID,
+							name: 'Afghan History Festival'
+						}
 					},
 					subProductions: [],
 					producerCredits: [
@@ -4455,8 +4580,13 @@ describe('Production with sub-sub-productions', () => {
 					},
 					festival: {
 						model: 'FESTIVAL',
-						uuid: AFGHAN_HISTORY_FESTIVAL_UUID,
-						name: 'Afghan History Festival'
+						uuid: AFGHAN_HISTORY_FESTIVAL_2009_FESTIVAL_UUID,
+						name: '2009',
+						festivalSeries: {
+							model: 'FESTIVAL_SERIES',
+							uuid: AFGHAN_HISTORY_FESTIVAL_FESTIVAL_SERIES_UUID,
+							name: 'Afghan History Festival'
+						}
 					},
 					subProductions: [],
 					producerCredits: [
@@ -4620,8 +4750,13 @@ describe('Production with sub-sub-productions', () => {
 				},
 				festival: {
 					model: 'FESTIVAL',
-					uuid: AFGHAN_HISTORY_FESTIVAL_UUID,
-					name: 'Afghan History Festival'
+					uuid: AFGHAN_HISTORY_FESTIVAL_2009_FESTIVAL_UUID,
+					name: '2009',
+					festivalSeries: {
+						model: 'FESTIVAL_SERIES',
+						uuid: AFGHAN_HISTORY_FESTIVAL_FESTIVAL_SERIES_UUID,
+						name: 'Afghan History Festival'
+					}
 				},
 				surProduction: {
 					model: 'PRODUCTION',
@@ -4673,8 +4808,13 @@ describe('Production with sub-sub-productions', () => {
 					},
 					festival: {
 						model: 'FESTIVAL',
-						uuid: AFGHAN_HISTORY_FESTIVAL_UUID,
-						name: 'Afghan History Festival'
+						uuid: AFGHAN_HISTORY_FESTIVAL_2009_FESTIVAL_UUID,
+						name: '2009',
+						festivalSeries: {
+							model: 'FESTIVAL_SERIES',
+							uuid: AFGHAN_HISTORY_FESTIVAL_FESTIVAL_SERIES_UUID,
+							name: 'Afghan History Festival'
+						}
 					},
 					producerCredits: [
 						{
@@ -4919,7 +5059,12 @@ describe('Production with sub-sub-productions', () => {
 						surVenue: null
 					},
 					season: null,
-					festival: null,
+					festival: {
+						model: 'FESTIVAL',
+						uuid: WORLD_POLITICS_FESTIVAL_FESTIVAL_UUID,
+						name: 'World Politics Festival',
+						festivalSeries: null
+					},
 					subProductions: [
 						{
 							model: 'PRODUCTION',
@@ -4970,7 +5115,12 @@ describe('Production with sub-sub-productions', () => {
 								surVenue: null
 							},
 							season: null,
-							festival: null,
+							festival: {
+								model: 'FESTIVAL',
+								uuid: WORLD_POLITICS_FESTIVAL_FESTIVAL_UUID,
+								name: 'World Politics Festival',
+								festivalSeries: null
+							},
 							producerCredits: [],
 							cast: [],
 							creativeCredits: [],
@@ -5025,7 +5175,12 @@ describe('Production with sub-sub-productions', () => {
 								surVenue: null
 							},
 							season: null,
-							festival: null,
+							festival: {
+								model: 'FESTIVAL',
+								uuid: WORLD_POLITICS_FESTIVAL_FESTIVAL_UUID,
+								name: 'World Politics Festival',
+								festivalSeries: null
+							},
 							producerCredits: [],
 							cast: [],
 							creativeCredits: [],
@@ -5080,7 +5235,12 @@ describe('Production with sub-sub-productions', () => {
 								surVenue: null
 							},
 							season: null,
-							festival: null,
+							festival: {
+								model: 'FESTIVAL',
+								uuid: WORLD_POLITICS_FESTIVAL_FESTIVAL_UUID,
+								name: 'World Politics Festival',
+								festivalSeries: null
+							},
 							producerCredits: [],
 							cast: [],
 							creativeCredits: [],
@@ -5137,7 +5297,12 @@ describe('Production with sub-sub-productions', () => {
 						surVenue: null
 					},
 					season: null,
-					festival: null,
+					festival: {
+						model: 'FESTIVAL',
+						uuid: WORLD_POLITICS_FESTIVAL_FESTIVAL_UUID,
+						name: 'World Politics Festival',
+						festivalSeries: null
+					},
 					subProductions: [
 						{
 							model: 'PRODUCTION',
@@ -5188,7 +5353,12 @@ describe('Production with sub-sub-productions', () => {
 								surVenue: null
 							},
 							season: null,
-							festival: null,
+							festival: {
+								model: 'FESTIVAL',
+								uuid: WORLD_POLITICS_FESTIVAL_FESTIVAL_UUID,
+								name: 'World Politics Festival',
+								festivalSeries: null
+							},
 							producerCredits: [],
 							cast: [],
 							creativeCredits: [],
@@ -5243,7 +5413,12 @@ describe('Production with sub-sub-productions', () => {
 								surVenue: null
 							},
 							season: null,
-							festival: null,
+							festival: {
+								model: 'FESTIVAL',
+								uuid: WORLD_POLITICS_FESTIVAL_FESTIVAL_UUID,
+								name: 'World Politics Festival',
+								festivalSeries: null
+							},
 							producerCredits: [],
 							cast: [],
 							creativeCredits: [],
@@ -5298,7 +5473,12 @@ describe('Production with sub-sub-productions', () => {
 								surVenue: null
 							},
 							season: null,
-							festival: null,
+							festival: {
+								model: 'FESTIVAL',
+								uuid: WORLD_POLITICS_FESTIVAL_FESTIVAL_UUID,
+								name: 'World Politics Festival',
+								festivalSeries: null
+							},
 							producerCredits: [],
 							cast: [],
 							creativeCredits: [],
@@ -5355,7 +5535,12 @@ describe('Production with sub-sub-productions', () => {
 						surVenue: null
 					},
 					season: null,
-					festival: null,
+					festival: {
+						model: 'FESTIVAL',
+						uuid: WORLD_POLITICS_FESTIVAL_FESTIVAL_UUID,
+						name: 'World Politics Festival',
+						festivalSeries: null
+					},
 					subProductions: [
 						{
 							model: 'PRODUCTION',
@@ -5406,7 +5591,12 @@ describe('Production with sub-sub-productions', () => {
 								surVenue: null
 							},
 							season: null,
-							festival: null,
+							festival: {
+								model: 'FESTIVAL',
+								uuid: WORLD_POLITICS_FESTIVAL_FESTIVAL_UUID,
+								name: 'World Politics Festival',
+								festivalSeries: null
+							},
 							producerCredits: [],
 							cast: [],
 							creativeCredits: [],
@@ -5461,7 +5651,12 @@ describe('Production with sub-sub-productions', () => {
 								surVenue: null
 							},
 							season: null,
-							festival: null,
+							festival: {
+								model: 'FESTIVAL',
+								uuid: WORLD_POLITICS_FESTIVAL_FESTIVAL_UUID,
+								name: 'World Politics Festival',
+								festivalSeries: null
+							},
 							producerCredits: [],
 							cast: [],
 							creativeCredits: [],
@@ -5516,7 +5711,12 @@ describe('Production with sub-sub-productions', () => {
 								surVenue: null
 							},
 							season: null,
-							festival: null,
+							festival: {
+								model: 'FESTIVAL',
+								uuid: WORLD_POLITICS_FESTIVAL_FESTIVAL_UUID,
+								name: 'World Politics Festival',
+								festivalSeries: null
+							},
 							producerCredits: [],
 							cast: [],
 							creativeCredits: [],
@@ -5582,7 +5782,12 @@ describe('Production with sub-sub-productions', () => {
 					surVenue: null
 				},
 				season: null,
-				festival: null,
+				festival: {
+					model: 'FESTIVAL',
+					uuid: WORLD_POLITICS_FESTIVAL_FESTIVAL_UUID,
+					name: 'World Politics Festival',
+					festivalSeries: null
+				},
 				surProduction: null,
 				producerCredits: [],
 				cast: [],
@@ -5648,7 +5853,12 @@ describe('Production with sub-sub-productions', () => {
 						surVenue: null
 					},
 					season: null,
-					festival: null,
+					festival: {
+						model: 'FESTIVAL',
+						uuid: WORLD_POLITICS_FESTIVAL_FESTIVAL_UUID,
+						name: 'World Politics Festival',
+						festivalSeries: null
+					},
 					subProductions: [],
 					producerCredits: [],
 					cast: [],
@@ -5704,7 +5914,12 @@ describe('Production with sub-sub-productions', () => {
 						surVenue: null
 					},
 					season: null,
-					festival: null,
+					festival: {
+						model: 'FESTIVAL',
+						uuid: WORLD_POLITICS_FESTIVAL_FESTIVAL_UUID,
+						name: 'World Politics Festival',
+						festivalSeries: null
+					},
 					subProductions: [],
 					producerCredits: [],
 					cast: [],
@@ -5760,7 +5975,12 @@ describe('Production with sub-sub-productions', () => {
 						surVenue: null
 					},
 					season: null,
-					festival: null,
+					festival: {
+						model: 'FESTIVAL',
+						uuid: WORLD_POLITICS_FESTIVAL_FESTIVAL_UUID,
+						name: 'World Politics Festival',
+						festivalSeries: null
+					},
 					subProductions: [],
 					producerCredits: [],
 					cast: [],
@@ -5826,7 +6046,12 @@ describe('Production with sub-sub-productions', () => {
 					surVenue: null
 				},
 				season: null,
-				festival: null,
+				festival: {
+					model: 'FESTIVAL',
+					uuid: WORLD_POLITICS_FESTIVAL_FESTIVAL_UUID,
+					name: 'World Politics Festival',
+					festivalSeries: null
+				},
 				surProduction: {
 					model: 'PRODUCTION',
 					uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -5867,7 +6092,12 @@ describe('Production with sub-sub-productions', () => {
 						surVenue: null
 					},
 					season: null,
-					festival: null,
+					festival: {
+						model: 'FESTIVAL',
+						uuid: WORLD_POLITICS_FESTIVAL_FESTIVAL_UUID,
+						name: 'World Politics Festival',
+						festivalSeries: null
+					},
 					producerCredits: [],
 					cast: [],
 					creativeCredits: [],
@@ -6954,7 +7184,7 @@ describe('Production with sub-sub-productions', () => {
 				}
 			];
 
-			const { productions } = afghanHistoryFestival.body;
+			const { productions } = afghanHistoryFestival2009.body;
 
 			expect(productions).to.deep.equal(expectedProductions);
 

--- a/test-e2e/uniqueness-in-db/festivals-api.test.js
+++ b/test-e2e/uniqueness-in-db/festivals-api.test.js
@@ -4,192 +4,348 @@ import { createSandbox } from 'sinon';
 
 import * as getRandomUuidModule from '../../src/lib/get-random-uuid';
 import app from '../../src/app';
-import { countNodesWithLabel, purgeDatabase } from '../test-helpers/neo4j';
+import { countNodesWithLabel, createNode, purgeDatabase } from '../test-helpers/neo4j';
 
 describe('Uniqueness in database: Festivals API', () => {
 
 	chai.use(chaiHttp);
 
-	const FESTIVAL_1_UUID = '1';
-	const FESTIVAL_2_UUID = '4';
-
 	const sandbox = createSandbox();
 
-	before(async () => {
+	describe('Festival uniqueness in database', () => {
 
-		let uuidCallCount = 0;
+		const FESTIVAL_1_UUID = '1';
+		const FESTIVAL_2_UUID = '4';
 
-		sandbox.stub(getRandomUuidModule, 'getRandomUuid').callsFake(() => (uuidCallCount++).toString());
+		before(async () => {
 
-		await purgeDatabase();
+			let uuidCallCount = 0;
+
+			sandbox.stub(getRandomUuidModule, 'getRandomUuid').callsFake(() => (uuidCallCount++).toString());
+
+			await purgeDatabase();
+
+		});
+
+		after(() => {
+
+			sandbox.restore();
+
+		});
+
+		it('creates festival without differentiator', async () => {
+
+			expect(await countNodesWithLabel('Festival')).to.equal(0);
+
+			const response = await chai.request(app)
+				.post('/festivals')
+				.send({
+					name: 'Globe to Globe'
+				});
+
+			const expectedResponseBody = {
+				model: 'FESTIVAL',
+				uuid: FESTIVAL_1_UUID,
+				name: 'Globe to Globe',
+				differentiator: '',
+				errors: {},
+				festivalSeries: {
+					model: 'FESTIVAL_SERIES',
+					name: '',
+					differentiator: '',
+					errors: {}
+				}
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Festival')).to.equal(1);
+
+		});
+
+		it('responds with errors if trying to create existing festival that does also not have differentiator', async () => {
+
+			expect(await countNodesWithLabel('Festival')).to.equal(1);
+
+			const response = await chai.request(app)
+				.post('/festivals')
+				.send({
+					name: 'Globe to Globe'
+				});
+
+			const expectedResponseBody = {
+				model: 'FESTIVAL',
+				name: 'Globe to Globe',
+				differentiator: '',
+				hasErrors: true,
+				errors: {
+					name: [
+						'Name and differentiator combination already exists'
+					],
+					differentiator: [
+						'Name and differentiator combination already exists'
+					]
+				},
+				festivalSeries: {
+					model: 'FESTIVAL_SERIES',
+					name: '',
+					differentiator: '',
+					errors: {}
+				}
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Festival')).to.equal(1);
+
+		});
+
+		it('creates festival with same name as existing festival but uses a differentiator', async () => {
+
+			expect(await countNodesWithLabel('Festival')).to.equal(1);
+
+			const response = await chai.request(app)
+				.post('/festivals')
+				.send({
+					name: 'Globe to Globe',
+					differentiator: '1'
+				});
+
+			const expectedResponseBody = {
+				model: 'FESTIVAL',
+				uuid: FESTIVAL_2_UUID,
+				name: 'Globe to Globe',
+				differentiator: '1',
+				errors: {},
+				festivalSeries: {
+					model: 'FESTIVAL_SERIES',
+					name: '',
+					differentiator: '',
+					errors: {}
+				}
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Festival')).to.equal(2);
+
+		});
+
+		it('responds with errors if trying to update festival to one with same name and differentiator combination', async () => {
+
+			expect(await countNodesWithLabel('Festival')).to.equal(2);
+
+			const response = await chai.request(app)
+				.put(`/festivals/${FESTIVAL_1_UUID}`)
+				.send({
+					name: 'Globe to Globe',
+					differentiator: '1'
+				});
+
+			const expectedResponseBody = {
+				model: 'FESTIVAL',
+				uuid: FESTIVAL_1_UUID,
+				name: 'Globe to Globe',
+				differentiator: '1',
+				hasErrors: true,
+				errors: {
+					name: [
+						'Name and differentiator combination already exists'
+					],
+					differentiator: [
+						'Name and differentiator combination already exists'
+					]
+				},
+				festivalSeries: {
+					model: 'FESTIVAL_SERIES',
+					name: '',
+					differentiator: '',
+					errors: {}
+				}
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Festival')).to.equal(2);
+
+		});
+
+		it('updates festival with same name as existing festival but uses a different differentiator', async () => {
+
+			expect(await countNodesWithLabel('Festival')).to.equal(2);
+
+			const response = await chai.request(app)
+				.put(`/festivals/${FESTIVAL_1_UUID}`)
+				.send({
+					name: 'Globe to Globe',
+					differentiator: '2'
+				});
+
+			const expectedResponseBody = {
+				model: 'FESTIVAL',
+				uuid: FESTIVAL_1_UUID,
+				name: 'Globe to Globe',
+				differentiator: '2',
+				errors: {},
+				festivalSeries: {
+					model: 'FESTIVAL_SERIES',
+					name: '',
+					differentiator: '',
+					errors: {}
+				}
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Festival')).to.equal(2);
+
+		});
+
+		it('updates festival with same name as existing festival but without a differentiator', async () => {
+
+			expect(await countNodesWithLabel('Festival')).to.equal(2);
+
+			const response = await chai.request(app)
+				.put(`/festivals/${FESTIVAL_2_UUID}`)
+				.send({
+					name: 'Globe to Globe'
+				});
+
+			const expectedResponseBody = {
+				model: 'FESTIVAL',
+				uuid: FESTIVAL_2_UUID,
+				name: 'Globe to Globe',
+				differentiator: '',
+				errors: {},
+				festivalSeries: {
+					model: 'FESTIVAL_SERIES',
+					name: '',
+					differentiator: '',
+					errors: {}
+				}
+			};
+
+			expect(response).to.have.status(200);
+			expect(response.body).to.deep.equal(expectedResponseBody);
+			expect(await countNodesWithLabel('Festival')).to.equal(2);
+
+		});
 
 	});
 
-	after(() => {
+	describe('Festival festival series uniqueness in database', () => {
 
-		sandbox.restore();
+		const TWO_THOUSAND_AND_EIGHT_FESTIVAL_UUID = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
 
-	});
-
-	it('creates festival without differentiator', async () => {
-
-		expect(await countNodesWithLabel('Festival')).to.equal(0);
-
-		const response = await chai.request(app)
-			.post('/festivals')
-			.send({
-				name: 'Globe to Globe'
-			});
-
-		const expectedResponseBody = {
-			model: 'FESTIVAL',
-			uuid: FESTIVAL_1_UUID,
-			name: 'Globe to Globe',
+		const expectedFestivalSeriesPerthArtsFestival1 = {
+			model: 'FESTIVAL_SERIES',
+			name: 'Perth Arts Festival',
 			differentiator: '',
 			errors: {}
 		};
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
-		expect(await countNodesWithLabel('Festival')).to.equal(1);
-
-	});
-
-	it('responds with errors if trying to create existing festival that does also not have differentiator', async () => {
-
-		expect(await countNodesWithLabel('Festival')).to.equal(1);
-
-		const response = await chai.request(app)
-			.post('/festivals')
-			.send({
-				name: 'Globe to Globe'
-			});
-
-		const expectedResponseBody = {
-			model: 'FESTIVAL',
-			name: 'Globe to Globe',
-			differentiator: '',
-			hasErrors: true,
-			errors: {
-				name: [
-					'Name and differentiator combination already exists'
-				],
-				differentiator: [
-					'Name and differentiator combination already exists'
-				]
-			}
-		};
-
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
-		expect(await countNodesWithLabel('Festival')).to.equal(1);
-
-	});
-
-	it('creates festival with same name as existing festival but uses a differentiator', async () => {
-
-		expect(await countNodesWithLabel('Festival')).to.equal(1);
-
-		const response = await chai.request(app)
-			.post('/festivals')
-			.send({
-				name: 'Globe to Globe',
-				differentiator: '1'
-			});
-
-		const expectedResponseBody = {
-			model: 'FESTIVAL',
-			uuid: FESTIVAL_2_UUID,
-			name: 'Globe to Globe',
+		const expectedFestivalSeriesPerthArtsFestival2 = {
+			model: 'FESTIVAL_SERIES',
+			name: 'Perth Arts Festival',
 			differentiator: '1',
 			errors: {}
 		};
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
-		expect(await countNodesWithLabel('Festival')).to.equal(2);
+		before(async () => {
 
-	});
+			await purgeDatabase();
 
-	it('responds with errors if trying to update festival to one with same name and differentiator combination', async () => {
-
-		expect(await countNodesWithLabel('Festival')).to.equal(2);
-
-		const response = await chai.request(app)
-			.put(`/festivals/${FESTIVAL_1_UUID}`)
-			.send({
-				name: 'Globe to Globe',
-				differentiator: '1'
+			await createNode({
+				label: 'Festival',
+				uuid: TWO_THOUSAND_AND_EIGHT_FESTIVAL_UUID,
+				name: '2008'
 			});
 
-		const expectedResponseBody = {
-			model: 'FESTIVAL',
-			uuid: FESTIVAL_1_UUID,
-			name: 'Globe to Globe',
-			differentiator: '1',
-			hasErrors: true,
-			errors: {
-				name: [
-					'Name and differentiator combination already exists'
-				],
-				differentiator: [
-					'Name and differentiator combination already exists'
-				]
-			}
-		};
+		});
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
-		expect(await countNodesWithLabel('Festival')).to.equal(2);
+		after(() => {
 
-	});
+			sandbox.restore();
 
-	it('updates festival with same name as existing festival but uses a different differentiator', async () => {
+		});
 
-		expect(await countNodesWithLabel('Festival')).to.equal(2);
+		it('updates festival and creates festival series that does not have a differentiator', async () => {
 
-		const response = await chai.request(app)
-			.put(`/festivals/${FESTIVAL_1_UUID}`)
-			.send({
-				name: 'Globe to Globe',
-				differentiator: '2'
-			});
+			expect(await countNodesWithLabel('FestivalSeries')).to.equal(0);
 
-		const expectedResponseBody = {
-			model: 'FESTIVAL',
-			uuid: FESTIVAL_1_UUID,
-			name: 'Globe to Globe',
-			differentiator: '2',
-			errors: {}
-		};
+			const response = await chai.request(app)
+				.put(`/festivals/${TWO_THOUSAND_AND_EIGHT_FESTIVAL_UUID}`)
+				.send({
+					name: '2008',
+					festivalSeries: {
+						name: 'Perth Arts Festival'
+					}
+				});
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
-		expect(await countNodesWithLabel('Festival')).to.equal(2);
+			expect(response).to.have.status(200);
+			expect(response.body.festivalSeries).to.deep.equal(expectedFestivalSeriesPerthArtsFestival1);
+			expect(await countNodesWithLabel('FestivalSeries')).to.equal(1);
 
-	});
+		});
 
-	it('updates festival with same name as existing festival but without a differentiator', async () => {
+		it('updates festival and creates festival series that has same name as existing festival series but uses a differentiator', async () => {
 
-		expect(await countNodesWithLabel('Festival')).to.equal(2);
+			expect(await countNodesWithLabel('FestivalSeries')).to.equal(1);
 
-		const response = await chai.request(app)
-			.put(`/festivals/${FESTIVAL_2_UUID}`)
-			.send({
-				name: 'Globe to Globe'
-			});
+			const response = await chai.request(app)
+				.put(`/festivals/${TWO_THOUSAND_AND_EIGHT_FESTIVAL_UUID}`)
+				.send({
+					name: '2008',
+					festivalSeries: {
+						name: 'Perth Arts Festival',
+						differentiator: '1'
+					}
+				});
 
-		const expectedResponseBody = {
-			model: 'FESTIVAL',
-			uuid: FESTIVAL_2_UUID,
-			name: 'Globe to Globe',
-			differentiator: '',
-			errors: {}
-		};
+			expect(response).to.have.status(200);
+			expect(response.body.festivalSeries).to.deep.equal(expectedFestivalSeriesPerthArtsFestival2);
+			expect(await countNodesWithLabel('FestivalSeries')).to.equal(2);
 
-		expect(response).to.have.status(200);
-		expect(response.body).to.deep.equal(expectedResponseBody);
-		expect(await countNodesWithLabel('Festival')).to.equal(2);
+		});
+
+		it('updates festival and uses existing festival series that does not have a differentiator', async () => {
+
+			expect(await countNodesWithLabel('FestivalSeries')).to.equal(2);
+
+			const response = await chai.request(app)
+				.put(`/festivals/${TWO_THOUSAND_AND_EIGHT_FESTIVAL_UUID}`)
+				.send({
+					name: '2008',
+					festivalSeries: {
+						name: 'Perth Arts Festival'
+					}
+				});
+
+			expect(response).to.have.status(200);
+			expect(response.body.festivalSeries).to.deep.equal(expectedFestivalSeriesPerthArtsFestival1);
+			expect(await countNodesWithLabel('FestivalSeries')).to.equal(2);
+
+		});
+
+		it('updates festival and uses existing festival series that has a differentiator', async () => {
+
+			expect(await countNodesWithLabel('FestivalSeries')).to.equal(2);
+
+			const response = await chai.request(app)
+				.put(`/festivals/${TWO_THOUSAND_AND_EIGHT_FESTIVAL_UUID}`)
+				.send({
+					name: '2008',
+					festivalSeries: {
+						name: 'Perth Arts Festival',
+						differentiator: '1'
+					}
+				});
+
+			expect(response).to.have.status(200);
+			expect(response.body.festivalSeries).to.deep.equal(expectedFestivalSeriesPerthArtsFestival2);
+			expect(await countNodesWithLabel('FestivalSeries')).to.equal(2);
+
+		});
 
 	});
 

--- a/test-int/input-validation-failures/festival.test.js
+++ b/test-int/input-validation-failures/festival.test.js
@@ -49,6 +49,12 @@ describe('Input validation failures: Festival instance', () => {
 						name: [
 							'Value is too short'
 						]
+					},
+					festivalSeries: {
+						uuid: undefined,
+						name: '',
+						differentiator: '',
+						errors: {}
 					}
 				};
 
@@ -79,6 +85,12 @@ describe('Input validation failures: Festival instance', () => {
 						name: [
 							'Value is too long'
 						]
+					},
+					festivalSeries: {
+						uuid: undefined,
+						name: '',
+						differentiator: '',
+						errors: {}
 					}
 				};
 
@@ -112,6 +124,95 @@ describe('Input validation failures: Festival instance', () => {
 						differentiator: [
 							'Value is too long'
 						]
+					},
+					festivalSeries: {
+						uuid: undefined,
+						name: '',
+						differentiator: '',
+						errors: {}
+					}
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		}
+
+	});
+
+	context('festival series name value exceeds maximum limit', () => {
+
+		for (const method of methods) {
+
+			it(`assigns appropriate error (${method} method)`, async () => {
+
+				const instance = new Festival({
+					name: '2008',
+					festivalSeries: {
+						name: ABOVE_MAX_LENGTH_STRING
+					}
+				});
+
+				const result = await instance[method]();
+
+				const expectedResponseBody = {
+					uuid: undefined,
+					name: '2008',
+					differentiator: '',
+					hasErrors: true,
+					errors: {},
+					festivalSeries: {
+						uuid: undefined,
+						name: ABOVE_MAX_LENGTH_STRING,
+						differentiator: '',
+						errors: {
+							name: [
+								'Value is too long'
+							]
+						}
+					}
+				};
+
+				expect(result).to.deep.equal(expectedResponseBody);
+
+			});
+
+		}
+
+	});
+
+	context('festival series differentiator value exceeds maximum limit', () => {
+
+		for (const method of methods) {
+
+			it(`assigns appropriate error (${method} method)`, async () => {
+
+				const instance = new Festival({
+					name: '2008',
+					festivalSeries: {
+						name: 'Edinburgh International Festival',
+						differentiator: ABOVE_MAX_LENGTH_STRING
+					}
+				});
+
+				const result = await instance[method]();
+
+				const expectedResponseBody = {
+					uuid: undefined,
+					name: '2008',
+					differentiator: '',
+					hasErrors: true,
+					errors: {},
+					festivalSeries: {
+						uuid: undefined,
+						name: 'Edinburgh International Festival',
+						differentiator: ABOVE_MAX_LENGTH_STRING,
+						errors: {
+							differentiator: [
+								'Value is too long'
+							]
+						}
 					}
 				};
 

--- a/test-unit/src/models/Festival.test.js
+++ b/test-unit/src/models/Festival.test.js
@@ -1,0 +1,103 @@
+import { expect } from 'chai';
+import proxyquire from 'proxyquire';
+import { assert, createStubInstance, spy } from 'sinon';
+
+import { FestivalSeries } from '../../../src/models';
+
+describe('Festival model', () => {
+
+	let stubs;
+
+	const FestivalSeriesStub = function () {
+
+		return createStubInstance(FestivalSeries);
+
+	};
+
+	beforeEach(() => {
+
+		stubs = {
+			models: {
+				FestivalSeries: FestivalSeriesStub
+			}
+		};
+
+	});
+
+	const createSubject = () =>
+
+		proxyquire('../../../src/models/Festival', {
+			'.': stubs.models
+		}).default;
+
+	const createInstance = props => {
+
+		const Festival = createSubject();
+
+		return new Festival(props);
+
+	};
+
+	describe('constructor method', () => {
+
+		describe('festivalSeries property', () => {
+
+			it('assigns instance if absent from props', () => {
+
+				const instance = createInstance({ name: '2008' });
+				expect(instance.festivalSeries instanceof FestivalSeries).to.be.true;
+
+			});
+
+			it('assigns instance if included in props', () => {
+
+				const instance = createInstance({
+					name: '2008',
+					festivalSeries: {
+						name: 'Edinburgh International Festival'
+					}
+				});
+				expect(instance.festivalSeries instanceof FestivalSeries).to.be.true;
+
+			});
+
+		});
+
+	});
+
+	describe('runInputValidations method', () => {
+
+		it('calls instance\'s validate methods and associated models\' validate methods', () => {
+
+			const props = {
+				name: '2008',
+				differentiator: '',
+				festivalSeries: {
+					name: 'Edinburgh International Festival',
+					differentiator: ''
+				}
+			};
+			const instance = createInstance(props);
+			spy(instance, 'validateName');
+			spy(instance, 'validateDifferentiator');
+			instance.runInputValidations();
+			assert.callOrder(
+				instance.validateName,
+				instance.validateDifferentiator,
+				instance.festivalSeries.validateName,
+				instance.festivalSeries.validateDifferentiator
+			);
+			assert.calledOnce(instance.validateName);
+			assert.calledWithExactly(instance.validateName, { isRequired: true });
+			assert.calledOnce(instance.validateDifferentiator);
+			assert.calledWithExactly(instance.validateDifferentiator);
+			assert.calledOnce(instance.festivalSeries.validateName);
+			assert.calledWithExactly(instance.festivalSeries.validateName, { isRequired: false });
+			assert.calledOnce(instance.festivalSeries.validateDifferentiator);
+			assert.calledWithExactly(instance.festivalSeries.validateDifferentiator);
+
+		});
+
+	});
+
+});

--- a/test-unit/src/models/Production.test.js
+++ b/test-unit/src/models/Production.test.js
@@ -6,7 +6,7 @@ import {
 	CastMember,
 	CreativeCredit,
 	CrewCredit,
-	Festival,
+	FestivalBase,
 	MaterialBase,
 	ProducerCredit,
 	Season,
@@ -36,9 +36,9 @@ describe('Production model', () => {
 
 	};
 
-	const FestivalStub = function () {
+	const FestivalBaseStub = function () {
 
-		return createStubInstance(Festival);
+		return createStubInstance(FestivalBase);
 
 	};
 
@@ -84,7 +84,7 @@ describe('Production model', () => {
 				CastMember: CastMemberStub,
 				CreativeCredit: CreativeCreditStub,
 				CrewCredit: CrewCreditStub,
-				Festival: FestivalStub,
+				FestivalBase: FestivalBaseStub,
 				MaterialBase: MaterialBaseStub,
 				ProducerCredit: ProducerCreditStub,
 				Season: SeasonStub,
@@ -302,7 +302,7 @@ describe('Production model', () => {
 			it('assigns instance if absent from props', () => {
 
 				const instance = createInstance({ name: 'Hamlet' });
-				expect(instance.festival instanceof Festival).to.be.true;
+				expect(instance.festival instanceof FestivalBase).to.be.true;
 
 			});
 
@@ -314,7 +314,7 @@ describe('Production model', () => {
 						name: 'The Complete Works'
 					}
 				});
-				expect(instance.festival instanceof Festival).to.be.true;
+				expect(instance.festival instanceof FestivalBase).to.be.true;
 
 			});
 

--- a/test-unit/src/neo4j/cypher-queries/festival.test.js
+++ b/test-unit/src/neo4j/cypher-queries/festival.test.js
@@ -1,0 +1,88 @@
+import { expect } from 'chai';
+
+import * as cypherQueriesFestival from '../../../../src/neo4j/cypher-queries/festival';
+import removeExcessWhitespace from '../../../test-helpers/remove-excess-whitespace';
+
+describe('Cypher Queries Festival module', () => {
+
+	describe('getCreateQuery function', () => {
+
+		it('returns requisite query', () => {
+
+			const result = cypherQueriesFestival.getCreateQuery();
+
+			const compactedResult = removeExcessWhitespace(result);
+
+			const startSegment = removeExcessWhitespace(`
+				CREATE (festival:Festival { uuid: $uuid, name: $name, differentiator: $differentiator })
+			`);
+
+			const middleSegment = removeExcessWhitespace(`
+				CREATE (festival)-[:PART_OF_FESTIVAL_SERIES]->(festivalSeries)
+			`);
+
+			const endSegment = removeExcessWhitespace(`
+				RETURN
+					festival.uuid AS uuid,
+					festival.name AS name,
+					festival.differentiator AS differentiator,
+					{
+						name: COALESCE(festivalSeries.name, ''),
+						differentiator: COALESCE(festivalSeries.differentiator, '')
+					} AS festivalSeries
+			`);
+
+			expect(compactedResult.startsWith(startSegment)).to.be.true;
+			expect(compactedResult.includes(middleSegment)).to.be.true;
+			expect(compactedResult.endsWith(endSegment)).to.be.true;
+
+		});
+
+	});
+
+	describe('getUpdateQuery function', () => {
+
+		it('returns requisite query', () => {
+
+			const result = cypherQueriesFestival.getUpdateQuery();
+
+			const compactedResult = removeExcessWhitespace(result);
+
+			const startSegment = removeExcessWhitespace(`
+				MATCH (festival:Festival { uuid: $uuid })
+
+				OPTIONAL MATCH (festival)-[festivalSeriesRel:PART_OF_FESTIVAL_SERIES]->(:FestivalSeries)
+
+				DELETE festivalSeriesRel
+
+				WITH DISTINCT festival
+
+				SET
+					festival.name = $name,
+					festival.differentiator = $differentiator
+			`);
+
+			const middleSegment = removeExcessWhitespace(`
+				CREATE (festival)-[:PART_OF_FESTIVAL_SERIES]->(festivalSeries)
+			`);
+
+			const endSegment = removeExcessWhitespace(`
+				RETURN
+					festival.uuid AS uuid,
+					festival.name AS name,
+					festival.differentiator AS differentiator,
+					{
+						name: COALESCE(festivalSeries.name, ''),
+						differentiator: COALESCE(festivalSeries.differentiator, '')
+					} AS festivalSeries
+			`);
+
+			expect(compactedResult.startsWith(startSegment)).to.be.true;
+			expect(compactedResult.includes(middleSegment)).to.be.true;
+			expect(compactedResult.endsWith(endSegment)).to.be.true;
+
+		});
+
+	});
+
+});


### PR DESCRIPTION
This PR adds festival festival series (i.e. the festival series of which a festival is a run), e.g.

- Edinburgh International Festival
- HighTide Festival
- Connections (the database seeds for this currently model it as a multi-tiered production, though these will be corrected in a subsequent PR)

---

#### Edinburgh International Festival 2006 (festival)
<img width="801" alt="edinburgh-international-festival-2006-festival" src="https://github.com/andygout/theatrebase-api/assets/10484515/ef4be010-4085-446c-8484-9a4ad5d7b436">

---

#### Edinburgh International Festival (festival series)
<img width="539" alt="edinburgh-international-festival-festival-series" src="https://github.com/andygout/theatrebase-api/assets/10484515/b98421fb-1a9f-4764-959b-66c9f07c7607">

---

#### Troilus and Cressida at King's Theatre (production)
<img width="604" alt="troilus-and-cressida-at-kings-theatre-production" src="https://github.com/andygout/theatrebase-api/assets/10484515/cc91d6e5-2749-4a85-addc-0f43e011cde5">

---

#### Festivals list
<img width="294" alt="festivals-list" src="https://github.com/andygout/theatrebase-api/assets/10484515/401dfce4-8be9-4a1f-9b49-736a33bd47d4">