### PR TITLE
Reduce pause in database seeding performFetch function

### DIFF
--- a/db-seeding/seed-db.js
+++ b/db-seeding/seed-db.js
@@ -14,7 +14,7 @@ const PLURALISED_MODEL_TO_EMOJI_MAP = {
 	'venues': '🏛️'
 };
 
-const PAUSE_DURATION_IN_MILLISECONDS = 1000;
+const PAUSE_DURATION_IN_MILLISECONDS = 500;
 
 const pause = duration => new Promise(resolve => setTimeout(resolve, duration));
 


### PR DESCRIPTION
This PR reduces the pause added to the database seeding process introduced in this PR: https://github.com/andygout/theatrebase-api/pull/605

It seems that a pause of 250ms is when the Java issue is encountered, but 500ms seems to plant all seeds without issue.