### PR TITLE
Correct production database seeds person name typo

### DIFF
--- a/db-seeding/seeds/productions/his-dark-materials-brt-1-part-one.json
+++ b/db-seeding/seeds/productions/his-dark-materials-brt-1-part-one.json
@@ -371,7 +371,7 @@
 			"name": "Fight Director",
 			"entities": [
 				{
-					"name": "Kate Walters"
+					"name": "Kate Waters"
 				}
 			]
 		},

--- a/db-seeding/seeds/productions/his-dark-materials-brt-2-part-two.json
+++ b/db-seeding/seeds/productions/his-dark-materials-brt-2-part-two.json
@@ -316,7 +316,7 @@
 			"name": "Fight Director",
 			"entities": [
 				{
-					"name": "Kate Walters"
+					"name": "Kate Waters"
 				}
 			]
 		},

--- a/db-seeding/seeds/productions/his-dark-materials-wyp-1-part-one.json
+++ b/db-seeding/seeds/productions/his-dark-materials-wyp-1-part-one.json
@@ -370,7 +370,7 @@
 			"name": "Fight Director",
 			"entities": [
 				{
-					"name": "Kate Walters"
+					"name": "Kate Waters"
 				}
 			]
 		},

--- a/db-seeding/seeds/productions/his-dark-materials-wyp-2-part-two.json
+++ b/db-seeding/seeds/productions/his-dark-materials-wyp-2-part-two.json
@@ -315,7 +315,7 @@
 			"name": "Fight Director",
 			"entities": [
 				{
-					"name": "Kate Walters"
+					"name": "Kate Waters"
 				}
 			]
 		},


### PR DESCRIPTION
This PR corrects a typo that exists for Kate Waters that appears in some of the production database seeds.