### PR TITLE
Add DB seeds to demonstrate characters in multiple materials

### DIFF
--- a/db-seeding/seeds/materials/rosencrantz-and-guildenstern-are-dead.json
+++ b/db-seeding/seeds/materials/rosencrantz-and-guildenstern-are-dead.json
@@ -1,0 +1,66 @@
+{
+	"name": "Rosencrantz and Guildenstern Are Dead",
+	"format": "play",
+	"year": "1966",
+	"writingCredits": [
+		{
+			"entities": [
+				{
+					"name": "Tom Stoppard"
+				}
+			]
+		}
+	],
+	"characterGroups": [
+		{
+			"characters": [
+				{
+					"name": "Rosencrantz"
+				},
+				{
+					"name": "Guildenstern"
+				},
+				{
+					"name": "The Player"
+				},
+				{
+					"name": "Players"
+				},
+				{
+					"name": "Hamlet"
+				},
+				{
+					"name": "Ophelia"
+				},
+				{
+					"name": "Claudius",
+					"differentiator": "Hamlet"
+				},
+				{
+					"name": "Gertrude"
+				},
+				{
+					"name": "Polonius"
+				},
+				{
+					"name": "Fortinbras"
+				},
+				{
+					"name": "Horatio"
+				},
+				{
+					"name": "Ambassador",
+					"underlyingName": "English Ambassador"
+				},
+				{
+					"name": "Courtiers",
+					"differentiator": "Hamlet"
+				},
+				{
+					"name": "Attendants",
+					"differentiator": "Hamlet"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/productions/rosencrantz-and-guildenstern-are-dead-cft.json
+++ b/db-seeding/seeds/productions/rosencrantz-and-guildenstern-are-dead-cft.json
@@ -1,0 +1,281 @@
+{
+	"name": "Rosencrantz and Guildenstern Are Dead",
+	"startDate": "2011-05-20",
+	"pressDate": "2011-05-31",
+	"endDate": "2011-06-11",
+	"material": {
+		"name": "Rosencrantz and Guildenstern Are Dead"
+	},
+	"venue": {
+		"name": "Festival Theatre"
+	},
+	"producerCredits": [
+		{
+			"entities": [
+				{
+					"model": "COMPANY",
+					"name": "Chichester Festival Theatre"
+				}
+			]
+		},
+		{
+			"name": "in association with",
+			"entities": [
+				{
+					"model": "COMPANY",
+					"name": "Theatre Royal Haymarket"
+				}
+			]
+		}
+	],
+	"cast": [
+		{
+			"name": "Samuel Barnett",
+			"roles": [
+				{
+					"name": "Rosencrantz"
+				}
+			]
+		},
+		{
+			"name": "Jamie Parker",
+			"roles": [
+				{
+					"name": "Guildenstern"
+				}
+			]
+		},
+		{
+			"name": "Chris Andrew Mellon",
+			"roles": [
+				{
+					"name": "The Player"
+				}
+			]
+		},
+		{
+			"name": "Charlie Hamblett",
+			"roles": [
+				{
+					"name": "Alfred"
+				}
+			]
+		},
+		{
+			"name": "Stephen Pallister",
+			"roles": [
+				{
+					"name": "Player King"
+				}
+			]
+		},
+		{
+			"name": "Trevor Allan Davies",
+			"roles": [
+				{
+					"name": "Player",
+					"characterName": "Players"
+				}
+			]
+		},
+		{
+			"name": "Zac Fox",
+			"roles": [
+				{
+					"name": "Player",
+					"characterName": "Players"
+				}
+			]
+		},
+		{
+			"name": "Greg Last",
+			"roles": [
+				{
+					"name": "Player",
+					"characterName": "Players"
+				}
+			]
+		},
+		{
+			"name": "James Northcote",
+			"roles": [
+				{
+					"name": "Player",
+					"characterName": "Players"
+				}
+			]
+		},
+		{
+			"name": "Keith Thompson",
+			"roles": [
+				{
+					"name": "Musican"
+				}
+			]
+		},
+		{
+			"name": "Katherine Press",
+			"roles": [
+				{
+					"name": "Ophelia"
+				}
+			]
+		},
+		{
+			"name": "Jack Hawkins",
+			"roles": [
+				{
+					"name": "Hamlet"
+				}
+			]
+		},
+		{
+			"name": "James Simmons",
+			"roles": [
+				{
+					"name": "Claudius"
+				}
+			]
+		},
+		{
+			"name": "Fiona Gillies",
+			"roles": [
+				{
+					"name": "Gertrude"
+				}
+			]
+		},
+		{
+			"name": "Andrew Jarvis",
+			"roles": [
+				{
+					"name": "Polonius"
+				},
+				{
+					"name": "Ambassador"
+				}
+			]
+		},
+		{
+			"name": "Tomm Coles",
+			"roles": [
+				{
+					"name": "Courtier",
+					"characterName": "Courtiers"
+				}
+			]
+		},
+		{
+			"name": "Elizabeth Hopper",
+			"roles": [
+				{
+					"name": "Courtier",
+					"characterName": "Courtiers"
+				}
+			]
+		},
+		{
+			"name": "Jody Elen Machin",
+			"roles": [
+				{
+					"name": "Courtier",
+					"characterName": "Courtiers"
+				}
+			]
+		},
+		{
+			"name": "Michael Benz",
+			"roles": [
+				{
+					"name": "Horatio"
+				}
+			]
+		},
+		{
+			"name": "Tom Golding",
+			"roles": [
+				{
+					"name": "Fortinbras"
+				},
+				{
+					"name": "Courtier",
+					"characterName": "Courtiers"
+				}
+			]
+		}
+	],
+	"creativeCredits": [
+		{
+			"name": "Director",
+			"entities": [
+				{
+					"name": "Trevor Nunn"
+				}
+			]
+		},
+		{
+			"name": "Designer",
+			"entities": [
+				{
+					"name": "Simon Higlett"
+				}
+			]
+		},
+		{
+			"name": "Costume Designer",
+			"entities": [
+				{
+					"name": "Fotini Dimou"
+				}
+			]
+		},
+		{
+			"name": "Lighting Designer",
+			"entities": [
+				{
+					"name": "Tim Mitchell"
+				}
+			]
+		},
+		{
+			"name": "Sound Designer",
+			"entities": [
+				{
+					"name": "Paul Groothuis"
+				}
+			]
+		},
+		{
+			"name": "Choreographer",
+			"entities": [
+				{
+					"name": "Etta Murfitt"
+				}
+			]
+		},
+		{
+			"name": "Music",
+			"entities": [
+				{
+					"name": "Steven Edis"
+				}
+			]
+		},
+		{
+			"name": "Fight Director",
+			"entities": [
+				{
+					"name": "Malcolm Ranson"
+				}
+			]
+		},
+		{
+			"name": "Casting Director",
+			"entities": [
+				{
+					"name": "Maggie Lunn"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/productions/rosencrantz-and-guildenstern-are-dead-old-vic.json
+++ b/db-seeding/seeds/productions/rosencrantz-and-guildenstern-are-dead-old-vic.json
@@ -1,0 +1,204 @@
+{
+	"name": "Rosencrantz and Guildenstern Are Dead",
+	"startDate": "2017-02-25",
+	"pressDate": "2017-03-07",
+	"endDate": "2017-05-06",
+	"material": {
+		"name": "Rosencrantz and Guildenstern Are Dead"
+	},
+	"venue": {
+		"name": "Old Vic Theatre"
+	},
+	"producerCredits": [
+		{
+			"entities": [
+				{
+					"model": "COMPANY",
+					"name": "Old Vic Theatre Company"
+				}
+			]
+		}
+	],
+	"cast": [
+		{
+			"name": "Daniel Radcliffe",
+			"roles": [
+				{
+					"name": "Rosencrantz"
+				}
+			]
+		},
+		{
+			"name": "Joshua McGuire",
+			"roles": [
+				{
+					"name": "Guildenstern"
+				}
+			]
+		},
+		{
+			"name": "David Haig",
+			"roles": [
+				{
+					"name": "The Player"
+				}
+			]
+		},
+		{
+			"name": "Hermeilio Miguel Aquino",
+			"roles": [
+				{
+					"name": "Courtier",
+					"characterName": "Courtiers"
+				}
+			]
+		},
+		{
+			"name": "Louisa Beadel",
+			"roles": [
+				{
+					"name": "Player",
+					"characterName": "Players"
+				}
+			]
+		},
+		{
+			"name": "William Chubb",
+			"roles": [
+				{
+					"name": "Polonius"
+				}
+			]
+		},
+		{
+			"name": "Josie Dunn",
+			"roles": [
+				{
+					"name": "Player",
+					"characterName": "Players"
+				}
+			]
+		},
+		{
+			"name": "Matthew Durkan",
+			"roles": [
+				{
+					"name": "Player",
+					"characterName": "Players"
+				}
+			]
+		},
+		{
+			"name": "Wil Johnson",
+			"roles": [
+				{
+					"name": "Claudius"
+				}
+			]
+		},
+		{
+			"name": "Luke Mullins",
+			"roles": [
+				{
+					"name": "Hamlet"
+				}
+			]
+		},
+		{
+			"name": "Theo Ogundipe",
+			"roles": [
+				{
+					"name": "Horatio"
+				}
+			]
+		},
+		{
+			"name": "Marianne Oldham",
+			"roles": [
+				{
+					"name": "Gertrude"
+				}
+			]
+		},
+		{
+			"name": "Evlyne Oyedokun",
+			"roles": [
+				{
+					"name": "Player",
+					"characterName": "Players"
+				}
+			]
+		},
+		{
+			"name": "Alex Sawyer",
+			"roles": [
+				{
+					"name": "Player",
+					"characterName": "Players"
+				}
+			]
+		},
+		{
+			"name": "Helena Wilson",
+			"roles": [
+				{
+					"name": "Ophelia"
+				}
+			]
+		},
+		{
+			"name": "Tim van Eyken",
+			"roles": [
+				{
+					"name": "Laertes"
+				},
+				{
+					"name": "Player",
+					"characterName": "Players"
+				}
+			]
+		}
+	],
+	"creativeCredits": [
+		{
+			"name": "Director",
+			"entities": [
+				{
+					"name": "David Leveaux"
+				}
+			]
+		},
+		{
+			"name": "Designer",
+			"entities": [
+				{
+					"name": "Anna Fleischle"
+				}
+			]
+		},
+		{
+			"name": "Lighting Designer",
+			"entities": [
+				{
+					"name": "Howard Harrison"
+				}
+			]
+		},
+		{
+			"name": "Sound Designer",
+			"entities": [
+				{
+					"name": "Fergus O'Hare"
+				}
+			]
+		},
+		{
+			"name": "Music",
+			"entities": [
+				{
+					"name": "Corin Buckeridge"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/productions/rosencrantz-and-guildenstern-are-dead-tr-haymarket.json
+++ b/db-seeding/seeds/productions/rosencrantz-and-guildenstern-are-dead-tr-haymarket.json
@@ -1,0 +1,281 @@
+{
+	"name": "Rosencrantz and Guildenstern Are Dead",
+	"startDate": "2011-06-16",
+	"pressDate": "2011-06-21",
+	"endDate": "2011-08-20",
+	"material": {
+		"name": "Rosencrantz and Guildenstern Are Dead"
+	},
+	"venue": {
+		"name": "Theatre Royal Haymarket"
+	},
+	"producerCredits": [
+		{
+			"entities": [
+				{
+					"model": "COMPANY",
+					"name": "Chichester Festival Theatre"
+				}
+			]
+		},
+		{
+			"name": "in association with",
+			"entities": [
+				{
+					"model": "COMPANY",
+					"name": "Theatre Royal Haymarket"
+				}
+			]
+		}
+	],
+	"cast": [
+		{
+			"name": "Samuel Barnett",
+			"roles": [
+				{
+					"name": "Rosencrantz"
+				}
+			]
+		},
+		{
+			"name": "Jamie Parker",
+			"roles": [
+				{
+					"name": "Guildenstern"
+				}
+			]
+		},
+		{
+			"name": "Chris Andrew Mellon",
+			"roles": [
+				{
+					"name": "The Player"
+				}
+			]
+		},
+		{
+			"name": "Charlie Hamblett",
+			"roles": [
+				{
+					"name": "Alfred"
+				}
+			]
+		},
+		{
+			"name": "Stephen Pallister",
+			"roles": [
+				{
+					"name": "Player King"
+				}
+			]
+		},
+		{
+			"name": "Trevor Allan Davies",
+			"roles": [
+				{
+					"name": "Player",
+					"characterName": "Players"
+				}
+			]
+		},
+		{
+			"name": "Zac Fox",
+			"roles": [
+				{
+					"name": "Player",
+					"characterName": "Players"
+				}
+			]
+		},
+		{
+			"name": "Greg Last",
+			"roles": [
+				{
+					"name": "Player",
+					"characterName": "Players"
+				}
+			]
+		},
+		{
+			"name": "James Northcote",
+			"roles": [
+				{
+					"name": "Player",
+					"characterName": "Players"
+				}
+			]
+		},
+		{
+			"name": "Keith Thompson",
+			"roles": [
+				{
+					"name": "Musican"
+				}
+			]
+		},
+		{
+			"name": "Katherine Press",
+			"roles": [
+				{
+					"name": "Ophelia"
+				}
+			]
+		},
+		{
+			"name": "Jack Hawkins",
+			"roles": [
+				{
+					"name": "Hamlet"
+				}
+			]
+		},
+		{
+			"name": "James Simmons",
+			"roles": [
+				{
+					"name": "Claudius"
+				}
+			]
+		},
+		{
+			"name": "Fiona Gillies",
+			"roles": [
+				{
+					"name": "Gertrude"
+				}
+			]
+		},
+		{
+			"name": "Andrew Jarvis",
+			"roles": [
+				{
+					"name": "Polonius"
+				},
+				{
+					"name": "Ambassador"
+				}
+			]
+		},
+		{
+			"name": "Tomm Coles",
+			"roles": [
+				{
+					"name": "Courtier",
+					"characterName": "Courtiers"
+				}
+			]
+		},
+		{
+			"name": "Elizabeth Hopper",
+			"roles": [
+				{
+					"name": "Courtier",
+					"characterName": "Courtiers"
+				}
+			]
+		},
+		{
+			"name": "Jody Elen Machin",
+			"roles": [
+				{
+					"name": "Courtier",
+					"characterName": "Courtiers"
+				}
+			]
+		},
+		{
+			"name": "Michael Benz",
+			"roles": [
+				{
+					"name": "Horatio"
+				}
+			]
+		},
+		{
+			"name": "Tom Golding",
+			"roles": [
+				{
+					"name": "Fortinbras"
+				},
+				{
+					"name": "Courtier",
+					"characterName": "Courtiers"
+				}
+			]
+		}
+	],
+	"creativeCredits": [
+		{
+			"name": "Director",
+			"entities": [
+				{
+					"name": "Trevor Nunn"
+				}
+			]
+		},
+		{
+			"name": "Designer",
+			"entities": [
+				{
+					"name": "Simon Higlett"
+				}
+			]
+		},
+		{
+			"name": "Costume Designer",
+			"entities": [
+				{
+					"name": "Fotini Dimou"
+				}
+			]
+		},
+		{
+			"name": "Lighting Designer",
+			"entities": [
+				{
+					"name": "Tim Mitchell"
+				}
+			]
+		},
+		{
+			"name": "Sound Designer",
+			"entities": [
+				{
+					"name": "Paul Groothuis"
+				}
+			]
+		},
+		{
+			"name": "Choreographer",
+			"entities": [
+				{
+					"name": "Etta Murfitt"
+				}
+			]
+		},
+		{
+			"name": "Music",
+			"entities": [
+				{
+					"name": "Steven Edis"
+				}
+			]
+		},
+		{
+			"name": "Fight Director",
+			"entities": [
+				{
+					"name": "Malcolm Ranson"
+				}
+			]
+		},
+		{
+			"name": "Casting Director",
+			"entities": [
+				{
+					"name": "Maggie Lunn"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
This PR adds some database seeds to demonstrate characters that appear in multiple materials.

There are already examples of this, such as King Richard III, but all the materials in which that character appears are written by the same playwright (William Shakespeare).

---

#### Rosencrantz (character)
<img width="953" alt="Screenshot 2023-10-30 at 17 39 13" src="https://github.com/andygout/theatrebase-api/assets/10484515/7f470c0f-d58a-47f2-baa9-46786fe17029">
