### PR TITLE
Catch file parse errors in database seeding process

### DIFF
--- a/db-seeding/seed-db.js
+++ b/db-seeding/seed-db.js
@@ -60,20 +60,32 @@ async function seedInstances (pluralisedModel) {
 
 				const filenamePathSlug = `${directoryName}/${filename}`;
 
+				const modelEmoji = PLURALISED_MODEL_TO_EMOJI_MAP[pluralisedModel];
+
 				try {
 
 					const rawData = fs.readFileSync(`${directoryPath}/${filename}`);
 
-					// Parse with jsonlint rather than JSON.parse() because
-					// its errors specify the line of parse errors.
-					const instance = jsonlint.parse(rawData.toString());
+					let instance;
+
+					try {
+						// Parse with jsonlint rather than JSON.parse() because
+						// its errors specify the line of parse errors.
+						instance = jsonlint.parse(rawData.toString());
+					} catch (parsingError) {
+						// eslint-disable-next-line no-console
+						console.log(`❌ Seeding Neo4j database: ${modelEmoji} ${filenamePathSlug}`);
+						console.log(parsingError);
+
+						return Promise.resolve();
+					}
 
 					const url = `${BASE_URL}/${modelUrlRoute}`;
 
 					return performFetch(
 						url,
 						instance,
-						PLURALISED_MODEL_TO_EMOJI_MAP[pluralisedModel],
+						modelEmoji,
 						filenamePathSlug
 					);
 


### PR DESCRIPTION
This PR revises the database seeding process so that file parse errors are caught and logged rather than failing the process outright.

This means that all files that are invalid JSONs will be identified by a single pass of the seeding process, rather than multiple iterations requiring a fix between each.

#### Before
![before](https://github.com/andygout/theatrebase-api/assets/10484515/8e27506d-8609-4b04-8af6-3251f84ab97b)

---

#### After
![after](https://github.com/andygout/theatrebase-api/assets/10484515/e2f77bdc-2b41-48f1-948d-f0aa5e2fcaaa)