### PR TITLE
Apply Node v18 features

### DIFF
--- a/db-seeding/seed-db.js
+++ b/db-seeding/seed-db.js
@@ -96,7 +96,7 @@ async function seedInstances (pluralisedModel) {
 
 				} catch (error) {
 
-					throw new Error(`${filenamePathSlug}: ${error.message}`);
+					throw new Error(`${filenamePathSlug}: ${error.message}`, { cause: error });
 
 				}
 

--- a/src/lib/get-duplicate-entity-info.js
+++ b/src/lib/get-duplicate-entity-info.js
@@ -20,7 +20,7 @@ const getDuplicateEntities = arrayOfEntities => {
 
 	arrayOfEntities.reduce((accumulator, entity) => {
 
-		Object.prototype.hasOwnProperty.call(entity, 'members') &&
+		Object.hasOwn(entity, 'members') &&
 		entity.members.forEach(nestedEntity => pushIntoRequisiteArray(nestedEntity, accumulator));
 
 		pushIntoRequisiteArray(entity, accumulator);

--- a/src/lib/has-errors.js
+++ b/src/lib/has-errors.js
@@ -6,7 +6,7 @@ const isObjectWithErrors = item => isObjectWithKeys(item) && hasErrors(item);
 
 export const hasErrors = instance => {
 
-	for (const prop in instance) if (Object.prototype.hasOwnProperty.call(instance, prop)) {
+	for (const prop in instance) if (Object.hasOwn(instance, prop)) {
 
 		const value = instance[prop];
 

--- a/src/lib/prepare-as-params.js
+++ b/src/lib/prepare-as-params.js
@@ -57,7 +57,7 @@ export const prepareAsParams = instance => {
 
 	const hasUuidIfRequired = key => item =>
 		!REQUIRES_NON_EMPTY_UUID_KEYS.has(key) ||
-		!Object.prototype.hasOwnProperty.call(item, 'uuid') ||
+		!Object.hasOwn(item, 'uuid') ||
 		Boolean(item.uuid);
 
 	const applyPositionPropertyAndRecurseObject = (item, index, array) => {

--- a/src/models/Base.js
+++ b/src/models/Base.js
@@ -59,7 +59,7 @@ export default class Base {
 
 			(opts.properties || defaultProperties).forEach(property => {
 
-				if (Object.prototype.hasOwnProperty.call(this, property))
+				if (Object.hasOwn(this, property))
 					this.addPropertyError(property, uniquenessErrorMessage);
 
 			});

--- a/src/models/Entity.js
+++ b/src/models/Entity.js
@@ -40,7 +40,7 @@ export default class Entity extends Base {
 
 	hasDifferentiatorProperty () {
 
-		return Object.prototype.hasOwnProperty.call(this, 'differentiator');
+		return Object.hasOwn(this, 'differentiator');
 
 	}
 


### PR DESCRIPTION
This PR applies some of the features we gain from running on a Node.js version of 18 or above, as described in this blog:

[The features we gain from the Node.js 16 sunset](https://financialtimes.atlassian.net/wiki/spaces/DS/blog/2023/09/06/8135344184/The+features+we+gain+from+the+Node.js+16+sunset) by @rowanmanning

### References:
- [MDN Web Docs: JavaScript — Object.hasOwn()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn)
- [MDN Web Docs: JavaScript — Error: cause](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause)