### PR TITLE
Hyphenate 'variant-named' (depictions/portrayals)

### DIFF
--- a/test-e2e/model-interaction/char-with-variant-depiction-portrayal-names.test.js
+++ b/test-e2e/model-interaction/char-with-variant-depiction-portrayal-names.test.js
@@ -505,7 +505,7 @@ describe('Character with variant depiction and portrayal names', () => {
 
 		});
 
-		it('includes distinct variant named depictions (i.e. depictions in materials with names different to the underlying character name)', () => {
+		it('includes distinct variant-named depictions (i.e. depictions in materials with names different to the underlying character name)', () => {
 
 			const expectedVariantNamedDepictions = [
 				'Henry, Prince of Wales',
@@ -524,7 +524,7 @@ describe('Character with variant depiction and portrayal names', () => {
 		// 'Henry, Prince of Wales' does not appear in this list because the portrayal
 		// was in a production of the material that used this name as the display name for King Henry V,
 		// and so this name instead only appears under variant depiction names.
-		it('includes distinct variant named portrayals (i.e. portrayals in productions with names different to that in material)', () => {
+		it('includes distinct variant-named portrayals (i.e. portrayals in productions with names different to that in material)', () => {
 
 			const expectedVariantNamedPortrayals = [
 				'Hal',
@@ -752,7 +752,7 @@ describe('Character with variant depiction and portrayal names', () => {
 
 	describe('Sir John Falstaff (character)', () => {
 
-		it('includes no variant named depictions where none exist', () => {
+		it('includes no variant-named depictions where none exist', () => {
 
 			const expectedVariantNamedDepictions = [];
 
@@ -762,7 +762,7 @@ describe('Character with variant depiction and portrayal names', () => {
 
 		});
 
-		it('includes no variant named portrayals where none exist', () => {
+		it('includes no variant-named portrayals where none exist', () => {
 
 			const expectedVariantNamedPortrayals = [];
 

--- a/test-e2e/model-interaction/char-with-variant-names-prods-diff-mats.test.js
+++ b/test-e2e/model-interaction/char-with-variant-names-prods-diff-mats.test.js
@@ -361,7 +361,7 @@ describe('Character with variant names from productions of different materials',
 
 		});
 
-		it('includes distinct variant named portrayals (i.e. portrayals in productions with names different to that in material)', () => {
+		it('includes distinct variant-named portrayals (i.e. portrayals in productions with names different to that in material)', () => {
 
 			const expectedVariantNamedPortrayals = [
 				'Hamlet, Prince of Denmark',

--- a/test-e2e/model-interaction/char-with-variant-names-prods-same-mat.test.js
+++ b/test-e2e/model-interaction/char-with-variant-names-prods-same-mat.test.js
@@ -216,7 +216,7 @@ describe('Character with variant names from productions of the same material', (
 
 	describe('Ghost (character)', () => {
 
-		it('includes variant named portrayals (i.e. portrayals in productions with names different to that in material)', () => {
+		it('includes variant-named portrayals (i.e. portrayals in productions with names different to that in material)', () => {
 
 			const expectedVariantNamedPortrayals = [
 				'Ghost of King Hamlet',

--- a/test-e2e/model-interaction/chars-same-name-same-mat.test.js
+++ b/test-e2e/model-interaction/chars-same-name-same-mat.test.js
@@ -359,7 +359,7 @@ describe('Different characters with the same name from the same material', () =>
 
 		});
 
-		it('includes distinct variant named depictions (i.e. depictions in materials with names different to the underlying character name)', () => {
+		it('includes distinct variant-named depictions (i.e. depictions in materials with names different to the underlying character name)', () => {
 
 			const expectedVariantNamedDepictions = [
 				'Lucius Cinna'
@@ -371,7 +371,7 @@ describe('Different characters with the same name from the same material', () =>
 
 		});
 
-		it('includes distinct variant named portrayals (i.e. portrayals in productions with names different to that in material)', () => {
+		it('includes distinct variant-named portrayals (i.e. portrayals in productions with names different to that in material)', () => {
 
 			const expectedVariantNamedPortrayals = [
 				'Lucius Cornelius Cinna'
@@ -448,7 +448,7 @@ describe('Different characters with the same name from the same material', () =>
 
 		});
 
-		it('includes distinct variant named depictions (i.e. depictions in materials with names different to the underlying character name)', () => {
+		it('includes distinct variant-named depictions (i.e. depictions in materials with names different to the underlying character name)', () => {
 
 			const expectedVariantNamedDepictions = [
 				'Gaius Helvius Cinna'
@@ -460,7 +460,7 @@ describe('Different characters with the same name from the same material', () =>
 
 		});
 
-		it('includes distinct variant named portrayals (i.e. portrayals in productions with names different to that in material)', () => {
+		it('includes distinct variant-named portrayals (i.e. portrayals in productions with names different to that in material)', () => {
 
 			const expectedVariantNamedPortrayals = [
 				'Cinna the poet'


### PR DESCRIPTION
This PR hyphenates 'variant-named' (in relation to depictions and portrayals):

> A compound modifier is made up of two or more words that work together to function like one adjective in describing a noun. When you connect words with a hyphen, you make it clear to readers that the words work together as a unit of meaning.

Ref. [Grammarly: Hypen Usage—Rules and Examples](https://www.grammarly.com/blog/hyphen)

### References:
- [Grammarly: Hypen Usage—Rules and Examples](https://www.grammarly.com/blog/hyphen)