### PR TITLE
Replace database seed en dashes with em dashes

### DIFF
--- a/db-seeding/seeds/materials/a-midsummer-nights-dream-3-subsequent-version.json
+++ b/db-seeding/seeds/materials/a-midsummer-nights-dream-3-subsequent-version.json
@@ -1,5 +1,5 @@
 {
-	"name": "A Midsummer Night's Dream (한여름밤의 꿈 - han-yeoleumbam-ui kkum - The dream of a summer night)",
+	"name": "A Midsummer Night's Dream (한여름밤의 꿈 — han-yeoleumbam-ui kkum — The dream of a summer night)",
 	"differentiator": "3",
 	"format": "play",
 	"year": "2012",

--- a/db-seeding/seeds/materials/alls-well-that-ends-well-3-subsequent-version.json
+++ b/db-seeding/seeds/materials/alls-well-that-ends-well-3-subsequent-version.json
@@ -1,5 +1,5 @@
 {
-	"name": "All's Well That Ends Well (મારો પિયો ગયો રંગૂન - Maro Piyo Gayo Rangoon - My brother went to Rangoon)",
+	"name": "All's Well That Ends Well (મારો પિયો ગયો રંગૂન — Maro Piyo Gayo Rangoon — My brother went to Rangoon)",
 	"differentiator": "3",
 	"format": "play",
 	"year": "2012",

--- a/db-seeding/seeds/materials/as-you-like-it-2-subsequent-version.json
+++ b/db-seeding/seeds/materials/as-you-like-it-2-subsequent-version.json
@@ -1,5 +1,5 @@
 {
-	"name": "As You Like It (როგორც შენ მოგწონს - rogorts shen mogts’ons)",
+	"name": "As You Like It (როგორც შენ მოგწონს — rogorts shen mogts’ons)",
 	"differentiator": "2",
 	"format": "play",
 	"year": "2012",

--- a/db-seeding/seeds/materials/coriolanus-2-subsequent-version.json
+++ b/db-seeding/seeds/materials/coriolanus-2-subsequent-version.json
@@ -1,5 +1,5 @@
 {
-	"name": "Coriolanus (コリオレーナス - Koriorēnasu)",
+	"name": "Coriolanus (コリオレーナス — Koriorēnasu)",
 	"differentiator": "2",
 	"format": "play",
 	"year": "2007",

--- a/db-seeding/seeds/materials/coriolanus-3-subsequent-version.json
+++ b/db-seeding/seeds/materials/coriolanus-3-subsequent-version.json
@@ -1,5 +1,5 @@
 {
-	"name": "Coriolanus (コリオレーナス - Koriorēnasu)",
+	"name": "Coriolanus (コリオレーナス — Koriorēnasu)",
 	"differentiator": "3",
 	"format": "play",
 	"year": "2012",

--- a/db-seeding/seeds/materials/henry-vi-part-1-2-subsequent-version.json
+++ b/db-seeding/seeds/materials/henry-vi-part-1-2-subsequent-version.json
@@ -1,5 +1,5 @@
 {
-	"name": "Henry VI, Part 1 (Хенри Шести први део - Henri Šesti prvi deo)",
+	"name": "Henry VI, Part 1 (Хенри Шести први део — Henri Šesti prvi deo)",
 	"differentiator": "2",
 	"format": "play",
 	"year": "2012",

--- a/db-seeding/seeds/materials/henry-vi-part-3-2-subsequent-version.json
+++ b/db-seeding/seeds/materials/henry-vi-part-3-2-subsequent-version.json
@@ -1,5 +1,5 @@
 {
-	"name": "Henry VI, Part 3 (Хенри Шестиот дел 3 - Henri Šesti Del 3)",
+	"name": "Henry VI, Part 3 (Хенри Шестиот дел 3 — Henri Šesti Del 3)",
 	"differentiator": "2",
 	"format": "play",
 	"year": "2012",

--- a/db-seeding/seeds/materials/his-dark-materials-5-play-part-one.json
+++ b/db-seeding/seeds/materials/his-dark-materials-5-play-part-one.json
@@ -41,7 +41,7 @@
 			]
 		},
 		{
-			"name": "Lyra's World - Jordan College",
+			"name": "Lyra's World — Jordan College",
 			"characters": [
 				{
 					"name": "Lyra Belacqua"
@@ -70,7 +70,7 @@
 			]
 		},
 		{
-			"name": "Lyra's World - London",
+			"name": "Lyra's World — London",
 			"characters": [
 				{
 					"name": "Mrs Coulter"
@@ -101,7 +101,7 @@
 			]
 		},
 		{
-			"name": "Lyra's World - The Church",
+			"name": "Lyra's World — The Church",
 			"characters": [
 				{
 					"name": "The President"
@@ -118,7 +118,7 @@
 			]
 		},
 		{
-			"name": "Lyra's World - Gyptians",
+			"name": "Lyra's World — Gyptians",
 			"characters": [
 				{
 					"name": "Lord Faa"
@@ -139,7 +139,7 @@
 			]
 		},
 		{
-			"name": "Lyra's World - Trollesund",
+			"name": "Lyra's World — Trollesund",
 			"characters": [
 				{
 					"name": "Lee Scoresby"
@@ -156,7 +156,7 @@
 			]
 		},
 		{
-			"name": "Lyra's World - Witches",
+			"name": "Lyra's World — Witches",
 			"characters": [
 				{
 					"name": "Serafina Pekkala"
@@ -182,7 +182,7 @@
 			]
 		},
 		{
-			"name": "Lyra's World - Bolvangar",
+			"name": "Lyra's World — Bolvangar",
 			"characters": [
 				{
 					"name": "Dr Sargent"
@@ -200,7 +200,7 @@
 			]
 		},
 		{
-			"name": "Lyra's World - Bears",
+			"name": "Lyra's World — Bears",
 			"characters": [
 				{
 					"name": "Iorek Byrnison"

--- a/db-seeding/seeds/materials/king-john-2-subsequent-version.json
+++ b/db-seeding/seeds/materials/king-john-2-subsequent-version.json
@@ -1,5 +1,5 @@
 {
-	"name": "King John (Թագավոր Ջոն - T’agavor Jon)",
+	"name": "King John (Թագավոր Ջոն — T’agavor Jon)",
 	"differentiator": "2",
 	"format": "play",
 	"year": "2012",

--- a/db-seeding/seeds/materials/king-lear-4-subsequent-version.json
+++ b/db-seeding/seeds/materials/king-lear-4-subsequent-version.json
@@ -1,5 +1,5 @@
 {
-	"name": "King Lear (Кароль Лір - Karoĺ Lir)",
+	"name": "King Lear (Кароль Лір — Karoĺ Lir)",
 	"differentiator": "4",
 	"format": "play",
 	"year": "2012",

--- a/db-seeding/seeds/materials/measure-for-measure-2-subsequent-version.json
+++ b/db-seeding/seeds/materials/measure-for-measure-2-subsequent-version.json
@@ -1,5 +1,5 @@
 {
-	"name": "Measure for Measure (мера за меру - Mera za meru)",
+	"name": "Measure for Measure (мера за меру — Mera za meru)",
 	"differentiator": "2",
 	"format": "play",
 	"year": "2012",

--- a/db-seeding/seeds/materials/much-ado-about-nothing-3-subsequent-version.json
+++ b/db-seeding/seeds/materials/much-ado-about-nothing-3-subsequent-version.json
@@ -1,5 +1,5 @@
 {
-	"name": "Much Ado About Nothing (Beaucoup de Bruit pour Rien - A lot of noise for nothing)",
+	"name": "Much Ado About Nothing (Beaucoup de Bruit pour Rien — A lot of noise for nothing)",
 	"differentiator": "3",
 	"format": "play",
 	"year": "2012",

--- a/db-seeding/seeds/materials/pericles-prince-of-tyre-2-subsequent-version.json
+++ b/db-seeding/seeds/materials/pericles-prince-of-tyre-2-subsequent-version.json
@@ -1,5 +1,5 @@
 {
-	"name": "Pericles (Περικλής - Periklís)",
+	"name": "Pericles (Περικλής — Periklís)",
 	"differentiator": "2",
 	"format": "play",
 	"year": "2012",

--- a/db-seeding/seeds/materials/richard-iii-3-subsequent-version.json
+++ b/db-seeding/seeds/materials/richard-iii-3-subsequent-version.json
@@ -1,5 +1,5 @@
 {
-	"name": "Richard III (理查三世 - Lǐ chá sānshì)",
+	"name": "Richard III (理查三世 — Lǐ chá sānshì)",
 	"differentiator": "3",
 	"format": "play",
 	"year": "2012",

--- a/db-seeding/seeds/materials/sixty-six-books-06-sola-fide-by-faith-alone.json
+++ b/db-seeding/seeds/materials/sixty-six-books-06-sola-fide-by-faith-alone.json
@@ -1,5 +1,5 @@
 {
-	"name": "Sola Fide - By Faith Alone",
+	"name": "Sola Fide — By Faith Alone",
 	"format": "play",
 	"year": "2011",
 	"writingCredits": [

--- a/db-seeding/seeds/materials/sixty-six-books-67-the-books-of-the-old-testament.json
+++ b/db-seeding/seeds/materials/sixty-six-books-67-the-books-of-the-old-testament.json
@@ -19,7 +19,7 @@
 			"name": "The Rules"
 		},
 		{
-			"name": "Sola Fide - By Faith Alone"
+			"name": "Sola Fide — By Faith Alone"
 		},
 		{
 			"name": "Beardy"

--- a/db-seeding/seeds/materials/the-life-and-adventures-of-nicholas-nickleby-4-play-collection.json
+++ b/db-seeding/seeds/materials/the-life-and-adventures-of-nicholas-nickleby-4-play-collection.json
@@ -146,7 +146,7 @@
 			]
 		},
 		{
-			"name": "Yorkshire - Boys",
+			"name": "Yorkshire — Boys",
 			"characters": [
 				{
 					"name": "Tomkins"

--- a/db-seeding/seeds/materials/the-merry-wives-of-windsor-2-subsequent-version.json
+++ b/db-seeding/seeds/materials/the-merry-wives-of-windsor-2-subsequent-version.json
@@ -1,5 +1,5 @@
 {
-	"name": "The Merry Wives of Windsor (Heri Wanawake Wa Windsor - Hail the Ladies of Windsor)",
+	"name": "The Merry Wives of Windsor (Heri Wanawake Wa Windsor — Hail the Ladies of Windsor)",
 	"differentiator": "2",
 	"format": "play",
 	"year": "2012",

--- a/db-seeding/seeds/materials/the-taming-of-the-shrew-2-subsequent-version.json
+++ b/db-seeding/seeds/materials/the-taming-of-the-shrew-2-subsequent-version.json
@@ -1,5 +1,5 @@
 {
-	"name": "The Taming of the Shrew (علاج ضد دستیاب ہے - Treatment is available)",
+	"name": "The Taming of the Shrew (علاج ضد دستیاب ہے — Treatment is available)",
 	"differentiator": "2",
 	"format": "play",
 	"year": "2012",

--- a/db-seeding/seeds/materials/the-tempest-4-subsequent-version.json
+++ b/db-seeding/seeds/materials/the-tempest-4-subsequent-version.json
@@ -1,5 +1,5 @@
 {
-	"name": "The Tempest (দ্যা টেম্পেস্ট - Dyā ṭēmpēsṭa)",
+	"name": "The Tempest (দ্যা টেম্পেস্ট — Dyā ṭēmpēsṭa)",
 	"differentiator": "4",
 	"format": "play",
 	"year": "2012",

--- a/db-seeding/seeds/materials/the-two-gentlemen-of-verona-3-subsequent-version.json
+++ b/db-seeding/seeds/materials/the-two-gentlemen-of-verona-3-subsequent-version.json
@@ -1,5 +1,5 @@
 {
-	"name": "The Two Gentlemen of Verona (Vakomana Vaviri Ve Zimbabwe - Two Zimbabwean Boys)",
+	"name": "The Two Gentlemen of Verona (Vakomana Vaviri Ve Zimbabwe — Two Zimbabwean Boys)",
 	"differentiator": "3",
 	"format": "play",
 	"year": "2012",

--- a/db-seeding/seeds/materials/the-winters-tale-2-subsequent-version.json
+++ b/db-seeding/seeds/materials/the-winters-tale-2-subsequent-version.json
@@ -1,5 +1,5 @@
 {
-	"name": "The Winter's Tale (Ìtàn Ògìnìntìn - History of Ògìnìntìn)",
+	"name": "The Winter's Tale (Ìtàn Ògìnìntìn — History of Ògìnìntìn)",
 	"differentiator": "2",
 	"format": "play",
 	"year": "2012",

--- a/db-seeding/seeds/materials/titus-andronicus-2-subsequent-version.json
+++ b/db-seeding/seeds/materials/titus-andronicus-2-subsequent-version.json
@@ -1,5 +1,5 @@
 {
-	"name": "Titus Andronicus (タイタス・アンドロニカス - Taitasu Andoronikasu)",
+	"name": "Titus Andronicus (タイタス・アンドロニカス — Taitasu Andoronikasu)",
 	"differentiator": "2",
 	"format": "play",
 	"year": "2006",

--- a/db-seeding/seeds/materials/titus-andronicus-3-subsequent-version.json
+++ b/db-seeding/seeds/materials/titus-andronicus-3-subsequent-version.json
@@ -1,5 +1,5 @@
 {
-	"name": "Titus Andronicus (泰特斯 - Tài tè sī)",
+	"name": "Titus Andronicus (泰特斯 — Tài tè sī)",
 	"differentiator": "3",
 	"format": "play",
 	"year": "2012",

--- a/db-seeding/seeds/materials/twelfth-night-3-subsequent-version.json
+++ b/db-seeding/seeds/materials/twelfth-night-3-subsequent-version.json
@@ -1,5 +1,5 @@
 {
-	"name": "Twelfth Night (पिया बहरूपिया - Piya Behrupiya - Beloved Imposter)",
+	"name": "Twelfth Night (पिया बहरूपिया — Piya Behrupiya — Beloved Imposter)",
 	"differentiator": "3",
 	"format": "play",
 	"year": "2012",

--- a/db-seeding/seeds/productions/a-midsummer-nights-dream-globe.json
+++ b/db-seeding/seeds/productions/a-midsummer-nights-dream-globe.json
@@ -1,9 +1,9 @@
 {
-	"name": "A Midsummer Night's Dream (한여름밤의 꿈 - han-yeoleumbam-ui kkum - The dream of a summer night)",
+	"name": "A Midsummer Night's Dream (한여름밤의 꿈 — han-yeoleumbam-ui kkum — The dream of a summer night)",
 	"startDate": "2012-04-30",
 	"endDate": "2012-05-01",
 	"material": {
-		"name": "A Midsummer Night's Dream (한여름밤의 꿈 - han-yeoleumbam-ui kkum - The dream of a summer night)",
+		"name": "A Midsummer Night's Dream (한여름밤의 꿈 — han-yeoleumbam-ui kkum — The dream of a summer night)",
 		"differentiator": "3"
 	},
 	"venue": {

--- a/db-seeding/seeds/productions/alls-well-that-ends-well-globe.json
+++ b/db-seeding/seeds/productions/alls-well-that-ends-well-globe.json
@@ -1,9 +1,9 @@
 {
-	"name": "All's Well That Ends Well (મારો પિયો ગયો રંગૂન - Maro Piyo Gayo Rangoon - My brother went to Rangoon)",
+	"name": "All's Well That Ends Well (મારો પિયો ગયો રંગૂન — Maro Piyo Gayo Rangoon — My brother went to Rangoon)",
 	"startDate": "2012-05-23",
 	"endDate": "2012-05-24",
 	"material": {
-		"name": "All's Well That Ends Well (મારો પિયો ગયો રંગૂન - Maro Piyo Gayo Rangoon - My brother went to Rangoon)",
+		"name": "All's Well That Ends Well (મારો પિયો ગયો રંગૂન — Maro Piyo Gayo Rangoon — My brother went to Rangoon)",
 		"differentiator": "3"
 	},
 	"venue": {

--- a/db-seeding/seeds/productions/as-you-like-it-globe.json
+++ b/db-seeding/seeds/productions/as-you-like-it-globe.json
@@ -1,9 +1,9 @@
 {
-	"name": "As You Like It (როგორც შენ მოგწონს - rogorts shen mogts’ons)",
+	"name": "As You Like It (როგორც შენ მოგწონს — rogorts shen mogts’ons)",
 	"startDate": "2012-05-18",
 	"endDate": "2012-05-19",
 	"material": {
-		"name": "As You Like It (როგორც შენ მოგწონს - rogorts shen mogts’ons)",
+		"name": "As You Like It (როგორც შენ მოგწონს — rogorts shen mogts’ons)",
 		"differentiator": "2"
 	},
 	"venue": {

--- a/db-seeding/seeds/productions/coriolanus-barbican.json
+++ b/db-seeding/seeds/productions/coriolanus-barbican.json
@@ -1,9 +1,9 @@
 {
-	"name": "Coriolanus (コリオレーナス - Koriorēnasu)",
+	"name": "Coriolanus (コリオレーナス — Koriorēnasu)",
 	"startDate": "2007-04-25",
 	"endDate": "2007-04-29",
 	"material": {
-		"name": "Coriolanus (コリオレーナス - Koriorēnasu)",
+		"name": "Coriolanus (コリオレーナス — Koriorēnasu)",
 		"differentiator": "2"
 	},
 	"venue": {

--- a/db-seeding/seeds/productions/coriolanus-globe.json
+++ b/db-seeding/seeds/productions/coriolanus-globe.json
@@ -1,9 +1,9 @@
 {
-	"name": "Coriolanus (コリオレーナス - Koriorēnasu)",
+	"name": "Coriolanus (コリオレーナス — Koriorēnasu)",
 	"startDate": "2012-05-21",
 	"endDate": "2012-05-22",
 	"material": {
-		"name": "Coriolanus (コリオレーナス - Koriorēnasu)",
+		"name": "Coriolanus (コリオレーナス — Koriorēnasu)",
 		"differentiator": "3"
 	},
 	"venue": {

--- a/db-seeding/seeds/productions/henry-vi-part-1-globe.json
+++ b/db-seeding/seeds/productions/henry-vi-part-1-globe.json
@@ -1,9 +1,9 @@
 {
-	"name": "Henry VI, Part 1 (Хенри Шести први део - Henri Šesti prvi deo)",
+	"name": "Henry VI, Part 1 (Хенри Шести први део — Henri Šesti prvi deo)",
 	"startDate": "2012-05-11",
 	"endDate": "2012-05-13",
 	"material": {
-		"name": "Henry VI, Part 1 (Хенри Шести први део - Henri Šesti prvi deo)",
+		"name": "Henry VI, Part 1 (Хенри Шести први део — Henri Šesti prvi deo)",
 		"differentiator": "2"
 	},
 	"venue": {

--- a/db-seeding/seeds/productions/henry-vi-part-3-globe.json
+++ b/db-seeding/seeds/productions/henry-vi-part-3-globe.json
@@ -1,9 +1,9 @@
 {
-	"name": "Henry VI, Part 3 (Хенри Шестиот дел 3 - Henri Šesti Del 3)",
+	"name": "Henry VI, Part 3 (Хенри Шестиот дел 3 — Henri Šesti Del 3)",
 	"startDate": "2012-05-12",
 	"endDate": "2012-05-13",
 	"material": {
-		"name": "Henry VI, Part 3 (Хенри Шестиот дел 3 - Henri Šesti Del 3)",
+		"name": "Henry VI, Part 3 (Хенри Шестиот дел 3 — Henri Šesti Del 3)",
 		"differentiator": "2"
 	},
 	"venue": {

--- a/db-seeding/seeds/productions/king-john-globe.json
+++ b/db-seeding/seeds/productions/king-john-globe.json
@@ -1,9 +1,9 @@
 {
-	"name": "King John (Թագավոր Ջոն - T’agavor Jon)",
+	"name": "King John (Թագավոր Ջոն — T’agavor Jon)",
 	"startDate": "2012-05-16",
 	"endDate": "2012-05-17",
 	"material": {
-		"name": "King John (Թագավոր Ջոն - T’agavor Jon)",
+		"name": "King John (Թագավոր Ջոն — T’agavor Jon)",
 		"differentiator": "2"
 	},
 	"venue": {

--- a/db-seeding/seeds/productions/king-lear-globe.json
+++ b/db-seeding/seeds/productions/king-lear-globe.json
@@ -1,9 +1,9 @@
 {
-	"name": "King Lear (Кароль Лір - Karoĺ Lir)",
+	"name": "King Lear (Кароль Лір — Karoĺ Lir)",
 	"startDate": "2012-05-17",
 	"endDate": "2012-05-18",
 	"material": {
-		"name": "King Lear (Кароль Лір - Karoĺ Lir)",
+		"name": "King Lear (Кароль Лір — Karoĺ Lir)",
 		"differentiator": "4"
 	},
 	"venue": {

--- a/db-seeding/seeds/productions/measure-for-measure-globe.json
+++ b/db-seeding/seeds/productions/measure-for-measure-globe.json
@@ -1,9 +1,9 @@
 {
-	"name": "Measure for Measure (мера за меру - Mera za meru)",
+	"name": "Measure for Measure (мера за меру — Mera za meru)",
 	"startDate": "2012-04-24",
 	"endDate": "2012-04-25",
 	"material": {
-		"name": "Measure for Measure (мера за меру - Mera za meru)",
+		"name": "Measure for Measure (мера за меру — Mera za meru)",
 		"differentiator": "2"
 	},
 	"venue": {

--- a/db-seeding/seeds/productions/much-ado-about-nothing-globe.json
+++ b/db-seeding/seeds/productions/much-ado-about-nothing-globe.json
@@ -1,9 +1,9 @@
 {
-	"name": "Much Ado About Nothing (Beaucoup de Bruit pour Rien - A lot of noise for nothing)",
+	"name": "Much Ado About Nothing (Beaucoup de Bruit pour Rien — A lot of noise for nothing)",
 	"startDate": "2012-06-01",
 	"endDate": "2012-06-02",
 	"material": {
-		"name": "Much Ado About Nothing (Beaucoup de Bruit pour Rien - A lot of noise for nothing)",
+		"name": "Much Ado About Nothing (Beaucoup de Bruit pour Rien — A lot of noise for nothing)",
 		"differentiator": "3"
 	},
 	"venue": {

--- a/db-seeding/seeds/productions/pericles-globe.json
+++ b/db-seeding/seeds/productions/pericles-globe.json
@@ -1,9 +1,9 @@
 {
-	"name": "Pericles (Περικλής - Periklís)",
+	"name": "Pericles (Περικλής — Periklís)",
 	"startDate": "2012-04-26",
 	"endDate": "2012-04-27",
 	"material": {
-		"name": "Pericles (Περικλής - Periklís)",
+		"name": "Pericles (Περικλής — Periklís)",
 		"differentiator": "2"
 	},
 	"venue": {

--- a/db-seeding/seeds/productions/richard-iii-globe.json
+++ b/db-seeding/seeds/productions/richard-iii-globe.json
@@ -1,9 +1,9 @@
 {
-	"name": "Richard III (理查三世 - Lǐ chá sānshì)",
+	"name": "Richard III (理查三世 — Lǐ chá sānshì)",
 	"startDate": "2012-04-28",
 	"endDate": "2012-04-29",
 	"material": {
-		"name": "Richard III (理查三世 - Lǐ chá sānshì)",
+		"name": "Richard III (理查三世 — Lǐ chá sānshì)",
 		"differentiator": "3"
 	},
 	"venue": {

--- a/db-seeding/seeds/productions/sixty-six-books-06-sola-fide-by-faith-alone-bush.json
+++ b/db-seeding/seeds/productions/sixty-six-books-06-sola-fide-by-faith-alone-bush.json
@@ -1,11 +1,11 @@
 {
 	"uuid": "886ef085-9be3-4c04-a859-a62827e83a15",
-	"name": "Sola Fide - By Faith Alone",
+	"name": "Sola Fide — By Faith Alone",
 	"startDate": "2011-10-10",
 	"pressDate": "2011-10-14",
 	"endDate": "2011-10-28",
 	"material": {
-		"name": "Sola Fide - By Faith Alone"
+		"name": "Sola Fide — By Faith Alone"
 	},
 	"venue": {
 		"name": "Bush Theatre"

--- a/db-seeding/seeds/productions/the-merry-wives-of-windsor-globe.json
+++ b/db-seeding/seeds/productions/the-merry-wives-of-windsor-globe.json
@@ -1,9 +1,9 @@
 {
-	"name": "The Merry Wives of Windsor (Heri Wanawake Wa Windsor - Hail the Ladies of Windsor)",
+	"name": "The Merry Wives of Windsor (Heri Wanawake Wa Windsor — Hail the Ladies of Windsor)",
 	"startDate": "2012-04-25",
 	"endDate": "2012-04-26",
 	"material": {
-		"name": "The Merry Wives of Windsor (Heri Wanawake Wa Windsor - Hail the Ladies of Windsor)",
+		"name": "The Merry Wives of Windsor (Heri Wanawake Wa Windsor — Hail the Ladies of Windsor)",
 		"differentiator": "2"
 	},
 	"venue": {

--- a/db-seeding/seeds/productions/the-taming-of-the-shrew-globe.json
+++ b/db-seeding/seeds/productions/the-taming-of-the-shrew-globe.json
@@ -1,9 +1,9 @@
 {
-	"name": "The Taming of the Shrew (علاج ضد دستیاب ہے - Treatment is available)",
+	"name": "The Taming of the Shrew (علاج ضد دستیاب ہے — Treatment is available)",
 	"startDate": "2012-05-25",
 	"endDate": "2012-05-26",
 	"material": {
-		"name": "The Taming of the Shrew (علاج ضد دستیاب ہے - Treatment is available)",
+		"name": "The Taming of the Shrew (علاج ضد دستیاب ہے — Treatment is available)",
 		"differentiator": "2"
 	},
 	"venue": {

--- a/db-seeding/seeds/productions/the-tempest-globe.json
+++ b/db-seeding/seeds/productions/the-tempest-globe.json
@@ -1,9 +1,9 @@
 {
-	"name": "The Tempest (দ্যা টেম্পেস্ট - Dyā ṭēmpēsṭa)",
+	"name": "The Tempest (দ্যা টেম্পেস্ট — Dyā ṭēmpēsṭa)",
 	"startDate": "2012-05-07",
 	"endDate": "2012-05-08",
 	"material": {
-		"name": "The Tempest (দ্যা টেম্পেস্ট - Dyā ṭēmpēsṭa)",
+		"name": "The Tempest (দ্যা টেম্পেস্ট — Dyā ṭēmpēsṭa)",
 		"differentiator": "4"
 	},
 	"venue": {

--- a/db-seeding/seeds/productions/the-two-gentlemen-of-verona-globe.json
+++ b/db-seeding/seeds/productions/the-two-gentlemen-of-verona-globe.json
@@ -1,9 +1,9 @@
 {
-	"name": "The Two Gentlemen of Verona (Vakomana Vaviri Ve Zimbabwe - Two Zimbabwean Boys)",
+	"name": "The Two Gentlemen of Verona (Vakomana Vaviri Ve Zimbabwe — Two Zimbabwean Boys)",
 	"startDate": "2012-05-09",
 	"endDate": "2012-05-10",
 	"material": {
-		"name": "The Two Gentlemen of Verona (Vakomana Vaviri Ve Zimbabwe - Two Zimbabwean Boys)",
+		"name": "The Two Gentlemen of Verona (Vakomana Vaviri Ve Zimbabwe — Two Zimbabwean Boys)",
 		"differentiator": "3"
 	},
 	"venue": {

--- a/db-seeding/seeds/productions/the-winters-tale-globe.json
+++ b/db-seeding/seeds/productions/the-winters-tale-globe.json
@@ -1,9 +1,9 @@
 {
-	"name": "The Winter's Tale (Ìtàn Ògìnìntìn - History of Ògìnìntìn)",
+	"name": "The Winter's Tale (Ìtàn Ògìnìntìn — History of Ògìnìntìn)",
 	"startDate": "2012-05-24",
 	"endDate": "2012-05-25",
 	"material": {
-		"name": "The Winter's Tale (Ìtàn Ògìnìntìn - History of Ògìnìntìn)",
+		"name": "The Winter's Tale (Ìtàn Ògìnìntìn — History of Ògìnìntìn)",
 		"differentiator": "2"
 	},
 	"venue": {

--- a/db-seeding/seeds/productions/titus-andronicus-globe-2012.json
+++ b/db-seeding/seeds/productions/titus-andronicus-globe-2012.json
@@ -1,9 +1,9 @@
 {
-	"name": "Titus Andronicus (泰特斯 - Tài tè sī)",
+	"name": "Titus Andronicus (泰特斯 — Tài tè sī)",
 	"startDate": "2012-05-03",
 	"endDate": "2012-05-04",
 	"material": {
-		"name": "Titus Andronicus (泰特斯 - Tài tè sī)",
+		"name": "Titus Andronicus (泰特斯 — Tài tè sī)",
 		"differentiator": "3"
 	},
 	"venue": {

--- a/db-seeding/seeds/productions/titus-andronicus-rst.json
+++ b/db-seeding/seeds/productions/titus-andronicus-rst.json
@@ -1,10 +1,10 @@
 {
-	"name": "Titus Andronicus (タイタス・アンドロニカス - Taitasu Andoronikasu)",
+	"name": "Titus Andronicus (タイタス・アンドロニカス — Taitasu Andoronikasu)",
 	"startDate": "2006-06-16",
 	"pressDate": "2006-06-20",
 	"endDate": "2006-06-24",
 	"material": {
-		"name": "Titus Andronicus (タイタス・アンドロニカス - Taitasu Andoronikasu)",
+		"name": "Titus Andronicus (タイタス・アンドロニカス — Taitasu Andoronikasu)",
 		"differentiator": "2"
 	},
 	"venue": {

--- a/db-seeding/seeds/productions/twelfth-night-globe.json
+++ b/db-seeding/seeds/productions/twelfth-night-globe.json
@@ -1,9 +1,9 @@
 {
-	"name": "Twelfth Night (पिया बहरूपिया - Piya Behrupiya - Beloved Imposter)",
+	"name": "Twelfth Night (पिया बहरूपिया — Piya Behrupiya — Beloved Imposter)",
 	"startDate": "2012-04-27",
 	"endDate": "2012-04-28",
 	"material": {
-		"name": "Twelfth Night (पिया बहरूपिया - Piya Behrupiya - Beloved Imposter)",
+		"name": "Twelfth Night (पिया बहरूपिया — Piya Behrupiya — Beloved Imposter)",
 		"differentiator": "3"
 	},
 	"venue": {

--- a/db-seeding/seeds/productions/what-are-they-like?-nt-olivier.json
+++ b/db-seeding/seeds/productions/what-are-they-like?-nt-olivier.json
@@ -183,7 +183,7 @@
 			]
 		},
 		{
-			"name": "Crew - Operating trap feed",
+			"name": "Crew — Operating trap feed",
 			"entities": [
 				{
 					"name": "Shauna Brady"


### PR DESCRIPTION
This PR changes the en dashes in the database seeds to em dashes.

> The en dash is approximately the length of the letter N, and the em dash the length of the letter M. The shorter en dash (–) is used to mark ranges and with the meaning “to” in phrases like “Dover–Calais crossing.” The longer em dash (—) is used to separate extra information or mark a break in a sentence.

Ref. [Scribbr: Em Dash (—) vs. En Dash (–) | How to Use in Sentences](https://www.scribbr.com/language-rules/dashes)

### References:
[Scribbr: Em Dash (—) vs. En Dash (–) | How to Use in Sentences](https://www.scribbr.com/language-rules/dashes)