### PR TITLE
Replace en dashes with em dashes

### DIFF
--- a/test-e2e/model-interaction/mat-with-sub-sub-mats.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-sub-mats.test.js
@@ -128,7 +128,7 @@ describe('Material with sub-sub-materials', () => {
 		await chai.request(app)
 			.post('/materials')
 			.send({
-				name: 'Part One - Invasions and Independence (1842-1930)',
+				name: 'Part One — Invasions and Independence (1842-1930)',
 				format: 'sub-collection of plays',
 				year: '2009',
 				subMaterials: [
@@ -211,7 +211,7 @@ describe('Material with sub-sub-materials', () => {
 		await chai.request(app)
 			.post('/materials')
 			.send({
-				name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+				name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 				format: 'sub-collection of plays',
 				year: '2009',
 				subMaterials: [
@@ -294,7 +294,7 @@ describe('Material with sub-sub-materials', () => {
 		await chai.request(app)
 			.post('/materials')
 			.send({
-				name: 'Part Three - Enduring Freedom (1996-2009)',
+				name: 'Part Three — Enduring Freedom (1996-2009)',
 				format: 'sub-collection of plays',
 				year: '2009',
 				subMaterials: [
@@ -318,13 +318,13 @@ describe('Material with sub-sub-materials', () => {
 				year: '2009',
 				subMaterials: [
 					{
-						name: 'Part One - Invasions and Independence (1842-1930)'
+						name: 'Part One — Invasions and Independence (1842-1930)'
 					},
 					{
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)'
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)'
 					},
 					{
-						name: 'Part Three - Enduring Freedom (1996-2009)'
+						name: 'Part Three — Enduring Freedom (1996-2009)'
 					}
 				]
 			});
@@ -347,12 +347,12 @@ describe('Material with sub-sub-materials', () => {
 		await chai.request(app)
 			.post('/productions')
 			.send({
-				name: 'Part One - Invasions and Independence (1842-1930)',
+				name: 'Part One — Invasions and Independence (1842-1930)',
 				startDate: '2009-04-17',
 				pressDate: '2009-04-24',
 				endDate: '2009-06-14',
 				material: {
-					name: 'Part One - Invasions and Independence (1842-1930)'
+					name: 'Part One — Invasions and Independence (1842-1930)'
 				},
 				venue: {
 					name: 'Tricycle Theatre'
@@ -382,12 +382,12 @@ describe('Material with sub-sub-materials', () => {
 		await chai.request(app)
 			.post('/productions')
 			.send({
-				name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+				name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 				startDate: '2009-04-17',
 				pressDate: '2009-04-24',
 				endDate: '2009-06-14',
 				material: {
-					name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)'
+					name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)'
 				},
 				venue: {
 					name: 'Tricycle Theatre'
@@ -417,12 +417,12 @@ describe('Material with sub-sub-materials', () => {
 		await chai.request(app)
 			.post('/productions')
 			.send({
-				name: 'Part Three - Enduring Freedom (1996-2009)',
+				name: 'Part Three — Enduring Freedom (1996-2009)',
 				startDate: '2009-04-17',
 				pressDate: '2009-04-24',
 				endDate: '2009-06-14',
 				material: {
-					name: 'Part Three - Enduring Freedom (1996-2009)'
+					name: 'Part Three — Enduring Freedom (1996-2009)'
 				},
 				venue: {
 					name: 'Tricycle Theatre'
@@ -503,7 +503,7 @@ describe('Material with sub-sub-materials', () => {
 				{
 					model: 'MATERIAL',
 					uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID,
-					name: 'Part One - Invasions and Independence (1842-1930)',
+					name: 'Part One — Invasions and Independence (1842-1930)',
 					format: 'sub-collection of plays',
 					year: 2009,
 					writingCredits: [],
@@ -600,7 +600,7 @@ describe('Material with sub-sub-materials', () => {
 				{
 					model: 'MATERIAL',
 					uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_MATERIAL_UUID,
-					name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+					name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 					format: 'sub-collection of plays',
 					year: 2009,
 					writingCredits: [],
@@ -697,7 +697,7 @@ describe('Material with sub-sub-materials', () => {
 				{
 					model: 'MATERIAL',
 					uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_MATERIAL_UUID,
-					name: 'Part Three - Enduring Freedom (1996-2009)',
+					name: 'Part Three — Enduring Freedom (1996-2009)',
 					format: 'sub-collection of plays',
 					year: 2009,
 					writingCredits: [],
@@ -801,7 +801,7 @@ describe('Material with sub-sub-materials', () => {
 
 	});
 
-	describe('Part One - Invasions and Independence (1842-1930) (material with sur-material and sub-materials)', () => {
+	describe('Part One — Invasions and Independence (1842-1930) (material with sur-material and sub-materials)', () => {
 
 		it('includes The Great Game: Afghanistan as its sur-material', () => {
 
@@ -926,12 +926,12 @@ describe('Material with sub-sub-materials', () => {
 
 	describe('Bugles at the Gates of Jalalabad (material with sur-sur-material)', () => {
 
-		it('includes Part One - Invasions and Independence (1842-1930) as its sur-material and The Great Game: Afghanistan as its sur-sur-material', () => {
+		it('includes Part One — Invasions and Independence (1842-1930) as its sur-material and The Great Game: Afghanistan as its sur-sur-material', () => {
 
 			const expectedSurMaterial = {
 				model: 'MATERIAL',
 				uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID,
-				name: 'Part One - Invasions and Independence (1842-1930)',
+				name: 'Part One — Invasions and Independence (1842-1930)',
 				format: 'sub-collection of plays',
 				year: 2009,
 				writingCredits: [],
@@ -971,7 +971,7 @@ describe('Material with sub-sub-materials', () => {
 					surMaterial: {
 						model: 'MATERIAL',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_MATERIAL_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -1007,7 +1007,7 @@ describe('Material with sub-sub-materials', () => {
 					surMaterial: {
 						model: 'MATERIAL',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_MATERIAL_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -1043,7 +1043,7 @@ describe('Material with sub-sub-materials', () => {
 					surMaterial: {
 						model: 'MATERIAL',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -1102,14 +1102,14 @@ describe('Material with sub-sub-materials', () => {
 
 	});
 
-	describe('Part One - Invasions and Independence (1842-1930) at Tricycle Theatre (production)', () => {
+	describe('Part One — Invasions and Independence (1842-1930) at Tricycle Theatre (production)', () => {
 
 		it('includes the material and its sur-material', () => {
 
 			const expectedMaterial = {
 				model: 'MATERIAL',
 				uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID,
-				name: 'Part One - Invasions and Independence (1842-1930)',
+				name: 'Part One — Invasions and Independence (1842-1930)',
 				format: 'sub-collection of plays',
 				year: 2009,
 				surMaterial: {
@@ -1142,7 +1142,7 @@ describe('Material with sub-sub-materials', () => {
 				surMaterial: {
 					model: 'MATERIAL',
 					uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID,
-					name: 'Part One - Invasions and Independence (1842-1930)',
+					name: 'Part One — Invasions and Independence (1842-1930)',
 					surMaterial: {
 						model: 'MATERIAL',
 						uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -1191,7 +1191,7 @@ describe('Material with sub-sub-materials', () => {
 					surMaterial: {
 						model: 'MATERIAL',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_MATERIAL_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -1226,7 +1226,7 @@ describe('Material with sub-sub-materials', () => {
 					surMaterial: {
 						model: 'MATERIAL',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_MATERIAL_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -1261,7 +1261,7 @@ describe('Material with sub-sub-materials', () => {
 					surMaterial: {
 						model: 'MATERIAL',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -1311,7 +1311,7 @@ describe('Material with sub-sub-materials', () => {
 					surMaterial: {
 						model: 'MATERIAL',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_MATERIAL_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -1346,7 +1346,7 @@ describe('Material with sub-sub-materials', () => {
 					surMaterial: {
 						model: 'MATERIAL',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_MATERIAL_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -1381,7 +1381,7 @@ describe('Material with sub-sub-materials', () => {
 					surMaterial: {
 						model: 'MATERIAL',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -1434,7 +1434,7 @@ describe('Material with sub-sub-materials', () => {
 					surMaterial: {
 						model: 'MATERIAL',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_MATERIAL_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -1464,7 +1464,7 @@ describe('Material with sub-sub-materials', () => {
 					surMaterial: {
 						model: 'MATERIAL',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_MATERIAL_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -1499,7 +1499,7 @@ describe('Material with sub-sub-materials', () => {
 					surMaterial: {
 						model: 'MATERIAL',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_MATERIAL_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -1529,7 +1529,7 @@ describe('Material with sub-sub-materials', () => {
 					surMaterial: {
 						model: 'MATERIAL',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_MATERIAL_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -1564,7 +1564,7 @@ describe('Material with sub-sub-materials', () => {
 					surMaterial: {
 						model: 'MATERIAL',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_MATERIAL_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -1594,7 +1594,7 @@ describe('Material with sub-sub-materials', () => {
 					surMaterial: {
 						model: 'MATERIAL',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_MATERIAL_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -1624,7 +1624,7 @@ describe('Material with sub-sub-materials', () => {
 					surMaterial: {
 						model: 'MATERIAL',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -1654,7 +1654,7 @@ describe('Material with sub-sub-materials', () => {
 					surMaterial: {
 						model: 'MATERIAL',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -1684,7 +1684,7 @@ describe('Material with sub-sub-materials', () => {
 					surMaterial: {
 						model: 'MATERIAL',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,

--- a/test-e2e/model-interaction/multi-tiered-mat-prod-credit-ordering.test.js
+++ b/test-e2e/model-interaction/multi-tiered-mat-prod-credit-ordering.test.js
@@ -144,7 +144,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 		await chai.request(app)
 			.post('/materials')
 			.send({
-				name: 'Part One - Invasions and Independence (1842-1930)',
+				name: 'Part One — Invasions and Independence (1842-1930)',
 				format: 'sub-collection of plays',
 				year: '2009',
 				subMaterials: [
@@ -223,7 +223,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 		await chai.request(app)
 			.post('/materials')
 			.send({
-				name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+				name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 				format: 'sub-collection of plays',
 				year: '2009',
 				subMaterials: [
@@ -302,7 +302,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 		await chai.request(app)
 			.post('/materials')
 			.send({
-				name: 'Part Three - Enduring Freedom (1996-2009)',
+				name: 'Part Three — Enduring Freedom (1996-2009)',
 				format: 'sub-collection of plays',
 				year: '2009',
 				subMaterials: [
@@ -335,13 +335,13 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				year: '2009',
 				subMaterials: [
 					{
-						name: 'Part One - Invasions and Independence (1842-1930)'
+						name: 'Part One — Invasions and Independence (1842-1930)'
 					},
 					{
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)'
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)'
 					},
 					{
-						name: 'Part Three - Enduring Freedom (1996-2009)'
+						name: 'Part Three — Enduring Freedom (1996-2009)'
 					}
 				],
 				characterGroups: [
@@ -601,12 +601,12 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 		await chai.request(app)
 			.post('/productions')
 			.send({
-				name: 'Part One - Invasions and Independence (1842-1930)',
+				name: 'Part One — Invasions and Independence (1842-1930)',
 				startDate: '2009-04-17',
 				pressDate: '2009-04-24',
 				endDate: '2009-06-14',
 				material: {
-					name: 'Part One - Invasions and Independence (1842-1930)'
+					name: 'Part One — Invasions and Independence (1842-1930)'
 				},
 				venue: {
 					name: 'Tricycle Theatre'
@@ -936,12 +936,12 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 		await chai.request(app)
 			.post('/productions')
 			.send({
-				name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+				name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 				startDate: '2009-04-17',
 				pressDate: '2009-04-24',
 				endDate: '2009-06-14',
 				material: {
-					name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)'
+					name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)'
 				},
 				venue: {
 					name: 'Tricycle Theatre'
@@ -1271,12 +1271,12 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 		await chai.request(app)
 			.post('/productions')
 			.send({
-				name: 'Part Three - Enduring Freedom (1996-2009)',
+				name: 'Part Three — Enduring Freedom (1996-2009)',
 				startDate: '2009-04-17',
 				pressDate: '2009-04-24',
 				endDate: '2009-06-14',
 				material: {
-					name: 'Part Three - Enduring Freedom (1996-2009)'
+					name: 'Part Three — Enduring Freedom (1996-2009)'
 				},
 				venue: {
 					name: 'Tricycle Theatre'
@@ -1772,7 +1772,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -1820,7 +1820,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -1868,7 +1868,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -1904,7 +1904,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part Three - Enduring Freedom (1996-2009)',
+					name: 'Part Three — Enduring Freedom (1996-2009)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -1960,7 +1960,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -2008,7 +2008,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -2056,7 +2056,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -2092,7 +2092,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+					name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -2148,7 +2148,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -2196,7 +2196,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -2244,7 +2244,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -2280,7 +2280,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part One - Invasions and Independence (1842-1930)',
+					name: 'Part One — Invasions and Independence (1842-1930)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -2390,7 +2390,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -2438,7 +2438,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -2486,7 +2486,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -2522,7 +2522,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part Three - Enduring Freedom (1996-2009)',
+					name: 'Part Three — Enduring Freedom (1996-2009)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -2578,7 +2578,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -2626,7 +2626,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -2674,7 +2674,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -2710,7 +2710,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+					name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -2766,7 +2766,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -2814,7 +2814,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -2862,7 +2862,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -2898,7 +2898,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part One - Invasions and Independence (1842-1930)',
+					name: 'Part One — Invasions and Independence (1842-1930)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -3008,7 +3008,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -3056,7 +3056,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -3104,7 +3104,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -3140,7 +3140,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part Three - Enduring Freedom (1996-2009)',
+					name: 'Part Three — Enduring Freedom (1996-2009)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -3196,7 +3196,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -3244,7 +3244,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -3292,7 +3292,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -3328,7 +3328,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+					name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -3384,7 +3384,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -3432,7 +3432,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -3480,7 +3480,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -3516,7 +3516,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part One - Invasions and Independence (1842-1930)',
+					name: 'Part One — Invasions and Independence (1842-1930)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -3626,7 +3626,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -3658,7 +3658,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -3690,7 +3690,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -3710,7 +3710,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part Three - Enduring Freedom (1996-2009)',
+					name: 'Part Three — Enduring Freedom (1996-2009)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -3750,7 +3750,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -3782,7 +3782,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -3814,7 +3814,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -3834,7 +3834,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+					name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -3874,7 +3874,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -3906,7 +3906,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -3938,7 +3938,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -3958,7 +3958,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part One - Invasions and Independence (1842-1930)',
+					name: 'Part One — Invasions and Independence (1842-1930)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -4036,7 +4036,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -4080,7 +4080,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -4124,7 +4124,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -4156,7 +4156,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part Three - Enduring Freedom (1996-2009)',
+					name: 'Part Three — Enduring Freedom (1996-2009)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -4208,7 +4208,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -4252,7 +4252,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -4296,7 +4296,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -4328,7 +4328,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+					name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -4380,7 +4380,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -4424,7 +4424,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -4468,7 +4468,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -4500,7 +4500,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part One - Invasions and Independence (1842-1930)',
+					name: 'Part One — Invasions and Independence (1842-1930)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -4602,7 +4602,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -4645,7 +4645,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -4688,7 +4688,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -4719,7 +4719,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part Three - Enduring Freedom (1996-2009)',
+					name: 'Part Three — Enduring Freedom (1996-2009)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -4770,7 +4770,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -4813,7 +4813,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -4856,7 +4856,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -4887,7 +4887,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+					name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -4938,7 +4938,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -4981,7 +4981,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -5024,7 +5024,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -5055,7 +5055,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part One - Invasions and Independence (1842-1930)',
+					name: 'Part One — Invasions and Independence (1842-1930)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -5155,7 +5155,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -5197,7 +5197,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -5239,7 +5239,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -5269,7 +5269,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part Three - Enduring Freedom (1996-2009)',
+					name: 'Part Three — Enduring Freedom (1996-2009)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -5319,7 +5319,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -5361,7 +5361,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -5403,7 +5403,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -5433,7 +5433,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+					name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -5483,7 +5483,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -5525,7 +5525,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -5567,7 +5567,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -5597,7 +5597,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part One - Invasions and Independence (1842-1930)',
+					name: 'Part One — Invasions and Independence (1842-1930)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -5695,7 +5695,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -5739,7 +5739,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -5783,7 +5783,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -5815,7 +5815,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part Three - Enduring Freedom (1996-2009)',
+					name: 'Part Three — Enduring Freedom (1996-2009)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -5867,7 +5867,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -5911,7 +5911,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -5955,7 +5955,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -5987,7 +5987,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+					name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -6039,7 +6039,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -6083,7 +6083,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -6127,7 +6127,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -6159,7 +6159,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part One - Invasions and Independence (1842-1930)',
+					name: 'Part One — Invasions and Independence (1842-1930)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -6261,7 +6261,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -6304,7 +6304,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -6347,7 +6347,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -6378,7 +6378,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part Three - Enduring Freedom (1996-2009)',
+					name: 'Part Three — Enduring Freedom (1996-2009)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -6429,7 +6429,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -6472,7 +6472,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -6515,7 +6515,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -6546,7 +6546,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+					name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -6597,7 +6597,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -6640,7 +6640,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -6683,7 +6683,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -6714,7 +6714,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part One - Invasions and Independence (1842-1930)',
+					name: 'Part One — Invasions and Independence (1842-1930)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -6814,7 +6814,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -6856,7 +6856,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -6898,7 +6898,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -6928,7 +6928,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part Three - Enduring Freedom (1996-2009)',
+					name: 'Part Three — Enduring Freedom (1996-2009)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -6978,7 +6978,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -7020,7 +7020,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -7062,7 +7062,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -7092,7 +7092,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+					name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -7142,7 +7142,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -7184,7 +7184,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -7226,7 +7226,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -7256,7 +7256,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part One - Invasions and Independence (1842-1930)',
+					name: 'Part One — Invasions and Independence (1842-1930)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -7349,7 +7349,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surMaterial: {
 						model: 'MATERIAL',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_MATERIAL_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -7368,7 +7368,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surMaterial: {
 						model: 'MATERIAL',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_MATERIAL_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -7387,7 +7387,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surMaterial: {
 						model: 'MATERIAL',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_MATERIAL_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -7399,7 +7399,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'MATERIAL',
 					uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_MATERIAL_UUID,
-					name: 'Part Three - Enduring Freedom (1996-2009)',
+					name: 'Part Three — Enduring Freedom (1996-2009)',
 					format: 'sub-collection of plays',
 					year: 2009,
 					writingCredits: [],
@@ -7421,7 +7421,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surMaterial: {
 						model: 'MATERIAL',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_MATERIAL_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -7440,7 +7440,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surMaterial: {
 						model: 'MATERIAL',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_MATERIAL_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -7459,7 +7459,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surMaterial: {
 						model: 'MATERIAL',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_MATERIAL_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -7471,7 +7471,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'MATERIAL',
 					uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_MATERIAL_UUID,
-					name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+					name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 					format: 'sub-collection of plays',
 					year: 2009,
 					writingCredits: [],
@@ -7493,7 +7493,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surMaterial: {
 						model: 'MATERIAL',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -7512,7 +7512,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surMaterial: {
 						model: 'MATERIAL',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -7531,7 +7531,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surMaterial: {
 						model: 'MATERIAL',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -7543,7 +7543,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'MATERIAL',
 					uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID,
-					name: 'Part One - Invasions and Independence (1842-1930)',
+					name: 'Part One — Invasions and Independence (1842-1930)',
 					format: 'sub-collection of plays',
 					year: 2009,
 					writingCredits: [],
@@ -7591,7 +7591,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -7625,7 +7625,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -7659,7 +7659,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -7681,7 +7681,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part Three - Enduring Freedom (1996-2009)',
+					name: 'Part Three — Enduring Freedom (1996-2009)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -7723,7 +7723,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -7757,7 +7757,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -7791,7 +7791,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -7813,7 +7813,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+					name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -7855,7 +7855,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -7889,7 +7889,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -7923,7 +7923,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -7945,7 +7945,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part One - Invasions and Independence (1842-1930)',
+					name: 'Part One — Invasions and Independence (1842-1930)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {

--- a/test-e2e/model-interaction/prod-with-sub-sub-prods.test.js
+++ b/test-e2e/model-interaction/prod-with-sub-sub-prods.test.js
@@ -245,7 +245,7 @@ describe('Production with sub-sub-productions', () => {
 		await chai.request(app)
 			.post('/materials')
 			.send({
-				name: 'Part One - Invasions and Independence (1842-1930)',
+				name: 'Part One — Invasions and Independence (1842-1930)',
 				format: 'sub-collection of plays',
 				year: '2009',
 				writingCredits: [
@@ -376,7 +376,7 @@ describe('Production with sub-sub-productions', () => {
 		await chai.request(app)
 			.post('/materials')
 			.send({
-				name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+				name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 				format: 'sub-collection of plays',
 				year: '2009',
 				writingCredits: [
@@ -507,7 +507,7 @@ describe('Production with sub-sub-productions', () => {
 		await chai.request(app)
 			.post('/materials')
 			.send({
-				name: 'Part Three - Enduring Freedom (1996-2009)',
+				name: 'Part Three — Enduring Freedom (1996-2009)',
 				format: 'sub-collection of plays',
 				year: '2009',
 				writingCredits: [
@@ -566,13 +566,13 @@ describe('Production with sub-sub-productions', () => {
 				],
 				subMaterials: [
 					{
-						name: 'Part One - Invasions and Independence (1842-1930)'
+						name: 'Part One — Invasions and Independence (1842-1930)'
 					},
 					{
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)'
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)'
 					},
 					{
-						name: 'Part Three - Enduring Freedom (1996-2009)'
+						name: 'Part Three — Enduring Freedom (1996-2009)'
 					}
 				],
 				characterGroups: [
@@ -850,12 +850,12 @@ describe('Production with sub-sub-productions', () => {
 		await chai.request(app)
 			.post('/productions')
 			.send({
-				name: 'Part One - Invasions and Independence (1842-1930)',
+				name: 'Part One — Invasions and Independence (1842-1930)',
 				startDate: '2010-10-22',
 				pressDate: '2010-10-25',
 				endDate: '2010-11-07',
 				material: {
-					name: 'Part One - Invasions and Independence (1842-1930)'
+					name: 'Part One — Invasions and Independence (1842-1930)'
 				},
 				venue: {
 					name: 'Roda Theatre'
@@ -1209,12 +1209,12 @@ describe('Production with sub-sub-productions', () => {
 		await chai.request(app)
 			.post('/productions')
 			.send({
-				name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+				name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 				startDate: '2010-10-22',
 				pressDate: '2010-10-25',
 				endDate: '2010-11-07',
 				material: {
-					name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)'
+					name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)'
 				},
 				venue: {
 					name: 'Roda Theatre'
@@ -1568,12 +1568,12 @@ describe('Production with sub-sub-productions', () => {
 		await chai.request(app)
 			.post('/productions')
 			.send({
-				name: 'Part Three - Enduring Freedom (1996-2009)',
+				name: 'Part Three — Enduring Freedom (1996-2009)',
 				startDate: '2010-10-22',
 				pressDate: '2010-10-25',
 				endDate: '2010-11-07',
 				material: {
-					name: 'Part Three - Enduring Freedom (1996-2009)'
+					name: 'Part Three — Enduring Freedom (1996-2009)'
 				},
 				venue: {
 					name: 'Roda Theatre'
@@ -1818,12 +1818,12 @@ describe('Production with sub-sub-productions', () => {
 		await chai.request(app)
 			.post('/productions')
 			.send({
-				name: 'Part One - Invasions and Independence (1842-1930)',
+				name: 'Part One — Invasions and Independence (1842-1930)',
 				startDate: '2009-04-17',
 				pressDate: '2009-04-24',
 				endDate: '2009-06-14',
 				material: {
-					name: 'Part One - Invasions and Independence (1842-1930)'
+					name: 'Part One — Invasions and Independence (1842-1930)'
 				},
 				venue: {
 					name: 'Tricycle Theatre'
@@ -1901,12 +1901,12 @@ describe('Production with sub-sub-productions', () => {
 		await chai.request(app)
 			.post('/productions')
 			.send({
-				name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+				name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 				startDate: '2009-04-17',
 				pressDate: '2009-04-24',
 				endDate: '2009-06-14',
 				material: {
-					name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)'
+					name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)'
 				},
 				venue: {
 					name: 'Tricycle Theatre'
@@ -1984,12 +1984,12 @@ describe('Production with sub-sub-productions', () => {
 		await chai.request(app)
 			.post('/productions')
 			.send({
-				name: 'Part Three - Enduring Freedom (1996-2009)',
+				name: 'Part Three — Enduring Freedom (1996-2009)',
 				startDate: '2009-04-17',
 				pressDate: '2009-04-24',
 				endDate: '2009-06-14',
 				material: {
-					name: 'Part Three - Enduring Freedom (1996-2009)'
+					name: 'Part Three — Enduring Freedom (1996-2009)'
 				},
 				venue: {
 					name: 'Tricycle Theatre'
@@ -2127,14 +2127,14 @@ describe('Production with sub-sub-productions', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-					name: 'Part One - Invasions and Independence (1842-1930)',
+					name: 'Part One — Invasions and Independence (1842-1930)',
 					startDate: '2010-10-22',
 					pressDate: '2010-10-25',
 					endDate: '2010-11-07',
 					material: {
 						model: 'MATERIAL',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						format: 'sub-collection of plays',
 						year: 2009,
 						surMaterial: {
@@ -2204,7 +2204,7 @@ describe('Production with sub-sub-productions', () => {
 								surMaterial: {
 									model: 'MATERIAL',
 									uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID,
-									name: 'Part One - Invasions and Independence (1842-1930)',
+									name: 'Part One — Invasions and Independence (1842-1930)',
 									surMaterial: {
 										model: 'MATERIAL',
 										uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -2363,7 +2363,7 @@ describe('Production with sub-sub-productions', () => {
 								surMaterial: {
 									model: 'MATERIAL',
 									uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID,
-									name: 'Part One - Invasions and Independence (1842-1930)',
+									name: 'Part One — Invasions and Independence (1842-1930)',
 									surMaterial: {
 										model: 'MATERIAL',
 										uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -2522,7 +2522,7 @@ describe('Production with sub-sub-productions', () => {
 								surMaterial: {
 									model: 'MATERIAL',
 									uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID,
-									name: 'Part One - Invasions and Independence (1842-1930)',
+									name: 'Part One — Invasions and Independence (1842-1930)',
 									surMaterial: {
 										model: 'MATERIAL',
 										uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -2761,14 +2761,14 @@ describe('Production with sub-sub-productions', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-					name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+					name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 					startDate: '2010-10-22',
 					pressDate: '2010-10-25',
 					endDate: '2010-11-07',
 					material: {
 						model: 'MATERIAL',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_MATERIAL_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						format: 'sub-collection of plays',
 						year: 2009,
 						surMaterial: {
@@ -2838,7 +2838,7 @@ describe('Production with sub-sub-productions', () => {
 								surMaterial: {
 									model: 'MATERIAL',
 									uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_MATERIAL_UUID,
-									name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+									name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 									surMaterial: {
 										model: 'MATERIAL',
 										uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -2997,7 +2997,7 @@ describe('Production with sub-sub-productions', () => {
 								surMaterial: {
 									model: 'MATERIAL',
 									uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_MATERIAL_UUID,
-									name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+									name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 									surMaterial: {
 										model: 'MATERIAL',
 										uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -3156,7 +3156,7 @@ describe('Production with sub-sub-productions', () => {
 								surMaterial: {
 									model: 'MATERIAL',
 									uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_MATERIAL_UUID,
-									name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+									name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 									surMaterial: {
 										model: 'MATERIAL',
 										uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -3395,14 +3395,14 @@ describe('Production with sub-sub-productions', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-					name: 'Part Three - Enduring Freedom (1996-2009)',
+					name: 'Part Three — Enduring Freedom (1996-2009)',
 					startDate: '2010-10-22',
 					pressDate: '2010-10-25',
 					endDate: '2010-11-07',
 					material: {
 						model: 'MATERIAL',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_MATERIAL_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						format: 'sub-collection of plays',
 						year: 2009,
 						surMaterial: {
@@ -3472,7 +3472,7 @@ describe('Production with sub-sub-productions', () => {
 								surMaterial: {
 									model: 'MATERIAL',
 									uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_MATERIAL_UUID,
-									name: 'Part Three - Enduring Freedom (1996-2009)',
+									name: 'Part Three — Enduring Freedom (1996-2009)',
 									surMaterial: {
 										model: 'MATERIAL',
 										uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -3631,7 +3631,7 @@ describe('Production with sub-sub-productions', () => {
 								surMaterial: {
 									model: 'MATERIAL',
 									uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_MATERIAL_UUID,
-									name: 'Part Three - Enduring Freedom (1996-2009)',
+									name: 'Part Three — Enduring Freedom (1996-2009)',
 									surMaterial: {
 										model: 'MATERIAL',
 										uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -3790,7 +3790,7 @@ describe('Production with sub-sub-productions', () => {
 								surMaterial: {
 									model: 'MATERIAL',
 									uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_MATERIAL_UUID,
-									name: 'Part Three - Enduring Freedom (1996-2009)',
+									name: 'Part Three — Enduring Freedom (1996-2009)',
 									surMaterial: {
 										model: 'MATERIAL',
 										uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -4036,7 +4036,7 @@ describe('Production with sub-sub-productions', () => {
 
 	});
 
-	describe('Part One - Invasions and Independence (1842-1930) at Roda Theatre (production with sur-production and sub-productions that have a sur-venue)', () => {
+	describe('Part One — Invasions and Independence (1842-1930) at Roda Theatre (production with sur-production and sub-productions that have a sur-venue)', () => {
 
 		it('includes The Great Game at Roda Theatre as its sur-production', () => {
 
@@ -4217,7 +4217,7 @@ describe('Production with sub-sub-productions', () => {
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID,
-							name: 'Part One - Invasions and Independence (1842-1930)',
+							name: 'Part One — Invasions and Independence (1842-1930)',
 							surMaterial: {
 								model: 'MATERIAL',
 								uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -4377,7 +4377,7 @@ describe('Production with sub-sub-productions', () => {
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID,
-							name: 'Part One - Invasions and Independence (1842-1930)',
+							name: 'Part One — Invasions and Independence (1842-1930)',
 							surMaterial: {
 								model: 'MATERIAL',
 								uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -4537,7 +4537,7 @@ describe('Production with sub-sub-productions', () => {
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID,
-							name: 'Part One - Invasions and Independence (1842-1930)',
+							name: 'Part One — Invasions and Independence (1842-1930)',
 							surMaterial: {
 								model: 'MATERIAL',
 								uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -4693,19 +4693,19 @@ describe('Production with sub-sub-productions', () => {
 
 	describe('Bugles at the Gates of Jalalabad at Roda Theatre', () => {
 
-		it('includes Part One - Invasions and Independence (1842-1930) at Roda Theatre as its sur-production and The Great Game: Afghanistan at Roda Theatre as its sur-sur-production', () => {
+		it('includes Part One — Invasions and Independence (1842-1930) at Roda Theatre as its sur-production and The Great Game: Afghanistan at Roda Theatre as its sur-sur-production', () => {
 
 			const expectedSurProduction = {
 				model: 'PRODUCTION',
 				uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-				name: 'Part One - Invasions and Independence (1842-1930)',
+				name: 'Part One — Invasions and Independence (1842-1930)',
 				startDate: '2010-10-22',
 				pressDate: '2010-10-25',
 				endDate: '2010-11-07',
 				material: {
 					model: 'MATERIAL',
 					uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID,
-					name: 'Part One - Invasions and Independence (1842-1930)',
+					name: 'Part One — Invasions and Independence (1842-1930)',
 					format: 'sub-collection of plays',
 					year: 2009,
 					surMaterial: {
@@ -5017,14 +5017,14 @@ describe('Production with sub-sub-productions', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part One - Invasions and Independence (1842-1930)',
+					name: 'Part One — Invasions and Independence (1842-1930)',
 					startDate: '2009-04-17',
 					pressDate: '2009-04-24',
 					endDate: '2009-06-14',
 					material: {
 						model: 'MATERIAL',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						format: 'sub-collection of plays',
 						year: 2009,
 						surMaterial: {
@@ -5082,7 +5082,7 @@ describe('Production with sub-sub-productions', () => {
 								surMaterial: {
 									model: 'MATERIAL',
 									uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID,
-									name: 'Part One - Invasions and Independence (1842-1930)',
+									name: 'Part One — Invasions and Independence (1842-1930)',
 									surMaterial: {
 										model: 'MATERIAL',
 										uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -5142,7 +5142,7 @@ describe('Production with sub-sub-productions', () => {
 								surMaterial: {
 									model: 'MATERIAL',
 									uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID,
-									name: 'Part One - Invasions and Independence (1842-1930)',
+									name: 'Part One — Invasions and Independence (1842-1930)',
 									surMaterial: {
 										model: 'MATERIAL',
 										uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -5202,7 +5202,7 @@ describe('Production with sub-sub-productions', () => {
 								surMaterial: {
 									model: 'MATERIAL',
 									uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID,
-									name: 'Part One - Invasions and Independence (1842-1930)',
+									name: 'Part One — Invasions and Independence (1842-1930)',
 									surMaterial: {
 										model: 'MATERIAL',
 										uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -5255,14 +5255,14 @@ describe('Production with sub-sub-productions', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+					name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 					startDate: '2009-04-17',
 					pressDate: '2009-04-24',
 					endDate: '2009-06-14',
 					material: {
 						model: 'MATERIAL',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_MATERIAL_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						format: 'sub-collection of plays',
 						year: 2009,
 						surMaterial: {
@@ -5320,7 +5320,7 @@ describe('Production with sub-sub-productions', () => {
 								surMaterial: {
 									model: 'MATERIAL',
 									uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_MATERIAL_UUID,
-									name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+									name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 									surMaterial: {
 										model: 'MATERIAL',
 										uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -5380,7 +5380,7 @@ describe('Production with sub-sub-productions', () => {
 								surMaterial: {
 									model: 'MATERIAL',
 									uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_MATERIAL_UUID,
-									name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+									name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 									surMaterial: {
 										model: 'MATERIAL',
 										uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -5440,7 +5440,7 @@ describe('Production with sub-sub-productions', () => {
 								surMaterial: {
 									model: 'MATERIAL',
 									uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_MATERIAL_UUID,
-									name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+									name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 									surMaterial: {
 										model: 'MATERIAL',
 										uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -5493,14 +5493,14 @@ describe('Production with sub-sub-productions', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part Three - Enduring Freedom (1996-2009)',
+					name: 'Part Three — Enduring Freedom (1996-2009)',
 					startDate: '2009-04-17',
 					pressDate: '2009-04-24',
 					endDate: '2009-06-14',
 					material: {
 						model: 'MATERIAL',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_MATERIAL_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						format: 'sub-collection of plays',
 						year: 2009,
 						surMaterial: {
@@ -5558,7 +5558,7 @@ describe('Production with sub-sub-productions', () => {
 								surMaterial: {
 									model: 'MATERIAL',
 									uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_MATERIAL_UUID,
-									name: 'Part Three - Enduring Freedom (1996-2009)',
+									name: 'Part Three — Enduring Freedom (1996-2009)',
 									surMaterial: {
 										model: 'MATERIAL',
 										uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -5618,7 +5618,7 @@ describe('Production with sub-sub-productions', () => {
 								surMaterial: {
 									model: 'MATERIAL',
 									uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_MATERIAL_UUID,
-									name: 'Part Three - Enduring Freedom (1996-2009)',
+									name: 'Part Three — Enduring Freedom (1996-2009)',
 									surMaterial: {
 										model: 'MATERIAL',
 										uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -5678,7 +5678,7 @@ describe('Production with sub-sub-productions', () => {
 								surMaterial: {
 									model: 'MATERIAL',
 									uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_MATERIAL_UUID,
-									name: 'Part Three - Enduring Freedom (1996-2009)',
+									name: 'Part Three — Enduring Freedom (1996-2009)',
 									surMaterial: {
 										model: 'MATERIAL',
 										uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -5738,7 +5738,7 @@ describe('Production with sub-sub-productions', () => {
 
 	});
 
-	describe('Part One - Invasions and Independence (1842-1930) at Tricycle Theatre (production with sur-production and sub-productions that do not have a sur-venue)', () => {
+	describe('Part One — Invasions and Independence (1842-1930) at Tricycle Theatre (production with sur-production and sub-productions that do not have a sur-venue)', () => {
 
 		it('includes The Great Game at Tricycle Theatre as its sur-production', () => {
 
@@ -5820,7 +5820,7 @@ describe('Production with sub-sub-productions', () => {
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID,
-							name: 'Part One - Invasions and Independence (1842-1930)',
+							name: 'Part One — Invasions and Independence (1842-1930)',
 							surMaterial: {
 								model: 'MATERIAL',
 								uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -5881,7 +5881,7 @@ describe('Production with sub-sub-productions', () => {
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID,
-							name: 'Part One - Invasions and Independence (1842-1930)',
+							name: 'Part One — Invasions and Independence (1842-1930)',
 							surMaterial: {
 								model: 'MATERIAL',
 								uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -5942,7 +5942,7 @@ describe('Production with sub-sub-productions', () => {
 						surMaterial: {
 							model: 'MATERIAL',
 							uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID,
-							name: 'Part One - Invasions and Independence (1842-1930)',
+							name: 'Part One — Invasions and Independence (1842-1930)',
 							surMaterial: {
 								model: 'MATERIAL',
 								uuid: THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID,
@@ -5999,19 +5999,19 @@ describe('Production with sub-sub-productions', () => {
 
 	describe('Bugles at the Gates of Jalalabad at Tricycle Theatre', () => {
 
-		it('includes Part One - Invasions and Independence (1842-1930) at Tricycle Theatre as its sur-production and The Great Game: Afghanistan at Tricycle Theatre as its sur-sur-production', () => {
+		it('includes Part One — Invasions and Independence (1842-1930) at Tricycle Theatre as its sur-production and The Great Game: Afghanistan at Tricycle Theatre as its sur-sur-production', () => {
 
 			const expectedSurProduction = {
 				model: 'PRODUCTION',
 				uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-				name: 'Part One - Invasions and Independence (1842-1930)',
+				name: 'Part One — Invasions and Independence (1842-1930)',
 				startDate: '2009-04-17',
 				pressDate: '2009-04-24',
 				endDate: '2009-06-14',
 				material: {
 					model: 'MATERIAL',
 					uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID,
-					name: 'Part One - Invasions and Independence (1842-1930)',
+					name: 'Part One — Invasions and Independence (1842-1930)',
 					format: 'sub-collection of plays',
 					year: 2009,
 					surMaterial: {
@@ -6164,7 +6164,7 @@ describe('Production with sub-sub-productions', () => {
 
 	});
 
-	describe('Part One - Invasions and Independence (1842-1930) (material)', () => {
+	describe('Part One — Invasions and Independence (1842-1930) (material)', () => {
 
 		it('includes its productions and their sur-productions', () => {
 
@@ -6172,7 +6172,7 @@ describe('Production with sub-sub-productions', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-					name: 'Part One - Invasions and Independence (1842-1930)',
+					name: 'Part One — Invasions and Independence (1842-1930)',
 					startDate: '2010-10-22',
 					endDate: '2010-11-07',
 					venue: {
@@ -6195,7 +6195,7 @@ describe('Production with sub-sub-productions', () => {
 				{
 					model: 'PRODUCTION',
 					uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-					name: 'Part One - Invasions and Independence (1842-1930)',
+					name: 'Part One — Invasions and Independence (1842-1930)',
 					startDate: '2009-04-17',
 					endDate: '2009-06-14',
 					venue: {
@@ -6245,7 +6245,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6268,7 +6268,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -6305,7 +6305,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6327,7 +6327,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6349,7 +6349,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6371,7 +6371,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6393,7 +6393,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6415,7 +6415,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6437,7 +6437,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6459,7 +6459,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6481,7 +6481,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6514,7 +6514,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6532,7 +6532,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6550,7 +6550,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6568,7 +6568,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6586,7 +6586,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6604,7 +6604,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6622,7 +6622,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6640,7 +6640,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6658,7 +6658,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6700,7 +6700,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6727,7 +6727,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6754,7 +6754,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6781,7 +6781,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6808,7 +6808,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6835,7 +6835,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6862,7 +6862,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6889,7 +6889,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6916,7 +6916,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6958,7 +6958,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -6985,7 +6985,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -7012,7 +7012,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -7039,7 +7039,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -7066,7 +7066,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -7093,7 +7093,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -7120,7 +7120,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -7147,7 +7147,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -7174,7 +7174,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -7216,7 +7216,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -7268,7 +7268,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -7320,7 +7320,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -7372,7 +7372,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -7424,7 +7424,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -7476,7 +7476,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -7528,7 +7528,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -7580,7 +7580,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -7632,7 +7632,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -7699,7 +7699,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -7751,7 +7751,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -7803,7 +7803,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -7855,7 +7855,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -7907,7 +7907,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -7959,7 +7959,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -8011,7 +8011,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -8063,7 +8063,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -8115,7 +8115,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -8182,7 +8182,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -8234,7 +8234,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -8286,7 +8286,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -8338,7 +8338,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -8390,7 +8390,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -8442,7 +8442,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -8494,7 +8494,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -8546,7 +8546,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -8598,7 +8598,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -8665,7 +8665,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -8701,7 +8701,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -8737,7 +8737,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -8773,7 +8773,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -8809,7 +8809,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -8845,7 +8845,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -8881,7 +8881,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -8917,7 +8917,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -8953,7 +8953,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -9004,7 +9004,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -9052,7 +9052,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -9100,7 +9100,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -9148,7 +9148,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -9196,7 +9196,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -9244,7 +9244,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -9292,7 +9292,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -9340,7 +9340,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -9388,7 +9388,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -9451,7 +9451,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -9498,7 +9498,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -9545,7 +9545,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -9592,7 +9592,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -9639,7 +9639,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -9686,7 +9686,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -9733,7 +9733,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -9780,7 +9780,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -9827,7 +9827,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -9889,7 +9889,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -9935,7 +9935,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -9981,7 +9981,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -10027,7 +10027,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -10073,7 +10073,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -10119,7 +10119,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -10165,7 +10165,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -10211,7 +10211,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -10257,7 +10257,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -10318,7 +10318,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -10366,7 +10366,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -10414,7 +10414,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -10462,7 +10462,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -10510,7 +10510,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -10558,7 +10558,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -10606,7 +10606,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -10654,7 +10654,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -10702,7 +10702,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -10765,7 +10765,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -10812,7 +10812,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -10859,7 +10859,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -10906,7 +10906,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -10953,7 +10953,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -11000,7 +11000,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -11047,7 +11047,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -11094,7 +11094,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -11141,7 +11141,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -11203,7 +11203,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -11249,7 +11249,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -11295,7 +11295,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -11341,7 +11341,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -11387,7 +11387,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -11433,7 +11433,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -11479,7 +11479,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -11525,7 +11525,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -11571,7 +11571,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -11632,7 +11632,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -11670,7 +11670,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -11708,7 +11708,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -11746,7 +11746,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -11784,7 +11784,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -11822,7 +11822,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -11860,7 +11860,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -11898,7 +11898,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -11936,7 +11936,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -11992,7 +11992,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -12019,7 +12019,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -12046,7 +12046,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_RODA_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -12073,7 +12073,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -12100,7 +12100,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -12127,7 +12127,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_RODA_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -12154,7 +12154,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -12181,7 +12181,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -12208,7 +12208,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID,
@@ -12231,7 +12231,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -12254,7 +12254,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -12277,7 +12277,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_THREE_ENDURING_FREEDOM_1996_2009_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Three - Enduring Freedom (1996-2009)',
+						name: 'Part Three — Enduring Freedom (1996-2009)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -12300,7 +12300,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -12323,7 +12323,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -12346,7 +12346,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_TWO_COMMUNISM_THE_MUJAHIDEEN_AND_THE_TALIBAN_1979_1996_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part Two - Communism, the Mujahideen and the Taliban (1979-1996)',
+						name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -12369,7 +12369,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -12392,7 +12392,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,
@@ -12415,7 +12415,7 @@ describe('Production with sub-sub-productions', () => {
 					surProduction: {
 						model: 'PRODUCTION',
 						uuid: PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID,
-						name: 'Part One - Invasions and Independence (1842-1930)',
+						name: 'Part One — Invasions and Independence (1842-1930)',
 						surProduction: {
 							model: 'PRODUCTION',
 							uuid: THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID,

--- a/test-e2e/test-helpers/get-stub-uuid.js
+++ b/test-e2e/test-helpers/get-stub-uuid.js
@@ -5,7 +5,7 @@ const constructStubUuid = components => {
 			.filter(Boolean)
 			.map(component =>
 				component
-					.replaceAll(' - ', ' ')
+					.replaceAll(' — ', ' ') // Replace whitespace-flanked em dash with single whitespace.
 					.toUpperCase()
 					.split(' ')
 					.join('_')


### PR DESCRIPTION
This PR changes en dashes to em dashes.

> The en dash is approximately the length of the letter N, and the em dash the length of the letter M. The shorter en dash (–) is used to mark ranges and with the meaning “to” in phrases like “Dover–Calais crossing.” The longer em dash (—) is used to separate extra information or mark a break in a sentence.

Ref. [Scribbr: Em Dash (—) vs. En Dash (–) | How to Use in Sentences](https://www.scribbr.com/language-rules/dashes)

### References:
[Scribbr: Em Dash (—) vs. En Dash (–) | How to Use in Sentences](https://www.scribbr.com/language-rules/dashes)