### PR TITLE
Add differentiators to characters in material database seeds

### DIFF
--- a/db-seeding/seeds/materials/angels-in-america-1-millennium-approaches.json
+++ b/db-seeding/seeds/materials/angels-in-america-1-millennium-approaches.json
@@ -51,7 +51,8 @@
 					"name": "The Voice"
 				},
 				{
-					"name": "Henry"
+					"name": "Henry",
+					"differentiator": "Angels in America"
 				},
 				{
 					"name": "Emily"

--- a/db-seeding/seeds/materials/angels-in-america-2-perestroika.json
+++ b/db-seeding/seeds/materials/angels-in-america-2-perestroika.json
@@ -45,7 +45,8 @@
 					"name": "Mr Lies"
 				},
 				{
-					"name": "Henry"
+					"name": "Henry",
+					"differentiator": "Angels in America"
 				},
 				{
 					"name": "Ethel Rosenberg"

--- a/db-seeding/seeds/materials/england-people-very-nice.json
+++ b/db-seeding/seeds/materials/england-people-very-nice.json
@@ -38,7 +38,7 @@
 				},
 				{
 					"name": "Ruth",
-					"differentiator": "Calendar Girls"
+					"differentiator": "England People Very Nice"
 				},
 				{
 					"name": "Deborah"

--- a/db-seeding/seeds/materials/nt-connections-2012-05-socialism-is-great.json
+++ b/db-seeding/seeds/materials/nt-connections-2012-05-socialism-is-great.json
@@ -15,7 +15,8 @@
 		{
 			"characters": [
 				{
-					"name": "Johnny"
+					"name": "Johnny",
+					"differentiator": "Socialism is Great"
 				},
 				{
 					"name": "Lotus"
@@ -51,7 +52,8 @@
 					"name": "Zhang's Dad"
 				},
 				{
-					"name": "Ensemble"
+					"name": "Ensemble",
+					"differentiator": "Socialism is Great"
 				}
 			]
 		}

--- a/db-seeding/seeds/materials/nt-connections-2012-07-alice-by-heart.json
+++ b/db-seeding/seeds/materials/nt-connections-2012-07-alice-by-heart.json
@@ -96,7 +96,8 @@
 					"name": "Little Queen of Hearts"
 				},
 				{
-					"name": "Crab"
+					"name": "Crab",
+					"differentiator": "Alice by Heart"
 				},
 				{
 					"name": "Mabel"

--- a/db-seeding/seeds/materials/nt-connections-2013-02-mobile-phone-show.json
+++ b/db-seeding/seeds/materials/nt-connections-2013-02-mobile-phone-show.json
@@ -24,7 +24,8 @@
 					"name": "Brains"
 				},
 				{
-					"name": "Georgie"
+					"name": "Georgie",
+					"differentiator": "Mobile Phone Show"
 				},
 				{
 					"name": "Sammie"

--- a/db-seeding/seeds/materials/nt-connections-2013-03-what-are-they-like?.json
+++ b/db-seeding/seeds/materials/nt-connections-2013-03-what-are-they-like?.json
@@ -35,7 +35,8 @@
 					"name": "Gary"
 				},
 				{
-					"name": "Johnny"
+					"name": "Johnny",
+					"differentiator": "What Are They Like?"
 				},
 				{
 					"name": "Indira"

--- a/db-seeding/seeds/materials/nt-connections-2013-08-dont-feed-the-animals.json
+++ b/db-seeding/seeds/materials/nt-connections-2013-08-dont-feed-the-animals.json
@@ -21,7 +21,8 @@
 					"name": "Pozzo"
 				},
 				{
-					"name": "Pip"
+					"name": "Pip",
+					"differentiator": "Don't Feed the Animals"
 				},
 				{
 					"name": "Missy"
@@ -67,7 +68,8 @@
 					"name": "Charlie"
 				},
 				{
-					"name": "Ensemble"
+					"name": "Ensemble",
+					"differentiator": "Don't Feed the Animals"
 				}
 			]
 		}

--- a/db-seeding/seeds/materials/nt-connections-2013-10-forty-five-minutes.json
+++ b/db-seeding/seeds/materials/nt-connections-2013-10-forty-five-minutes.json
@@ -25,7 +25,8 @@
 					"differentiator": "Forty-Five Minutes"
 				},
 				{
-					"name": "Georgie"
+					"name": "Georgie",
+					"differentiator": "Forty-Five Minutes"
 				},
 				{
 					"name": "Trent"

--- a/db-seeding/seeds/materials/that-face.json
+++ b/db-seeding/seeds/materials/that-face.json
@@ -21,7 +21,8 @@
 					"name": "Mia"
 				},
 				{
-					"name": "Henry"
+					"name": "Henry",
+					"differentiator": "That Face"
 				},
 				{
 					"name": "Izzy"

--- a/db-seeding/seeds/materials/the-two-gentlemen-of-verona-1-original-version.json
+++ b/db-seeding/seeds/materials/the-two-gentlemen-of-verona-1-original-version.json
@@ -51,7 +51,8 @@
 					"name": "Launce"
 				},
 				{
-					"name": "Crab"
+					"name": "Crab",
+					"differentiator": "The Two Gentlemen of Verona"
 				},
 				{
 					"name": "Panthino"

--- a/db-seeding/seeds/materials/the-two-gentlemen-of-verona-2-subsequent-version.json
+++ b/db-seeding/seeds/materials/the-two-gentlemen-of-verona-2-subsequent-version.json
@@ -70,7 +70,8 @@
 					"name": "Launce"
 				},
 				{
-					"name": "Crab"
+					"name": "Crab",
+					"differentiator": "The Two Gentlemen of Verona"
 				},
 				{
 					"name": "Panthino"

--- a/db-seeding/seeds/materials/three-days-of-rain.json
+++ b/db-seeding/seeds/materials/three-days-of-rain.json
@@ -22,7 +22,8 @@
 					"differentiator": "Three Days of Rain"
 				},
 				{
-					"name": "Pip"
+					"name": "Pip",
+					"differentiator": "Three Days of Rain"
 				},
 				{
 					"name": "Theo"

--- a/db-seeding/seeds/materials/whipping-it-up.json
+++ b/db-seeding/seeds/materials/whipping-it-up.json
@@ -25,7 +25,7 @@
 				},
 				{
 					"name": "Maggie",
-					"differentiator": "Fatal Light"
+					"differentiator": "Whipping It Up"
 				},
 				{
 					"name": "Fulton"


### PR DESCRIPTION
This PR adds differentiators to characters in material database seeds where required so that they are not considered the same as separate characters.

The characters that needed fixing were identified with the following Cypher queries:

```cypher
MATCH (m1:Material)-[:DEPICTS]->(c:Character)<-[rel:DEPICTS]-(m2:Material)
WHERE
	m1 <> m2 AND
	NOT (m1)-[:HAS_WRITING_ENTITY]->(:Person|Company)<-[:HAS_WRITING_ENTITY]-(m2)
WITH c, COUNT(rel) AS relCount
WHERE relCount > 1
RETURN DISTINCT { name: c.name, uuid: c.uuid } LIMIT 100
```

---

```cypher
MATCH (m1:Material)-[:DEPICTS]->(c:Character)<-[rel:DEPICTS]-(m2:Material)
WHERE
	m1 <> m2 AND
	NOT (m1)-[:HAS_WRITING_ENTITY]->(:Person|Company)<-[:HAS_WRITING_ENTITY]-(m2)
WITH c, COUNT(rel) AS rel_count
WHERE rel_count > 1
RETURN COUNT(DISTINCT({name: c.name, uuid: c.uuid }))
```
Result: 79