### PR TITLE
Fix Cymbeline adaptation material database seed

### DIFF
--- a/db-seeding/seeds/materials/cymbeline-2-adaptation.json
+++ b/db-seeding/seeds/materials/cymbeline-2-adaptation.json
@@ -1,0 +1,100 @@
+{
+	"name": "Cymbeline",
+	"differentiator": "2",
+	"format": "play",
+	"year": "2006",
+	"writingCredits": [
+		{
+			"name": "adapted by",
+			"entities": [
+				{
+					"name": "Emma Rice"
+				}
+			]
+		},
+		{
+			"name": "written by",
+			"entities": [
+				{
+					"name": "Carl Grose"
+				}
+			]
+		},
+		{
+			"name": "from",
+			"entities": [
+				{
+					"model": "MATERIAL",
+					"name": "Cymbeline",
+					"differentiator": "1"
+				}
+			]
+		}
+	],
+	"characterGroups": [
+		{
+			"characters": [
+				{
+					"name": "Cymbeline",
+					"underlyingName": "Cymbeline, King of Britain"
+				},
+				{
+					"name": "Queen"
+				},
+				{
+					"name": "Cloten",
+					"underlyingName": "Lord Cloten"
+				},
+				{
+					"name": "Imogen",
+					"underlyingName": "Princess Imogen"
+				},
+				{
+					"name": "Posthumus",
+					"underlyingName": "Posthumus Leonatus"
+				},
+				{
+					"name": "Joan"
+				},
+				{
+					"name": "Pisanio"
+				},
+				{
+					"name": "Iachimo"
+				},
+				{
+					"name": "Belarius"
+				},
+				{
+					"name": "Two boys",
+					"underlyingName": "Two brothers of Posthumus"
+				},
+				{
+					"name": "Jupiter"
+				},
+				{
+					"name": "Father",
+					"underlyingName": "Sicilius Leonatus"
+				},
+				{
+					"name": "Mother",
+					"underlyingName": "Mother of Posthumus"
+				},
+				{
+					"name": "Parkas"
+				},
+				{
+					"name": "Whores"
+				},
+				{
+					"name": "Musicians",
+					"differentiator": "Cymbeline"
+				},
+				{
+					"name": "Ambassadors",
+					"differentiator": "Cymbeline"
+				}
+			]
+		}
+	]
+}

--- a/db-seeding/seeds/materials/cymbeline-3-subsequent-version.json
+++ b/db-seeding/seeds/materials/cymbeline-3-subsequent-version.json
@@ -1,6 +1,6 @@
 {
 	"name": "Cymbeline",
-	"differentiator": "2",
+	"differentiator": "3",
 	"format": "play",
 	"year": "2012",
 	"originalVersionMaterial": {

--- a/db-seeding/seeds/productions/cymbeline-globe.json
+++ b/db-seeding/seeds/productions/cymbeline-globe.json
@@ -4,7 +4,7 @@
 	"endDate": "2012-05-03",
 	"material": {
 		"name": "Cymbeline",
-		"differentiator": "2"
+		"differentiator": "3"
 	},
 	"venue": {
 		"name": "Globe Theatre"

--- a/db-seeding/seeds/productions/cymbeline-swan.json
+++ b/db-seeding/seeds/productions/cymbeline-swan.json
@@ -5,7 +5,7 @@
 	"endDate": "2006-09-30",
 	"material": {
 		"name": "Cymbeline",
-		"differentiator": "1"
+		"differentiator": "2"
 	},
 	"venue": {
 		"name": "Swan Theatre"
@@ -28,8 +28,7 @@
 			"name": "Hayley Carmichael",
 			"roles": [
 				{
-					"name": "Imogen",
-					"characterName": "Princess Imogen"
+					"name": "Imogen"
 				}
 			]
 		},
@@ -37,8 +36,7 @@
 			"name": "Carl Grose",
 			"roles": [
 				{
-					"name": "Posthumus",
-					"characterName": "Posthumus Leonatus"
+					"name": "Posthumus"
 				}
 			]
 		},
@@ -46,8 +44,7 @@
 			"name": "Craig Johnson",
 			"roles": [
 				{
-					"name": "Cloten",
-					"characterName": "Lord Cloten"
+					"name": "Cloten"
 				}
 			]
 		},
@@ -56,7 +53,7 @@
 			"roles": [
 				{
 					"name": "Brother",
-					"characterName": "Two brothers of Posthumus"
+					"characterName": "Two boys"
 				}
 			]
 		},
@@ -80,8 +77,7 @@
 			"name": "Mike Shepherd",
 			"roles": [
 				{
-					"name": "Cymbeline",
-					"characterName": "Cymbeline, King of Britain"
+					"name": "Cymbeline"
 				}
 			]
 		},


### PR DESCRIPTION
This PR fixes the database seed for Kneehigh's adaptation of Cymbeline, to reflect that it was "freely adapted".

### References:
- [Amazon: Cymbeline (Oberon Modern Plays)](https://www.amazon.co.uk/Cymbeline-Oberon-Modern-William-Shakespeare/dp/1840027215)