### PR TITLE
Add material productions of subsequent versions

### DIFF
--- a/test-e2e/crud/materials-api.test.js
+++ b/test-e2e/crud/materials-api.test.js
@@ -329,6 +329,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 				writingCredits: [],
 				originalVersionMaterial: null,
 				subsequentVersionMaterials: [],
+				subsequentVersionMaterialProductions: [],
 				sourcingMaterials: [],
 				surMaterial: null,
 				subMaterials: [],
@@ -763,6 +764,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 					writingCredits: []
 				},
 				subsequentVersionMaterials: [],
+				subsequentVersionMaterialProductions: [],
 				sourcingMaterials: [],
 				surMaterial: null,
 				subMaterials: [
@@ -1651,6 +1653,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 					writingCredits: []
 				},
 				subsequentVersionMaterials: [],
+				subsequentVersionMaterialProductions: [],
 				sourcingMaterials: [],
 				surMaterial: null,
 				subMaterials: [

--- a/test-e2e/model-interaction/mat-with-sub-mats-subsequent-versions.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-mats-subsequent-versions.test.js
@@ -524,6 +524,59 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 
 		});
 
+		it('includes productions of subsequent versions, including the sur-production', () => {
+
+			const expectedSubsequentVersionMaterialProductions = [
+				{
+					model: 'PRODUCTION',
+					uuid: AGAMEMNON_TRAFALGAR_STUDIOS_PRODUCTION_UUID,
+					name: 'Agamemnon',
+					startDate: '2015-08-22',
+					endDate: '2015-11-07',
+					venue: {
+						model: 'VENUE',
+						uuid: STUDIO_1_VENUE_UUID,
+						name: 'Studio 1',
+						surVenue: {
+							model: 'VENUE',
+							uuid: TRAFALGAR_STUDIOS_VENUE_UUID,
+							name: 'Trafalgar Studios'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: ORESTEIA_TRAFALGAR_STUDIOS_PRODUCTION_UUID,
+						name: 'Oresteia',
+						surProduction: null
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: AGAMEMNON_ALMEIDA_PRODUCTION_UUID,
+					name: 'Agamemnon',
+					startDate: '2015-05-29',
+					endDate: '2015-07-18',
+					venue: {
+						model: 'VENUE',
+						uuid: ALMEIDA_THEATRE_VENUE_UUID,
+						name: 'Almeida Theatre',
+						surVenue: null
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: ORESTEIA_ALMEIDA_PRODUCTION_UUID,
+						name: 'Oresteia',
+						surProduction: null
+					}
+				}
+			];
+
+			const { subsequentVersionMaterialProductions } = agamemnonOriginalVersionMaterial.body;
+
+			expect(subsequentVersionMaterialProductions).to.deep.equal(expectedSubsequentVersionMaterialProductions);
+
+		});
+
 	});
 
 	describe('Agamemnon (subsequent version) (material)', () => {

--- a/test-e2e/model-interaction/mat-with-sub-sub-mats-subsequent-versions.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-sub-mats-subsequent-versions.test.js
@@ -453,6 +453,67 @@ describe('Material with sub-sub-materials and subsequent versions thereof', () =
 
 		});
 
+		it('includes productions of subsequent versions, including the sur-production and sur-sur-production', () => {
+
+			const expectedSubsequentVersionMaterialProductions = [
+				{
+					model: 'PRODUCTION',
+					uuid: RICHARD_II_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
+					name: 'Richard II',
+					startDate: '2013-10-10',
+					endDate: '2013-11-16',
+					venue: {
+						model: 'VENUE',
+						uuid: ROYAL_SHAKESPEARE_THEATRE_VENUE_UUID,
+						name: 'Royal Shakespeare Theatre',
+						surVenue: null
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: THE_FIRST_HENRIAD_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
+						name: 'The First Henriad',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_HENRIAD_ROYAL_SHAKESPEARE_PRODUCTION_UUID,
+							name: 'The Henriad'
+						}
+					}
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: RICHARD_II_UNICORN_PRODUCTION_UUID,
+					name: 'Richard II',
+					startDate: '2013-08-12',
+					endDate: '2013-09-28',
+					venue: {
+						model: 'VENUE',
+						uuid: WESTON_THEATRE_VENUE_UUID,
+						name: 'Weston Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: UNICORN_THEATRE_VENUE_UUID,
+							name: 'Unicorn Theatre'
+						}
+					},
+					surProduction: {
+						model: 'PRODUCTION',
+						uuid: THE_FIRST_HENRIAD_UNICORN_PRODUCTION_UUID,
+						name: 'The First Henriad',
+						surProduction: {
+							model: 'PRODUCTION',
+							uuid: THE_HENRIAD_UNICORN_PRODUCTION_UUID,
+							name: 'The Henriad'
+						}
+					}
+				}
+			];
+
+			const { subsequentVersionMaterialProductions } = richardIIOriginalVersionMaterial.body;
+
+			expect(subsequentVersionMaterialProductions).to.deep.equal(expectedSubsequentVersionMaterialProductions);
+
+		});
+
 	});
 
 	describe('Richard II (subsequent version) (material)', () => {

--- a/test-e2e/model-interaction/mat-with-subsequent-versions.test.js
+++ b/test-e2e/model-interaction/mat-with-subsequent-versions.test.js
@@ -459,6 +459,53 @@ describe('Material with subsequent versions', () => {
 
 		});
 
+		it('includes productions of material\'s subsequent versions', () => {
+
+			const expectedSubsequentVersionMaterialProductions = [
+				{
+					model: 'PRODUCTION',
+					uuid: PEER_GYNT_BARBICAN_PRODUCTION_UUID,
+					name: 'Peer Gynt',
+					startDate: '2007-02-28',
+					endDate: '2007-03-10',
+					venue: {
+						model: 'VENUE',
+						uuid: BARBICAN_THEATRE_VENUE_UUID,
+						name: 'Barbican Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: BARBICAN_CENTRE_VENUE_UUID,
+							name: 'Barbican Centre'
+						}
+					},
+					surProduction: null
+				},
+				{
+					model: 'PRODUCTION',
+					uuid: PEER_GYNT_OLIVIER_PRODUCTION_UUID,
+					name: 'Peer Gynt',
+					startDate: '2000-10-16',
+					endDate: '2000-12-09',
+					venue: {
+						model: 'VENUE',
+						uuid: OLIVIER_THEATRE_VENUE_UUID,
+						name: 'Olivier Theatre',
+						surVenue: {
+							model: 'VENUE',
+							uuid: NATIONAL_THEATRE_VENUE_UUID,
+							name: 'National Theatre'
+						}
+					},
+					surProduction: null
+				}
+			];
+
+			const { subsequentVersionMaterialProductions } = peerGyntOriginalVersionMaterial.body;
+
+			expect(subsequentVersionMaterialProductions).to.deep.equal(expectedSubsequentVersionMaterialProductions);
+
+		});
+
 	});
 
 	describe('Peer Gynt (subsequent version) (material)', () => {


### PR DESCRIPTION
This PR modifies the Cypher queries to fetch the productions of a material to include productions of any subsequent versions

---

#### A Midsummer Night's Dream (material)

<img width="943" alt="a-midsummer-nights-dream-material" src="https://github.com/andygout/theatrebase-api/assets/10484515/77efbca2-bb17-4d19-b0ee-cbc209e4deba">