### PR TITLE
Optimise Cypher queries

### DIFF
--- a/src/neo4j/cypher-queries/material/show/show-materials.js
+++ b/src/neo4j/cypher-queries/material/show/show-materials.js
@@ -9,6 +9,10 @@ export default () => `
 				(material)<-[:SUBSEQUENT_VERSION_OF]-(:Material)<-[:HAS_SUB_MATERIAL*1..2]-(subsequentVersionMaterial)
 			)
 
+		WITH
+			material,
+			COLLECT(subsequentVersionMaterial) AS subsequentVersionMaterials
+
 		OPTIONAL MATCH (material)<-[:USES_SOURCE_MATERIAL]-(sourcingMaterial:Material)
 			WHERE NOT EXISTS(
 				(material)<-[:USES_SOURCE_MATERIAL]-(:Material)<-[:HAS_SUB_MATERIAL*1..2]-(sourcingMaterial)
@@ -16,7 +20,7 @@ export default () => `
 
 		WITH
 			material,
-			COLLECT(subsequentVersionMaterial) AS subsequentVersionMaterials,
+			subsequentVersionMaterials,
 			COLLECT(sourcingMaterial) AS sourcingMaterials
 
 		WITH

--- a/src/neo4j/cypher-queries/material/show/show.js
+++ b/src/neo4j/cypher-queries/material/show/show.js
@@ -3,11 +3,15 @@ export default () => `
 
 	OPTIONAL MATCH (material)<-[:HAS_SUB_MATERIAL*1..2]-(surMaterial:Material)
 
+	WITH
+		material,
+		COLLECT(surMaterial) AS surMaterials
+
 	OPTIONAL MATCH (material)-[:HAS_SUB_MATERIAL*1..2]->(subMaterial:Material)
 
 	WITH
 		material,
-		COLLECT(surMaterial) AS surMaterials,
+		surMaterials,
 		COLLECT(subMaterial) AS subMaterials
 
 	WITH

--- a/src/neo4j/cypher-queries/production/show/show.js
+++ b/src/neo4j/cypher-queries/production/show/show.js
@@ -3,11 +3,15 @@ export default () => `
 
 	OPTIONAL MATCH (production)<-[:HAS_SUB_PRODUCTION*1..2]-(surProduction:Production)
 
+	WITH
+		production,
+		COLLECT(surProduction) AS surProductions
+
 	OPTIONAL MATCH (production)-[:HAS_SUB_PRODUCTION*1..2]->(subProduction:Production)
 
 	WITH
 		production,
-		COLLECT(surProduction) AS surProductions,
+		surProductions,
 		COLLECT(subProduction) AS subProductions
 
 	WITH


### PR DESCRIPTION
When working on the changes in this PR https://github.com/andygout/theatrebase-api/pull/637, specifically those being made to [this file](https://github.com/andygout/theatrebase-api/pull/637/files#diff-151227d8cd70471e9e35eb913fd8cb0d3a0e933b2a6c29b99a1c5f13d1aff51f), the first attempt was to write the query like so:

```cypher
MATCH (material:Material { uuid: $uuid })

OPTIONAL MATCH (material)<-[:SUBSEQUENT_VERSION_OF]-(subsequentVersionMaterial:Material)
	WHERE NOT EXISTS(
		(material)<-[:SUBSEQUENT_VERSION_OF]-(:Material)<-[:HAS_SUB_MATERIAL*1..2]-(subsequentVersionMaterial)
	)

OPTIONAL MATCH (material)<-[:USES_SOURCE_MATERIAL]-(sourcingMaterial:Material)
	WHERE NOT EXISTS(
		(material)<-[:USES_SOURCE_MATERIAL]-(:Material)<-[:HAS_SUB_MATERIAL*1..2]-(sourcingMaterial)
	)

WITH
	material,
	COLLECT(subsequentVersionMaterial) AS subsequentVersionMaterials,
	COLLECT(sourcingMaterial) AS sourcingMaterials

WITH
	material,
	[material] + subsequentVersionMaterials + sourcingMaterials AS relatedMaterials
```

This resulted in duplicates in the `relatedMaterials` and also the payload results, e.g. when using the original version of A Midsummer Night's Dream as the subject material, it would contain duplicates of:
- A Midsummer Night's Dream (한여름밤의 꿈 — Han-yeoleumbam-ui kkum — The Dream of a Summer Night) (2006 subsequent version)
- A Midsummer Night's Dream (2006 subsequent version)
- The Indian Boy
- The Donkey Show

This is presumably because after matching `subsequentVersionMaterial`s, this would create rows for each of those, and the subsequent matches for `sourcingMaterial`s would be performed for each of those rows.

The solution would be to either make a single `MATCH` statement accommodate multiple cases (i.e. materials, subsequent versions, and sourcing materials), which would likely be hard to parse, or `COLLECT` the results between each `MATCH`, like so:

```cypher
MATCH (material:Material { uuid: $uuid })

OPTIONAL MATCH (material)<-[:SUBSEQUENT_VERSION_OF]-(subsequentVersionMaterial:Material)
	WHERE NOT EXISTS(
		(material)<-[:SUBSEQUENT_VERSION_OF]-(:Material)<-[:HAS_SUB_MATERIAL*1..2]-(subsequentVersionMaterial)
	)

WITH
	material,
	COLLECT(subsequentVersionMaterial) AS subsequentVersionMaterials

OPTIONAL MATCH (material)<-[:USES_SOURCE_MATERIAL]-(sourcingMaterial:Material)
	WHERE NOT EXISTS(
		(material)<-[:USES_SOURCE_MATERIAL]-(:Material)<-[:HAS_SUB_MATERIAL*1..2]-(sourcingMaterial)
	)

WITH
	material,
	subsequentVersionMaterials,
	COLLECT(sourcingMaterial) AS sourcingMaterials

RETURN
	material,
	[material] + subsequentVersionMaterials + sourcingMaterials AS relatedMaterials
```

The Cypher queries that have this change applied by this PR have the same duplicates in the `relatedMaterials`/`collectionMaterials`/`collectionProductions` but do not experience duplicates in the payload results, possibly because once all the `COLLECT`s are done they were the point of origin and resolves itself that way, whereas in `src/neo4j/cypher-queries/material/show/show-productions.js`, the `relatedMaterials` are a means to finding their productions and the `COLLECT`s end with those instead. This is just a guess without digging too deeply…

Making these changes also come with the benefit of optimising the queries, which can be ascertained using the `PROFILE` Cypher query prefix.

Again using the original version of A Midsummer Night's Dream, the query in `src/neo4j/cypher-queries/material/show/show-materials.js` can be prefixed with `PROFILE`, e.g. `PROFILE MATCH (material:Material { uuid: $uuid }) …`, and run in the Neo4j browser to surface the following information:

- Approach 1: not `COLLECT`ing between `MATCH` statements
- Approach 2: `COLLECT`ing between `MATCH` statements

#### A Midsummer Night's Dream
- Approach 1: 1476 total db hits in 226 ms
- Approach 2: 1110 total db hits in 117 ms

A Midsummer Night's Dream only has 2 x subsequent versions and 2 x sourcing materials, though the difference in number of database hits is already substantial. This effect would become magnified in a production environment for a material with many subsequent versions and sourcing materials (A Midsummer Night's Dream would likely be one such material).

---

I also tested the Cypher query in `src/neo4j/cypher-queries/material/show/show.js` on a material collection that had many sub-materials: Sixty-Six Books, which has two direct sub-materials (The Books of the Old Testament and The Books of the New Testament), which in turn collectively have 66 sub-materials between them (based on the "sixty-six books" of the grandparent material).

- Approach 1: not `COLLECT`ing between `MATCH` statements
- Approach 2: `COLLECT`ing between `MATCH` statements

#### Sixty-Six Books
- Approach 1: 15670 total db hits in 8 ms
- Approach 2: 15402 total db hits in 7 ms

#### The Books of the Old Testament
- Approach 1: 11922 total db hits in 6 ms
- Approach 2: 9794 total db hits in 6 ms

#### Godblog
- Approach 1: 1127 total db hits in 2 ms
- Approach 2: 1127 total db hits in 2 ms

After a few queries (and maybe making the same query multiple times), the time reduces to something rather small, so really the key difference is the number of database hits, which ostensibly will result in consistently more efficient queries regardless of how they are handled under the hood.

---

This PR's changes set a pattern for Cypher queries of `COLLECT`ing after each `MATCH` for nodes which will then be combined, which will:
- prevent the unnecessary exponential accumulation of rows and increase efficiency
- prevent the possible duplication of entries in payload results of future queries

### References:
- [Neo4j Docs — Cypher Manual: Execution plans and query tuning](https://neo4j.com/docs/cypher-manual/current/planning-and-tuning)