### PR TITLE
Remove venue.name from venue productions ORDER BY clause

### DIFF
--- a/src/neo4j/cypher-queries/venue/show/show-productions.js
+++ b/src/neo4j/cypher-queries/venue/show/show-productions.js
@@ -27,8 +27,7 @@ export default () => `
 				production.startDate DESC,
 				COALESCE(surSurProduction.name, surProduction.name, production.name),
 				surSurProductionRel.position DESC,
-				surProductionRel.position DESC,
-				venue.name
+				surProductionRel.position DESC
 
 		RETURN
 			COLLECT(


### PR DESCRIPTION
This PR fixes a mistake introduced in the preceding PR: https://github.com/andygout/theatrebase-api/pull/640.

`venue.name` is not required in this `ORDER BY` clause because, with the venue being the subject of the query, this value will be the same for all productions and is therefore redundant.