### PR TITLE
Omit original version writing entities in company/person subsequent version material credits

### DIFF
--- a/src/neo4j/cypher-queries/person/show/show-materials.js
+++ b/src/neo4j/cypher-queries/person/show/show-materials.js
@@ -16,7 +16,7 @@ export default () => `
 
 			OPTIONAL MATCH (person)<-[writerRel:HAS_WRITING_ENTITY]-(material)
 
-			OPTIONAL MATCH (person)<-[:HAS_WRITING_ENTITY]-(:Material)
+			OPTIONAL MATCH (person)<-[:HAS_WRITING_ENTITY]-(originalVersionMaterial:Material)
 				<-[subsequentVersionRel:SUBSEQUENT_VERSION_OF]-(material)
 
 			OPTIONAL MATCH (person)<-[:HAS_WRITING_ENTITY]-(:Material)
@@ -24,6 +24,8 @@ export default () => `
 
 			OPTIONAL MATCH (material)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->
 				(entity:Person|Company|Material)
+
+			OPTIONAL MATCH (entity)<-[originalVersionWritingEntityRel:HAS_WRITING_ENTITY]-(originalVersionMaterial)
 
 			OPTIONAL MATCH (entity:Material)<-[:HAS_SUB_MATERIAL]-(entitySurMaterial:Material)
 
@@ -40,6 +42,10 @@ export default () => `
 				CASE WHEN sourcingMaterialRel IS NULL THEN false ELSE true END AS isSourcingMaterial,
 				entityRel,
 				entity,
+				CASE WHEN originalVersionWritingEntityRel IS NULL
+					THEN false
+					ELSE true
+				END AS isOriginalVersionWritingEntity,
 				entitySurMaterial,
 				entitySurSurMaterial,
 				sourceMaterialWriterRel,
@@ -54,6 +60,7 @@ export default () => `
 				isSourcingMaterial,
 				entityRel,
 				entity,
+				isOriginalVersionWritingEntity,
 				entitySurMaterial,
 				entitySurSurMaterial,
 				sourceMaterialWriterRel.credit AS sourceMaterialWritingCreditName,
@@ -72,6 +79,7 @@ export default () => `
 				isSourcingMaterial,
 				entityRel,
 				entity,
+				isOriginalVersionWritingEntity,
 				entitySurMaterial,
 				entitySurSurMaterial,
 				COLLECT(
@@ -94,7 +102,7 @@ export default () => `
 				isSourcingMaterial,
 				entityRel.credit AS writingCreditName,
 				COLLECT(
-					CASE WHEN entity IS NULL
+					CASE WHEN entity IS NULL OR (isSubsequentVersion AND isOriginalVersionWritingEntity)
 						THEN null
 						ELSE entity {
 							model: TOUPPER(HEAD(LABELS(entity))),

--- a/test-e2e/model-interaction/mat-with-sub-mats-subsequent-versions.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-mats-subsequent-versions.test.js
@@ -482,7 +482,7 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 
 	describe('Agamemnon (original version) (material)', () => {
 
-		it('includes subsequent versions of this material, with corresponding sur-material', () => {
+		it('includes subsequent versions of this material, with corresponding sur-material; will omit original version writers', () => {
 
 			const expectedSubsequentVersionMaterials = [
 				{
@@ -581,7 +581,7 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 
 	describe('Agamemnon (subsequent version) (material)', () => {
 
-		it('includes original version of this material, with corresponding sur-material', () => {
+		it('includes original version of this material, with corresponding sur-material; will omit original version writers', () => {
 
 			const expectedOriginalVersionMaterial = {
 				model: 'MATERIAL',
@@ -794,7 +794,7 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 
 	describe('Aeschylus (person)', () => {
 
-		it('includes subsequent versions of materials they originally wrote, with corresponding sur-material; will exclude sur-materials when included via sub-material association', () => {
+		it('includes subsequent versions of materials they originally wrote, with corresponding sur-material; will exclude sur-materials when included via sub-material association; will omit original version writers', () => {
 
 			const expectedSubsequentVersionMaterials = [
 				{
@@ -810,22 +810,6 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 						surMaterial: null
 					},
 					writingCredits: [
-						{
-							model: 'WRITING_CREDIT',
-							name: 'by',
-							entities: [
-								{
-									model: 'PERSON',
-									uuid: AESCHYLUS_PERSON_UUID,
-									name: 'Aeschylus'
-								},
-								{
-									model: 'COMPANY',
-									uuid: THE_FATHERS_OF_TRAGEDY_COMPANY_UUID,
-									name: 'The Fathers of Tragedy'
-								}
-							]
-						},
 						{
 							model: 'WRITING_CREDIT',
 							name: 'adapted by',
@@ -909,7 +893,7 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 
 	describe('The Fathers of Tragedy (company)', () => {
 
-		it('includes subsequent versions of materials it originally wrote, with corresponding sur-material; will exclude sur-materials when included via sub-material association', () => {
+		it('includes subsequent versions of materials it originally wrote, with corresponding sur-material; will exclude sur-materials when included via sub-material association; will omit original version writers', () => {
 
 			const expectedSubsequentVersionMaterials = [
 				{
@@ -925,22 +909,6 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 						surMaterial: null
 					},
 					writingCredits: [
-						{
-							model: 'WRITING_CREDIT',
-							name: 'by',
-							entities: [
-								{
-									model: 'PERSON',
-									uuid: AESCHYLUS_PERSON_UUID,
-									name: 'Aeschylus'
-								},
-								{
-									model: 'COMPANY',
-									uuid: THE_FATHERS_OF_TRAGEDY_COMPANY_UUID,
-									name: 'The Fathers of Tragedy'
-								}
-							]
-						},
 						{
 							model: 'WRITING_CREDIT',
 							name: 'adapted by',

--- a/test-e2e/model-interaction/mat-with-sub-sub-mats-subsequent-versions.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-sub-mats-subsequent-versions.test.js
@@ -407,7 +407,7 @@ describe('Material with sub-sub-materials and subsequent versions thereof', () =
 
 	describe('Richard II (original version) (material)', () => {
 
-		it('includes subsequent versions of this material, with corresponding sur-material and sur-sur-material', () => {
+		it('includes subsequent versions of this material, with corresponding sur-material and sur-sur-material; will omit original version writers', () => {
 
 			const expectedSubsequentVersionMaterials = [
 				{
@@ -1058,7 +1058,7 @@ describe('Material with sub-sub-materials and subsequent versions thereof', () =
 
 	describe('William Shakespeare (person)', () => {
 
-		it('includes subsequent versions of materials they originally wrote, with corresponding sur-material and sur-sur-material; will exclude sur-materials when included via sub-material association', () => {
+		it('includes subsequent versions of materials they originally wrote, with corresponding sur-material and sur-sur-material; will exclude sur-materials when included via sub-material association; will omit original version writers', () => {
 
 			const expectedSubsequentVersionMaterials = [
 				{
@@ -1078,22 +1078,6 @@ describe('Material with sub-sub-materials and subsequent versions thereof', () =
 						}
 					},
 					writingCredits: [
-						{
-							model: 'WRITING_CREDIT',
-							name: 'by',
-							entities: [
-								{
-									model: 'PERSON',
-									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
-									name: 'William Shakespeare'
-								},
-								{
-									model: 'COMPANY',
-									uuid: THE_KINGS_MEN_COMPANY_UUID,
-									name: 'The King\'s Men'
-								}
-							]
-						},
 						{
 							model: 'WRITING_CREDIT',
 							name: 'adapted for young people by',
@@ -1185,7 +1169,7 @@ describe('Material with sub-sub-materials and subsequent versions thereof', () =
 
 	describe('The King\'s Men (company)', () => {
 
-		it('includes subsequent versions of materials it originally wrote, with corresponding sur-material and sur-sur-material; will exclude sur-materials when included via sub-material association', () => {
+		it('includes subsequent versions of materials it originally wrote, with corresponding sur-material and sur-sur-material; will exclude sur-materials when included via sub-material association; will omit original version writers', () => {
 
 			const expectedSubsequentVersionMaterials = [
 				{
@@ -1205,22 +1189,6 @@ describe('Material with sub-sub-materials and subsequent versions thereof', () =
 						}
 					},
 					writingCredits: [
-						{
-							model: 'WRITING_CREDIT',
-							name: 'by',
-							entities: [
-								{
-									model: 'PERSON',
-									uuid: WILLIAM_SHAKESPEARE_PERSON_UUID,
-									name: 'William Shakespeare'
-								},
-								{
-									model: 'COMPANY',
-									uuid: THE_KINGS_MEN_COMPANY_UUID,
-									name: 'The King\'s Men'
-								}
-							]
-						},
 						{
 							model: 'WRITING_CREDIT',
 							name: 'adapted for young people by',

--- a/test-e2e/model-interaction/mat-with-subsequent-versions.test.js
+++ b/test-e2e/model-interaction/mat-with-subsequent-versions.test.js
@@ -358,7 +358,7 @@ describe('Material with subsequent versions', () => {
 
 	describe('Peer Gynt (original version) (material)', () => {
 
-		it('includes subsequent versions of this material, with corresponding writers (version writers only, i.e. excludes original version writers)', () => {
+		it('includes subsequent versions of this material; will omit original version writers', () => {
 
 			const expectedSubsequentVersionMaterials = [
 				{
@@ -671,7 +671,7 @@ describe('Material with subsequent versions', () => {
 
 		});
 
-		it('includes subsequent versions of materials they originally wrote, with corresponding writers', () => {
+		it('includes subsequent versions of materials they originally wrote; will omit original version writers', () => {
 
 			const expectedSubsequentVersionMaterials = [
 				{
@@ -682,22 +682,6 @@ describe('Material with subsequent versions', () => {
 					year: 2008,
 					surMaterial: null,
 					writingCredits: [
-						{
-							model: 'WRITING_CREDIT',
-							name: 'by',
-							entities: [
-								{
-									model: 'PERSON',
-									uuid: HENRIK_IBSEN_PERSON_UUID,
-									name: 'Henrik Ibsen'
-								},
-								{
-									model: 'COMPANY',
-									uuid: IBSEN_THEATRE_COMPANY_UUID,
-									name: 'Ibsen Theatre Company'
-								}
-							]
-						},
 						{
 							model: 'WRITING_CREDIT',
 							name: 'translated by',
@@ -742,22 +726,6 @@ describe('Material with subsequent versions', () => {
 					writingCredits: [
 						{
 							model: 'WRITING_CREDIT',
-							name: 'by',
-							entities: [
-								{
-									model: 'PERSON',
-									uuid: HENRIK_IBSEN_PERSON_UUID,
-									name: 'Henrik Ibsen'
-								},
-								{
-									model: 'COMPANY',
-									uuid: IBSEN_THEATRE_COMPANY_UUID,
-									name: 'Ibsen Theatre Company'
-								}
-							]
-						},
-						{
-							model: 'WRITING_CREDIT',
 							name: 'translated by',
 							entities: [
 								{
@@ -798,22 +766,6 @@ describe('Material with subsequent versions', () => {
 					year: 2000,
 					surMaterial: null,
 					writingCredits: [
-						{
-							model: 'WRITING_CREDIT',
-							name: 'by',
-							entities: [
-								{
-									model: 'PERSON',
-									uuid: HENRIK_IBSEN_PERSON_UUID,
-									name: 'Henrik Ibsen'
-								},
-								{
-									model: 'COMPANY',
-									uuid: IBSEN_THEATRE_COMPANY_UUID,
-									name: 'Ibsen Theatre Company'
-								}
-							]
-						},
 						{
 							model: 'WRITING_CREDIT',
 							name: 'version by',
@@ -900,7 +852,7 @@ describe('Material with subsequent versions', () => {
 
 	describe('Gerry Bamman (person)', () => {
 
-		it('includes materials they have written, with corresponding writers', () => {
+		it('includes materials they have written', () => {
 
 			const expectedMaterials = [
 				{
@@ -1094,7 +1046,7 @@ describe('Material with subsequent versions', () => {
 
 		});
 
-		it('includes subsequent versions of materials it originally wrote, with corresponding writers', () => {
+		it('includes subsequent versions of materials it originally wrote; will omit original version writers', () => {
 
 			const expectedSubsequentVersionMaterials = [
 				{
@@ -1105,22 +1057,6 @@ describe('Material with subsequent versions', () => {
 					year: 2008,
 					surMaterial: null,
 					writingCredits: [
-						{
-							model: 'WRITING_CREDIT',
-							name: 'by',
-							entities: [
-								{
-									model: 'PERSON',
-									uuid: HENRIK_IBSEN_PERSON_UUID,
-									name: 'Henrik Ibsen'
-								},
-								{
-									model: 'COMPANY',
-									uuid: IBSEN_THEATRE_COMPANY_UUID,
-									name: 'Ibsen Theatre Company'
-								}
-							]
-						},
 						{
 							model: 'WRITING_CREDIT',
 							name: 'translated by',
@@ -1165,22 +1101,6 @@ describe('Material with subsequent versions', () => {
 					writingCredits: [
 						{
 							model: 'WRITING_CREDIT',
-							name: 'by',
-							entities: [
-								{
-									model: 'PERSON',
-									uuid: HENRIK_IBSEN_PERSON_UUID,
-									name: 'Henrik Ibsen'
-								},
-								{
-									model: 'COMPANY',
-									uuid: IBSEN_THEATRE_COMPANY_UUID,
-									name: 'Ibsen Theatre Company'
-								}
-							]
-						},
-						{
-							model: 'WRITING_CREDIT',
 							name: 'translated by',
 							entities: [
 								{
@@ -1221,22 +1141,6 @@ describe('Material with subsequent versions', () => {
 					year: 2000,
 					surMaterial: null,
 					writingCredits: [
-						{
-							model: 'WRITING_CREDIT',
-							name: 'by',
-							entities: [
-								{
-									model: 'PERSON',
-									uuid: HENRIK_IBSEN_PERSON_UUID,
-									name: 'Henrik Ibsen'
-								},
-								{
-									model: 'COMPANY',
-									uuid: IBSEN_THEATRE_COMPANY_UUID,
-									name: 'Ibsen Theatre Company'
-								}
-							]
-						},
 						{
 							model: 'WRITING_CREDIT',
 							name: 'version by',


### PR DESCRIPTION
This PR omits the original version writing entities in company/person subsequent version material credits, which is consistent with the subsequent material credits for a material, e.g. the subsequent versions of Peer Gynt do not include the Henrik Ibsen credit, only the writing entities who have a writing credit specific to the subsequent version.

### William Shakespeare (person)

#### Before:
<img width="943" alt="before" src="https://github.com/andygout/theatrebase-api/assets/10484515/e38f8fb0-196e-48d0-ae68-12f64bc3717e">

---

#### After:
<img width="931" alt="after" src="https://github.com/andygout/theatrebase-api/assets/10484515/e08e1f43-96bb-44e2-bf72-6594cbe42d0e">