### PR TITLE
Upgrade Neo4j v5.9.0 -> v5.16.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     docker:
       - image: cimg/node:20.5.0
-      - image: neo4j:5.9.0
+      - image: neo4j:5.16.0
         environment:
           NEO4J_AUTH: none
     steps:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     neo4j:
         container_name: neo4j
-        image: neo4j:5.9.0
+        image: neo4j:5.16.0
         environment:
             - NEO4J_AUTH=none
         ports:


### PR DESCRIPTION
This PR upgrades the Neo4j version from v5.9.0 to v5.16.0 (current latest) by updating the Docker Neo4j image (for local usage and in the CI workflow).

> |Release|Release Date|Hotfixes until|Compatible Driver Versions|
> |---|---|---|---|
> |5.16|January 22, 2024, 2023|Release of 5.17|5.x, 4.4|

Ref. [Neo4j Knowledge Base: Neo4j Supported Versions](https://neo4j.com/developer/kb/neo4j-supported-versions)

The previous Neo4j upgrade was done on 01 Jul 2023 in this PR: https://github.com/andygout/theatrebase-api/pull/563

### References:
- [Neo4j Knowledge Base: Neo4j Supported Versions](https://neo4j.com/developer/kb/neo4j-supported-versions)