### PR TITLE
Add Neo4j setup function to create full-text indexes

### DIFF
--- a/src/neo4j/create-full-text-indexes.js
+++ b/src/neo4j/create-full-text-indexes.js
@@ -1,0 +1,120 @@
+import directly from 'directly';
+
+import { neo4jQuery } from './query';
+import { MODEL_TO_NODE_LABEL_MAP } from '../utils/constants';
+
+const NAMES_FULL_TEXT_INDEX_NAME = 'names';
+
+const FULL_TEXT_INDEX_NAME_TO_PROPERTY_MAP = {
+	[NAMES_FULL_TEXT_INDEX_NAME]: 'name'
+};
+
+const FULL_TEXT_INDEX_NAME_TO_LABELS_MAP = {
+	[NAMES_FULL_TEXT_INDEX_NAME]: new Set([
+		MODEL_TO_NODE_LABEL_MAP.AWARD,
+		MODEL_TO_NODE_LABEL_MAP.AWARD_CEREMONY,
+		MODEL_TO_NODE_LABEL_MAP.CHARACTER,
+		MODEL_TO_NODE_LABEL_MAP.COMPANY,
+		MODEL_TO_NODE_LABEL_MAP.FESTIVAL,
+		MODEL_TO_NODE_LABEL_MAP.FESTIVAL_SERIES,
+		MODEL_TO_NODE_LABEL_MAP.MATERIAL,
+		MODEL_TO_NODE_LABEL_MAP.PERSON,
+		MODEL_TO_NODE_LABEL_MAP.PRODUCTION,
+		MODEL_TO_NODE_LABEL_MAP.SEASON,
+		MODEL_TO_NODE_LABEL_MAP.VENUE
+	])
+};
+
+const FULL_TEXT_INDEX_NAMES = new Set([
+	NAMES_FULL_TEXT_INDEX_NAME
+]);
+
+const createFullTextIndex = async fullTextIndexName => {
+
+	const dropFullTextIndexQuery = `DROP INDEX ${fullTextIndexName} IF EXISTS`;
+
+	const pipeSeparatedLabels = [...FULL_TEXT_INDEX_NAME_TO_LABELS_MAP[fullTextIndexName]].join('|');
+
+	const property = FULL_TEXT_INDEX_NAME_TO_PROPERTY_MAP[fullTextIndexName];
+
+	const createFullTextIndexQuery =
+		`CREATE FULLTEXT INDEX ${fullTextIndexName} FOR (n:${pipeSeparatedLabels}) ON EACH [n.${property}]`;
+
+	try {
+
+		await neo4jQuery(
+			{ query: dropFullTextIndexQuery },
+			{ isOptionalResult: true }
+		);
+
+		console.log(`Neo4j database: Full-text index ${fullTextIndexName} has been dropped (if pre-existing)`); // eslint-disable-line no-console
+
+		await neo4jQuery(
+			{ query: createFullTextIndexQuery },
+			{ isOptionalResult: true }
+		);
+
+		const commaSeparatedLabels = [...FULL_TEXT_INDEX_NAME_TO_LABELS_MAP[fullTextIndexName]].join(',');
+
+		console.log(`Neo4j database: Full-text index '${fullTextIndexName}' has been created on the ${property} property for labels: ${commaSeparatedLabels}`); // eslint-disable-line no-console
+
+	} catch (error) {
+
+		console.error(`Neo4j database: Error attempting query '${createFullTextIndexQuery}': `, error); // eslint-disable-line no-console
+
+	}
+
+};
+
+export default async () => {
+
+	const callDbIndexesQuery = 'SHOW FULLTEXT INDEXES';
+
+	try {
+
+		const fullTextIndexes = await neo4jQuery(
+			{ query: callDbIndexesQuery },
+			{ isOptionalResult: true, isArrayResult: true }
+		);
+
+		const fullTextIndexesToCreate =
+			[...FULL_TEXT_INDEX_NAMES]
+				.filter(fullTextIndexName => {
+					const fullTextIndex =
+						fullTextIndexes.find(fullTextIndex => fullTextIndex.name === fullTextIndexName);
+
+					if (!fullTextIndex) return true;
+
+					const isFullTextIndexLackingLabels =
+						![...FULL_TEXT_INDEX_NAME_TO_LABELS_MAP[fullTextIndexName]]
+							.every(label => fullTextIndex.labelsOrTypes.includes(label));
+
+					if (isFullTextIndexLackingLabels) return true;
+
+					return false;
+				});
+
+		console.log('Neo4j database: Creating full-text indexes…'); // eslint-disable-line no-console
+
+		if (!fullTextIndexesToCreate.length) {
+
+			console.log('Neo4j database: No full-text indexes required'); // eslint-disable-line no-console
+
+			return;
+
+		}
+
+		const fullTextIndexFunctions =
+			fullTextIndexesToCreate.map(fullTextIndexName => () => createFullTextIndex(fullTextIndexName));
+
+		await directly(1, fullTextIndexFunctions);
+
+		console.log('Neo4j database: All full-text indexes created'); // eslint-disable-line no-console
+
+	} catch (error) {
+
+		console.error(`Neo4j database: Error attempting query '${callDbIndexesQuery}': `, error); // eslint-disable-line no-console
+
+	}
+
+};

--- a/src/setup.js
+++ b/src/setup.js
@@ -1,6 +1,7 @@
 import './dotenv';
 
 import createNeo4jConstraints from './neo4j/create-constraints';
+import createNeo4jFullTextIndexes from './neo4j/create-full-text-indexes';
 import createNeo4jIndexes from './neo4j/create-indexes';
 import { getDriver as getNeo4jDriver } from './neo4j/get-driver';
 
@@ -11,6 +12,8 @@ const neo4jDriver = getNeo4jDriver();
 	await createNeo4jConstraints();
 
 	await createNeo4jIndexes();
+
+	await createNeo4jFullTextIndexes();
 
 	await neo4jDriver.close();
 

--- a/test-e2e/setup.js
+++ b/test-e2e/setup.js
@@ -1,4 +1,5 @@
 import createNeo4jConstraints from '../src/neo4j/create-constraints';
+import createNeo4jFullTextIndexes from '../src/neo4j/create-full-text-indexes';
 import createNeo4jIndexes from '../src/neo4j/create-indexes';
 import { shutDown } from '../src/app';
 
@@ -7,6 +8,8 @@ before(async () => {
 	await createNeo4jConstraints();
 
 	await createNeo4jIndexes();
+
+	await createNeo4jFullTextIndexes();
 
 });
 


### PR DESCRIPTION
This PR adds a Neo4j setup function to create full-text indexes on the `name` property of all the nodes.

This is the first step to enabling some basic search functionality. With the index in place, it will allow queries like the below search for 'hamlet':

```cypher
CALL db.index.fulltext.queryNodes('names', 'hamlet') YIELD node, score
RETURN node.name, LABELS(node), score
```

```
╒═══════════════════╤══════════════╤══════════════════╕
│node.name          │LABELS(node)  │score             │
╞═══════════════════╪══════════════╪══════════════════╡
│"Hamlet"           │["Material"]  │3.888427734375    │
├───────────────────┼──────────────┼──────────────────┤
│"Hamlet"           │["Production"]│3.888427734375    │
├───────────────────┼──────────────┼──────────────────┤
│"Hamlet"           │["Production"]│3.888427734375    │
├───────────────────┼──────────────┼──────────────────┤
│"Hamlet"           │["Production"]│3.888427734375    │
├───────────────────┼──────────────┼──────────────────┤
│"Hamlet"           │["Production"]│3.888427734375    │
├───────────────────┼──────────────┼──────────────────┤
│"Hamlet"           │["Production"]│3.888427734375    │
├───────────────────┼──────────────┼──────────────────┤
│"Hamlet"           │["Character"] │3.888427734375    │
├───────────────────┼──────────────┼──────────────────┤
│"Hamlet (Hamletas)"│["Production"]│3.1230127811431885│
├───────────────────┼──────────────┼──────────────────┤
│"King Hamlet"      │["Character"] │3.1230127811431885│
├───────────────────┼──────────────┼──────────────────┤
│"Hamlet (Hamletas)"│["Material"]  │3.1230127811431885│
└───────────────────┴──────────────┴──────────────────┘
```

Ref. [Neo4j Docs: Full-text indexes — Lists of `STRING` values](https://neo4j.com/docs/cypher-manual/5/indexes/semantic-indexes/full-text-indexes/#string-list-properties)

---

The default tokenisation and analysis is not particularly flexible, e.g. a search for 'hamle' returns no results, and seems that when a stream of characters is broken up into individual tokens that they are individual words rather than individual characters.

That said, it is better than only returning results for exact matches which without this index is the current alternative.

However, the docs make clear that:
> Neo4j supports the use of custom analyzers

This indicates that we can improve on the current search via customising configuration.

Refs.
- [Neo4j Docs: Full-text indexes — Tokenization and analyzers](https://neo4j.com/docs/cypher-manual/5/indexes/semantic-indexes/full-text-indexes/#tokenization-analyzers)
- [Neo4j Docs: Full-text index analyzer providers](https://neo4j.com/docs/java-reference/5/extending-neo4j/full-text-analyzer-provider)

---

The index's tokenisers and analyser can be configured to better suit the search requirements, e.g.
```cypher
CREATE FULLTEXT INDEX $name FOR (n:Employee|Manager) ON EACH [n.peerReviews]
OPTIONS {
  indexConfig: {
    `fulltext.analyzer`: 'english',
    `fulltext.eventually_consistent`: true
  }
}
```

Ref. [Neo4j Docs: Full-text indexes — Configuration settings](https://neo4j.com/docs/cypher-manual/5/indexes/semantic-indexes/full-text-indexes/#configuration-settings)

---

The current data modelling of the database (or means of how search is conducted entirely) will need revising to make this search more effective, e.g. some nodes' names are almost meaningless without the context of another node to which they are attached:
- '2009' (AwardCeremony) could be the 2009 award ceremony for any award; it only acquires specific meaning once it has been combined with its associated award to create: 'Laurence Olivier Awards 2009'
- '2012' (Festival) could be the 2010 festival of any festival series; it only acquires specific meaning once it has been combined with its associated festival series to create: 'Connections 2012'
- 'Studio Theatre' (venue) could be the studio theatre for any venue; it only acquires specific meaning once it has been combined with its associated sur-venue to create: 'Soho Theatre: Studio Theatre'

With this approach, the names of nodes are searched in isolation; there will be no knowledge of the context of other nodes to which they are associated and the scores will be calculated accordingly.

Work will also need to be done to disambiguate these sorts of results where their specificity/context is provided by other nodes to which they are associated. E.g. in the below example it is currently unclear to which awards the two '2009' award ceremonies (rows 2 and 3) relate. They will both have distinct UUIDs but this is not much help to an end user.

```cypher
CALL db.index.fulltext.queryNodes('names', 'laurence olivier awards 2009') YIELD node, score
RETURN node.name, LABELS(node), score
```

```
╒═════════════════════════════════╤═════════════════╤══════════════════╕
│node.name                        │LABELS(node)     │score             │
╞═════════════════════════════════╪═════════════════╪══════════════════╡
│"Laurence Olivier Awards"        │["Award"]        │9.145642280578613 │
├─────────────────────────────────┼─────────────────┼──────────────────┤
│"2009"                           │["AwardCeremony"]│4.263924598693848 │
├─────────────────────────────────┼─────────────────┼──────────────────┤
│"2009"                           │["AwardCeremony"]│4.263924598693848 │
├─────────────────────────────────┼─────────────────┼──────────────────┤
│"Olivier Theatre"                │["Venue"]        │3.6353979110717773│
├─────────────────────────────────┼─────────────────┼──────────────────┤
│"Friar Laurence"                 │["Character"]    │3.5181870460510254│
├─────────────────────────────────┼─────────────────┼──────────────────┤
│"Laurence Clayton"               │["Person"]       │3.5181870460510254│
├─────────────────────────────────┼─────────────────┼──────────────────┤
│"Laurence Marks"                 │["Person"]       │3.5181870460510254│
├─────────────────────────────────┼─────────────────┼──────────────────┤
│"2009-10"                        │["AwardCeremony"]│3.424595355987549 │
├─────────────────────────────────┼─────────────────┼──────────────────┤
│"Evening Standard Theatre Awards"│["Award"]        │2.721071243286133 │
├─────────────────────────────────┼─────────────────┼──────────────────┤
│"Enduring Freedom (1996-2009)"   │["Production"]   │2.457216262817383 │
├─────────────────────────────────┼─────────────────┼──────────────────┤
│"Enduring Freedom (1996-2009)"   │["Material"]     │2.457216262817383 │
└─────────────────────────────────┴─────────────────┴──────────────────┘
```

A potential easy fix would be for award ceremony nodes to contain the full names, e.g. 'Laurence Olivier Awards 2009', admittedly resulting in repetition in the award node to which it is associated as well as in all the other sibling awards ceremonies.

Ultimately, getting search right will require substantial consideration, fine-tuning, and a potential revision of the current data modelling (or at least parts thereof).

---

### References:
- [Neo4j Docs: Full-text indexes](https://neo4j.com/docs/cypher-manual/5/indexes/semantic-indexes/full-text-indexes)
- [Neo4j Docs: Full-text index analyzer providers](https://neo4j.com/docs/java-reference/5/extending-neo4j/full-text-analyzer-provider)
- [Neo4j Docs: Create, show, and delete indexes](https://neo4j.com/docs/cypher-manual/current/indexes/search-performance-indexes/managing-indexes)
- [Stack Overflow: Lucene Autocomplete in JSON data](https://stackoverflow.com/questions/33346354/lucene-autocomplete-in-json-data)
- [Implementing a Searchbox with Neo4j by Bert Radke](https://blog.faboo.org/2020/01/implementing-a-searchbox-with-neo4j)