### PR TITLE
Add search endpoint

### DIFF
--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -7,6 +7,7 @@ import * as festivalSerieses from './festival-serieses';
 import * as materials from './materials';
 import * as people from './people';
 import * as productions from './productions';
+import search from './search';
 import * as seasons from './seasons';
 import * as venues from './venues';
 
@@ -20,6 +21,7 @@ export {
 	materials,
 	people,
 	productions,
+	search,
 	seasons,
 	venues
 };

--- a/src/controllers/search.js
+++ b/src/controllers/search.js
@@ -1,0 +1,34 @@
+import { sendJsonResponse } from '../lib/send-json-response';
+import { searchQueries } from '../neo4j/cypher-queries';
+import { neo4jQuery } from '../neo4j/query';
+
+export default async (request, response, next) => {
+
+	try {
+
+		const searchTerm = request.query.searchTerm;
+
+		if (!searchTerm) return sendJsonResponse(response, []);
+
+		const { getSearchQuery } = searchQueries;
+
+		const searchResults = await neo4jQuery(
+			{
+				query: getSearchQuery(),
+				params: { searchTerm }
+			},
+			{
+				isOptionalResult: true,
+				isArrayResult: true
+			}
+		);
+
+		return sendJsonResponse(response, searchResults);
+
+	} catch (error) {
+
+		return next(error);
+
+	}
+
+};

--- a/src/neo4j/cypher-queries/index.js
+++ b/src/neo4j/cypher-queries/index.js
@@ -31,6 +31,7 @@ import {
 	getShowQueries as getProductionShowQueries,
 	getListQuery as getProductionListQuery
 } from './production';
+import { getSearchQuery } from './search';
 import { getShowQueries as getSeasonShowQueries } from './season';
 import {
 	getCreateQuery as getSharedCreateQuery,
@@ -119,12 +120,17 @@ const validationQueries = {
 	getSubVenueChecksQuery
 };
 
+const searchQueries = {
+	getSearchQuery
+};
+
 export {
 	getCreateQueries,
 	getEditQueries,
 	getUpdateQueries,
 	getShowQueries,
 	getListQueries,
+	searchQueries,
 	sharedQueries,
 	validationQueries
 };

--- a/src/neo4j/cypher-queries/search/index.js
+++ b/src/neo4j/cypher-queries/search/index.js
@@ -1,0 +1,5 @@
+import getSearchQuery from './search';
+
+export {
+	getSearchQuery
+};

--- a/src/neo4j/cypher-queries/search/search.js
+++ b/src/neo4j/cypher-queries/search/search.js
@@ -1,0 +1,16 @@
+export default () => `
+	CALL db.index.fulltext.queryNodes('names', $searchTerm)
+
+	YIELD node, score
+
+	RETURN
+		CASE HEAD(LABELS(node))
+			WHEN 'AwardCeremony' THEN 'AWARD_CEREMONY'
+			WHEN 'FestivalSeries' THEN 'FESTIVAL_SERIES'
+			ELSE TOUPPER(HEAD(LABELS(node)))
+		END AS model,
+		node.uuid AS uuid,
+		node.name AS name
+
+	LIMIT 10
+`;

--- a/src/router.js
+++ b/src/router.js
@@ -12,11 +12,14 @@ import {
 	materials as materialsController,
 	people as peopleController,
 	productions as productionsController,
+	search as searchController,
 	seasons as seasonsController,
 	venues as venuesController
 } from './controllers';
 
 const router = new Router();
+
+router.get('/search', searchController);
 
 router.get('/awards/new', awardsController.newRoute);
 router.post('/awards', awardsController.createRoute);

--- a/test-unit/src/controllers/search.test.js
+++ b/test-unit/src/controllers/search.test.js
@@ -1,0 +1,146 @@
+import { expect } from 'chai';
+import httpMocks from 'node-mocks-http';
+import { assert, createSandbox } from 'sinon';
+
+import searchController from '../../../src/controllers/search';
+import * as sendJsonResponseModule from '../../../src/lib/send-json-response';
+import * as cypherQueries from '../../../src/neo4j/cypher-queries';
+import * as neo4jQueryModule from '../../../src/neo4j/query';
+
+describe('Search controller', () => {
+
+	let stubs;
+
+	const sandbox = createSandbox();
+
+	beforeEach(() => {
+
+		stubs = {
+			sendJsonResponse:
+				sandbox.stub(sendJsonResponseModule, 'sendJsonResponse').returns('sendJsonResponse response'),
+			getSearchQuery:
+				sandbox.stub(cypherQueries.searchQueries, 'getSearchQuery').returns('getSearchQuery response'),
+			neo4jQuery: sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves(['foo bar']),
+			request: httpMocks.createRequest({ query: { searchTerm: 'foo' } }),
+			response: httpMocks.createResponse(),
+			next: sandbox.stub()
+		};
+
+	});
+
+	afterEach(() => {
+
+		sandbox.restore();
+
+	});
+
+	context('searchTerm is not present in request.query', () => {
+
+		it('calls sendJsonResponse with the response object and an empty array; does not call neo4jQuery', async () => {
+
+			const request = httpMocks.createRequest();
+			const result = await searchController(request, stubs.response, stubs.next);
+			assert.calledOnce(stubs.sendJsonResponse);
+			assert.calledWithExactly(
+				stubs.sendJsonResponse,
+				stubs.response, []
+			);
+			expect(result).to.equal('sendJsonResponse response');
+			assert.notCalled(stubs.neo4jQuery);
+			assert.notCalled(stubs.getSearchQuery);
+			assert.notCalled(stubs.next);
+
+		});
+
+	});
+
+	context('searchTerm is present in request.query and is an empty string', () => {
+
+		it('calls sendJsonResponse with the response object and an empty array; does not call neo4jQuery', async () => {
+
+			const request = httpMocks.createRequest({ query: { searchTerm: '' } });
+			const result = await searchController(request, stubs.response, stubs.next);
+			assert.calledOnce(stubs.sendJsonResponse);
+			assert.calledWithExactly(
+				stubs.sendJsonResponse,
+				stubs.response, []
+			);
+			expect(result).to.equal('sendJsonResponse response');
+			assert.notCalled(stubs.neo4jQuery);
+			assert.notCalled(stubs.getSearchQuery);
+			assert.notCalled(stubs.next);
+
+		});
+
+	});
+
+	context('searchTerm is present in request.query and is a non-empty string', () => {
+
+		context('neo4jQuery responds as expected', () => {
+
+			it('calls getSearchQuery, neo4jQuery, then sendJsonResponse with the response object and the neo4jQuery response', async () => {
+
+				const result = await searchController(stubs.request, stubs.response, stubs.next);
+				assert.calledOnce(stubs.getSearchQuery);
+				assert.calledWithExactly(stubs.getSearchQuery);
+				assert.calledOnce(stubs.neo4jQuery);
+				assert.calledWithExactly(
+					stubs.neo4jQuery,
+					{
+						query: 'getSearchQuery response',
+						params: {
+							searchTerm: 'foo'
+						}
+					},
+					{
+						isOptionalResult: true,
+						isArrayResult: true
+					}
+				);
+				assert.calledOnce(stubs.sendJsonResponse);
+				assert.calledWithExactly(
+					stubs.sendJsonResponse,
+					stubs.response, ['foo bar']
+				);
+				expect(result).to.equal('sendJsonResponse response');
+				assert.notCalled(stubs.next);
+
+			});
+
+		});
+
+		context('neo4jQuery throws an error', () => {
+
+			it('calls getSearchQuery, neo4jQuery, then next with the error object', async () => {
+
+				const neo4jQueryError = new Error('neo4jQuery error');
+				stubs.neo4jQuery.rejects(neo4jQueryError);
+				
+				await searchController(stubs.request, stubs.response, stubs.next);
+				assert.calledOnce(stubs.getSearchQuery);
+				assert.calledWithExactly(stubs.getSearchQuery);
+				assert.calledOnce(stubs.neo4jQuery);
+				assert.calledWithExactly(
+					stubs.neo4jQuery,
+					{
+						query: 'getSearchQuery response',
+						params: {
+							searchTerm: 'foo'
+						}
+					},
+					{
+						isOptionalResult: true,
+						isArrayResult: true
+					}
+				);
+				assert.notCalled(stubs.sendJsonResponse);
+				assert.calledOnce(stubs.next);
+				assert.calledWithExactly(stubs.next, neo4jQueryError);
+
+			});
+
+		});
+
+	});
+
+});


### PR DESCRIPTION
This PR adds a search endpoint to be used by a front-end search bar component.

The query employed in `src/neo4j/cypher-queries/search/search.js` is based on the example query provided in [Neo4j Docs: Full-text indexes — Query full-text indexes](https://neo4j.com/docs/cypher-manual/5/indexes/semantic-indexes/full-text-indexes/#query-full-text-indexes):

```cypher
CALL db.index.fulltext.queryNodes("namesAndTeams", "nils") YIELD node, score
RETURN node.name, score
```

### Example:

GET http://localhost:3000/search?searchTerm=shakespeare

Returns:

```json
[
    {
        "model": "PERSON",
        "uuid": "28114109-0ac8-48be-aa2c-1f6c835d2594",
        "name": "William Shakespeare"
    },
    {
        "model": "VENUE",
        "uuid": "62d6509a-b123-483f-8ee5-7219f02873d7",
        "name": "Shakespeare Centre"
    },
    {
        "model": "COMPANY",
        "uuid": "f4194342-1343-4206-951e-fa51c179c15a",
        "name": "Bremer Shakespeare Company"
    },
    {
        "model": "COMPANY",
        "uuid": "851b115c-df6a-4f90-a409-530535433e7f",
        "name": "Shakespeare Theatre Company"
    },
    {
        "model": "COMPANY",
        "uuid": "59e03c29-11d0-406b-9400-df92ffb258f1",
        "name": "Chicago Shakespeare Theater"
    },
    {
        "model": "COMPANY",
        "uuid": "de0c7d8b-1068-4ba8-b964-038de2cb8165",
        "name": "Royal Shakespeare Company"
    },
    {
        "model": "VENUE",
        "uuid": "77a2a67a-6d35-4744-b74a-c6581b710e93",
        "name": "Royal Shakespeare Theatre"
    }
]
```

### References:
- [Neo4j Docs: Full-text indexes — Query full-text indexes](https://neo4j.com/docs/cypher-manual/5/indexes/semantic-indexes/full-text-indexes/#query-full-text-indexes)