### PR TITLE
Revise Neo4j setup queries naming: model -> label

### DIFF
--- a/src/neo4j/create-constraints.js
+++ b/src/neo4j/create-constraints.js
@@ -3,7 +3,7 @@ import directly from 'directly';
 import { neo4jQuery } from './query';
 import { MODEL_TO_NODE_LABEL_MAP } from '../utils/constants';
 
-const CONSTRAINABLE_MODELS = new Set([
+const CONSTRAINABLE_LABELS = new Set([
 	MODEL_TO_NODE_LABEL_MAP.AWARD,
 	MODEL_TO_NODE_LABEL_MAP.AWARD_CEREMONY,
 	MODEL_TO_NODE_LABEL_MAP.CHARACTER,
@@ -17,9 +17,9 @@ const CONSTRAINABLE_MODELS = new Set([
 	MODEL_TO_NODE_LABEL_MAP.VENUE
 ]);
 
-const createConstraint = async model => {
+const createConstraint = async label => {
 
-	const createConstraintQuery = `CREATE CONSTRAINT FOR (node:${model}) REQUIRE node.uuid IS UNIQUE`;
+	const createConstraintQuery = `CREATE CONSTRAINT FOR (node:${label}) REQUIRE node.uuid IS UNIQUE`;
 
 	try {
 
@@ -28,7 +28,7 @@ const createConstraint = async model => {
 			{ isOptionalResult: true }
 		);
 
-		console.log(`Neo4j database: Constraint on uuid property created for ${model}`); // eslint-disable-line no-console
+		console.log(`Neo4j database: Constraint on uuid property created for ${label}`); // eslint-disable-line no-console
 
 	} catch (error) {
 
@@ -49,13 +49,13 @@ export default async () => {
 			{ isOptionalResult: true, isArrayResult: true }
 		);
 
-		const modelsWithConstraint = constraints.map(constraint => constraint.labelsOrTypes[0]);
+		const labelsWithConstraint = constraints.map(constraint => constraint.labelsOrTypes[0]);
 
-		const modelsToConstrain = [...CONSTRAINABLE_MODELS].filter(model => !modelsWithConstraint.includes(model));
+		const labelsToConstrain = [...CONSTRAINABLE_LABELS].filter(label => !labelsWithConstraint.includes(label));
 
 		console.log('Neo4j database: Creating constraints…'); // eslint-disable-line no-console
 
-		if (!modelsToConstrain.length) {
+		if (!labelsToConstrain.length) {
 
 			console.log('Neo4j database: No constraints required'); // eslint-disable-line no-console
 
@@ -63,9 +63,9 @@ export default async () => {
 
 		}
 
-		const modelConstraintFunctions = modelsToConstrain.map(model => () => createConstraint(model));
+		const labelConstraintFunctions = labelsToConstrain.map(label => () => createConstraint(label));
 
-		await directly(1, modelConstraintFunctions);
+		await directly(1, labelConstraintFunctions);
 
 		console.log('Neo4j database: All constraints created'); // eslint-disable-line no-console
 

--- a/src/neo4j/create-indexes.js
+++ b/src/neo4j/create-indexes.js
@@ -3,7 +3,7 @@ import directly from 'directly';
 import { neo4jQuery } from './query';
 import { MODEL_TO_NODE_LABEL_MAP } from '../utils/constants';
 
-const INDEXABLE_MODELS = new Set([
+const INDEXABLE_LABELS = new Set([
 	MODEL_TO_NODE_LABEL_MAP.AWARD,
 	MODEL_TO_NODE_LABEL_MAP.CHARACTER,
 	MODEL_TO_NODE_LABEL_MAP.COMPANY,
@@ -15,9 +15,9 @@ const INDEXABLE_MODELS = new Set([
 	MODEL_TO_NODE_LABEL_MAP.VENUE
 ]);
 
-const createIndex = async model => {
+const createIndex = async label => {
 
-	const createIndexQuery = `CREATE INDEX FOR (n:${model}) ON (n.name)`;
+	const createIndexQuery = `CREATE INDEX FOR (n:${label}) ON (n.name)`;
 
 	try {
 
@@ -26,7 +26,7 @@ const createIndex = async model => {
 			{ isOptionalResult: true }
 		);
 
-		console.log(`Neo4j database: Index on name property created for ${model}`); // eslint-disable-line no-console
+		console.log(`Neo4j database: Index on name property created for ${label}`); // eslint-disable-line no-console
 
 	} catch (error) {
 
@@ -47,16 +47,16 @@ export default async () => {
 			{ isOptionalResult: true, isArrayResult: true }
 		);
 
-		const modelsWithIndex =
+		const labelsWithIndex =
 			indexes
 				.filter(index => index.properties?.includes('name'))
 				.map(index => index.labelsOrTypes[0]);
 
-		const modelsToIndex = [...INDEXABLE_MODELS].filter(model => !modelsWithIndex.includes(model));
+		const labelsToIndex = [...INDEXABLE_LABELS].filter(label => !labelsWithIndex.includes(label));
 
 		console.log('Neo4j database: Creating indexes…'); // eslint-disable-line no-console
 
-		if (!modelsToIndex.length) {
+		if (!labelsToIndex.length) {
 
 			console.log('Neo4j database: No indexes required'); // eslint-disable-line no-console
 
@@ -64,9 +64,9 @@ export default async () => {
 
 		}
 
-		const modelIndexFunctions = modelsToIndex.map(model => () => createIndex(model));
+		const labelIndexFunctions = labelsToIndex.map(label => () => createIndex(label));
 
-		await directly(1, modelIndexFunctions);
+		await directly(1, labelIndexFunctions);
 
 		console.log('Neo4j database: All indexes created'); // eslint-disable-line no-console
 


### PR DESCRIPTION
This PR updates the naming ('model -> 'label') in the files invoking the Neo4j setup queries to be consistent with [src/neo4j/create-full-text-indexes.js](https://github.com/andygout/theatrebase-api/blob/e9044bca9b5109e825077856364ebd9c2b51b802/src/neo4j/create-full-text-indexes.js) (the Neo4j database only has a concept of labels, not models, and the model values have been mapped to node labels (via `MODEL_TO_NODE_LABEL_MAP`) so it makes send to refer to the former not the latter).