### PR TITLE
Update README 'Database setup' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Graph database-driven API for site of theatrical productions, materials, and ass
 	- Neo4j local graph database password matches `.env` `DATABASE_PASSWORD` value
 	- `.env` `DATABASE_URL` value is endpoint on which Neo4j local graph database is running
 	- N.B. Neo4j user name and Neo4j local graph database endpoint can be viewed via the Desktop app by running the local Neo4j graph database, then launching the Neo4j Browser and viewing its connection status, which is displayed upon opening the browser and can be returned via browser command `:server status`)
+- Open Neo4j Desktop app
+	- On the requisite database, click `…`, then `Settings…`, then edit the settings as below to avoid encountering `Neo4jError: There is not enough memory to perform the current task` when seeding the database:
+	- Uncomment and increase the value: `#server.memory.heap.initial_size=512m` -> `server.memory.heap.initial_size=5000m`
+	- Uncomment and increase the value: `#server.memory.heap.max_size=512m` -> `server.memory.heap.max_size=5000m`
+	- Press `Apply`
 
 ## To run local Neo4j graph database
 - Open Neo4j Desktop app


### PR DESCRIPTION
This PR updates the 'Database setup' section of the README to include details about increase the Neo4j database's heap memory initial and max size.

Without doing this, seeding the database is very likely (possibly certain) to encounter:

```
Neo4jError: There is not enough memory to perform the current task. Please try increasing 'server.memory.heap.max_size' in the neo4j configuration (normally in 'conf/neo4j.conf' or, if you are using Neo4j Desktop, found through the user interface) or if you are running an embedded installation increase the heap by using '-Xmx' command line flag, and then restart the database.
:
    at captureStacktrace (/{path}/theatrebase-api/node_modules/neo4j-driver-core/lib/result.js:620:17)
    at new Result (/{path}/theatrebase-api/node_modules/neo4j-driver-core/lib/result.js:112:23)
    at Session._run (/{path}/theatrebase-api/node_modules/neo4j-driver-core/lib/session.js:215:16)
    at Session.run (/{path}/theatrebase-api/node_modules/neo4j-driver-core/lib/session.js:180:27)
    at neo4jQuery (/{path}/theatrebase-api/built/webpack:/theatrebase-api/src/neo4j/query.js:15:33)
    at Production.createUpdate (/{path}/theatrebase-api/built/webpack:/theatrebase-api/src/models/Entity.js:145:41)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at callInstanceMethod (/{path}/theatrebase-api/built/webpack:/theatrebase-api/src/lib/call-class-methods.js:7:20) {
  constructor: [Function: Neo4jError] { isRetriable: [Function (anonymous)] },
  code: 'Neo.TransientError.General.OutOfMemoryError',
  retriable: true
}
```

The README instructions give an example of increase the values to `5000m` (i.e. 5000MB, basically equivalent to 5GB). With this amount of memory it is possible to seed the database without this 500ms pause between each seed (though it is unproven if it will always succeed):

https://github.com/andygout/theatrebase-api/blob/7e1be37b68ad704b5de1d2326f580471d443ec9c/db-seeding/seed-db.js#L31

I'll nevertheless lease the pause in because when identifying what length of pause was sufficient, it was when the pause was lower that the seeding process more frequently encountered the above error (perhaps owing to time required for garbage collection), so its presence may reduce the number of occurrences of the error and is therefore worthwhile keeping there.

### References:
- [Neo4j Docs: Memory configuration - Operations Manual](https://neo4j.com/docs/operations-manual/current/performance/memory-configuration)
- [Neo4j Docs: Memory recommendations - Operations Manual](https://neo4j.com/docs/operations-manual/current/tools/neo4j-admin/neo4j-admin-memrec)
- [Neo4j Docs: Tuning of the garbage collector - Operations Manual](https://neo4j.com/docs/operations-manual/current/performance/gc-tuning)
- [Stack Overflow: how to increase heap size in neo4j](https://stackoverflow.com/questions/61439728/how-to-increase-heap-size-in-neo4j)