### PR TITLE
Increase end-to-end tests mocha timeout to 60000ms

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "unit-test": "mocha --require @babel/register test-unit/mocha.env.js test-unit/**/*.test.js",
     "int-test": "mocha --require @babel/register test-int/mocha.env.js test-int/**/*.test.js",
     "e2e-test-resources": "docker-compose -f docker/docker-compose.yml up",
-    "e2e-test": "mocha --timeout 25000 --reporter-option maxDiffSize=8192 --require @babel/register test-e2e/mocha.env.js test-e2e/setup.js test-e2e/**/*.test.js",
+    "e2e-test": "mocha --timeout 60000 --reporter-option maxDiffSize=8192 --require @babel/register test-e2e/mocha.env.js test-e2e/setup.js test-e2e/**/*.test.js",
     "seed-db": "node db-seeding/seed-db",
     "transfer-env-dev": "node transfer-env-dev",
     "build": "webpack",


### PR DESCRIPTION
The mocha timeout for the end-to-end tests was:
- originally extended in this PR (from the 2,000ms default to 5,000ms): https://github.com/andygout/theatrebase-api/pull/184
- again (from 5,000ms to 10,000ms) in this PR https://github.com/andygout/theatrebase-api/pull/348
- again (from 10,000ms to 15,000ms) in this PR https://github.com/andygout/theatrebase-api/pull/470
- and again (from 15,000ms to 25,000ms) in this PR https://github.com/andygout/theatrebase-api/pull/472

With the increase of end-to-end tests since then, the test suite is again failing some tests owing to timeouts, and so this PR increases the timeout to 60,000ms to allow the tests the time they need to run.

The E2E test that fails the most frequently is `test-e2e/model-interaction/prod-with-sub-sub-prods.test.js` (see [here](https://app.circleci.com/pipelines/github/andygout/theatrebase-api/2525/workflows/e828d8d0-2adb-4ada-8dfa-a3c4e761170e/jobs/3038)). Admittedly, this file (at time of writing) is 13,435 lines long (😅) so it is not surprising the tests cannot reliably be fully run within the current 25,000ms timeout.

Another option is to simplify this test file by reducing the number of requests it needs to make in its `before()` function (2,020 lines alone), though this file is testing a fair amount of complexity and to break it down will result in multiple files that repeat a substantial amount of the same setup only to test a different aspect (e.g. creative team credits in one test, crew credits in another, etc.). The net effect would likely be that all the individual tests could run within the 25,000ms timeout but that the aggregate amount of time to run all the tests would be much higher, so increasing the timeout again seems to be the best solution.

#### Other attempts
I also tried:
- Running each end-to-end test directory as a separate step in the CircleCI workflow (`test-e2e/model-interaction/prod-with-sub-sub-prods.test.js` failed — see [here](https://app.circleci.com/pipelines/github/andygout/theatrebase-api/2527/workflows/f68dd1c4-7136-4160-81cc-d771d78c1100/jobs/3041))
- Running `test-e2e/model-interaction/prod-with-sub-sub-prods.test.js` in isolation (it failed — see [here](https://app.circleci.com/pipelines/github/andygout/theatrebase-api/2526/workflows/de4a58f3-9994-4b10-8ec1-949d74c77bb7/jobs/3040))

#### Other options
I could reduce when the end-to-end tests are run in the CircleCI workflow, e.g. only build pull requests, as described [here](https://circleci.com/docs/oss/#only-build-pull-requests):

> #### Only build pull requests
> By default, CircleCI builds every commit from every branch. This behavior may be too aggressive for open source projects, which often have significantly more commits than private projects.
>
> To change this setting, go to the **Project Settings>Advanced** of your project and set the **Only build pull requests** option to _On_.

---

PR description from https://github.com/andygout/theatrebase-api/pull/184:
> End-to-end tests are being flaky: occasionally the second test to run (which is the first that interacts with the Docker-served Neo4j database) will fail owing to:

> `"before all" hook`

> ```
> 1) CRUD (Create, Read, Update, Delete): Characters API CRUD "before all" hook:
>   Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
>    at listOnTimeout (internal/timers.js:551:17)
>    at processTimers (internal/timers.js:494:7)
> ```

> This happens both locally and (more recently) in CircleCI - see here for an example: https://circleci.com/gh/andygout/theatrebase-api/827.

> The general suggestion to fix this issue is to increase the mocha timeout value. The default is 2000ms and this PR increases it to 5000ms.

> My guess is that the Docker-served Neo4j database currently does not have enough time to prepare for requests, so hopefully this extension will allow that to happen.

> ### References:
> - [GitHub - pact-foundation/pact-js - Issues: Tests timeout before pact daemon starts](https://github.com/pact-foundation/pact-js/issues/49#issuecomment-395004092)