### PR TITLE
Change project name: TheatreBase -> Dramatis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# theatrebase-api [![CircleCI](https://circleci.com/gh/andygout/theatrebase-api/tree/main.svg?style=svg)](https://circleci.com/gh/andygout/theatrebase-api/tree/main)
+# dramatis-api [![CircleCI](https://circleci.com/gh/andygout/dramatis-api/tree/main.svg?style=svg)](https://circleci.com/gh/andygout/dramatis-api/tree/main)
 
 Graph database-driven API for site of theatrical productions, materials, and associated data.
 
@@ -7,7 +7,7 @@ Graph database-driven API for site of theatrical productions, materials, and ass
 - Set Node.js to version specified in `.nvmrc`, which can be achieved by running `$ nvm use` (if using [Volta](https://docs.volta.sh/guide/getting-started) then it will be set automatically)
 - Install Node.js modules: `$ npm install`
 - Compile code: `$ npm run build`
-- Copy development environment variables from `.env-dev` into `.env` by running command `$ npm run transfer-env-dev`; N.B. values may need to be amended to match your specific local database configuration (see: [Database setup](https://github.com/andygout/theatrebase-api#user-content-database-setup))
+- Copy development environment variables from `.env-dev` into `.env` by running command `$ npm run transfer-env-dev`; N.B. values may need to be amended to match your specific local database configuration (see: [Database setup](https://github.com/andygout/dramatis-api#user-content-database-setup))
 
 ## Database setup
 - Download the [Neo4j Desktop app](https://neo4j.com/download) (the version of the Neo4j image in `docker/docker-compose.yml` will be a compatible version)
@@ -36,14 +36,14 @@ Graph database-driven API for site of theatrical productions, materials, and ass
 - Run `$ npm run seed-db`
 
 ## To edit content via CMS (content management system) (locally)
-- Run a local instance of [`theatrebase-cms`](https://github.com/andygout/theatrebase-cms) on `http://localhost:3001`, which will point at this API on port 3000
+- Run a local instance of [`dramatis-cms`](https://github.com/andygout/dramatis-cms) on `http://localhost:3001`, which will point at this API on port 3000
 
 ## To view content via user interface (locally)
-- Run a local instance of [`theatrebase-spa`](https://github.com/andygout/theatrebase-spa) (single-page application) on `http://localhost:3002`, which will point at this API on port 3000
+- Run a local instance of [`dramatis-spa`](https://github.com/andygout/dramatis-spa) (single-page application) on `http://localhost:3002`, which will point at this API on port 3000
 
 or
 
-- Run a local instance of [`theatrebase-ssr`](https://github.com/andygout/theatrebase-ssr) (server-side rendered) on `http://localhost:3003`, which will point at this API on port 3000
+- Run a local instance of [`dramatis-ssr`](https://github.com/andygout/dramatis-ssr) (server-side rendered) on `http://localhost:3003`, which will point at this API on port 3000
 
 ## To run linting checks
 - `$ npm run lint-check`

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "theatrebase-api",
+  "name": "dramatis-api",
   "version": "0.0.0",
   "description": "Graph database-driven API for site of theatrical productions, materials, and associated data.",
   "author": "https://github.com/andygout",


### PR DESCRIPTION
This PR changes the project name from **TheatreBase** to **Dramatis**.

Dramatis is Latin for 'of or relating to the drama' and is most commonly known in the context of 'dramatis personae' (literally 'persons of the drama').

It was also the name of an English synth-pop band from the early 1980s: https://en.wikipedia.org/wiki/Dramatis.

It is also a shorter title, meaning (as well as other places that might be an advantage) more of the word will appear in the browser tab when many tabs are open (or the browser window is narrow) and less of the document title text can display.

An obvious idea for a logo would be to incorporate the tragedy and comedy masks — the symmetry of the 'a's (i.e. the third and fifth characters) could be used for this purpose.

TheatreBase also has some drawbacks:
- theatre/theater has different spellings in the UK and US (which may result in needing to acquire more domain names to account for attempts to visit URLs of both spellings)
- its initialism, TB, is an abbreviation of tuberculosis
- the name was something of a play of it sounding similar to 'database' (i.e. a database of theatrebase), though this is not particularly obvious and it reads more of it being a base for theatre, and it's not entirely clear what that is