### PR TITLE
Add validatePropertyPresenceIfNamedChildren() function

### DIFF
--- a/src/models/Base.js
+++ b/src/models/Base.js
@@ -71,9 +71,15 @@ export default class Base {
 
 	validateNamePresenceIfNamedChildren (children) {
 
-		if (this.name === '' && children.some(child => Boolean(child.name))) {
+		this.validatePropertyPresenceIfNamedChildren('name', children);
 
-			this.addPropertyError('name', 'Name is required if named children exist');
+	}
+
+	validatePropertyPresenceIfNamedChildren (property, children) {
+
+		if (this[property] === '' && children.some(child => Boolean(child.name))) {
+
+			this.addPropertyError(property, 'Value is required if named children exist');
 
 		}
 

--- a/src/models/Review.js
+++ b/src/models/Review.js
@@ -67,11 +67,7 @@ export default class Review extends Base {
 
 	validateUrlPresenceIfNamedChildren (children) {
 
-		if (this.url === '' && children.some(child => Boolean(child.name))) {
-
-			this.addPropertyError('url', 'URL is required if named children exist');
-
-		}
+		this.validatePropertyPresenceIfNamedChildren('url', children);
 
 	}
 

--- a/test-int/input-validation-failures/award-ceremony.test.js
+++ b/test-int/input-validation-failures/award-ceremony.test.js
@@ -363,7 +363,7 @@ describe('Input validation failures: AwardCeremony instance', () => {
 							name: '',
 							errors: {
 								name: [
-									'Name is required if named children exist'
+									'Value is required if named children exist'
 								]
 							},
 							nominations: [
@@ -984,7 +984,7 @@ describe('Input validation failures: AwardCeremony instance', () => {
 											differentiator: '',
 											errors: {
 												name: [
-													'Name is required if named children exist'
+													'Value is required if named children exist'
 												]
 											},
 											members: [

--- a/test-int/input-validation-failures/production.test.js
+++ b/test-int/input-validation-failures/production.test.js
@@ -1988,7 +1988,7 @@ describe('Input validation failures: Production instance', () => {
 									differentiator: '',
 									errors: {
 										name: [
-											'Name is required if named children exist'
+											'Value is required if named children exist'
 										]
 									},
 									members: [
@@ -2577,7 +2577,7 @@ describe('Input validation failures: Production instance', () => {
 							differentiator: '',
 							errors: {
 								name: [
-									'Name is required if named children exist'
+									'Value is required if named children exist'
 								]
 							},
 							roles: [
@@ -3465,7 +3465,7 @@ describe('Input validation failures: Production instance', () => {
 							name: '',
 							errors: {
 								name: [
-									'Name is required if named children exist'
+									'Value is required if named children exist'
 								]
 							},
 							entities: [
@@ -4103,7 +4103,7 @@ describe('Input validation failures: Production instance', () => {
 									differentiator: '',
 									errors: {
 										name: [
-											'Name is required if named children exist'
+											'Value is required if named children exist'
 										]
 									},
 									members: [
@@ -4573,7 +4573,7 @@ describe('Input validation failures: Production instance', () => {
 							name: '',
 							errors: {
 								name: [
-									'Name is required if named children exist'
+									'Value is required if named children exist'
 								]
 							},
 							entities: [
@@ -5211,7 +5211,7 @@ describe('Input validation failures: Production instance', () => {
 									differentiator: '',
 									errors: {
 										name: [
-											'Name is required if named children exist'
+											'Value is required if named children exist'
 										]
 									},
 									members: [
@@ -5864,7 +5864,7 @@ describe('Input validation failures: Production instance', () => {
 							date: '',
 							errors: {
 								url: [
-									'URL is required if named children exist'
+									'Value is required if named children exist'
 								]
 							},
 							publication: {
@@ -5957,7 +5957,7 @@ describe('Input validation failures: Production instance', () => {
 							date: '',
 							errors: {
 								url: [
-									'URL is required if named children exist'
+									'Value is required if named children exist'
 								]
 							},
 							publication: {

--- a/test-unit/src/models/Base.test.js
+++ b/test-unit/src/models/Base.test.js
@@ -420,15 +420,38 @@ describe('Base model', () => {
 
 	describe('validateNamePresenceIfNamedChildren method', () => {
 
+		it('will call validatePropertyPresenceIfNamedChildren', () => {
+
+			spy(instance, 'validatePropertyPresenceIfNamedChildren');
+			instance.validateNamePresenceIfNamedChildren([
+				{
+					name: 'Foo'
+				},
+				{
+					name: 'Bar'
+				}
+			]);
+			assert.calledOnce(instance.validatePropertyPresenceIfNamedChildren);
+			assert.calledWithExactly(
+				instance.validatePropertyPresenceIfNamedChildren,
+				'name', [{ name: 'Foo' }, { name: 'Bar' }]
+			);
+
+		});
+
+	});
+
+	describe('validatePropertyPresenceIfNamedChildren method', () => {
+
 		context('valid data', () => {
 
 			context('instance does not have name nor any children with names', () => {
 
 				it('will not add properties to errors property', () => {
 
-					const instance = new Base({ name: '' });
+					instance.name = '';
 					spy(instance, 'addPropertyError');
-					instance.validateNamePresenceIfNamedChildren([{ name: '' }]);
+					instance.validatePropertyPresenceIfNamedChildren('name', [{ name: '' }]);
 					assert.notCalled(instance.addPropertyError);
 
 				});
@@ -439,9 +462,8 @@ describe('Base model', () => {
 
 				it('will not add properties to errors property', () => {
 
-					const instance = new Base({ name: 'Foo' });
 					spy(instance, 'addPropertyError');
-					instance.validateNamePresenceIfNamedChildren([{ name: '' }]);
+					instance.validatePropertyPresenceIfNamedChildren('name', [{ name: '' }]);
 					assert.notCalled(instance.addPropertyError);
 				});
 
@@ -451,9 +473,8 @@ describe('Base model', () => {
 
 				it('will not add properties to errors property', () => {
 
-					const instance = new Base({ name: 'Foo' });
 					spy(instance, 'addPropertyError');
-					instance.validateNamePresenceIfNamedChildren([{ name: 'Bar' }]);
+					instance.validatePropertyPresenceIfNamedChildren('name', [{ name: 'Bar' }]);
 					assert.notCalled(instance.addPropertyError);
 
 				});
@@ -466,13 +487,13 @@ describe('Base model', () => {
 
 			it('adds properties to errors property', () => {
 
-				const instance = new Base({ name: '' });
+				instance.name = '';
 				spy(instance, 'addPropertyError');
-				instance.validateNamePresenceIfNamedChildren([{ name: 'Bar' }]);
+				instance.validatePropertyPresenceIfNamedChildren('name', [{ name: 'Bar' }]);
 				assert.calledOnce(instance.addPropertyError);
 				assert.calledWithExactly(
 					instance.addPropertyError,
-					'name', 'Name is required if named children exist'
+					'name', 'Value is required if named children exist'
 				);
 
 			});

--- a/test-unit/src/models/Review.test.js
+++ b/test-unit/src/models/Review.test.js
@@ -327,62 +327,23 @@ describe('Review model', () => {
 
 	describe('validateUrlPresenceIfNamedChildren method', () => {
 
-		context('valid data', () => {
+		it('will call validatePropertyPresenceIfNamedChildren', () => {
 
-			context('instance does not have url nor any children with names', () => {
-
-				it('will not add properties to errors property', () => {
-
-					const instance = new Review({ url: '' });
-					spy(instance, 'addPropertyError');
-					instance.validateUrlPresenceIfNamedChildren([{ name: '' }]);
-					assert.notCalled(instance.addPropertyError);
-
-				});
-
-			});
-
-			context('instance has a url and no children with names', () => {
-
-				it('will not add properties to errors property', () => {
-
-					const instance = new Review({ url: 'https://www.foo.com' });
-					spy(instance, 'addPropertyError');
-					instance.validateUrlPresenceIfNamedChildren([{ name: '' }]);
-					assert.notCalled(instance.addPropertyError);
-				});
-
-			});
-
-			context('instance has a url and children with names', () => {
-
-				it('will not add properties to errors property', () => {
-
-					const instance = new Review({ url: 'https://www.foo.com' });
-					spy(instance, 'addPropertyError');
-					instance.validateUrlPresenceIfNamedChildren([{ name: 'Financial Times' }]);
-					assert.notCalled(instance.addPropertyError);
-
-				});
-
-			});
-
-		});
-
-		context('invalid data', () => {
-
-			it('adds properties to errors property', () => {
-
-				const instance = new Review({ url: '' });
-				spy(instance, 'addPropertyError');
-				instance.validateUrlPresenceIfNamedChildren([{ name: 'Financial Times' }]);
-				assert.calledOnce(instance.addPropertyError);
-				assert.calledWithExactly(
-					instance.addPropertyError,
-					'url', 'URL is required if named children exist'
-				);
-
-			});
+			const instance = new Review();
+			spy(instance, 'validatePropertyPresenceIfNamedChildren');
+			instance.validateUrlPresenceIfNamedChildren([
+				{
+					name: 'Financial Times'
+				},
+				{
+					name: 'Sarah Hemming'
+				}
+			]);
+			assert.calledOnce(instance.validatePropertyPresenceIfNamedChildren);
+			assert.calledWithExactly(
+				instance.validatePropertyPresenceIfNamedChildren,
+				'url', [{ name: 'Financial Times' }, { name: 'Sarah Hemming' }]
+			);
 
 		});
 


### PR DESCRIPTION
This PR adds a `validatePropertyPresenceIfNamedChildren()` function to consolidate the repeated logic used by `validateNamePresenceIfNamedChildren()` (Base class) and `validateUrlPresenceIfNamedChildren()` (Review class).