### PR TITLE
Call randomUUID from globally available Web Crypto API

### DIFF
--- a/src/lib/get-random-uuid.js
+++ b/src/lib/get-random-uuid.js
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import { getStubUuid } from '../../test-e2e/test-helpers/index.js';
 
 export const getRandomUuid = (opts = {}) => {
@@ -10,6 +8,6 @@ export const getRandomUuid = (opts = {}) => {
 
 	}
 
-	return randomUUID({ disableEntropyCache: true });
+	return crypto.randomUUID({ disableEntropyCache: true });
 
 };


### PR DESCRIPTION
This PR removes the now-redundant import statement for `randomUUID` and instead invokes this method directly from the globally-available [Web Crypto API](https://nodejs.org/api/webcrypto.html).

### References:
- [Node.js Documentation: Web Crypto API — `crypto.randomUUID()`](https://nodejs.org/api/webcrypto.html#cryptorandomuuid)
- [The features we gain from the Node.js 18 sunset — WebCrypto support](https://financialtimes.atlassian.net/wiki/spaces/DS/blog/2024/09/16/8595668993/The+features+we+gain+from+the+Node.js+18+sunset#WebCrypto-support)