### PR TITLE
Add expectations to CastMember.runInputValidations method test

### DIFF
--- a/test-unit/src/models/CastMember.test.js
+++ b/test-unit/src/models/CastMember.test.js
@@ -98,6 +98,7 @@ describe('CastMember model', () => {
 				stubs.getDuplicateIndicesModule.getDuplicateRoleIndices,
 				instance.roles[0].validateName,
 				instance.roles[0].validateCharacterName,
+				instance.roles[0].validateCharacterDifferentiator,
 				instance.roles[0].validateQualifier,
 				instance.roles[0].validateRoleNameCharacterNameDisparity,
 				instance.roles[0].validateUniquenessInGroup
@@ -109,6 +110,7 @@ describe('CastMember model', () => {
 			sinonAssert.calledOnceWithExactly(stubs.getDuplicateIndicesModule.getDuplicateRoleIndices, instance.roles);
 			sinonAssert.calledOnceWithExactly(instance.roles[0].validateName, { isRequired: false });
 			sinonAssert.calledOnceWithExactly(instance.roles[0].validateCharacterName);
+			sinonAssert.calledOnceWithExactly(instance.roles[0].validateCharacterDifferentiator);
 			sinonAssert.calledOnceWithExactly(instance.roles[0].validateQualifier);
 			sinonAssert.calledOnceWithExactly(instance.roles[0].validateRoleNameCharacterNameDisparity);
 			sinonAssert.calledOnceWithExactly(instance.roles[0].validateUniquenessInGroup, { isDuplicate: false });


### PR DESCRIPTION
This PR adds a couple of extra expectations to the `CastMember.runInputValidations` method tests for its invocations of `role.validateCharacterDifferentiator()`.