### PR TITLE
Reconfigure .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,63 @@
 version: 2
 jobs:
-  build:
+  install:
+    docker:
+      - image: cimg/node:26.1.0
+    steps:
+      - checkout
+      - run:
+          name: Install
+          command: npm install
+      - persist_to_workspace:
+          root: .
+          paths:
+            - node_modules
+
+  format:
+    docker:
+      - image: cimg/node:26.1.0
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Format checks
+          command: npm run format-check
+
+  lint:
+    docker:
+      - image: cimg/node:26.1.0
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Lint checks
+          command: npm run lint-check
+
+  unit-tests:
+    docker:
+      - image: cimg/node:26.1.0
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Unit tests
+          command: npm run unit-test
+
+  integration-tests:
+    docker:
+      - image: cimg/node:26.1.0
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Integration tests
+          command: npm run int-test
+
+  e2e-tests:
     docker:
       - image: cimg/node:26.1.0
       - image: neo4j:5.26.8
@@ -11,21 +68,58 @@ jobs:
           NEO4J_server_memory_pagecache_size: 512M
     steps:
       - checkout
+      - attach_workspace:
+          at: .
       - run:
-          name: Install
-          command: npm install
-      - run:
-          name: Format checks
-          command: npm run format-check
-      - run:
-          name: Lint checks
-          command: npm run lint-check
-      - run:
-          name: Unit tests
-          command: npm run unit-test
-      - run:
-          name: Integration tests
-          command: npm run int-test
+          name: Wait for Neo4j
+          command: |
+            node --env-file=./test-e2e/.env -e "
+              import neo4j from 'neo4j-driver';
+
+              const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+              const driver = neo4j.driver(
+                process.env.DATABASE_URL,
+                neo4j.auth.basic(process.env.DATABASE_USERNAME, process.env.DATABASE_PASSWORD)
+              );
+
+              // CircleCI starts the Neo4j sidecar asynchronously, so retry until
+              // it accepts driver connections before running the e2e tests.
+              for (let attempt = 1; attempt <= 60; attempt += 1) {
+                try {
+                  await driver.verifyConnectivity();
+                  await driver.close();
+                  process.exit(0);
+                } catch (error) {
+                  if (attempt === 60) {
+                    await driver.close();
+                    throw error;
+                  }
+
+                  await sleep(1000);
+                }
+              }
+            "
       - run:
           name: End-to-end tests
           command: npm run e2e-test
+
+workflows:
+  version: 2
+  workflow:
+    jobs:
+      - install
+      - format:
+          requires:
+            - install
+      - lint:
+          requires:
+            - install
+      - unit-tests:
+          requires:
+            - install
+      - integration-tests:
+          requires:
+            - install
+      - e2e-tests:
+          requires:
+            - install


### PR DESCRIPTION
This PR reconfigures .circleci/config.yml so that instead of a single job with multiple steps, those steps are now broken out into their own jobs and run in parallel to one another.

This is a measure with the ultimate objective of reducing the time it takes the CI pipeline to run. Admittedly, the largest contributor is the end-to-end tests and further investigation will be done to see how those in particular can be sped up further.

### Before
<img width="1438" height="665" alt="Screenshot 2026-05-16 at 17 35 48" src="https://github.com/user-attachments/assets/962a878c-6bef-429a-aa84-9673a2a403b1" />

<img width="1920" height="933" alt="Screenshot 2026-05-16 at 17 36 11" src="https://github.com/user-attachments/assets/054f7c9a-2b1e-451c-9dd7-d8a4fe30a594" />

### After
<img width="1438" height="665" alt="Screenshot 2026-05-17 at 12 25 07" src="https://github.com/user-attachments/assets/78210ed1-c3a5-484b-b337-14dac93d04bd" />

Each job will then have its own set of steps:
<img width="1440" height="666" alt="Screenshot 2026-05-17 at 12 25 50" src="https://github.com/user-attachments/assets/bdd1db7f-5ddf-4a8c-88d0-093107838a05" />
