### PR TITLE
Seed E2E test model-interaction data via batched Cypher queries

### DIFF
--- a/test-e2e/model-interaction/award-ceremonies-with-crediting-mat-collections-via-assocs.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-crediting-mat-collections-via-assocs.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { createRelationship, deleteRelationship, purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const SUB_PLUGH_PART_I_ORIGINAL_VERSION_MATERIAL_UUID = 'SUB_PLUGH_PART_I_MATERIAL_1_UUID';

--- a/test-e2e/model-interaction/award-ceremonies-with-crediting-mats.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-crediting-mats.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const PIYO_MATERIAL_UUID = 'PIYO_MATERIAL_UUID';

--- a/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-mats-via-assocs.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-mats-via-assocs.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const SUB_FRED_PART_I_MATERIAL_UUID = 'SUB_FRED_PART_I_MATERIAL_UUID';

--- a/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-mats.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-mats.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const SUB_FRED_MATERIAL_UUID = 'SUB_FRED_MATERIAL_UUID';

--- a/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-sub-mats-via-assocs.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-sub-mats-via-assocs.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const SUB_FRED_PART_I_MATERIAL_UUID = 'SUB_FRED_PART_I_MATERIAL_UUID';

--- a/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-sub-mats.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-sub-mats.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const SUB_FRED_MATERIAL_UUID = 'SUB_FRED_MATERIAL_UUID';

--- a/test-e2e/model-interaction/award-ceremonies-with-sub-mats-sub-prods.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-sub-mats-sub-prods.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const ROYAL_COURT_THEATRE_VENUE_UUID = 'ROYAL_COURT_THEATRE_VENUE_UUID';

--- a/test-e2e/model-interaction/award-ceremonies-with-sub-sub-mats-sub-sub-prods.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-sub-sub-mats-sub-sub-prods.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const ROYAL_COURT_THEATRE_VENUE_UUID = 'ROYAL_COURT_THEATRE_VENUE_UUID';

--- a/test-e2e/model-interaction/award-ceremonies.test.js
+++ b/test-e2e/model-interaction/award-ceremonies.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const NATIONAL_THEATRE_VENUE_UUID = 'NATIONAL_THEATRE_VENUE_UUID';

--- a/test-e2e/model-interaction/cast-member-diff-roles-diff-prods-same-mat.test.js
+++ b/test-e2e/model-interaction/cast-member-diff-roles-diff-prods-same-mat.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const KING_LEAR_CHARACTER_UUID = 'KING_LEAR_CHARACTER_UUID';

--- a/test-e2e/model-interaction/cast-member-same-role-diff-prods-same-mat.test.js
+++ b/test-e2e/model-interaction/cast-member-same-role-diff-prods-same-mat.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const TITANIA_CHARACTER_UUID = 'TITANIA_QUEEN_OF_THE_FAIRIES_CHARACTER_UUID';

--- a/test-e2e/model-interaction/cast-member-with-prods.test.js
+++ b/test-e2e/model-interaction/cast-member-with-prods.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const THE_GREEKS_ALDWYCH_PRODUCTION_UUID = 'THE_GREEKS_PRODUCTION_UUID';

--- a/test-e2e/model-interaction/char-diff-groups-same-mat.test.js
+++ b/test-e2e/model-interaction/char-diff-groups-same-mat.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const THREE_WINTERS_MATERIAL_UUID = '3_WINTERS_MATERIAL_UUID';

--- a/test-e2e/model-interaction/char-groups-grouping.test.js
+++ b/test-e2e/model-interaction/char-groups-grouping.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const JULIUS_CAESAR_MATERIAL_UUID = 'JULIUS_CAESAR_MATERIAL_UUID';

--- a/test-e2e/model-interaction/char-multi-appearances-same-mat.test.js
+++ b/test-e2e/model-interaction/char-multi-appearances-same-mat.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const ROCK_N_ROLL_MATERIAL_UUID = 'ROCK_N_ROLL_MATERIAL_UUID';

--- a/test-e2e/model-interaction/char-multi-prods-multi-mats.test.js
+++ b/test-e2e/model-interaction/char-multi-prods-multi-mats.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const HENRY_IV_PART_1_MATERIAL_UUID = 'HENRY_IV_PART_1_MATERIAL_UUID';

--- a/test-e2e/model-interaction/char-portrayed-with-other-roles.test.js
+++ b/test-e2e/model-interaction/char-portrayed-with-other-roles.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const JOEYS_MOTHER_CHARACTER_UUID = 'JOEYS_MOTHER_CHARACTER_UUID';

--- a/test-e2e/model-interaction/char-with-variant-depiction-portrayal-names.test.js
+++ b/test-e2e/model-interaction/char-with-variant-depiction-portrayal-names.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const HENRY_IV_PART_1_MATERIAL_UUID = 'HENRY_IV_PART_1_MATERIAL_UUID';

--- a/test-e2e/model-interaction/char-with-variant-names-prods-diff-mats.test.js
+++ b/test-e2e/model-interaction/char-with-variant-names-prods-diff-mats.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const HAMLET_MATERIAL_UUID = 'HAMLET_MATERIAL_UUID';

--- a/test-e2e/model-interaction/char-with-variant-names-prods-same-mat.test.js
+++ b/test-e2e/model-interaction/char-with-variant-names-prods-same-mat.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const HAMLET_CHARACTER_UUID = 'HAMLET_CHARACTER_UUID';

--- a/test-e2e/model-interaction/chars-same-name-diff-mats.test.js
+++ b/test-e2e/model-interaction/chars-same-name-diff-mats.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID = 'A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID';

--- a/test-e2e/model-interaction/chars-same-name-same-mat.test.js
+++ b/test-e2e/model-interaction/chars-same-name-same-mat.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const JULIUS_CAESAR_MATERIAL_UUID = 'JULIUS_CAESAR_MATERIAL_UUID';

--- a/test-e2e/model-interaction/festival-series-with-festivals.test.js
+++ b/test-e2e/model-interaction/festival-series-with-festivals.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const EDINBURGH_INTERNATIONAL_FESTIVAL_2008_FESTIVAL_UUID = '2008_FESTIVAL_EDINBURGH_INTERNATIONAL_FESTIVAL_UUID';

--- a/test-e2e/model-interaction/festival-with-prods.test.js
+++ b/test-e2e/model-interaction/festival-with-prods.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const ROMEO_AND_JULIET_ROYAL_SHAKESPEARE_PRODUCTION_UUID = 'ROMEO_AND_JULIET_PRODUCTION_UUID';

--- a/test-e2e/model-interaction/mat-with-credited-entities.test.js
+++ b/test-e2e/model-interaction/mat-with-credited-entities.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const XYZZY_MATERIAL_UUID = 'XYZZY_MATERIAL_UUID';

--- a/test-e2e/model-interaction/mat-with-prods.test.js
+++ b/test-e2e/model-interaction/mat-with-prods.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const TWELFTH_NIGHT_MATERIAL_UUID = 'TWELFTH_NIGHT_MATERIAL_UUID';

--- a/test-e2e/model-interaction/mat-with-rights-grantor.test.js
+++ b/test-e2e/model-interaction/mat-with-rights-grantor.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const LIVERPOOL_EVERYMAN_PLAYHOUSE_VENUE_UUID = 'LIVERPOOL_EVERYMAN_PLAYHOUSE_VENUE_UUID';

--- a/test-e2e/model-interaction/mat-with-sub-mats-rights-grantor.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-mats-rights-grantor.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const BIRMINGHAM_REPERTORY_THEATRE_VENUE_UUID = 'BIRMINGHAM_REPERTORY_THEATRE_VENUE_UUID';

--- a/test-e2e/model-interaction/mat-with-sub-mats-source-mats.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-mats-source-mats.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const BRING_UP_THE_BODIES_NOVEL_MATERIAL_UUID = 'BRING_UP_THE_BODIES_MATERIAL_1_UUID';

--- a/test-e2e/model-interaction/mat-with-sub-mats-subsequent-versions.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-mats-subsequent-versions.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const TRAFALGAR_STUDIOS_VENUE_UUID = 'TRAFALGAR_STUDIOS_VENUE_UUID';

--- a/test-e2e/model-interaction/mat-with-sub-mats.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-mats.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const VOYAGE_MATERIAL_UUID = 'VOYAGE_MATERIAL_UUID';

--- a/test-e2e/model-interaction/mat-with-sub-sub-mats-rights-grantor.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-sub-mats-rights-grantor.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const THE_FELLOWSHIP_OF_THE_RING_NOVEL_MATERIAL_UUID = 'THE_FELLOWSHIP_OF_THE_RING_MATERIAL_1_UUID';

--- a/test-e2e/model-interaction/mat-with-sub-sub-mats-source-mats.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-sub-mats-source-mats.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const GENESIS_RELIGIOUS_TEXT_MATERIAL_UUID = 'GENESIS_MATERIAL_UUID';

--- a/test-e2e/model-interaction/mat-with-sub-sub-mats-subsequent-versions.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-sub-mats-subsequent-versions.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const UNICORN_THEATRE_VENUE_UUID = 'UNICORN_THEATRE_VENUE_UUID';

--- a/test-e2e/model-interaction/mat-with-sub-sub-mats.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-sub-mats.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const BUGLES_AT_THE_GATES_OF_JALALABAD_MATERIAL_UUID = 'BUGLES_AT_THE_GATES_OF_JALALABAD_MATERIAL_UUID';

--- a/test-e2e/model-interaction/mat-with-subsequent-versions.test.js
+++ b/test-e2e/model-interaction/mat-with-subsequent-versions.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const BARBICAN_CENTRE_VENUE_UUID = 'BARBICAN_CENTRE_VENUE_UUID';

--- a/test-e2e/model-interaction/mats-with-source-mat.test.js
+++ b/test-e2e/model-interaction/mats-with-source-mat.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const ROYAL_SHAKESPEARE_THEATRE_VENUE_UUID = 'ROYAL_SHAKESPEARE_THEATRE_VENUE_UUID';

--- a/test-e2e/model-interaction/multi-tiered-mat-prod-credit-ordering.test.js
+++ b/test-e2e/model-interaction/multi-tiered-mat-prod-credit-ordering.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const BUGLES_AT_THE_GATES_OF_JALALABAD_MATERIAL_UUID = 'BUGLES_AT_THE_GATES_OF_JALALABAD_MATERIAL_UUID';

--- a/test-e2e/model-interaction/prod-with-sub-prods.test.js
+++ b/test-e2e/model-interaction/prod-with-sub-prods.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const NATIONAL_THEATRE_VENUE_UUID = 'NATIONAL_THEATRE_VENUE_UUID';

--- a/test-e2e/model-interaction/prod-with-sub-sub-prods.test.js
+++ b/test-e2e/model-interaction/prod-with-sub-sub-prods.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const BERKELEY_REPERTORY_THEATRE_VENUE_UUID = 'BERKELEY_REPERTORY_THEATRE_VENUE_UUID';

--- a/test-e2e/model-interaction/prods-with-creative-team.test.js
+++ b/test-e2e/model-interaction/prods-with-creative-team.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const NATIONAL_THEATRE_VENUE_UUID = 'NATIONAL_THEATRE_VENUE_UUID';

--- a/test-e2e/model-interaction/prods-with-crew.test.js
+++ b/test-e2e/model-interaction/prods-with-crew.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const NATIONAL_THEATRE_VENUE_UUID = 'NATIONAL_THEATRE_VENUE_UUID';

--- a/test-e2e/model-interaction/prods-with-producers.test.js
+++ b/test-e2e/model-interaction/prods-with-producers.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const ROYAL_COURT_THEATRE_VENUE_UUID = 'ROYAL_COURT_THEATRE_VENUE_UUID';

--- a/test-e2e/model-interaction/prods-with-reviews.test.js
+++ b/test-e2e/model-interaction/prods-with-reviews.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const NATIONAL_THEATRE_VENUE_UUID = 'NATIONAL_THEATRE_VENUE_UUID';

--- a/test-e2e/model-interaction/roles-with-alternating-cast.test.js
+++ b/test-e2e/model-interaction/roles-with-alternating-cast.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const AUSTIN_CHARACTER_UUID = 'AUSTIN_CHARACTER_UUID';

--- a/test-e2e/model-interaction/season-with-prods.test.js
+++ b/test-e2e/model-interaction/season-with-prods.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const SEIZE_THE_DAY_TRICYCLE_PRODUCTION_UUID = 'SEIZE_THE_DAY_PRODUCTION_UUID';

--- a/test-e2e/model-interaction/venue-with-prods.test.js
+++ b/test-e2e/model-interaction/venue-with-prods.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const A_STREETCAR_NAMED_DESIRE_DONMAR_PRODUCTION_UUID = 'A_STREETCAR_NAMED_DESIRE_PRODUCTION_UUID';

--- a/test-e2e/model-interaction/venue-with-sub-venues.test.js
+++ b/test-e2e/model-interaction/venue-with-sub-venues.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const NATIONAL_THEATRE_VENUE_UUID = 'NATIONAL_THEATRE_VENUE_UUID';

--- a/test-e2e/model-interaction/wri-groups-grouping.test.js
+++ b/test-e2e/model-interaction/wri-groups-grouping.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { before, describe, it } from 'node:test';
 
-import request from 'supertest';
-
 import app from '../../src/app.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+import request from '../test-helpers/model-interaction-request.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 
 const XYZZY_MATERIAL_UUID = 'XYZZY_MATERIAL_UUID';

--- a/test-e2e/test-helpers/model-interaction-request.js
+++ b/test-e2e/test-helpers/model-interaction-request.js
@@ -1,0 +1,22 @@
+import supertest from 'supertest';
+
+import { flushModelInteractionSeedQueue, queueModelInteractionSeed } from './model-interaction-seed-queue.js';
+
+export default (app) => {
+	const request = supertest(app);
+
+	return {
+		get: async (...args) => {
+			await flushModelInteractionSeedQueue();
+
+			return request.get(...args);
+		},
+		post: (path) => ({
+			send: async (body) => {
+				queueModelInteractionSeed(path, body);
+
+				return { status: 201 };
+			}
+		})
+	};
+};

--- a/test-e2e/test-helpers/model-interaction-seed-queue.js
+++ b/test-e2e/test-helpers/model-interaction-seed-queue.js
@@ -1,0 +1,150 @@
+import prepareAsParams from '../../src/lib/prepare-as-params.js';
+import { AwardCeremony, Festival, Material, Production, Venue } from '../../src/models/index.js';
+import { getCreateQueries, sharedQueries } from '../../src/neo4j/cypher-queries/index.js';
+import { neo4jQuery } from '../../src/neo4j/query.js';
+import { MODELS } from '../../src/utils/constants.js';
+
+const PATH_TO_MODEL_MAP = new Map([
+	['/award-ceremonies', MODELS.AWARD_CEREMONY],
+	['/festivals', MODELS.FESTIVAL],
+	['/materials', MODELS.MATERIAL],
+	['/productions', MODELS.PRODUCTION],
+	['/venues', MODELS.VENUE]
+]);
+
+const MODEL_TO_CLASS_MAP = new Map([
+	[MODELS.AWARD_CEREMONY, AwardCeremony],
+	[MODELS.FESTIVAL, Festival],
+	[MODELS.MATERIAL, Material],
+	[MODELS.PRODUCTION, Production],
+	[MODELS.VENUE, Venue]
+]);
+
+const MODEL_TO_QUERY_SCOPE_VARIABLE_MAP = new Map([
+	[MODELS.AWARD_CEREMONY, 'ceremony'],
+	[MODELS.FESTIVAL, 'festival'],
+	[MODELS.MATERIAL, 'material'],
+	[MODELS.PRODUCTION, 'production'],
+	[MODELS.VENUE, 'venue']
+]);
+
+let queuedSeeds = [];
+
+const seedQueryByModel = new Map();
+
+const replaceQueryParamsWithRowProperties = (query) =>
+	query.replace(/\$([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)/g, 'row.$1');
+
+const preserveRowAcrossWithClauses = (query) =>
+	query
+		.replace(/^(\s*)WITH DISTINCT\s+/gm, '$1WITH DISTINCT row, ')
+		.replace(/^(\s*)WITH\s*$/gm, '$1WITH\n$1\trow,')
+		.replace(/^(\s*)WITH\s+(?!row\b|DISTINCT row\b)/gm, '$1WITH row, ');
+
+const stripEditQuery = (model, query) => {
+	const scopeVariable = MODEL_TO_QUERY_SCOPE_VARIABLE_MAP.get(model);
+	const finalWithClause = `WITH DISTINCT ${scopeVariable}`;
+	const finalWithClauseIndex = query.lastIndexOf(finalWithClause);
+
+	if (finalWithClauseIndex === -1) return query;
+
+	return `${query.slice(0, finalWithClauseIndex)}
+
+		RETURN 1 AS seeded
+	`;
+};
+
+const getCreateQuery = (model) => {
+	const createQueryFactory = getCreateQueries[model] || sharedQueries.getCreateQuery;
+
+	return replaceQueryParamsWithRowProperties(
+		preserveRowAcrossWithClauses(stripEditQuery(model, createQueryFactory(model)))
+	);
+};
+
+const getSeedQuery = (model) => {
+	if (!seedQueryByModel.has(model)) {
+		seedQueryByModel.set(
+			model,
+			`
+				UNWIND $rows AS seedRow
+
+				WITH seedRow
+					ORDER BY seedRow.position
+
+				CALL {
+					WITH seedRow
+
+					WITH seedRow.params AS row
+
+					${getCreateQuery(model)}
+				}
+
+				RETURN COUNT(*) AS count
+			`
+		);
+	}
+
+	return seedQueryByModel.get(model);
+};
+
+const getSeedChunks = () => {
+	return queuedSeeds.reduce((chunks, seed) => {
+		const currentChunk = chunks.at(-1);
+
+		if (currentChunk?.model === seed.model) {
+			currentChunk.seeds.push(seed);
+		} else {
+			chunks.push({ model: seed.model, seeds: [seed] });
+		}
+
+		return chunks;
+	}, []);
+};
+
+const queueModelInteractionSeed = (path, body) => {
+	const model = PATH_TO_MODEL_MAP.get(path);
+
+	if (!model) throw new Error(`Unsupported model-interaction seed path: ${path}`);
+
+	const Class = MODEL_TO_CLASS_MAP.get(model);
+	const instance = new Class(body);
+
+	if (model === MODELS.AWARD_CEREMONY) {
+		prepareAsParams(instance);
+	}
+
+	queuedSeeds.push({
+		model,
+		params: prepareAsParams(instance)
+	});
+};
+
+const clearModelInteractionSeedQueue = () => {
+	queuedSeeds = [];
+};
+
+const flushModelInteractionSeedQueue = async () => {
+	if (!queuedSeeds.length) return;
+
+	const seedChunks = getSeedChunks();
+
+	clearModelInteractionSeedQueue();
+
+	for (const { model, seeds } of seedChunks) {
+		await neo4jQuery(
+			{
+				query: getSeedQuery(model),
+				params: {
+					rows: seeds.map((seed, position) => ({
+						position,
+						params: seed.params
+					}))
+				}
+			},
+			{ isOptionalResult: true }
+		);
+	}
+};
+
+export { clearModelInteractionSeedQueue, flushModelInteractionSeedQueue, queueModelInteractionSeed };

--- a/test-e2e/test-helpers/neo4j/create-relationship.js
+++ b/test-e2e/test-helpers/neo4j/create-relationship.js
@@ -1,6 +1,9 @@
 import { neo4jQuery } from '../../../src/neo4j/query.js';
+import { flushModelInteractionSeedQueue } from '../model-interaction-seed-queue.js';
 
 export default async (opts) => {
+	await flushModelInteractionSeedQueue();
+
 	const { sourceLabel, sourceUuid, destinationLabel, destinationUuid, relationshipName } = opts;
 
 	const params = { sourceUuid, destinationUuid };

--- a/test-e2e/test-helpers/neo4j/delete-relationship.js
+++ b/test-e2e/test-helpers/neo4j/delete-relationship.js
@@ -1,6 +1,9 @@
 import { neo4jQuery } from '../../../src/neo4j/query.js';
+import { flushModelInteractionSeedQueue } from '../model-interaction-seed-queue.js';
 
 export default async (opts) => {
+	await flushModelInteractionSeedQueue();
+
 	const { sourceLabel, sourceUuid, destinationLabel, destinationUuid, relationshipName } = opts;
 
 	const params = { sourceUuid, destinationUuid };

--- a/test-e2e/test-helpers/neo4j/purge-database.js
+++ b/test-e2e/test-helpers/neo4j/purge-database.js
@@ -1,6 +1,9 @@
 import { neo4jQuery } from '../../../src/neo4j/query.js';
+import { clearModelInteractionSeedQueue } from '../model-interaction-seed-queue.js';
 
 export default async () => {
+	clearModelInteractionSeedQueue();
+
 	const query = `
 		MATCH (n)
 


### PR DESCRIPTION
This PR applies some helper functions so that for the model interaction end-to-end tests, the data is seeded via batched Cypher queries rather than via POST requests to the app, which has a significant effect on the time it takes the tests to run.

There are other end-to-end tests that need to make their requests via the app because they are, e.g. testing the CRUD lifecycle or ensuring that the app performs sufficient validation on the requests. However, the model interaction tests are only testing the GET/show logic for queries and so it is fine for the data to pre-exist in the database by whatever (i.e. the fastest) means possible.

The changes hav also been done in such a way that has resulted in minimal interference to the test files themselves.

### `e2e-tests` job

#### Before
- [CircleCI link](https://app.circleci.com/pipelines/github/andygout/dramatis-api/2918/workflows/5cd3e601-a1a7-4461-84a0-0fa5cfaa9fe0/jobs/3469): **10m 15s**

#### After
- [CircleCI link](https://app.circleci.com/pipelines/github/andygout/dramatis-api/2920/workflows/a10dabeb-96b3-4841-9f15-de18b0cfa5e9/jobs/3478): **6m 5s**

That is a saving of 4m 10s (~40.7%).