### PR TITLE
Disable logger for end-to-end tests

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -8,6 +8,10 @@ import router from './router.js';
 
 const app = express();
 
-app.use(express.json(), logger('dev'), accessControlSetter, router, errorHandler);
+// Disable logger for end-to-end tests to prevent it
+// from contributing to their duration.
+const requestLogger = process.env.NODE_ENV === 'e2e-test' ? [] : [logger('dev')];
+
+app.use(express.json(), ...requestLogger, accessControlSetter, router, errorHandler);
 
 export default app;


### PR DESCRIPTION
This PR disables the logger for end-to-end tests to prevent it from contributing to their duration on the basis that CI logs can add overhead.

A before and after test of running the end-to-end tests indicated that this change will shave off ~14 seconds.