### PR TITLE
Parallelise e2e-tests job in CI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ jobs:
           NEO4J_server_memory_heap_initial__size: 512M
           NEO4J_server_memory_heap_max__size: 512M
           NEO4J_server_memory_pagecache_size: 512M
+    parallelism: 6
     steps:
       - checkout
       - attach_workspace:
@@ -101,7 +102,10 @@ jobs:
             "
       - run:
           name: End-to-end tests
-          command: npm run e2e-test
+          command: |
+            circleci tests glob "test-e2e/**/*.test.js" \
+              | circleci tests split --split-by=name \
+              | xargs -r node --env-file=./test-e2e/.env --import=./test-e2e/per-test-file-teardown.js --test --test-global-setup=test-e2e/global-setup.js --test-timeout=60000 --test-concurrency=1
 
 workflows:
   version: 2


### PR DESCRIPTION
This PR parallelises the e2e-tests job in the CI workflow.

In doing so, it reduces the duration of this job:
- from: **6m 27s** ([link](https://app.circleci.com/pipelines/gh/andygout/dramatis-api/2924/workflows/8cb14ef4-a3c6-4304-a3df-44ce8c71f281/jobs/3503))
- to: **2m 20s** ([link](https://app.circleci.com/pipelines/gh/andygout/dramatis-api/2929/workflows/6489510f-30b3-475c-b50b-0239e391da27/jobs/3547))

That is a reduction of **4m 07s** (63.82%).