### PR TITLE
Add settings property to setting materials

### DIFF
--- a/src/neo4j/cypher-queries/locale/show/show-materials.js
+++ b/src/neo4j/cypher-queries/locale/show/show-materials.js
@@ -6,9 +6,38 @@ export default () => `
 
 		OPTIONAL MATCH (locale)<-[:HAS_SETTING]-(material:Material)
 
-		WITH COLLECT(DISTINCT(material)) AS materials
+		WITH locale, COLLECT(DISTINCT(material)) AS materials
 
 		UNWIND (CASE materials WHEN [] THEN [null] ELSE materials END) AS material
+
+			OPTIONAL MATCH (material)-[localeSettingRel:HAS_SETTING]->(locale)
+
+			OPTIONAL MATCH (time:Time { uuid: localeSettingRel.timeUuid })
+
+			OPTIONAL MATCH (place:Place { uuid: localeSettingRel.placeUuid })
+
+			WITH material, locale, localeSettingRel, time, place
+				ORDER BY localeSettingRel.position
+
+			WITH
+				material,
+				COLLECT(
+					CASE WHEN localeSettingRel IS NULL
+						THEN null
+						ELSE {
+							model: 'SETTING',
+							time: CASE WHEN time IS NULL
+								THEN null
+								ELSE time { model: 'TIME', .uuid, .name }
+							END,
+							place: CASE WHEN place IS NULL
+								THEN null
+								ELSE place { model: 'PLACE', .uuid, .name }
+							END,
+							locale: locale { model: 'LOCALE', .uuid, .name }
+						}
+					END
+				) AS settings
 
 			OPTIONAL MATCH (material)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity:Person|Company|Material)
 
@@ -21,6 +50,7 @@ export default () => `
 
 			WITH
 				material,
+				settings,
 				entityRel,
 				entity,
 				entitySurMaterial,
@@ -31,6 +61,7 @@ export default () => `
 
 			WITH
 				material,
+				settings,
 				entityRel,
 				entity,
 				entitySurMaterial,
@@ -43,7 +74,7 @@ export default () => `
 					END
 				) AS sourceMaterialWriters
 
-			WITH material, entityRel, entity, entitySurMaterial, entitySurSurMaterial,
+			WITH material, settings, entityRel, entity, entitySurMaterial, entitySurSurMaterial,
 				COLLECT(
 					CASE SIZE(sourceMaterialWriters) WHEN 0
 						THEN null
@@ -56,7 +87,7 @@ export default () => `
 				) AS sourceMaterialWritingCredits
 				ORDER BY entityRel.creditPosition, entityRel.entityPosition
 
-			WITH material, entityRel.credit AS writingCreditName,
+			WITH material, settings, entityRel.credit AS writingCreditName,
 				COLLECT(
 					CASE WHEN entity IS NULL
 						THEN null
@@ -83,13 +114,13 @@ export default () => `
 					END
 				) AS entities
 
-			WITH material, writingCreditName,
+			WITH material, settings, writingCreditName,
 				[entity IN entities | CASE entity.model WHEN 'MATERIAL'
 					THEN entity
 					ELSE entity { .model, .uuid, .name }
 				END] AS entities
 
-			WITH material,
+			WITH material, settings,
 				COLLECT(
 					CASE SIZE(entities) WHEN 0
 						THEN null
@@ -105,7 +136,7 @@ export default () => `
 
 			OPTIONAL MATCH (surMaterial)<-[surSurMaterialRel:HAS_SUB_MATERIAL]-(surSurMaterial:Material)
 
-			WITH material, writingCredits, surMaterial, surSurMaterial
+			WITH material, settings, writingCredits, surMaterial, surSurMaterial
 				ORDER BY
 					material.year DESC,
 					COALESCE(surSurMaterial.name, surMaterial.name, material.name),
@@ -135,7 +166,8 @@ export default () => `
 								END
 							}
 						END,
-						writingCredits
+						writingCredits,
+						settings
 					}
 				END
 			) AS materials

--- a/src/neo4j/cypher-queries/place/show/show-materials.js
+++ b/src/neo4j/cypher-queries/place/show/show-materials.js
@@ -6,9 +6,38 @@ export default () => `
 
 		OPTIONAL MATCH (place)<-[:HAS_SETTING]-(material:Material)
 
-		WITH COLLECT(DISTINCT(material)) AS materials
+		WITH place, COLLECT(DISTINCT(material)) AS materials
 
 		UNWIND (CASE materials WHEN [] THEN [null] ELSE materials END) AS material
+
+			OPTIONAL MATCH (material)-[placeSettingRel:HAS_SETTING]->(place)
+
+			OPTIONAL MATCH (time:Time { uuid: placeSettingRel.timeUuid })
+
+			OPTIONAL MATCH (locale:Locale { uuid: placeSettingRel.localeUuid })
+
+			WITH material, place, placeSettingRel, time, locale
+				ORDER BY placeSettingRel.position
+
+			WITH
+				material,
+				COLLECT(
+					CASE WHEN placeSettingRel IS NULL
+						THEN null
+						ELSE {
+							model: 'SETTING',
+							time: CASE WHEN time IS NULL
+								THEN null
+								ELSE time { model: 'TIME', .uuid, .name }
+							END,
+							place: place { model: 'PLACE', .uuid, .name },
+							locale: CASE WHEN locale IS NULL
+								THEN null
+								ELSE locale { model: 'LOCALE', .uuid, .name }
+							END
+						}
+					END
+				) AS settings
 
 			OPTIONAL MATCH (material)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity:Person|Company|Material)
 
@@ -21,6 +50,7 @@ export default () => `
 
 			WITH
 				material,
+				settings,
 				entityRel,
 				entity,
 				entitySurMaterial,
@@ -31,6 +61,7 @@ export default () => `
 
 			WITH
 				material,
+				settings,
 				entityRel,
 				entity,
 				entitySurMaterial,
@@ -43,7 +74,7 @@ export default () => `
 					END
 				) AS sourceMaterialWriters
 
-			WITH material, entityRel, entity, entitySurMaterial, entitySurSurMaterial,
+			WITH material, settings, entityRel, entity, entitySurMaterial, entitySurSurMaterial,
 				COLLECT(
 					CASE SIZE(sourceMaterialWriters) WHEN 0
 						THEN null
@@ -56,7 +87,7 @@ export default () => `
 				) AS sourceMaterialWritingCredits
 				ORDER BY entityRel.creditPosition, entityRel.entityPosition
 
-			WITH material, entityRel.credit AS writingCreditName,
+			WITH material, settings, entityRel.credit AS writingCreditName,
 				COLLECT(
 					CASE WHEN entity IS NULL
 						THEN null
@@ -83,13 +114,13 @@ export default () => `
 					END
 				) AS entities
 
-			WITH material, writingCreditName,
+			WITH material, settings, writingCreditName,
 				[entity IN entities | CASE entity.model WHEN 'MATERIAL'
 					THEN entity
 					ELSE entity { .model, .uuid, .name }
 				END] AS entities
 
-			WITH material,
+			WITH material, settings,
 				COLLECT(
 					CASE SIZE(entities) WHEN 0
 						THEN null
@@ -105,7 +136,7 @@ export default () => `
 
 			OPTIONAL MATCH (surMaterial)<-[surSurMaterialRel:HAS_SUB_MATERIAL]-(surSurMaterial:Material)
 
-			WITH material, writingCredits, surMaterial, surSurMaterial
+			WITH material, settings, writingCredits, surMaterial, surSurMaterial
 				ORDER BY
 					material.year DESC,
 					COALESCE(surSurMaterial.name, surMaterial.name, material.name),
@@ -135,7 +166,8 @@ export default () => `
 								END
 							}
 						END,
-						writingCredits
+						writingCredits,
+						settings
 					}
 				END
 			) AS materials

--- a/src/neo4j/cypher-queries/time/show/show-materials.js
+++ b/src/neo4j/cypher-queries/time/show/show-materials.js
@@ -6,9 +6,38 @@ export default () => `
 
 		OPTIONAL MATCH (time)<-[:HAS_SETTING]-(material:Material)
 
-		WITH COLLECT(DISTINCT(material)) AS materials
+		WITH time, COLLECT(DISTINCT(material)) AS materials
 
 		UNWIND (CASE materials WHEN [] THEN [null] ELSE materials END) AS material
+
+			OPTIONAL MATCH (material)-[timeSettingRel:HAS_SETTING]->(time)
+
+			OPTIONAL MATCH (place:Place { uuid: timeSettingRel.placeUuid })
+
+			OPTIONAL MATCH (locale:Locale { uuid: timeSettingRel.localeUuid })
+
+			WITH material, time, timeSettingRel, place, locale
+				ORDER BY timeSettingRel.position
+
+			WITH
+				material,
+				COLLECT(
+					CASE WHEN timeSettingRel IS NULL
+						THEN null
+						ELSE {
+							model: 'SETTING',
+							time: time { model: 'TIME', .uuid, .name },
+							place: CASE WHEN place IS NULL
+								THEN null
+								ELSE place { model: 'PLACE', .uuid, .name }
+							END,
+							locale: CASE WHEN locale IS NULL
+								THEN null
+								ELSE locale { model: 'LOCALE', .uuid, .name }
+							END
+						}
+					END
+				) AS settings
 
 			OPTIONAL MATCH (material)-[entityRel:HAS_WRITING_ENTITY|USES_SOURCE_MATERIAL]->(entity:Person|Company|Material)
 
@@ -21,6 +50,7 @@ export default () => `
 
 			WITH
 				material,
+				settings,
 				entityRel,
 				entity,
 				entitySurMaterial,
@@ -31,6 +61,7 @@ export default () => `
 
 			WITH
 				material,
+				settings,
 				entityRel,
 				entity,
 				entitySurMaterial,
@@ -43,7 +74,7 @@ export default () => `
 					END
 				) AS sourceMaterialWriters
 
-			WITH material, entityRel, entity, entitySurMaterial, entitySurSurMaterial,
+			WITH material, settings, entityRel, entity, entitySurMaterial, entitySurSurMaterial,
 				COLLECT(
 					CASE SIZE(sourceMaterialWriters) WHEN 0
 						THEN null
@@ -56,7 +87,7 @@ export default () => `
 				) AS sourceMaterialWritingCredits
 				ORDER BY entityRel.creditPosition, entityRel.entityPosition
 
-			WITH material, entityRel.credit AS writingCreditName,
+			WITH material, settings, entityRel.credit AS writingCreditName,
 				COLLECT(
 					CASE WHEN entity IS NULL
 						THEN null
@@ -83,13 +114,13 @@ export default () => `
 					END
 				) AS entities
 
-			WITH material, writingCreditName,
+			WITH material, settings, writingCreditName,
 				[entity IN entities | CASE entity.model WHEN 'MATERIAL'
 					THEN entity
 					ELSE entity { .model, .uuid, .name }
 				END] AS entities
 
-			WITH material,
+			WITH material, settings,
 				COLLECT(
 					CASE SIZE(entities) WHEN 0
 						THEN null
@@ -105,7 +136,7 @@ export default () => `
 
 			OPTIONAL MATCH (surMaterial)<-[surSurMaterialRel:HAS_SUB_MATERIAL]-(surSurMaterial:Material)
 
-			WITH material, writingCredits, surMaterial, surSurMaterial
+			WITH material, settings, writingCredits, surMaterial, surSurMaterial
 				ORDER BY
 					material.year DESC,
 					COALESCE(surSurMaterial.name, surMaterial.name, material.name),
@@ -135,7 +166,8 @@ export default () => `
 								END
 							}
 						END,
-						writingCredits
+						writingCredits,
+						settings
 					}
 				END
 			) AS materials

--- a/test-e2e/model-interaction/mat-with-sub-mats.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-mats.test.js
@@ -644,6 +644,26 @@ describe('Material with sub-materials', () => {
 						name: 'The Coast of Utopia',
 						surMaterial: null
 					},
+					settings: [
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_THIRTY_THREE_TIME_UUID,
+								name: '1833'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: MOSCOW_PLACE_UUID,
+								name: 'Moscow'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_HOUSE_LOCALE_UUID,
+								name: 'Country house'
+							}
+						}
+					],
 					writingCredits: [
 						{
 							model: 'WRITING_CREDIT',
@@ -675,6 +695,26 @@ describe('Material with sub-materials', () => {
 						name: 'The Coast of Utopia',
 						surMaterial: null
 					},
+					settings: [
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_THIRTY_THREE_TIME_UUID,
+								name: '1833'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: MOSCOW_PLACE_UUID,
+								name: 'Moscow'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_HOUSE_LOCALE_UUID,
+								name: 'Country house'
+							}
+						}
+					],
 					writingCredits: [
 						{
 							model: 'WRITING_CREDIT',
@@ -706,6 +746,26 @@ describe('Material with sub-materials', () => {
 						name: 'The Coast of Utopia',
 						surMaterial: null
 					},
+					settings: [
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_THIRTY_THREE_TIME_UUID,
+								name: '1833'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: MOSCOW_PLACE_UUID,
+								name: 'Moscow'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_HOUSE_LOCALE_UUID,
+								name: 'Country house'
+							}
+						}
+					],
 					writingCredits: [
 						{
 							model: 'WRITING_CREDIT',
@@ -748,6 +808,26 @@ describe('Material with sub-materials', () => {
 						name: 'The Coast of Utopia',
 						surMaterial: null
 					},
+					settings: [
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_THIRTY_THREE_TIME_UUID,
+								name: '1833'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: MOSCOW_PLACE_UUID,
+								name: 'Moscow'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_HOUSE_LOCALE_UUID,
+								name: 'Country house'
+							}
+						}
+					],
 					writingCredits: [
 						{
 							model: 'WRITING_CREDIT',
@@ -779,6 +859,26 @@ describe('Material with sub-materials', () => {
 						name: 'The Coast of Utopia',
 						surMaterial: null
 					},
+					settings: [
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_THIRTY_THREE_TIME_UUID,
+								name: '1833'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: MOSCOW_PLACE_UUID,
+								name: 'Moscow'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_HOUSE_LOCALE_UUID,
+								name: 'Country house'
+							}
+						}
+					],
 					writingCredits: [
 						{
 							model: 'WRITING_CREDIT',
@@ -810,6 +910,26 @@ describe('Material with sub-materials', () => {
 						name: 'The Coast of Utopia',
 						surMaterial: null
 					},
+					settings: [
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_THIRTY_THREE_TIME_UUID,
+								name: '1833'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: MOSCOW_PLACE_UUID,
+								name: 'Moscow'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_HOUSE_LOCALE_UUID,
+								name: 'Country house'
+							}
+						}
+					],
 					writingCredits: [
 						{
 							model: 'WRITING_CREDIT',
@@ -852,6 +972,26 @@ describe('Material with sub-materials', () => {
 						name: 'The Coast of Utopia',
 						surMaterial: null
 					},
+					settings: [
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_THIRTY_THREE_TIME_UUID,
+								name: '1833'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: MOSCOW_PLACE_UUID,
+								name: 'Moscow'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_HOUSE_LOCALE_UUID,
+								name: 'Country house'
+							}
+						}
+					],
 					writingCredits: [
 						{
 							model: 'WRITING_CREDIT',
@@ -883,6 +1023,26 @@ describe('Material with sub-materials', () => {
 						name: 'The Coast of Utopia',
 						surMaterial: null
 					},
+					settings: [
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_THIRTY_THREE_TIME_UUID,
+								name: '1833'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: MOSCOW_PLACE_UUID,
+								name: 'Moscow'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_HOUSE_LOCALE_UUID,
+								name: 'Country house'
+							}
+						}
+					],
 					writingCredits: [
 						{
 							model: 'WRITING_CREDIT',
@@ -914,6 +1074,26 @@ describe('Material with sub-materials', () => {
 						name: 'The Coast of Utopia',
 						surMaterial: null
 					},
+					settings: [
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_THIRTY_THREE_TIME_UUID,
+								name: '1833'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: MOSCOW_PLACE_UUID,
+								name: 'Moscow'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_HOUSE_LOCALE_UUID,
+								name: 'Country house'
+							}
+						}
+					],
 					writingCredits: [
 						{
 							model: 'WRITING_CREDIT',

--- a/test-e2e/model-interaction/mat-with-sub-sub-mats.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-sub-mats.test.js
@@ -1239,6 +1239,26 @@ describe('Material with sub-sub-materials', () => {
 							name: 'The Great Game: Afghanistan'
 						}
 					},
+					settings: [
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_FORTY_TWO_TIME_UUID,
+								name: '1842'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: KABUL_PLACE_UUID,
+								name: 'Kabul'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: PRISON_CELL_LOCALE_UUID,
+								name: 'Prison cell'
+							}
+						}
+					],
 					writingCredits: [
 						{
 							model: 'WRITING_CREDIT',
@@ -1274,6 +1294,26 @@ describe('Material with sub-sub-materials', () => {
 							name: 'The Great Game: Afghanistan'
 						}
 					},
+					settings: [
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_FORTY_TWO_TIME_UUID,
+								name: '1842'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: KABUL_PLACE_UUID,
+								name: 'Kabul'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: PRISON_CELL_LOCALE_UUID,
+								name: 'Prison cell'
+							}
+						}
+					],
 					writingCredits: [
 						{
 							model: 'WRITING_CREDIT',
@@ -1309,6 +1349,26 @@ describe('Material with sub-sub-materials', () => {
 							name: 'The Great Game: Afghanistan'
 						}
 					},
+					settings: [
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_FORTY_TWO_TIME_UUID,
+								name: '1842'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: KABUL_PLACE_UUID,
+								name: 'Kabul'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: PRISON_CELL_LOCALE_UUID,
+								name: 'Prison cell'
+							}
+						}
+					],
 					writingCredits: [
 						{
 							model: 'WRITING_CREDIT',
@@ -1355,6 +1415,26 @@ describe('Material with sub-sub-materials', () => {
 							name: 'The Great Game: Afghanistan'
 						}
 					},
+					settings: [
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_FORTY_TWO_TIME_UUID,
+								name: '1842'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: KABUL_PLACE_UUID,
+								name: 'Kabul'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: PRISON_CELL_LOCALE_UUID,
+								name: 'Prison cell'
+							}
+						}
+					],
 					writingCredits: [
 						{
 							model: 'WRITING_CREDIT',
@@ -1390,6 +1470,26 @@ describe('Material with sub-sub-materials', () => {
 							name: 'The Great Game: Afghanistan'
 						}
 					},
+					settings: [
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_FORTY_TWO_TIME_UUID,
+								name: '1842'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: KABUL_PLACE_UUID,
+								name: 'Kabul'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: PRISON_CELL_LOCALE_UUID,
+								name: 'Prison cell'
+							}
+						}
+					],
 					writingCredits: [
 						{
 							model: 'WRITING_CREDIT',
@@ -1425,6 +1525,26 @@ describe('Material with sub-sub-materials', () => {
 							name: 'The Great Game: Afghanistan'
 						}
 					},
+					settings: [
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_FORTY_TWO_TIME_UUID,
+								name: '1842'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: KABUL_PLACE_UUID,
+								name: 'Kabul'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: PRISON_CELL_LOCALE_UUID,
+								name: 'Prison cell'
+							}
+						}
+					],
 					writingCredits: [
 						{
 							model: 'WRITING_CREDIT',
@@ -1471,6 +1591,26 @@ describe('Material with sub-sub-materials', () => {
 							name: 'The Great Game: Afghanistan'
 						}
 					},
+					settings: [
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_FORTY_TWO_TIME_UUID,
+								name: '1842'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: KABUL_PLACE_UUID,
+								name: 'Kabul'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: PRISON_CELL_LOCALE_UUID,
+								name: 'Prison cell'
+							}
+						}
+					],
 					writingCredits: [
 						{
 							model: 'WRITING_CREDIT',
@@ -1506,6 +1646,26 @@ describe('Material with sub-sub-materials', () => {
 							name: 'The Great Game: Afghanistan'
 						}
 					},
+					settings: [
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_FORTY_TWO_TIME_UUID,
+								name: '1842'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: KABUL_PLACE_UUID,
+								name: 'Kabul'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: PRISON_CELL_LOCALE_UUID,
+								name: 'Prison cell'
+							}
+						}
+					],
 					writingCredits: [
 						{
 							model: 'WRITING_CREDIT',
@@ -1541,6 +1701,26 @@ describe('Material with sub-sub-materials', () => {
 							name: 'The Great Game: Afghanistan'
 						}
 					},
+					settings: [
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_FORTY_TWO_TIME_UUID,
+								name: '1842'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: KABUL_PLACE_UUID,
+								name: 'Kabul'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: PRISON_CELL_LOCALE_UUID,
+								name: 'Prison cell'
+							}
+						}
+					],
 					writingCredits: [
 						{
 							model: 'WRITING_CREDIT',

--- a/test-e2e/model-interaction/mats-with-settings.test.js
+++ b/test-e2e/model-interaction/mats-with-settings.test.js
@@ -69,12 +69,22 @@ describe('Materials with settings', () => {
 					{
 						time: {
 							name: '1895'
+						}
+					},
+					{
+						time: {
+							name: '1895'
 						},
 						place: {
 							name: 'Romania'
 						},
 						locale: {
 							name: 'Country estate'
+						}
+					},
+					{
+						place: {
+							name: 'Russia'
 						}
 					},
 					{
@@ -86,6 +96,11 @@ describe('Materials with settings', () => {
 						},
 						locale: {
 							name: 'Hillside'
+						}
+					},
+					{
+						locale: {
+							name: 'Country estate'
 						}
 					}
 				]
@@ -132,12 +147,22 @@ describe('Materials with settings', () => {
 					{
 						time: {
 							name: '1895'
+						}
+					},
+					{
+						time: {
+							name: '1895'
 						},
 						place: {
 							name: 'Romania'
 						},
 						locale: {
 							name: 'Country estate'
+						}
+					},
+					{
+						place: {
+							name: 'Russia'
 						}
 					},
 					{
@@ -149,6 +174,11 @@ describe('Materials with settings', () => {
 						},
 						locale: {
 							name: 'Hillside'
+						}
+					},
+					{
+						locale: {
+							name: 'Country estate'
 						}
 					}
 				]
@@ -183,6 +213,11 @@ describe('Materials with settings', () => {
 					},
 					{
 						time: {
+							name: '1895'
+						}
+					},
+					{
+						time: {
 							name: '1896'
 						},
 						place: {
@@ -204,6 +239,11 @@ describe('Materials with settings', () => {
 						}
 					},
 					{
+						place: {
+							name: 'Russia'
+						}
+					},
+					{
 						time: {
 							name: '1895'
 						},
@@ -212,6 +252,11 @@ describe('Materials with settings', () => {
 						},
 						locale: {
 							name: 'Hillside'
+						}
+					},
+					{
+						locale: {
+							name: 'Country estate'
 						}
 					}
 				]
@@ -272,6 +317,16 @@ describe('Materials with settings', () => {
 						uuid: EIGHTEEN_NINETY_FIVE_TIME_UUID,
 						name: '1895'
 					},
+					place: null,
+					locale: null
+				},
+				{
+					model: 'SETTING',
+					time: {
+						model: 'TIME',
+						uuid: EIGHTEEN_NINETY_FIVE_TIME_UUID,
+						name: '1895'
+					},
 					place: {
 						model: 'PLACE',
 						uuid: ROMANIA_PLACE_UUID,
@@ -282,6 +337,16 @@ describe('Materials with settings', () => {
 						uuid: COUNTRY_ESTATE_LOCALE_UUID,
 						name: 'Country estate'
 					}
+				},
+				{
+					model: 'SETTING',
+					time: null,
+					place: {
+						model: 'PLACE',
+						uuid: RUSSIA_PLACE_UUID,
+						name: 'Russia'
+					},
+					locale: null
 				},
 				{
 					model: 'SETTING',
@@ -299,6 +364,16 @@ describe('Materials with settings', () => {
 						model: 'LOCALE',
 						uuid: HILLSIDE_LOCALE_UUID,
 						name: 'Hillside'
+					}
+				},
+				{
+					model: 'SETTING',
+					time: null,
+					place: null,
+					locale: {
+						model: 'LOCALE',
+						uuid: COUNTRY_ESTATE_LOCALE_UUID,
+						name: 'Country estate'
 					}
 				}
 			];
@@ -331,6 +406,72 @@ describe('Materials with settings', () => {
 								}
 							]
 						}
+					],
+					settings: [
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_NINETY_FIVE_TIME_UUID,
+								name: '1895'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: RUSSIA_PLACE_UUID,
+								name: 'Russia'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_ESTATE_LOCALE_UUID,
+								name: 'Country estate'
+							}
+						},
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_NINETY_FIVE_TIME_UUID,
+								name: '1895'
+							},
+							place: null,
+							locale: null
+						},
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_NINETY_FIVE_TIME_UUID,
+								name: '1895'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: ROMANIA_PLACE_UUID,
+								name: 'Romania'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_ESTATE_LOCALE_UUID,
+								name: 'Country estate'
+							}
+						},
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_NINETY_FIVE_TIME_UUID,
+								name: '1895'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: RUSSIA_PLACE_UUID,
+								name: 'Russia'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: HILLSIDE_LOCALE_UUID,
+								name: 'Hillside'
+							}
+						}
 					]
 				},
 				{
@@ -352,6 +493,72 @@ describe('Materials with settings', () => {
 								}
 							]
 						}
+					],
+					settings: [
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_NINETY_FIVE_TIME_UUID,
+								name: '1895'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: RUSSIA_PLACE_UUID,
+								name: 'Russia'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_ESTATE_LOCALE_UUID,
+								name: 'Country estate'
+							}
+						},
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_NINETY_FIVE_TIME_UUID,
+								name: '1895'
+							},
+							place: null,
+							locale: null
+						},
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_NINETY_FIVE_TIME_UUID,
+								name: '1895'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: ROMANIA_PLACE_UUID,
+								name: 'Romania'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_ESTATE_LOCALE_UUID,
+								name: 'Country estate'
+							}
+						},
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_NINETY_FIVE_TIME_UUID,
+								name: '1895'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: RUSSIA_PLACE_UUID,
+								name: 'Russia'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: HILLSIDE_LOCALE_UUID,
+								name: 'Hillside'
+							}
+						}
 					]
 				},
 				{
@@ -372,6 +579,72 @@ describe('Materials with settings', () => {
 									name: 'Anton Chekhov'
 								}
 							]
+						}
+					],
+					settings: [
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_NINETY_FIVE_TIME_UUID,
+								name: '1895'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: RUSSIA_PLACE_UUID,
+								name: 'Russia'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_ESTATE_LOCALE_UUID,
+								name: 'Country estate'
+							}
+						},
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_NINETY_FIVE_TIME_UUID,
+								name: '1895'
+							},
+							place: null,
+							locale: null
+						},
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_NINETY_FIVE_TIME_UUID,
+								name: '1895'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: ROMANIA_PLACE_UUID,
+								name: 'Romania'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_ESTATE_LOCALE_UUID,
+								name: 'Country estate'
+							}
+						},
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_NINETY_FIVE_TIME_UUID,
+								name: '1895'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: RUSSIA_PLACE_UUID,
+								name: 'Russia'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: HILLSIDE_LOCALE_UUID,
+								name: 'Hillside'
+							}
 						}
 					]
 				}
@@ -405,6 +678,72 @@ describe('Materials with settings', () => {
 								}
 							]
 						}
+					],
+					settings: [
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_NINETY_FIVE_TIME_UUID,
+								name: '1895'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: RUSSIA_PLACE_UUID,
+								name: 'Russia'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_ESTATE_LOCALE_UUID,
+								name: 'Country estate'
+							}
+						},
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_NINETY_SIX_TIME_UUID,
+								name: '1896'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: RUSSIA_PLACE_UUID,
+								name: 'Russia'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_ESTATE_LOCALE_UUID,
+								name: 'Country estate'
+							}
+						},
+						{
+							model: 'SETTING',
+							time: null,
+							place: {
+								model: 'PLACE',
+								uuid: RUSSIA_PLACE_UUID,
+								name: 'Russia'
+							},
+							locale: null
+						},
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_NINETY_FIVE_TIME_UUID,
+								name: '1895'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: RUSSIA_PLACE_UUID,
+								name: 'Russia'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: HILLSIDE_LOCALE_UUID,
+								name: 'Hillside'
+							}
+						}
 					]
 				},
 				{
@@ -426,6 +765,72 @@ describe('Materials with settings', () => {
 								}
 							]
 						}
+					],
+					settings: [
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_NINETY_FIVE_TIME_UUID,
+								name: '1895'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: RUSSIA_PLACE_UUID,
+								name: 'Russia'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_ESTATE_LOCALE_UUID,
+								name: 'Country estate'
+							}
+						},
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_NINETY_SIX_TIME_UUID,
+								name: '1896'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: RUSSIA_PLACE_UUID,
+								name: 'Russia'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_ESTATE_LOCALE_UUID,
+								name: 'Country estate'
+							}
+						},
+						{
+							model: 'SETTING',
+							time: null,
+							place: {
+								model: 'PLACE',
+								uuid: RUSSIA_PLACE_UUID,
+								name: 'Russia'
+							},
+							locale: null
+						},
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_NINETY_FIVE_TIME_UUID,
+								name: '1895'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: RUSSIA_PLACE_UUID,
+								name: 'Russia'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: HILLSIDE_LOCALE_UUID,
+								name: 'Hillside'
+							}
+						}
 					]
 				},
 				{
@@ -446,6 +851,72 @@ describe('Materials with settings', () => {
 									name: 'Anton Chekhov'
 								}
 							]
+						}
+					],
+					settings: [
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_NINETY_FIVE_TIME_UUID,
+								name: '1895'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: RUSSIA_PLACE_UUID,
+								name: 'Russia'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_ESTATE_LOCALE_UUID,
+								name: 'Country estate'
+							}
+						},
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_NINETY_SIX_TIME_UUID,
+								name: '1896'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: RUSSIA_PLACE_UUID,
+								name: 'Russia'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_ESTATE_LOCALE_UUID,
+								name: 'Country estate'
+							}
+						},
+						{
+							model: 'SETTING',
+							time: null,
+							place: {
+								model: 'PLACE',
+								uuid: RUSSIA_PLACE_UUID,
+								name: 'Russia'
+							},
+							locale: null
+						},
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_NINETY_FIVE_TIME_UUID,
+								name: '1895'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: RUSSIA_PLACE_UUID,
+								name: 'Russia'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: HILLSIDE_LOCALE_UUID,
+								name: 'Hillside'
+							}
 						}
 					]
 				}
@@ -479,6 +950,72 @@ describe('Materials with settings', () => {
 								}
 							]
 						}
+					],
+					settings: [
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_NINETY_FIVE_TIME_UUID,
+								name: '1895'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: RUSSIA_PLACE_UUID,
+								name: 'Russia'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_ESTATE_LOCALE_UUID,
+								name: 'Country estate'
+							}
+						},
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_NINETY_SIX_TIME_UUID,
+								name: '1896'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: RUSSIA_PLACE_UUID,
+								name: 'Russia'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_ESTATE_LOCALE_UUID,
+								name: 'Country estate'
+							}
+						},
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_NINETY_FIVE_TIME_UUID,
+								name: '1895'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: ROMANIA_PLACE_UUID,
+								name: 'Romania'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_ESTATE_LOCALE_UUID,
+								name: 'Country estate'
+							}
+						},
+						{
+							model: 'SETTING',
+							time: null,
+							place: null,
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_ESTATE_LOCALE_UUID,
+								name: 'Country estate'
+							}
+						}
 					]
 				},
 				{
@@ -500,6 +1037,72 @@ describe('Materials with settings', () => {
 								}
 							]
 						}
+					],
+					settings: [
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_NINETY_FIVE_TIME_UUID,
+								name: '1895'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: RUSSIA_PLACE_UUID,
+								name: 'Russia'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_ESTATE_LOCALE_UUID,
+								name: 'Country estate'
+							}
+						},
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_NINETY_SIX_TIME_UUID,
+								name: '1896'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: RUSSIA_PLACE_UUID,
+								name: 'Russia'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_ESTATE_LOCALE_UUID,
+								name: 'Country estate'
+							}
+						},
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_NINETY_FIVE_TIME_UUID,
+								name: '1895'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: ROMANIA_PLACE_UUID,
+								name: 'Romania'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_ESTATE_LOCALE_UUID,
+								name: 'Country estate'
+							}
+						},
+						{
+							model: 'SETTING',
+							time: null,
+							place: null,
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_ESTATE_LOCALE_UUID,
+								name: 'Country estate'
+							}
+						}
 					]
 				},
 				{
@@ -520,6 +1123,72 @@ describe('Materials with settings', () => {
 									name: 'Anton Chekhov'
 								}
 							]
+						}
+					],
+					settings: [
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_NINETY_FIVE_TIME_UUID,
+								name: '1895'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: RUSSIA_PLACE_UUID,
+								name: 'Russia'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_ESTATE_LOCALE_UUID,
+								name: 'Country estate'
+							}
+						},
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_NINETY_SIX_TIME_UUID,
+								name: '1896'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: RUSSIA_PLACE_UUID,
+								name: 'Russia'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_ESTATE_LOCALE_UUID,
+								name: 'Country estate'
+							}
+						},
+						{
+							model: 'SETTING',
+							time: {
+								model: 'TIME',
+								uuid: EIGHTEEN_NINETY_FIVE_TIME_UUID,
+								name: '1895'
+							},
+							place: {
+								model: 'PLACE',
+								uuid: ROMANIA_PLACE_UUID,
+								name: 'Romania'
+							},
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_ESTATE_LOCALE_UUID,
+								name: 'Country estate'
+							}
+						},
+						{
+							model: 'SETTING',
+							time: null,
+							place: null,
+							locale: {
+								model: 'LOCALE',
+								uuid: COUNTRY_ESTATE_LOCALE_UUID,
+								name: 'Country estate'
+							}
 						}
 					]
 				}


### PR DESCRIPTION
This PR adds a `settings` property to setting materials so as to provide contextual information about the other setting elements.

#### 2001 (time)
Multiple materials that share the same time setting.

<img width="736" height="247" alt="2001-time" src="https://github.com/user-attachments/assets/f2c0552c-dab5-494e-979d-96e1ce8b8d5c" />

---

#### 490 BC (time)
A material that has multiple settings that include the same time setting.

<img width="943" height="200" alt="time-490-bc" src="https://github.com/user-attachments/assets/712e6fa3-61ec-4e36-8ab2-d843262ed3e8" />

---

#### Rome (place)
Multiple materials that share the same place setting. (Coincidentally, these also all have multiple settings that include the same place setting)

<img width="955" height="280" alt="place-rome" src="https://github.com/user-attachments/assets/dcdc0b2a-9e1a-41a7-ae06-8401af933ff3" />

---

#### Derbyshire (place)
A material that has multiple settings that include the same place setting.

<img width="902" height="185" alt="place-derbyshire" src="https://github.com/user-attachments/assets/5d6e84a0-4e37-4627-bdb4-9fe50264a8b2" />

---

#### Battlefield (locale)
Multiple materials that share the same locale setting.

<img width="655" height="210" alt="locale-battlefield" src="https://github.com/user-attachments/assets/73ea46c2-33ce-47ab-8d7a-aad132b5d3f5" />

---

#### Stately home (locale)
A material that has multiple settings that include the same locale setting.

<img width="902" height="190" alt="locale-stately-home" src="https://github.com/user-attachments/assets/7de25f59-6823-44cd-a018-b7a60d8d7f3b" />